### PR TITLE
Clean up global commands and help text

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -153,35 +153,6 @@ func (h *Handler) initFromTemplate(ctx context.Context, req *entity.CommandReque
 	return nil
 }
 
-func (h *Handler) initFromAccount(ctx context.Context, req *entity.CommandRequest) error {
-	projects, err := h.ctrl.GetProjects(ctx)
-	if err != nil {
-		return err
-	}
-
-	project, err := ui.PromptProjects(projects)
-	if err != nil {
-		return err
-	}
-
-	err = h.cfg.SetNewProject(project.Id)
-	if err != nil {
-		return err
-	}
-
-	environment, err := ui.PromptEnvironments(project.Environments)
-	if err != nil {
-		return err
-	}
-
-	err = h.cfg.SetEnvironment(environment.Id)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (h *Handler) saveProjectWithID(ctx context.Context, projectID string) error {
 	project, err := h.ctrl.GetProject(ctx, projectID)
 	if err != nil {
@@ -206,15 +177,6 @@ func (h *Handler) saveProjectWithID(ctx context.Context, projectID string) error
 	return nil
 }
 
-func (h *Handler) initFromID(ctx context.Context, req *entity.CommandRequest) error {
-	projectID, err := ui.PromptText("Enter your project id")
-	if err != nil {
-		return err
-	}
-
-	return h.saveProjectWithID(ctx, projectID)
-}
-
 func (h *Handler) Init(ctx context.Context, req *entity.CommandRequest) error {
 	if len(req.Args) > 0 {
 		// projectID provided as argument
@@ -228,7 +190,7 @@ func (h *Handler) Init(ctx context.Context, req *entity.CommandRequest) error {
 		return errors.New(fmt.Sprintf("%s\nRun %s", ui.RedText("Account require to init project"), ui.Bold("railway login")))
 	}
 
-	selection, err := ui.PromptInit(isLoggedIn)
+	selection, err := ui.PromptInit()
 	if err != nil {
 		return err
 	}
@@ -238,10 +200,6 @@ func (h *Handler) Init(ctx context.Context, req *entity.CommandRequest) error {
 		return h.initNew(ctx, req)
 	case ui.InitFromTemplate:
 		return h.initFromTemplate(ctx, req)
-	case ui.InitFromAccount:
-		return h.initFromAccount(ctx, req)
-	case ui.InitFromID:
-		return h.initFromID(ctx, req)
 	default:
 		return errors.New("Invalid selection")
 	}

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"github.com/railwayapp/cli/entity"
+	"github.com/railwayapp/cli/ui"
+)
+
+func (h *Handler) Link(ctx context.Context, req *entity.CommandRequest) error {
+	isLoggedIn, err := h.ctrl.IsLoggedIn(ctx)
+	if err != nil {
+		return err
+	}
+
+	if isLoggedIn {
+		return h.linkFromAccount(ctx, req)
+	} else {
+		return h.linkFromID(ctx, req)
+	}
+}
+
+func (h *Handler) linkFromAccount(ctx context.Context, req *entity.CommandRequest) error {
+	projects, err := h.ctrl.GetProjects(ctx)
+	if err != nil {
+		return err
+	}
+
+	project, err := ui.PromptProjects(projects)
+	if err != nil {
+		return err
+	}
+
+	err = h.cfg.SetNewProject(project.Id)
+	if err != nil {
+		return err
+	}
+
+	environment, err := ui.PromptEnvironments(project.Environments)
+	if err != nil {
+		return err
+	}
+
+	err = h.cfg.SetEnvironment(environment.Id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Handler) linkFromID(ctx context.Context, req *entity.CommandRequest) error {
+	projectID, err := ui.PromptText("Enter your project id")
+	if err != nil {
+		return err
+	}
+
+	return h.saveProjectWithID(ctx, projectID)
+}

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -8,7 +8,7 @@ import (
 	"github.com/railwayapp/cli/ui"
 )
 
-func (h *Handler) Disconnect(ctx context.Context, req *entity.CommandRequest) error {
+func (h *Handler) Unlink(ctx context.Context, req *entity.CommandRequest) error {
 	projectCfg, _ := h.cfg.GetProjectConfigs()
 
 	project, err := h.ctrl.GetProject(ctx, projectCfg.Project)

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -21,7 +21,7 @@ func Max(x, y int) int {
 	return y
 }
 
-func (h *Handler) Env(ctx context.Context, req *entity.CommandRequest) error {
+func (h *Handler) Variables(ctx context.Context, req *entity.CommandRequest) error {
 	envs, err := h.ctrl.GetEnvs(ctx)
 	if err != nil {
 		return err

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ func (h *Handler) Version(ctx context.Context, req *entity.CommandRequest) error
 func (h *Handler) CheckVersion(ctx context.Context, req *entity.CommandRequest) error {
 	if constants.Version != constants.VersionDefault {
 		latest, _ := h.ctrl.GetLatestVersion()
-		// Surpressing error as getting latest version is desired, not required
+		// Suppressing error as getting latest version is desired, not required
 		if latest != "" && latest[1:] != constants.Version {
 			fmt.Println(ui.Bold(fmt.Sprintf("A newer version of the Railway CLI is available, please update to: %s", ui.MagentaText(latest))))
 		}

--- a/configs/main.go
+++ b/configs/main.go
@@ -94,16 +94,23 @@ func New() *Configs {
 	}
 	projectViper := viper.New()
 
-	projectPath := path.Join(projectDir, "./config.json")
-	projectViper.SetConfigFile(projectPath)
+	// NOTE: viper.ConfigFileNotFound not produced if using projectViper.setConfigFile()
+	projectViper.AddConfigPath(projectDir)
+	projectViper.SetConfigName("config")
+	projectViper.SetConfigType("json")
 	err = projectViper.ReadInConfig()
 	if err != nil {
-		fmt.Println("Unable to load project config!")
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			// Config file not found; that's okay
+		} else {
+			// Config file was found but another error was produced
+			fmt.Printf("Unable to load project config! %#v\n", err)
+		}
 	}
 
 	projectConfig := &Config{
 		viper:      projectViper,
-		configPath: projectPath,
+		configPath: projectViper.ConfigFileUsed(),
 	}
 
 	return &Configs{

--- a/configs/main.go
+++ b/configs/main.go
@@ -99,13 +99,11 @@ func New() *Configs {
 	projectViper.SetConfigName("config")
 	projectViper.SetConfigType("json")
 	err = projectViper.ReadInConfig()
-	if err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			// Config file not found; that's okay
-		} else {
-			// Config file was found but another error was produced
-			fmt.Printf("Unable to load project config! %#v\n", err)
-		}
+	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		// Config file not found; that's okay
+	} else if err != nil {
+		// Config file was found but another error was produced
+		fmt.Printf("Unable to load project config! %#v\n", err)
 	}
 
 	projectConfig := &Config{

--- a/configs/project.go
+++ b/configs/project.go
@@ -61,7 +61,10 @@ func (c *Configs) getCWD() (string, error) {
 }
 
 func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
-	c.MigrateLocalProjectConfig()
+	err := c.MigrateLocalProjectConfig()
+	if err != nil {
+		// It's okay, it may not exist yet
+	}
 
 	userCfg, err := c.GetRootConfigs()
 	if err != nil {

--- a/configs/project.go
+++ b/configs/project.go
@@ -65,7 +65,6 @@ func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	userCfg, err := c.GetRootConfigs()
 	if err != nil {
 		return nil, errors.ProjectConfigNotFound

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func init() {
 
 	loginCmd := &cobra.Command{
 		Use:   "login",
-		Short: "Login to Railway",
+		Short: "Login to your Railway account",
 		RunE:  contextualize(handler.Login, handler.Panic),
 	}
 	loginCmd.Flags().Bool("browserless", false, "--browserless")
@@ -60,53 +60,65 @@ func init() {
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "logout",
-		Short: "Logout of Railway",
+		Short: "Logout of your Railway account",
 		RunE:  contextualize(handler.Logout, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "whoami",
-		Short: "Show the currently logged in user",
+		Short: "Get the current logged in user",
 		RunE:  contextualize(handler.Whoami, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:               "init",
-		Short:             "Initialize Railway",
+		Short:             "Initialize a project in the current directory",
 		PersistentPreRunE: contextualize(handler.CheckVersion, handler.Panic),
 		RunE:              contextualize(handler.Init, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "disconnect",
-		Short: "Disconnect from Railway",
+		Use:        "disconnect",
+		Short:      "Disconnect from Railway",
+		RunE:       contextualize(handler.Disconnect, handler.Panic),
+		Deprecated: "The 'railway disconnect' command is now railway 'disassociate'", /**/
+	})
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "disassociate",
+		Short: "Remove association between project and current directory",
 		RunE:  contextualize(handler.Disconnect, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "env",
-		Short: "Show environment variables",
-		RunE:  contextualize(handler.Env, handler.Panic),
+		Use:        "env",
+		Short:      "Show variables from active environment",
+		RunE:       contextualize(handler.Variables, handler.Panic),
+		Deprecated: "The 'railway env' command is now 'railway variables'",
+	})
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "variables",
+		Short: "Show variables for active environment",
+		RunE:  contextualize(handler.Variables, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "status",
-		Short: "Show status",
+		Short: "Show information about the current project",
 		RunE:  contextualize(handler.Status, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "environment",
-		Short: "Select an environment",
+		Short: "Change the active environment",
 		RunE:  contextualize(handler.Environment, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "open",
-		Short: "Open the project in railway",
+		Short: "Open project dashboard in default browser",
 		RunE:  contextualize(handler.Open, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "list",
-		Short: "Show all your projects",
+		Short: "List all projects in your Railway account",
 		RunE:  contextualize(handler.List, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:                "run",
-		Short:              "Run command inside the Railway environment",
+		Short:              "Run a local command using variables from the active environment",
 		PersistentPreRunE:  contextualize(handler.CheckVersion, handler.Panic),
 		RunE:               contextualize(handler.Run, handler.Panic),
 		DisableFlagParsing: true,
@@ -118,28 +130,28 @@ func init() {
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:               "version",
-		Short:             "Get version of the Railway CLI",
+		Short:             "Get the version of the Railway CLI",
 		PersistentPreRunE: contextualize(handler.CheckVersion, handler.Panic),
 		RunE:              contextualize(handler.Version, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "up",
-		Short: "Upload and deploy",
+		Short: "Upload and deploy project from the current directory",
 		RunE:  contextualize(handler.Up, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "docs",
-		Short: "Open Railway Docs in browser",
+		Short: "Open Railway Documentation in default browser",
 		RunE:  contextualize(handler.Docs, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "add",
-		Short: "Add Railway plugins",
+		Short: "Add a new plugin to your project",
 		RunE:  contextualize(handler.Add, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "connect",
-		Short: "Connect to your Railway database",
+		Short: "Open an interactive shell to a database",
 		RunE:  contextualize(handler.Connect, handler.Panic),
 	})
 }

--- a/main.go
+++ b/main.go
@@ -89,13 +89,13 @@ func init() {
 		Use:        "disconnect",
 		Short:      "Disassociate project from current directory",
 		RunE:       contextualize(handler.Unlink, handler.Panic),
-		Deprecated: "The disconnect command is now 'railway unlink'", /**/
+		Deprecated: "Please use 'railway unlink' instead", /**/
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:        "env",
 		Short:      "Show variables from active environment",
 		RunE:       contextualize(handler.Variables, handler.Panic),
-		Deprecated: "The 'railway env' command is now 'railway variables'",
+		Deprecated: "Please use 'railway variables' instead", /**/
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "variables",

--- a/main.go
+++ b/main.go
@@ -70,20 +70,26 @@ func init() {
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:               "init",
-		Short:             "Initialize a project in the current directory",
+		Short:             "Create a new Railway project",
 		PersistentPreRunE: contextualize(handler.CheckVersion, handler.Panic),
 		RunE:              contextualize(handler.Init, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
-		Use:        "disconnect",
-		Short:      "Disconnect from Railway",
-		RunE:       contextualize(handler.Disconnect, handler.Panic),
-		Deprecated: "The 'railway disconnect' command is now railway 'disassociate'", /**/
+		Use:               "link",
+		Short:             "Associate current directory to existing project",
+		PersistentPreRunE: contextualize(handler.CheckVersion, handler.Panic),
+		RunE:              contextualize(handler.Link, handler.Panic),
 	})
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "disassociate",
-		Short: "Remove association between project and current directory",
-		RunE:  contextualize(handler.Disconnect, handler.Panic),
+		Use:   "unlink",
+		Short: "Disassociate project from current directory",
+		RunE:  contextualize(handler.Unlink, handler.Panic),
+	})
+	rootCmd.AddCommand(&cobra.Command{
+		Use:        "disconnect",
+		Short:      "Disassociate project from current directory",
+		RunE:       contextualize(handler.Unlink, handler.Panic),
+		Deprecated: "The disconnect command is now 'railway unlink'", /**/
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:        "env",

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func init() {
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:               "link",
-		Short:             "Associate current directory to existing project",
+		Short:             "Associate existing project with current directory",
 		PersistentPreRunE: contextualize(handler.CheckVersion, handler.Panic),
 		RunE:              contextualize(handler.Link, handler.Panic),
 	})
@@ -90,13 +90,11 @@ func init() {
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:        "disconnect",
-		Short:      "Disassociate project from current directory",
 		RunE:       contextualize(handler.Unlink, handler.Panic),
 		Deprecated: "Please use 'railway unlink' instead", /**/
 	})
 	rootCmd.AddCommand(&cobra.Command{
 		Use:        "env",
-		Short:      "Show variables from active environment",
 		RunE:       contextualize(handler.Variables, handler.Panic),
 		Deprecated: "Please use 'railway variables' instead", /**/
 	})

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -17,19 +17,13 @@ type Selection string
 const (
 	InitPrompt       Prompt    = "What would you like to do?"
 	InitNew          Selection = "Create new Project"
-	InitFromTemplate Selection = "Deploy a starter project"
-	InitFromAccount  Selection = "Connect to existing project"
-	InitFromID       Selection = "Enter existing project id"
+	InitFromTemplate Selection = "Select starter template"
 )
 
-func PromptInit(isLoggedIn bool) (Selection, error) {
-	existingProjectPrompt := InitFromID
-	if isLoggedIn {
-		existingProjectPrompt = InitFromAccount
-	}
+func PromptInit() (Selection, error) {
 	selectPrompt := promptui.Select{
 		Label: InitPrompt,
-		Items: []Selection{InitNew, existingProjectPrompt, InitFromTemplate},
+		Items: []Selection{InitNew, InitFromTemplate},
 	}
 	_, selection, err := selectPrompt.Run()
 	return Selection(selection), err


### PR DESCRIPTION
Changes:

- Renamed `disconnect` to `unlink` and split `init` into `init` and `link`
- Renamed `env` to `variables` to align verbiage with Dashboard
- Adjusted help text for all commands
- Both Stripe and Heroku CLIs were used as a style reference

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/587576/113050837-280da880-915a-11eb-9954-c2e790952e77.png">

Old renamed command still work but are deprecated.

<img width="502" alt="image" src="https://user-images.githubusercontent.com/587576/113046850-681e5c80-9155-11eb-88d3-fb79e4e562bf.png">


