### PR TITLE
Show Dockerbuild + Handle Signal for teardown

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -59,9 +59,7 @@ func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error
 		return nil
 	}
 
-	childCtx, cancel := context.WithCancel(ctx)
-
-	cmd := exec.CommandContext(childCtx, command[0], command[1:]...)
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
 	cmd.Env = os.Environ()
 	for k, v := range connectEnv {
@@ -71,7 +69,7 @@ func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout
 	cmd.Stdin = os.Stdin
-	catchSignals(childCtx, cmd, cancel)
+	catchSignals(ctx, cmd, nil)
 
 	err = cmd.Run()
 	if err != nil {

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -59,7 +59,9 @@ func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error
 		return nil
 	}
 
-	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
+	childCtx, cancel := context.WithCancel(ctx)
+
+	cmd := exec.CommandContext(childCtx, command[0], command[1:]...)
 
 	cmd.Env = os.Environ()
 	for k, v := range connectEnv {
@@ -69,7 +71,7 @@ func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout
 	cmd.Stdin = os.Stdin
-	catchSignals(cmd)
+	catchSignals(childCtx, cmd, cancel)
 
 	err = cmd.Run()
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -151,10 +151,19 @@ func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs
 		Tokens:  ui.TrainEmojis,
 	})
 
-	out, err := buildCmd.CombinedOutput()
+	buildCmd.Stdout = os.Stdout
+	buildCmd.Stderr = os.Stderr
+
+	err = buildCmd.Start()
 	if err != nil {
-		ui.StopSpinner("")
-		return showCmdError(buildCmd.Args, out, err)
+		ui.StopSpinner("Failed to start cmd!")
+		return err
+	}
+
+	err = buildCmd.Wait()
+	if err != nil {
+		ui.StopSpinner("Failed to exec command!")
+		return err
 	}
 
 	ui.StopSpinner(fmt.Sprintf("🎉 Built %s", ui.GreenText(image)))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -198,9 +198,13 @@ func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs
 	}
 	// Listen for cancel to remove the container
 	catchSignals(ctx, logCmd, func() {
-		exec.Command("docker", "rm", "-f", string(containerId)).Run()
+		err = exec.Command("docker", "rm", "-f", string(containerId)).Run()
 	})
-	logCmd.Wait()
+	err = logCmd.Wait()
+	if !strings.Contains(err.Error(), "255") {
+		// 255 is a graceeful exit with ctrl + c
+		return err
+	}
 
 	printLooksGood()
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -219,25 +219,6 @@ func isAvailable(port int) bool {
 	return true
 }
 
-func showCmdError(args []string, output []byte, err error) error {
-	if _, ok := err.(*exec.ExitError); ok {
-		// Full cmd for error logging
-		argstr := ""
-		for _, arg := range args {
-			argstr += arg + " "
-		}
-
-		fmt.Println(ui.RedText("exec error:"))
-		fmt.Println(ui.RedText("-- START OUTPUT --"))
-		fmt.Printf("%s\n", string(output))
-		fmt.Println(ui.RedText("-- END OUTPUT --"))
-		fmt.Println()
-		fmt.Println(ui.RedText("while running:"))
-		fmt.Printf("%+v\n", argstr)
-	}
-	return err
-}
-
 func catchSignals(cmd *exec.Cmd) {
 	sigs := make(chan os.Signal, 1)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -235,7 +235,9 @@ func catchSignals(ctx context.Context, cmd *exec.Cmd, onSignal context.CancelFun
 	go func() {
 		sig := <-sigs
 		err := cmd.Process.Signal(sig)
-		onSignal()
+		if onSignal != nil {
+			onSignal()
+		}
 		if err != nil {
 			fmt.Println("Child process error: \n", err)
 		}


### PR DESCRIPTION
Previously we didn't show wtf we were doing for the docker build under the hood

Now, we show that such that the user doesn't sit there on this screen. Additionally, we can teardown the container if you hit CTRL + C on the log step now.

![image](https://user-images.githubusercontent.com/5499880/117517987-e63f0180-af52-11eb-9145-4bc352c1bc60.png)

