### PR TITLE
expand open command

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -16,5 +16,27 @@ func (h *Handler) Open(ctx context.Context, req *entity.CommandRequest) error {
 		return err
 	}
 
+	if (req.Cmd.Use != "open") {
+		return h.ctrl.OpenProjectPathInBrowser(ctx, projectId, environmentId, req.Cmd.Use)
+	}
+
 	return h.ctrl.OpenProjectInBrowser(ctx, projectId, environmentId)
+}
+
+func (h *Handler) OpenApp(ctx context.Context, req *entity.CommandRequest) error {
+	projectId, err := h.cfg.GetProject()
+	if err != nil {
+		return err
+	}
+	environmentId, err := h.cfg.GetEnvironment()
+	if err != nil {
+		return err
+	}
+
+	deployment, err := h.ctrl.GetLatestDeploymentForEnvironment(ctx, projectId, environmentId)
+	if err != nil {
+		return err
+	}
+
+	return h.ctrl.OpenStaticUrlInBrowser(deployment.StaticUrl)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,6 +41,11 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 		return errors.CommandNotSpecified
 	}
 
+	if _, err := exec.LookPath(req.Args[0]); err != nil {
+		fmt.Printf("%s is not in $PATH\n", req.Args[0])
+		os.Exit(1)
+	}
+
 	cmd := exec.CommandContext(ctx, req.Args[0], req.Args[1:]...)
 	cmd.Env = os.Environ()
 
@@ -58,6 +63,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
+			fmt.Println(err.Error())
 			os.Exit(exitError.ExitCode())
 		}
 

--- a/controller/project.go
+++ b/controller/project.go
@@ -36,6 +36,11 @@ func (c *Controller) OpenProjectInBrowser(ctx context.Context, projectID string,
 	return c.gtwy.OpenProjectInBrowser(projectID, environmentID)
 }
 
+// OpenProjectPathInBrowser opens the provided projectId with the provided path in the browser
+func (c *Controller) OpenProjectPathInBrowser(ctx context.Context, projectID string, environmentID string, path string) error {
+	return c.gtwy.OpenProjectPathInBrowser(projectID, environmentID, path)
+}
+
 // OpenProjectDeploymentsInBrowser opens the provided projectId's depolyments in the browser
 func (c *Controller) OpenProjectDeploymentsInBrowser(ctx context.Context, projectID string) error {
 	return c.gtwy.OpenProjectDeploymentsInBrowser(projectID)
@@ -44,4 +49,13 @@ func (c *Controller) OpenProjectDeploymentsInBrowser(ctx context.Context, projec
 // GetProjectDeploymentsURL returns the URL to access project deployment in browser
 func (c *Controller) GetProjectDeploymentsURL(ctx context.Context, projectID string) string {
 	return c.gtwy.GetProjectDeploymentsURL(projectID)
+}
+
+// GetProjectDeploymentsURL returns the URL to access project deployment in browser
+func (c *Controller) GetLatestDeploymentForEnvironment(ctx context.Context, projectID string, environmentID string) (*entity.Deployment, error) {
+	return c.gtwy.GetLatestDeploymentForEnvironment(ctx, projectID, environmentID)
+}
+
+func (c *Controller) OpenStaticUrlInBrowser(staticUrl string) error {
+	return c.gtwy.OpenStaticUrlInBrowser(staticUrl)
 }

--- a/entity/deployment.go
+++ b/entity/deployment.go
@@ -21,6 +21,7 @@ type Deployment struct {
 	BuildLogs  string          `json:"buildLogs"`
 	DeployLogs string          `json:"deployLogs"`
 	Status     string          `json:"status"`
+	StaticUrl  string          `json:"staticUrl"`
 	Meta       *DeploymentMeta `json:"meta"`
 }
 

--- a/gateway/deployment.go
+++ b/gateway/deployment.go
@@ -18,6 +18,7 @@ func (g *Gateway) GetDeploymentsForEnvironment(ctx context.Context, projectId, e
 				status
 				projectId
 				meta
+				staticUrl
 			}
 		}
 	`)

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -26,7 +26,7 @@ func (g *Gateway) GetProject(ctx context.Context, projectId string) (*entity.Pro
 				environments {
 					id,
 					name
-				}, 
+				},
 			}
 		}
 	`)
