### PR TITLE
Support railway link <project_id>

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -176,9 +176,9 @@ func (h *Handler) saveProjectWithID(ctx context.Context, projectID string) error
 
 func (h *Handler) Init(ctx context.Context, req *entity.CommandRequest) error {
 	if len(req.Args) > 0 {
-		// projectID provided as argument
-		projectID := req.Args[0]
-		return h.saveProjectWithID(ctx, projectID)
+		// NOTE: This is to support legacy `railway init <PROJECT_ID>` which should
+		//  now be `railway link <PROJECT_ID>`
+		return h.Link(ctx, req)
 	}
 
 	isLoggedIn, _ := h.ctrl.IsLoggedIn(ctx)

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -7,6 +7,12 @@ import (
 )
 
 func (h *Handler) Link(ctx context.Context, req *entity.CommandRequest) error {
+	if len(req.Args) > 0 {
+		// projectID provided as argument
+		projectID := req.Args[0]
+		return h.saveProjectWithID(ctx, projectID)
+	}
+
 	isLoggedIn, err := h.ctrl.IsLoggedIn(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds support for `railway link <project_id>` and keeps `railway init <project_id>` for legacy use (should remove later).