### PR TITLE
Run command exit code

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,8 +55,13 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 	catchSignals(cmd)
 
 	err = cmd.Run()
+
 	if err != nil {
-		return err
+		if exitError, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitError.ExitCode())
+		}
+
+		os.Exit(1)
 	}
 
 	printLooksGood()
@@ -129,6 +134,7 @@ func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs
 	catchSignals(runCmd)
 
 	err = runCmd.Run()
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, if the command that `run` is running fails with an exit code, the actual railway run command returns with exit code 0. This isn't great and breaks things like CI.

Ideally we just capture the exit code of the sub command and exit with the same error. But it seems that this is not always the same cross platform.

See

- https://stackoverflow.com/questions/10385551/get-exit-code-go
- https://github.com/golang/go/issues/26539

In go 1.12 they released [ExitCode](https://golang.org/pkg/os/#ProcessState.ExitCode) on ProcessState, but I can not seem to get it to work locally on my Mac. Seems that is the case for others as well.

So as a comprimise, I try to use the exit code if it exists, otherwise I exit with exit code 1.

![image](https://user-images.githubusercontent.com/3044853/116503232-6b972780-a86a-11eb-8e19-e22fa7508cc6.png)

![image](https://user-images.githubusercontent.com/3044853/116503263-7b167080-a86a-11eb-9630-3215cd9a34e3.png)
