### PR TITLE
Logout Session and Hostname

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -199,6 +199,11 @@ func (c *Controller) browserlessLogin(ctx context.Context) (*entity.User, error)
 }
 
 func (c *Controller) Login(ctx context.Context, isBrowserless bool) (*entity.User, error) {
+	// Invalidate current session if it exists
+	if err := c.gtwy.Logout(ctx); err != nil {
+		return nil, err
+	}
+
 	if isBrowserless || isSSH() || isCodeSpaces() {
 		return c.browserlessLogin(ctx)
 	}
@@ -216,10 +221,17 @@ func (c *Controller) Logout(ctx context.Context) error {
 		fmt.Printf("🚪  %s\n", ui.YellowText("Already logged out"))
 		return nil
 	}
+
+	err = c.gtwy.Logout(ctx)
+	if err != nil {
+		return err
+	}
+
 	err = c.cfg.SetUserConfigs(&entity.UserConfig{})
 	if err != nil {
 		return err
 	}
+
 	fmt.Printf("👋 %s\n", ui.YellowText("Logged out"))
 	return nil
 }

--- a/controller/user.go
+++ b/controller/user.go
@@ -200,8 +200,10 @@ func (c *Controller) browserlessLogin(ctx context.Context) (*entity.User, error)
 
 func (c *Controller) Login(ctx context.Context, isBrowserless bool) (*entity.User, error) {
 	// Invalidate current session if it exists
-	if err := c.gtwy.Logout(ctx); err != nil {
-		return nil, err
+	if loggedIn, _ := c.IsLoggedIn(ctx); loggedIn {
+		if err := c.gtwy.Logout(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	if isBrowserless || isSSH() || isCodeSpaces() {

--- a/controller/user.go
+++ b/controller/user.go
@@ -271,14 +271,26 @@ func getAPIURL() string {
 	return baseRailwayURL
 }
 
+func getHostName() string {
+	name, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+
+	return name
+}
+
 func getBrowserBasedLoginURL(port int, code string) string {
-	buffer := b64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("port=%d&code=%s", port, code)))
+	hostname := getHostName()
+	buffer := b64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("port=%d&code=%s&hostname=%s", port, code, hostname)))
 	url := fmt.Sprintf("%s/cli-login?d=%s", getAPIURL(), buffer)
 	return url
 }
 
 func getBrowserlessLoginURL(wordCode string) string {
-	buffer := b64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("wordCode=%s", wordCode)))
+	hostname := getHostName()
+	buffer := b64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("wordCode=%s&hostname=%s", wordCode, hostname)))
+
 	url := fmt.Sprintf("%s/cli-login?d=%s", getAPIURL(), buffer)
 	return url
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -23,6 +23,7 @@ func (g *Gateway) authorize(ctx context.Context, header http.Header) error {
 	if err != nil {
 		return err
 	}
+
 	header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
 	header.Add("x-source", CLI_SOURCE_HEADER)
 	if g.cfg.RailwayProductionToken != "" {

--- a/gateway/user.go
+++ b/gateway/user.go
@@ -19,7 +19,6 @@ func (g *Gateway) GetUser(ctx context.Context) (*entity.User, error) {
 	`)
 
 	err := g.authorize(ctx, gqlReq.Header)
-
 	if err != nil {
 		return nil, err
 	}
@@ -64,4 +63,19 @@ func (g *Gateway) ConsumeLoginSession(ctx context.Context, code string) (string,
 	}
 
 	return resp.Token, nil
+}
+
+func (g *Gateway) Logout(ctx context.Context) error {
+	gqlReq := gql.NewRequest(`mutation { logout }`)
+
+	err := g.authorize(ctx, gqlReq.Header)
+	if err != nil {
+		return err
+	}
+
+	if err := g.gqlClient.Run(ctx, gqlReq, nil); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/gateway/user.go
+++ b/gateway/user.go
@@ -69,8 +69,9 @@ func (g *Gateway) Logout(ctx context.Context) error {
 	gqlReq := gql.NewRequest(`mutation { logout }`)
 
 	err := g.authorize(ctx, gqlReq.Header)
+	// If we can't authorize the request then we are already logged out
 	if err != nil {
-		return err
+		return nil
 	}
 
 	if err := g.gqlClient.Run(ctx, gqlReq, nil); err != nil {


### PR DESCRIPTION
Associated Backboard PR https://github.com/railwayapp/mono/pull/1212

- Logout session in logout command and before logging in. This means that if you repeadedly login, you should only have a single user session (as opposed to a session for each login call)
- Send hostname with login request. The hostname will be used as the session name and appear on the /account/security page

