### PR TITLE
Offset Printlogs

### DIFF
--- a/controller/logs.go
+++ b/controller/logs.go
@@ -57,7 +57,7 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 		if len(delta) == 0 {
 			continue
 		}
-		fmt.Printf(strings.Join(delta, "\n"))
+		fmt.Print(strings.Join(delta, "\n"))
 		prevIdx = nextIdx
 		if req.NumLines != 0 {
 			// Break if numlines provided

--- a/controller/logs.go
+++ b/controller/logs.go
@@ -37,9 +37,9 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 	// 2) If numLines is not provided, poll for deploymentLogs while keeping a pointer for the line number
 	//    This pointer will be used to determine what to send to stdout
 	//    e.g We fetch 10 lines initially. Subsequent fetch returns 12. We print the last 2 lines (delta)
-	prevIdx := 1
+	prevIdx := 0
 	for {
-		if prevIdx != 1 {
+		if prevIdx != 0 {
 			time.Sleep(time.Second * 2)
 		}
 		deploy, err := c.gtwy.GetDeploymentByID(ctx, req.ProjectID, req.DeploymentID)
@@ -48,12 +48,12 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 		}
 		partials := strings.Split(deploy.DeployLogs, "\n")
 		nextIdx := len(partials)
-		delimiter := prevIdx
+		delimiter := prevIdx // Go's slices aren't inclusive
 		if req.NumLines != 0 {
 			// If num is provided do a walkback by n lines to get latest n logs
 			delimiter = int(math.Max(float64(len(partials)-int(req.NumLines)), float64(prevIdx)))
 		}
-		delta := partials[delimiter-1 : nextIdx]
+		delta := partials[delimiter:nextIdx]
 		if len(delta) == 0 {
 			continue
 		}

--- a/controller/logs.go
+++ b/controller/logs.go
@@ -37,9 +37,9 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 	// 2) If numLines is not provided, poll for deploymentLogs while keeping a pointer for the line number
 	//    This pointer will be used to determine what to send to stdout
 	//    e.g We fetch 10 lines initially. Subsequent fetch returns 12. We print the last 2 lines (delta)
-	prevIdx := 0
+	prevIdx := 1
 	for {
-		if prevIdx != 0 {
+		if prevIdx != 1 {
 			time.Sleep(time.Second * 2)
 		}
 		deploy, err := c.gtwy.GetDeploymentByID(ctx, req.ProjectID, req.DeploymentID)
@@ -53,11 +53,11 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 			// If num is provided do a walkback by n lines to get latest n logs
 			delimiter = int(math.Max(float64(len(partials)-int(req.NumLines)), float64(prevIdx)))
 		}
-		delta := partials[delimiter:nextIdx]
+		delta := partials[delimiter-1 : nextIdx]
 		if len(delta) == 0 {
 			continue
 		}
-		fmt.Println(strings.Join(delta, "\n"))
+		fmt.Printf(strings.Join(delta, "\n"))
 		prevIdx = nextIdx
 		if req.NumLines != 0 {
 			// Break if numlines provided

--- a/controller/logs.go
+++ b/controller/logs.go
@@ -37,9 +37,9 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 	// 2) If numLines is not provided, poll for deploymentLogs while keeping a pointer for the line number
 	//    This pointer will be used to determine what to send to stdout
 	//    e.g We fetch 10 lines initially. Subsequent fetch returns 12. We print the last 2 lines (delta)
-	prevIdx := 0
+	prevIdx := 1
 	for {
-		if prevIdx != 0 {
+		if prevIdx != 1 {
 			time.Sleep(time.Second * 2)
 		}
 		deploy, err := c.gtwy.GetDeploymentByID(ctx, req.ProjectID, req.DeploymentID)
@@ -48,7 +48,7 @@ func (c *Controller) LogsForDeployment(ctx context.Context, req *entity.Deployme
 		}
 		partials := strings.Split(deploy.DeployLogs, "\n")
 		nextIdx := len(partials)
-		delimiter := prevIdx // Go's slices aren't inclusive
+		delimiter := prevIdx - 1 // Go's slices aren't inclusive
 		if req.NumLines != 0 {
 			// If num is provided do a walkback by n lines to get latest n logs
 			delimiter = int(math.Max(float64(len(partials)-int(req.NumLines)), float64(prevIdx)))


### PR DESCRIPTION
As if this section of code wasn't already confusing enough

99% sure what's happening here is that Golang's slices aren't inclusive, so when new content comes in we're not amply buffering the slice?

1% unsure wtf is happening