### PR TITLE
Move cli configs into root dir

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -22,7 +22,7 @@ func (h *Handler) initNew(ctx context.Context, req *entity.CommandRequest) error
 		return err
 	}
 
-	err = h.cfg.SetProject(project.Id)
+	err = h.cfg.SetNewProject(project.Id)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (h *Handler) initFromAccount(ctx context.Context, req *entity.CommandReques
 		return err
 	}
 
-	err = h.cfg.SetProject(project.Id)
+	err = h.cfg.SetNewProject(project.Id)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (h *Handler) saveProjectWithID(ctx context.Context, projectID string) error
 		return err
 	}
 
-	err = h.cfg.SetProject(project.Id)
+	err = h.cfg.SetNewProject(project.Id)
 	if err != nil {
 		return err
 	}

--- a/configs/main.go
+++ b/configs/main.go
@@ -1,11 +1,10 @@
 package configs
 
 import (
-	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 
 	"github.com/spf13/viper"
 )
@@ -49,31 +48,15 @@ func (c *Configs) unmarshalConfig(config *Config, data interface{}) error {
 }
 
 func (c *Configs) marshalConfig(config *Config, cfg interface{}) error {
-	// reflectCfg := reflect.ValueOf(cfg)
-	// for i := 0; i < reflectCfg.NumField(); i++ {
-	// 	k := reflectCfg.Type().Field(i).Name
-	// 	v := reflectCfg.Field(i).Interface()
-	// 	config.viper.Set(k, v)
-	// }
+	reflectCfg := reflect.ValueOf(cfg)
+	for i := 0; i < reflectCfg.NumField(); i++ {
+		k := reflectCfg.Type().Field(i).Name
+		v := reflectCfg.Field(i).Interface()
 
-	// err = config.viper.WriteConfig()
-
-	err := c.CreatePathIfNotExist(config.configPath)
-	if err != nil {
-		return err
+		config.viper.Set(k, v)
 	}
 
-	jsonString, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(config.configPath, jsonString, os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	return err
+	return config.viper.WriteConfig()
 }
 
 func New() *Configs {

--- a/configs/main.go
+++ b/configs/main.go
@@ -16,8 +16,8 @@ type Config struct {
 }
 
 type Configs struct {
+	rootConfigs            *Config
 	projectConfigs         *Config
-	userConfigs            *Config
 	RailwayProductionToken string
 	RailwayEnvFilePath     string
 }
@@ -79,14 +79,14 @@ func (c *Configs) marshalConfig(config *Config, cfg interface{}) error {
 func New() *Configs {
 	// Configs stored in root (~/.railway)
 	// Includes token, etc
-	userViper := viper.New()
-	userPath := path.Join(os.Getenv("HOME"), ".railway/config.json")
-	userViper.SetConfigFile(userPath)
-	userViper.ReadInConfig()
+	rootViper := viper.New()
+	rootConfigPath := path.Join(os.Getenv("HOME"), ".railway/config.json")
+	rootViper.SetConfigFile(rootConfigPath)
+	rootViper.ReadInConfig()
 
-	userConfig := &Config{
-		viper:      userViper,
-		configPath: userPath,
+	rootConfig := &Config{
+		viper:      rootViper,
+		configPath: rootConfigPath,
 	}
 
 	// Configs stored in projects (<project>/.railway)
@@ -108,7 +108,7 @@ func New() *Configs {
 
 	return &Configs{
 		projectConfigs:         projectConfig,
-		userConfigs:            userConfig,
+		rootConfigs:            rootConfig,
 		RailwayProductionToken: os.Getenv("RAILWAY_TOKEN"),
 		RailwayEnvFilePath:     path.Join(projectDir, "env.json"),
 	}

--- a/configs/project.go
+++ b/configs/project.go
@@ -69,18 +69,11 @@ func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
 		return nil, err
 	}
 
+	// find longest matching parent path
 	var longestPath = -1
 	var pathMatch = ""
 	for path := range userCfg.Projects {
-		// use exact match if it exsits
-		if path == cwd {
-			longestPath = len(path)
-			pathMatch = path
-			break
-		}
-
-		// check if parent path matches
-		var matches = strings.HasPrefix(cwd, fmt.Sprintf("%s/", path))
+		var matches = strings.HasPrefix(fmt.Sprintf("%s/", cwd), fmt.Sprintf("%s/", path))
 		if matches && len(path) > longestPath {
 			longestPath = len(path)
 			pathMatch = path

--- a/configs/project.go
+++ b/configs/project.go
@@ -1,21 +1,91 @@
 package configs
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/errors"
 )
 
-func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
-	var cfg entity.ProjectConfig
+// MigrateLocalProjectConfig moves a local project config
+// to the global config and removes the local .railway directory
+// if it exists
+func (c *Configs) MigrateLocalProjectConfig() error {
+	// Get local config directory
+	projectDir, err := filepath.Abs(filepath.Dir(filepath.Dir(c.projectConfigs.configPath)))
+	if err != nil {
+		return err
+	}
 
+	if _, err := os.Stat(projectDir); os.IsNotExist(err) {
+		// Local project directory does not exist
+		return nil
+	}
+
+	// Read local project config
+	var cfg entity.ProjectConfig
 	if err := c.unmarshalConfig(c.projectConfigs, &cfg); err != nil {
+		return err
+	}
+
+	// Save project config to root config
+	cfg.ProjectPath = strings.ToLower(projectDir)
+	if err = c.SetProjectConfigs(&cfg); err != nil {
+		return err
+	}
+
+	// Delete local config directory
+	if err = os.RemoveAll(fmt.Sprintf("%s/.railway", projectDir)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
+	c.MigrateLocalProjectConfig()
+
+	userCfg, err := c.GetUserConfigs()
+	if err != nil {
 		return nil, errors.ProjectConfigNotFound
 	}
-	return &cfg, nil
+
+	// lookup project in global config based on pwd
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	pwd = strings.ToLower(pwd)
+
+	projectCfg, found := userCfg.Projects[pwd]
+
+	if !found {
+		return nil, errors.ProjectConfigNotFound
+	}
+
+	return &projectCfg, nil
 }
 
 func (c *Configs) SetProjectConfigs(cfg *entity.ProjectConfig) error {
-	return c.marshalConfig(c.projectConfigs, *cfg)
+	userCfg, err := c.GetUserConfigs()
+	if err != nil {
+		// User config not found, create it
+		userCfg = &entity.UserConfig{
+			Token:    "",
+			Projects: make(map[string]entity.ProjectConfig),
+		}
+	}
+
+	if userCfg.Projects == nil {
+		userCfg.Projects = make(map[string]entity.ProjectConfig)
+	}
+
+	userCfg.Projects[cfg.ProjectPath] = *cfg
+
+	return c.marshalConfig(c.userConfigs, userCfg)
 }
 
 func (c *Configs) SaveProjectConfig() error {
@@ -29,27 +99,39 @@ func (c *Configs) SaveProjectConfig() error {
 }
 
 func (c *Configs) SetProject(projectId string) error {
-	c.projectConfigs.viper.Set("project", projectId)
-	return c.SaveProjectConfig()
+	projectCfg, err := c.GetProjectConfigs()
+	if err != nil {
+		return err
+	}
+
+	projectCfg.Project = projectId
+	return c.SetProjectConfigs(projectCfg)
 }
 
 func (c *Configs) SetEnvironment(environmentId string) error {
-	c.projectConfigs.viper.Set("environment", environmentId)
-	return c.SaveProjectConfig()
+	projectCfg, err := c.GetProjectConfigs()
+	if err != nil {
+		return err
+	}
+
+	projectCfg.Environment = environmentId
+	return c.SetProjectConfigs(projectCfg)
 }
 
 func (c *Configs) GetProject() (string, error) {
-	err := c.projectConfigs.viper.ReadInConfig()
-	if err != nil {
-		return "", errors.ProjectConfigNotFound
-	}
-	return c.projectConfigs.viper.GetString("project"), nil
-}
-
-func (c *Configs) GetEnvironment() (string, error) {
-	err := c.projectConfigs.viper.ReadInConfig()
+	projectCfg, err := c.GetProjectConfigs()
 	if err != nil {
 		return "", err
 	}
-	return c.projectConfigs.viper.GetString("environment"), nil
+
+	return projectCfg.Project, nil
+}
+
+func (c *Configs) GetEnvironment() (string, error) {
+	projectCfg, err := c.GetProjectConfigs()
+	if err != nil {
+		return "", err
+	}
+
+	return projectCfg.Environment, nil
 }

--- a/configs/root.go
+++ b/configs/root.go
@@ -1,0 +1,22 @@
+package configs
+
+import (
+	"github.com/railwayapp/cli/entity"
+)
+
+func (c *Configs) GetRootConfigs() (*entity.RootConfig, error) {
+	var cfg entity.RootConfig
+
+	if err := c.unmarshalConfig(c.rootConfigs, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (c *Configs) SetRootConfig(cfg *entity.RootConfig) error {
+	if cfg.Projects == nil {
+		cfg.Projects = make(map[string]entity.ProjectConfig)
+	}
+
+	return c.marshalConfig(c.rootConfigs, *cfg)
+}

--- a/configs/user.go
+++ b/configs/user.go
@@ -6,14 +6,27 @@ import (
 )
 
 func (c *Configs) GetUserConfigs() (*entity.UserConfig, error) {
-	var cfg entity.UserConfig
-
-	if err := c.unmarshalConfig(c.userConfigs, &cfg); err != nil {
+	var rootCfg *entity.RootConfig
+	rootCfg, err := c.GetRootConfigs()
+	if err != nil {
 		return nil, errors.UserConfigNotFound
 	}
-	return &cfg, nil
+
+	if &rootCfg.User == nil || rootCfg.User.Token == "" {
+		return nil, errors.UserConfigNotFound
+	}
+
+	return &rootCfg.User, nil
 }
 
 func (c *Configs) SetUserConfigs(cfg *entity.UserConfig) error {
-	return c.marshalConfig(c.userConfigs, *cfg)
+	var rootCfg *entity.RootConfig
+	rootCfg, err := c.GetRootConfigs()
+	if err != nil {
+		rootCfg = &entity.RootConfig{}
+	}
+
+	rootCfg.User = *cfg
+
+	return c.SetRootConfig(rootCfg)
 }

--- a/entity/config.go
+++ b/entity/config.go
@@ -1,0 +1,16 @@
+package entity
+
+type RootConfig struct {
+	User     UserConfig               `json:"user"`
+	Projects map[string]ProjectConfig `json:"projects"`
+}
+
+type UserConfig struct {
+	Token string `json:"token"`
+}
+
+type ProjectConfig struct {
+	ProjectPath string `json:"projectPath,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Environment string `json:"environment,omitempty"`
+}

--- a/entity/project.go
+++ b/entity/project.go
@@ -18,9 +18,3 @@ type Project struct {
 	Environments []*Environment `json:"environments,omitempty"`
 	Plugins      []*Plugin      `json:"plugins,omitempty"`
 }
-
-type ProjectConfig struct {
-	ProjectPath string `json:"projectPath,omitempty"`
-	Project     string `json:"project,omitempty"`
-	Environment string `json:"environment,omitempty"`
-}

--- a/entity/project.go
+++ b/entity/project.go
@@ -20,6 +20,7 @@ type Project struct {
 }
 
 type ProjectConfig struct {
+	ProjectPath string `json:"projectPath,omitempty"`
 	Project     string `json:"project,omitempty"`
 	Environment string `json:"environment,omitempty"`
 }

--- a/entity/user.go
+++ b/entity/user.go
@@ -7,8 +7,3 @@ type User struct {
 	Avatar   string    `json:"avatar,omitempty"`
 	Projects []Project `json:"projects,omitempty"`
 }
-
-type UserConfig struct {
-	Token    string                   `json:"token"`
-	Projects map[string]ProjectConfig `json:"projects"`
-}

--- a/entity/user.go
+++ b/entity/user.go
@@ -9,5 +9,6 @@ type User struct {
 }
 
 type UserConfig struct {
-	Token string `json:"token"`
+	Token    string                   `json:"token"`
+	Projects map[string]ProjectConfig `json:"projects"`
 }


### PR DESCRIPTION
- Migrate local project ./railway config to user level ~/.railway config
- When looking for project config, find closest parent directory that has been init'd with a railway project
- When initing a new railway project, always use current working directory

The top level config has been split into user config and project config. The APIs for reading/writing user/project configs have stayed the same. But their implementations now call into the root config which deals with marsheling/unmarshelling the configs

The top level config will now look something like

```json
{
  "user": {
    "token": ""
  },
  "projects": {
    "/users/jakerunzer/dev/railway-cli": {
      "projectPath": "/users/jakerunzer/dev/railway-cli",
      "project": "XXX",
      "environment": "XXX"
    },
    "/users/jakerunzer/dev/railway-cli/node_modules": {
      "projectPath": "/users/jakerunzer/dev/railway-cli/node_modules",
      "project": "XXX",
      "environment": "XXX"
    }
  }
}
```

<img width="833" alt="image" src="https://user-images.githubusercontent.com/3044853/99607207-3a851200-2a03-11eb-9866-579d04ab885c.png">
