### PR TITLE
Display team projects in link command

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/ui"
 )
@@ -29,6 +31,11 @@ func (h *Handler) linkFromAccount(ctx context.Context, req *entity.CommandReques
 	projects, err := h.ctrl.GetProjects(ctx)
 	if err != nil {
 		return err
+	}
+
+	if len(projects) == 0 {
+		fmt.Printf("No Projects. Create one with %s\n", ui.GreenText("railway init"))
+		return nil
 	}
 
 	project, err := ui.PromptProjects(projects)

--- a/entity/user.go
+++ b/entity/user.go
@@ -1,9 +1,7 @@
 package entity
 
 type User struct {
-	Id       string    `json:"id,omitempty"`
-	Name     string    `json:"name,omitempty"`
-	Email    string    `json:"email,omitempty"`
-	Avatar   string    `json:"avatar,omitempty"`
-	Projects []Project `json:"projects,omitempty"`
+	Id    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
 }

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -208,9 +208,7 @@ func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 
 	projects := resp.Me.Projects
 	for _, team := range resp.Me.Teams {
-		for _, p := range team.Projects {
-			projects = append(projects, p)
-		}
+		projects = append(projects, team.Projects...)
 	}
 
 	return projects, nil

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -158,24 +158,33 @@ func (g *Gateway) DeleteProject(ctx context.Context, projectId string) error {
 // their environments associated with those projects, error otherwise
 // Performs a dual join
 func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
-	gqlReq := gql.NewRequest(`
+	projectFrag := `
+		id,
+		name,
+		plugins {
+			id,
+			name,
+		},
+		environments {
+			id,
+			name
+		}, 
+	`
+
+	gqlReq := gql.NewRequest(fmt.Sprintf(`
 		query {
 			me {
 				projects {
-					id,
-					name,
-					plugins {
-					  id,
-					  name,
-					},
-					environments {
-					  id,
-					  name
-					}, 
+					%s
 			  }
+				teams {
+					projects {
+						%s
+					}
+				}
 			}
 		}
-	`)
+	`, projectFrag, projectFrag))
 
 	// TODO build this into the GQL client
 	err := g.authorize(ctx, gqlReq.Header)
@@ -186,13 +195,25 @@ func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 
 	var resp struct {
 		Me struct {
-			Projects []*entity.Project
+			Projects []*entity.Project `json:"projects"`
+			Teams    []*struct {
+				Projects []*entity.Project `json:"projects"`
+			} `json:"teams"`
 		} `json:"me"`
 	}
+
 	if err := g.gqlClient.Run(ctx, gqlReq, &resp); err != nil {
 		return nil, errors.ProblemFetchingProjects
 	}
-	return resp.Me.Projects, nil
+
+	projects := resp.Me.Projects
+	for _, team := range resp.Me.Teams {
+		for _, p := range team.Projects {
+			projects = append(projects, p)
+		}
+	}
+
+	return projects, nil
 }
 
 func GetRailwayUrl() string {


### PR DESCRIPTION
- Handle when there are no projects found
- remove avatar and projects from user entity
- display team projects in link command

It would be nice to eventually show which team the project is in when they are listed out. But for now, this PR just fixes the team projects not being selectable in the `railway link` project list.
