### PR TITLE
Fix CLI on Windows

### DIFF
--- a/configs/main.go
+++ b/configs/main.go
@@ -6,7 +6,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"runtime"
 
 	"github.com/railwayapp/cli/constants"
 	"github.com/spf13/viper"
@@ -84,14 +83,16 @@ func New() *Configs {
 	if IsDevMode() {
 		rootConfigPartialPath = ".railway/dev-config.json"
 	}
-	rootConfigPath := path.Join(os.Getenv("HOME"), rootConfigPartialPath)
-	
-	if (runtime.GOOS == "windows") {
-		rootConfigPath = path.Join(os.Getenv("APPDATA"), rootConfigPartialPath)
-	}
 
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	
+	rootConfigPath := path.Join(homeDir, rootConfigPartialPath)
+	
 	rootViper.SetConfigFile(rootConfigPath)
-	err := rootViper.ReadInConfig()
+	err = rootViper.ReadInConfig()
 	if os.IsNotExist(err) {
 		// That's okay, configs are created as needed
 	} else if err != nil {

--- a/configs/main.go
+++ b/configs/main.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"runtime"
 
 	"github.com/railwayapp/cli/constants"
 	"github.com/spf13/viper"
@@ -84,6 +85,11 @@ func New() *Configs {
 		rootConfigPartialPath = ".railway/dev-config.json"
 	}
 	rootConfigPath := path.Join(os.Getenv("HOME"), rootConfigPartialPath)
+	
+	if (runtime.GOOS == "windows") {
+		rootConfigPath = path.Join(os.Getenv("APPDATA"), rootConfigPartialPath)
+	}
+
 	rootViper.SetConfigFile(rootConfigPath)
 	err := rootViper.ReadInConfig()
 	if os.IsNotExist(err) {

--- a/configs/project.go
+++ b/configs/project.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"runtime"
 
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/errors"
@@ -21,7 +22,7 @@ func (c *Configs) MigrateLocalProjectConfig() error {
 	}
 
 	// Avoid deleting ~/.railway
-	if projectDir == os.Getenv("HOME") {
+	if projectDir == os.Getenv("HOME") || (runtime.GOOS == "windows" && projectDir == os.Getenv("APPDATA") {
 		return nil
 	}
 

--- a/configs/project.go
+++ b/configs/project.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"runtime"
 
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/errors"
@@ -22,7 +21,12 @@ func (c *Configs) MigrateLocalProjectConfig() error {
 	}
 
 	// Avoid deleting ~/.railway
-	if projectDir == os.Getenv("HOME") || (runtime.GOOS == "windows" && projectDir == os.Getenv("APPDATA")) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	if projectDir == homeDir {
 		return nil
 	}
 

--- a/configs/project.go
+++ b/configs/project.go
@@ -22,7 +22,7 @@ func (c *Configs) MigrateLocalProjectConfig() error {
 	}
 
 	// Avoid deleting ~/.railway
-	if projectDir == os.Getenv("HOME") || (runtime.GOOS == "windows" && projectDir == os.Getenv("APPDATA") {
+	if projectDir == os.Getenv("HOME") || (runtime.GOOS == "windows" && projectDir == os.Getenv("APPDATA")) {
 		return nil
 	}
 


### PR DESCRIPTION
I think I was able to fix the CLI not working on Windows. As windows doesn't really have a defined HOME directory, chose to use APPDATA/Roaming instead (lots of apps like Heroku CLI use this), ran a few tests with a example project and was able to get it working, short video walkthrough here:

https://www.loom.com/share/4ce6188c7406406a837a7710d70284d8

Let me know if there needs to be any changes or want a longer demo.
Thanks

UPDATE: updated to use `os.UserHomeDir`