### PR TITLE
Add vars alias for variables command

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,9 +111,10 @@ func init() {
 	})
 
 	variablesCmd := addRootCmd(&cobra.Command{
-		Use:   "variables",
-		Short: "Show variables for active environment",
-		RunE:  contextualize(handler.Variables, handler.Panic),
+		Use:     "variables",
+		Aliases: []string{"vars"},
+		Short:   "Show variables for active environment",
+		RunE:    contextualize(handler.Variables, handler.Panic),
 	})
 	variablesCmd.AddCommand(&cobra.Command{
 		Use:   "get",
@@ -183,12 +184,6 @@ func init() {
 		Short: "Upload and deploy project from the current directory",
 		RunE:  contextualize(handler.Up, handler.Panic),
 	}).Flags().BoolP("detach", "d", false, "Detach from cloud build/deploy logs")
-
-	addRootCmd(&cobra.Command{
-		Use:   "logs",
-		Short: "View the most-recent deploy's logs",
-		RunE:  contextualize(handler.Logs, handler.Panic),
-	}).Flags().Int32P("lines", "n", 0, "Output a specific number of lines")
 
 	addRootCmd(&cobra.Command{
 		Use:   "logs",


### PR DESCRIPTION
Variables is a bit long, so here's a `vars` alias to help out!

This also removes a duplicate definition of the `logs` command.

<img width="329" alt="image" src="https://user-images.githubusercontent.com/587576/116120793-c9fab500-a674-11eb-952f-2f15aa9b6599.png">

<img width="711" alt="image" src="https://user-images.githubusercontent.com/587576/116121019-09290600-a675-11eb-806c-b5d340e7f709.png">

