### PR TITLE
Guard against NPE on version check

### DIFF
--- a/controller/version.go
+++ b/controller/version.go
@@ -9,5 +9,5 @@ func (c *Controller) GetLatestVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return *rep.TagName, err
+	return *rep.TagName, nil
 }

--- a/controller/version.go
+++ b/controller/version.go
@@ -6,5 +6,8 @@ import (
 
 func (c *Controller) GetLatestVersion() (string, error) {
 	rep, _, err := c.ghc.Repositories.GetLatestRelease(context.Background(), "railwayapp", "cli")
+	if err != nil {
+		return "", err
+	}
 	return *rep.TagName, err
 }


### PR DESCRIPTION
If the version check code errors, we should bubble up that error before we deref