### PR TITLE
Only get env variables when updating

### DIFF
--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -40,7 +40,7 @@ func (h *Handler) VariablesGet(ctx context.Context, req *entity.CommandRequest) 
 }
 
 func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) error {
-	envs, err := h.ctrl.GetEnvs(ctx)
+	envs, err := h.ctrl.GetEnvsForEnvPlugin(ctx)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 		updatedEnvNames = append(updatedEnvNames, key)
 	}
 
-	_, err = h.ctrl.UpdateEnvs(ctx, envs)
+	_, err = h.ctrl.UpdateEnvsForEnvPlugin(ctx, envs)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 }
 
 func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandRequest) error {
-	envs, err := h.ctrl.GetEnvs(ctx)
+	envs, err := h.ctrl.GetEnvsForEnvPlugin(ctx)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 		envs.Delete(key)
 	}
 
-	_, err = h.ctrl.UpdateEnvs(ctx, envs)
+	_, err = h.ctrl.UpdateEnvsForEnvPlugin(ctx, envs)
 	if err != nil {
 		return err
 	}

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -110,7 +110,7 @@ func (c *Controller) UpdateEnvsForEnvPlugin(ctx context.Context, envs *entity.En
 }
 
 func (c *Controller) GetEnvsForEnvPlugin(ctx context.Context) (*entity.Envs, error) {
-	// Get envs through production token if it exists
+	// Get envs through project token if it exists
 	if c.cfg.RailwayProductionToken != "" {
 		envs, err := c.gtwy.GetEnvsWithProjectToken(ctx)
 		if err != nil {

--- a/entity/envs.go
+++ b/entity/envs.go
@@ -5,6 +5,12 @@ type GetEnvsRequest struct {
 	EnvironmentID string
 }
 
+type GetEnvsForPluginRequest struct {
+	ProjectID     string
+	EnvironmentID string
+	PluginID      string
+}
+
 type UpdateEnvsRequest struct {
 	ProjectID     string
 	EnvironmentID string

--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -30,6 +30,30 @@ func (g *Gateway) GetEnvs(ctx context.Context, req *entity.GetEnvsRequest) (*ent
 	return resp.Envs, nil
 }
 
+func (g *Gateway) GetEnvsForPlugin(ctx context.Context, req *entity.GetEnvsForPluginRequest) (*entity.Envs, error) {
+	gqlReq := gql.NewRequest(`
+		query ($projectId: String!, $environmentId: String!, $pluginId: String!) {
+			allEnvsForPlugin(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId)
+		}
+	`)
+	gqlReq.Var("projectId", req.ProjectID)
+	gqlReq.Var("environmentId", req.EnvironmentID)
+	gqlReq.Var("pluginId", req.PluginID)
+
+	err := g.authorize(ctx, gqlReq.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Envs *entity.Envs `json:"allEnvsForPlugin"`
+	}
+	if err := g.gqlClient.Run(ctx, gqlReq, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Envs, nil
+}
+
 func (g *Gateway) GetEnvsWithProjectToken(ctx context.Context) (*entity.Envs, error) {
 	gqlReq := gql.NewRequest(`
 	  	query {


### PR DESCRIPTION
Before, the CLI was getting all plugin variables (pg, redis, etc), then pushing them all to the `env` plugin. This PR fixes this so that it only pulls vars from the `env` plugin.