### PR TITLE
Ignore node_modules by default

### DIFF
--- a/controller/up.go
+++ b/controller/up.go
@@ -31,7 +31,7 @@ func compress(src string, buf io.Writer) error {
 			return nil
 		}
 
-		if strings.HasPrefix(file, ".git") {
+		if strings.HasPrefix(file, ".git") || strings.HasPrefix(file, "node_modules") {
 			return nil
 		}
 


### PR DESCRIPTION
`node_modules` are the cause of a lot of failed deploys. For some reason pack does not recognize the project is a node if there is a `node_modules` directory.

This PR ignores it by default