### PR TITLE
Update install.sh to include arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ get_machine() {
       echo "amd64" ;;
     "i386"|"i86pc"|"x86"|"i686")
       echo "i386" ;;
-    "armv6l"|"aarch64")
+    "arm64"|"armv6l"|"aarch64")
       echo "arm64"
   esac
 }


### PR DESCRIPTION
We had some arm64 alternative names in the install script, but missed adding the basic `arm64`

Fixes #104