### PR TITLE
Support railway init projectid

### DIFF
--- a/errors/main.go
+++ b/errors/main.go
@@ -5,10 +5,11 @@ import "errors"
 type RailwayError error
 
 var (
-	UserConfigNotFound    RailwayError = errors.New("Not logged in. Please run railway login.")
-	ProjectConfigNotFound RailwayError = errors.New("Not connected to a project. Run railway init to get started.")
-	ProjectNotFound       RailwayError = errors.New("Project not found.")
-	ProjectCreateFailed   RailwayError = errors.New("There was a problem creating the project")
-	ProductionTokenNotSet RailwayError = errors.New("RAILWAY_TOKEN environment variable not set")
-	CommandNotSpecified   RailwayError = errors.New("Specify a command to run in side the railway environment. railway run <cmd>")
+	UserConfigNotFound      RailwayError = errors.New("Not logged in. Please run railway login.")
+	ProjectConfigNotFound   RailwayError = errors.New("Not connected to a project. Run railway init to get started.")
+	ProjectNotFound         RailwayError = errors.New("Project not found.")
+	ProblemFetchingProjects RailwayError = errors.New("There was a problem fetching your projects")
+	ProjectCreateFailed     RailwayError = errors.New("There was a problem creating the project")
+	ProductionTokenNotSet   RailwayError = errors.New("RAILWAY_TOKEN environment variable not set")
+	CommandNotSpecified     RailwayError = errors.New("Specify a command to run in side the railway environment. railway run <cmd>")
 )

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -39,7 +39,7 @@ func (g *Gateway) GetProject(ctx context.Context, projectId string) (*entity.Pro
 		Project *entity.Project `json:"projectById"`
 	}
 	if err := g.gqlClient.Run(ctx, gqlReq, &resp); err != nil {
-		return nil, err
+		return nil, errors.ProjectNotFound
 	}
 	return resp.Project, nil
 }
@@ -153,7 +153,7 @@ func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 		} `json:"me"`
 	}
 	if err := g.gqlClient.Run(ctx, gqlReq, &resp); err != nil {
-		return nil, err
+		return nil, errors.ProblemFetchingProjects
 	}
 	return resp.Me.Projects, nil
 }


### PR DESCRIPTION
- Support railway init <projectID>
- Prompt for environment if there is more than 1 in a project
- Show "Project not found" error instead of "graphql: Not authorised" if fetching a project fails