### PR TITLE
Browserless login in Codespaces

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -189,7 +189,7 @@ func (c *Controller) browserlessLogin(ctx context.Context) (*entity.User, error)
 }
 
 func (c *Controller) Login(ctx context.Context, isBrowserless bool) (*entity.User, error) {
-	if isBrowserless || isSSH() {
+	if isBrowserless || isSSH() || isCodeSpaces() {
 		return c.browserlessLogin(ctx)
 	}
 
@@ -265,4 +265,8 @@ func isSSH() bool {
 	}
 
 	return false
+}
+
+func isCodeSpaces() bool {
+	return os.Getenv("CODESPACES") == "true"
 }

--- a/controller/user.go
+++ b/controller/user.go
@@ -233,7 +233,7 @@ func (c *Controller) ConfirmBrowserOpen(spinnerMsg string, url string) error {
 	err := browser.OpenURL(url)
 
 	if err != nil {
-		ui.StopSpinner(fmt.Sprintf("Failed to open browser, attempting browserless login.", url))
+		ui.StopSpinner(fmt.Sprintf("Failed to open browser, attempting browserless login."))
 		return err
 	}
 


### PR DESCRIPTION
- Use browserless login automatically if we detect we are in a codespaces environment
- Fix printf when falling back to browserless login