### PR TITLE
Allow installation with custom binary name and install location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,9 +10,10 @@ set -e
 #   sh -c "$(curl -sSL https://github.com/railwayapp/cli/blob/master/install.sh)"
 #
 
+INSTALL_DIR=${INSTALL_DIR:-"/usr/local/bin"}
+BINARY_NAME=${BINARY_NAME:-"railway"}
+
 REPO_NAME="railwayapp/cli"
-INSTALL_DIR="/usr/local/bin"
-BINARY_NAME="railway"
 ISSUE_URL="https://github.com/railwayapp/cli/issues/new"
 
 # Usage

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,7 @@ do_checksum() {
     return 0
   fi
 
-  if [[ "$checksum" != "$expected_checksum" ]]; then
+  if [ "$checksum" != "$expected_checksum" ]; then
     fmt_error "Checksums do not match"
     exit 1
   fi
@@ -171,7 +171,7 @@ main() {
     echo "Please create an issue so we can add support. $ISSUE_URL"
     exit 1
   fi
-  
+
   do_install_binary
 
   printf "$MAGENTA"


### PR DESCRIPTION
I'm running Ubuntu 20.04 and can't install via curl without `sudo` since `/usr/local/bin` is owned by root. These changes allow the user to specify an install directory (and binary name) optionally with environment variables. I also included a change to make the checksum test more compatible across different sh implementations. Bash/zsh implement `[[` but it's not in the sh spec. `[` is equivalent here.