### PR TITLE
Use width of longest env var name when printing

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -7,14 +7,38 @@ import (
 	"github.com/railwayapp/cli/entity"
 )
 
+func Min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func Max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}
+
 func (h *Handler) Env(ctx context.Context, req *entity.CommandRequest) error {
 	envs, err := h.ctrl.GetEnvs(ctx)
 	if err != nil {
 		return err
 	}
 
+	var minSpacing = 15
+	var maxSpacing = 100
+	var longest = 0
+
+	for k := range *envs {
+		if len(k) > longest {
+			longest = len(k)
+		}
+	}
+
 	for k, v := range *envs {
-		fmt.Printf("%-15s%-15s\n", k, v)
+		fmt.Printf("%-*s\t%s\n", Max(minSpacing, Min(maxSpacing, longest)), k, v)
 	}
 	return nil
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3044853/100136384-e2c32c80-2e82-11eb-8eec-fa1d09909bf4.png)

I know we don't want a utils folder, but min/max for ints should probably live somewhere else?