### PR TITLE
Remove build command, rename project token, and handle railway run with no command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,18 +3,22 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 
 	"github.com/railwayapp/cli/entity"
+	"github.com/railwayapp/cli/errors"
 )
 
 func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 	envs, err := h.ctrl.GetEnvs(ctx)
 
 	if err != nil {
-		log.Fatal(err)
+		return err
+	}
+
+	if len(req.Args) == 0 {
+		return errors.CommandNotSpecified
 	}
 
 	cmd := exec.Command(req.Args[0], req.Args[1:]...)
@@ -31,7 +35,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 
 	err = cmd.Run()
 	if err != nil {
-		fmt.Println(err.Error())
+		return err
 	}
 
 	return nil

--- a/configs/main.go
+++ b/configs/main.go
@@ -103,7 +103,7 @@ func New() *Configs {
 	return &Configs{
 		projectConfigs:         projectConfig,
 		userConfigs:            userConfig,
-		RailwayProductionToken: os.Getenv("RAILWAY_PRODUCTION_TOKEN"),
+		RailwayProductionToken: os.Getenv("RAILWAY_TOKEN"),
 		RailwayEnvFilePath:     path.Join(projectDir, "env.json"),
 	}
 }

--- a/errors/main.go
+++ b/errors/main.go
@@ -10,4 +10,5 @@ var (
 	ProjectNotFound       RailwayError = errors.New("Project not found.")
 	ProjectCreateFailed   RailwayError = errors.New("There was a problem creating the project")
 	ProductionTokenNotSet RailwayError = errors.New("RAILWAY_PRODUCTION_TOKEN environment variable not set")
+	CommandNotSpecified   RailwayError = errors.New("Specify a command to run in side the railway environment. railway run <cmd>")
 )

--- a/errors/main.go
+++ b/errors/main.go
@@ -9,6 +9,6 @@ var (
 	ProjectConfigNotFound RailwayError = errors.New("Not connected to a project. Run railway init to get started.")
 	ProjectNotFound       RailwayError = errors.New("Project not found.")
 	ProjectCreateFailed   RailwayError = errors.New("There was a problem creating the project")
-	ProductionTokenNotSet RailwayError = errors.New("RAILWAY_PRODUCTION_TOKEN environment variable not set")
+	ProductionTokenNotSet RailwayError = errors.New("RAILWAY_TOKEN environment variable not set")
 	CommandNotSpecified   RailwayError = errors.New("Specify a command to run in side the railway environment. railway run <cmd>")
 )

--- a/main.go
+++ b/main.go
@@ -92,11 +92,6 @@ func init() {
 		Short: "Run command inside the Railway environment",
 		RunE:  contextualize(handler.Run),
 	})
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "build",
-		Short: "Generate env file for running Railway in production",
-		RunE:  contextualize(handler.Build),
-	})
 }
 
 func main() {


### PR DESCRIPTION
- Remove build command as it is no longer needed
- Rename RAILWAY_PRODUCTION_TOKEN to RAILWAY_TOKEN
- Handle calling railway run with no command