### PR TITLE
Revert config path handling and update DNE logic

### DIFF
--- a/configs/main.go
+++ b/configs/main.go
@@ -80,7 +80,7 @@ func New() *Configs {
 	if os.IsNotExist(err) {
 		// That's okay, configs are created as needed
 	} else if err != nil {
-		fmt.Printf("Unable to parse railway config! %#v\n", err)
+		fmt.Printf("Unable to parse railway config! %s\n", err)
 	}
 
 	rootConfig := &Config{
@@ -102,7 +102,7 @@ func New() *Configs {
 	if os.IsNotExist(err) {
 		// That's okay, configs are created as needed
 	} else if err != nil {
-		fmt.Printf("Unable to parse project config! %#v\n", err)
+		fmt.Printf("Unable to parse project config! %s\n", err)
 	}
 
 	projectConfig := &Config{

--- a/configs/main.go
+++ b/configs/main.go
@@ -77,8 +77,10 @@ func New() *Configs {
 	rootConfigPath := path.Join(os.Getenv("HOME"), rootConfigPartialPath)
 	rootViper.SetConfigFile(rootConfigPath)
 	err := rootViper.ReadInConfig()
-	if err != nil {
-		fmt.Println("Unable to load root config!")
+	if os.IsNotExist(err) {
+		// That's okay, continue
+	} else if err != nil {
+		fmt.Println("Unable to load project config!")
 	}
 
 	rootConfig := &Config{
@@ -94,21 +96,18 @@ func New() *Configs {
 	}
 	projectViper := viper.New()
 
-	// NOTE: viper.ConfigFileNotFound not produced if using projectViper.setConfigFile()
-	projectViper.AddConfigPath(projectDir)
-	projectViper.SetConfigName("config")
-	projectViper.SetConfigType("json")
+	projectPath := path.Join(projectDir, "./config.json")
+	projectViper.SetConfigFile(projectPath)
 	err = projectViper.ReadInConfig()
-	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-		// Config file not found; that's okay
+	if os.IsNotExist(err) {
+		// That's okay, continue
 	} else if err != nil {
-		// Config file was found but another error was produced
-		fmt.Printf("Unable to load project config! %#v\n", err)
+		fmt.Println("Unable to load project config!")
 	}
 
 	projectConfig := &Config{
 		viper:      projectViper,
-		configPath: projectViper.ConfigFileUsed(),
+		configPath: projectPath,
 	}
 
 	return &Configs{

--- a/configs/main.go
+++ b/configs/main.go
@@ -78,9 +78,9 @@ func New() *Configs {
 	rootViper.SetConfigFile(rootConfigPath)
 	err := rootViper.ReadInConfig()
 	if os.IsNotExist(err) {
-		// That's okay, continue
+		// That's okay, configs are created as needed
 	} else if err != nil {
-		fmt.Println("Unable to load project config!")
+		fmt.Printf("Unable to parse railway config! %#v\n", err)
 	}
 
 	rootConfig := &Config{
@@ -100,9 +100,9 @@ func New() *Configs {
 	projectViper.SetConfigFile(projectPath)
 	err = projectViper.ReadInConfig()
 	if os.IsNotExist(err) {
-		// That's okay, continue
+		// That's okay, configs are created as needed
 	} else if err != nil {
-		fmt.Println("Unable to load project config!")
+		fmt.Printf("Unable to parse project config! %#v\n", err)
 	}
 
 	projectConfig := &Config{

--- a/configs/project.go
+++ b/configs/project.go
@@ -61,11 +61,9 @@ func (c *Configs) getCWD() (string, error) {
 }
 
 func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
-	err := c.MigrateLocalProjectConfig()
-	if err != nil {
-		// This probably failed because the config doesn't exist yet
-		// TODO: Better error handling herer
-	}
+	_ = c.MigrateLocalProjectConfig()
+	// Ignore error because the config probably doesn't exist yet
+	// TODO: Better error handling here
 
 	userCfg, err := c.GetRootConfigs()
 	if err != nil {

--- a/configs/project.go
+++ b/configs/project.go
@@ -63,8 +63,10 @@ func (c *Configs) getCWD() (string, error) {
 func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
 	err := c.MigrateLocalProjectConfig()
 	if err != nil {
-		return nil, err
+		// This probably failed because the config doesn't exist yet
+		// TODO: Better error handling herer
 	}
+
 	userCfg, err := c.GetRootConfigs()
 	if err != nil {
 		return nil, errors.ProjectConfigNotFound


### PR DESCRIPTION
I had originally changed the config loading logic in #77 in order to have `ReadInConfig` return `viper.ConfigFileNotFoundError`. However, this broke things because `Config.configPath` would be unset if the project config didn't exist yet, breaking `railway run` (and possibly other commands).

This PR reverts back to the old way of loading configs with a fixed path and uses `os.IsNotExist()` to check the error instead