### PR TITLE
Add use of context to a bunch of places

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -59,7 +59,7 @@ func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error
 		return nil
 	}
 
-	cmd := exec.Command(command[0], command[1:]...)
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
 	cmd.Env = os.Environ()
 	for k, v := range connectEnv {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,7 +41,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 		return errors.CommandNotSpecified
 	}
 
-	cmd := exec.Command(req.Args[0], req.Args[1:]...)
+	cmd := exec.CommandContext(ctx, req.Args[0], req.Args[1:]...)
 	cmd.Env = os.Environ()
 
 	// Inject railway envs
@@ -93,7 +93,7 @@ func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs
 		buildArgs = append(buildArgs, "--build-arg", fmt.Sprintf("%s=\"%+v\"", k, v))
 	}
 
-	buildCmd := exec.Command("docker", buildArgs...)
+	buildCmd := exec.CommandContext(ctx, "docker", buildArgs...)
 	ui.StartSpinner(&ui.SpinnerCfg{
 		Message: fmt.Sprintf("Building %s from Dockerfile... (this may take a bit)", ui.GreenText(image)),
 		Tokens:  ui.TrainEmojis,
@@ -122,7 +122,7 @@ func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs
 	runArgs = append(runArgs, image)
 
 	// Run the container
-	runCmd := exec.Command("docker", runArgs...)
+	runCmd := exec.CommandContext(ctx, "docker", runArgs...)
 	runCmd.Stdout = os.Stdout
 	runCmd.Stderr = os.Stdout
 	runCmd.Stdin = os.Stdin

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -13,7 +13,7 @@ import (
 
 func constructReq(ctx context.Context, req *entity.UpRequest) (*http.Request, error) {
 	url := fmt.Sprintf("%s/project/%s/environment/%s/up", GetHost(), req.ProjectID, req.EnvironmentID)
-	httpReq, err := http.NewRequest("POST", url, &req.Data)
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, &req.Data)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Noticed that `ctx` wasn't being used for a bunch of stuff, so fixed it.