@@ -168,7 +168,7 @@ func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 		environments {
 			id,
 			name
-		}, 
+		},
 	`
 
 	gqlReq := gql.NewRequest(fmt.Sprintf(`
@@ -242,10 +242,18 @@ func (g *Gateway) OpenProjectInBrowser(projectID string, environmentID string) e
 	return browser.OpenURL(fmt.Sprintf("%s/project/%s?environmentId=%s", GetRailwayUrl(), projectID, environmentID))
 }
 
+func (g *Gateway) OpenProjectPathInBrowser(projectID string, environmentID string, path string) error {
+	return browser.OpenURL(fmt.Sprintf("%s/project/%s/%s?environmentId=%s", GetRailwayUrl(), projectID, path, environmentID))
+}
+
 func (g *Gateway) OpenProjectDeploymentsInBrowser(projectID string) error {
 	return browser.OpenURL(g.GetProjectDeploymentsURL(projectID))
 }
 
 func (g *Gateway) GetProjectDeploymentsURL(projectID string) string {
 	return fmt.Sprintf("%s/project/%s/deployments?open=true", GetRailwayUrl(), projectID)
+}
+
+func (g *Gateway) OpenStaticUrlInBrowser(staticUrl string) error {
+	return browser.OpenURL("https://" + staticUrl)
 }

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -234,7 +234,7 @@ func (g *Gateway) OpenProjectInBrowser(projectID string, environmentID string) e
 }
 
 func (g *Gateway) OpenProjectPathInBrowser(projectID string, environmentID string, path string) error {
-	return browser.OpenURL(fmt.Sprintf("%s/project/%s/%s?environmentId=%s", GetRailwayUrl(), projectID, path, environmentID))
+	return browser.OpenURL(fmt.Sprintf("%s/project/%s/%s?environmentId=%s", configs.GetRailwayURL(), projectID, path, environmentID))
 }
 
 func (g *Gateway) OpenProjectDeploymentsInBrowser(projectID string) error {

--- a/main.go
+++ b/main.go
@@ -146,10 +146,28 @@ func init() {
 		RunE:  contextualize(handler.Environment, handler.Panic),
 	})
 
-	addRootCmd(&cobra.Command{
+	openCmd := addRootCmd(&cobra.Command{
 		Use:   "open",
-		Short: "Open project dashboard in default browser",
+		Short: "Open your project dashboard",
 		RunE:  contextualize(handler.Open, handler.Panic),
+	})
+	openCmd.AddCommand(&cobra.Command{
+		Use: "metrics",
+		Short: "Open project metrics",
+		Aliases: []string{"m"},
+		RunE:  contextualize(handler.Open, handler.Panic),
+	})
+	openCmd.AddCommand(&cobra.Command{
+		Use: "settings",
+		Short: "Open project settings",
+		Aliases: []string{"s"},
+		RunE:  contextualize(handler.Open, handler.Panic),
+	})
+	openCmd.AddCommand(&cobra.Command{
+		Use: "live",
+		Short: "Open the deployed application",
+		Aliases: []string{"l"},
+		RunE:  contextualize(handler.OpenApp, handler.Panic),
 	})
 
 	addRootCmd(&cobra.Command{


### PR DESCRIPTION
This PR closes [RAIL-826](https://linear.app/railway/issue/RAIL-826/expand-open-command-for-cli).

- `railway open` now opens your project dashboard.
- `railway open metrics` will open the metrics page. Aliased as `m`.
- `railway open settings` will open the settings page. Aliased as `s`.
- `railway open live` will open the deployed application. Aliased as `l`.

I've also left some questions in my self-review of the PR.