### PR TITLE
Use project/environment from project token if it exists

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *Handler) Add(ctx context.Context, req *entity.CommandRequest) error {
-	projectCfg, err := h.cfg.GetProjectConfigs()
+	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error {
-	projectCfg, _ := h.cfg.GetProjectConfigs()
+	projectCfg, _ := h.ctrl.GetProjectConfigs(ctx)
 
 	project, err := h.ctrl.GetProject(ctx, projectCfg.Project)
 	if err != nil {

--- a/cmd/protect.go
+++ b/cmd/protect.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (h *Handler) Protect(ctx context.Context, req *entity.CommandRequest) error {
-	projectConfigs, err := h.cfg.GetProjectConfigs()
+	projectConfigs, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -120,7 +120,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 
 func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs) error {
 	// Start building the image
-	projectCfg, err := h.cfg.GetProjectConfigs()
+	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *Handler) Status(ctx context.Context, req *entity.CommandRequest) error {
-	projectCfg, err := h.cfg.GetProjectConfigs()
+	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (h *Handler) Unlink(ctx context.Context, req *entity.CommandRequest) error {
-	projectCfg, _ := h.cfg.GetProjectConfigs()
+	projectCfg, _ := h.ctrl.GetProjectConfigs(ctx)
 
 	project, err := h.ctrl.GetProject(ctx, projectCfg.Project)
 	if err != nil {

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/railwayapp/cli/ui"
 	"strings"
+
+	"github.com/railwayapp/cli/ui"
 
 	"github.com/railwayapp/cli/entity"
 )

--- a/configs/main.go
+++ b/configs/main.go
@@ -88,9 +88,9 @@ func New() *Configs {
 	if err != nil {
 		panic(err)
 	}
-	
+
 	rootConfigPath := path.Join(homeDir, rootConfigPartialPath)
-	
+
 	rootViper.SetConfigFile(rootConfigPath)
 	err = rootViper.ReadInConfig()
 	if os.IsNotExist(err) {

--- a/controller/config.go
+++ b/controller/config.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/railwayapp/cli/entity"
+)
+
+func (c *Controller) GetProjectConfigs(ctx context.Context) (*entity.ProjectConfig, error) {
+	if c.cfg.RailwayProductionToken != "" {
+		// Get project config from api
+		projectToken, err := c.gtwy.GetProjectToken(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if projectToken != nil {
+			return &entity.ProjectConfig{
+				Project:         projectToken.ProjectId,
+				Environment:     projectToken.EnvironmentId,
+				LockedEnvsNames: map[string]bool{},
+			}, nil
+		}
+	}
+
+	return c.cfg.GetProjectConfigs()
+}

--- a/controller/deployment.go
+++ b/controller/deployment.go
@@ -2,33 +2,26 @@ package controller
 
 import (
 	"context"
+
 	"github.com/railwayapp/cli/entity"
 )
 
 func (c *Controller) GetDeployments(ctx context.Context) ([]*entity.Deployment, error) {
-	projectID, err := c.cfg.GetProject()
+	projectConfig, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}
-	environmentID, err := c.cfg.GetEnvironment()
-	if err != nil {
-		return nil, err
-	}
-	return c.gtwy.GetDeploymentsForEnvironment(ctx, projectID, environmentID)
+
+	return c.gtwy.GetDeploymentsForEnvironment(ctx, projectConfig.Project, projectConfig.Environment)
 }
 
 func (c *Controller) GetActiveDeployment(ctx context.Context) (*entity.Deployment, error) {
-	projectID, err := c.cfg.GetProject()
+	projectConfig, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	environmentID, err := c.cfg.GetEnvironment()
-	if err != nil {
-		return nil, err
-	}
-
-	deployment, err := c.gtwy.GetLatestDeploymentForEnvironment(ctx, projectID, environmentID)
+	deployment, err := c.gtwy.GetLatestDeploymentForEnvironment(ctx, projectConfig.Project, projectConfig.Environment)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/deployment_trigger.go
+++ b/controller/deployment_trigger.go
@@ -2,11 +2,12 @@ package controller
 
 import (
 	"context"
+
 	"github.com/railwayapp/cli/entity"
 )
 
 func (c *Controller) DeployEnvironmentTriggers(ctx context.Context) error {
-	projectCfg, err := c.cfg.GetProjectConfigs()
+	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}

--- a/controller/environment.go
+++ b/controller/environment.go
@@ -9,7 +9,7 @@ import (
 
 // GetEnvironment returns the currently active environment for the Railway project
 func (c *Controller) GetEnvironment(ctx context.Context) (*entity.Environment, error) {
-	projectCfg, err := c.cfg.GetProjectConfigs()
+	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -94,14 +94,9 @@ func (c *Controller) UpdateEnvsForEnvPlugin(ctx context.Context, envs *entity.En
 		}
 	}
 
-	environment, err := c.cfg.GetEnvironment()
-	if err != nil {
-		return nil, err
-	}
-
 	return c.gtwy.UpdateEnvsForPlugin(ctx, &entity.UpdateEnvsRequest{
 		ProjectID:     projectCfg.Project,
-		EnvironmentID: environment,
+		EnvironmentID: projectCfg.Environment,
 		PluginID:      pluginID,
 		Envs:          envs,
 	})

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -12,17 +12,7 @@ import (
 )
 
 func (c *Controller) GetEnvs(ctx context.Context) (*entity.Envs, error) {
-	// Get envs through production token if it exists
-	if c.cfg.RailwayProductionToken != "" {
-		envs, err := c.gtwy.GetEnvsWithProjectToken(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		return envs, err
-	}
-
-	projectCfg, err := c.cfg.GetProjectConfigs()
+	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -76,10 +66,11 @@ func (c *Controller) SaveEnvsToFile(ctx context.Context) error {
 }
 
 func (c *Controller) UpdateEnvsForEnvPlugin(ctx context.Context, envs *entity.Envs) (*entity.Envs, error) {
-	projectCfg, err := c.cfg.GetProjectConfigs()
+	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}
+
 	if val, ok := projectCfg.LockedEnvsNames[projectCfg.Environment]; ok && val {
 		fmt.Println(ui.Bold(ui.RedText("Protected Environment Detected!").String()))
 		confirm, err := ui.PromptYesNo("Continue updating variables?")
@@ -127,7 +118,7 @@ func (c *Controller) GetEnvsForEnvPlugin(ctx context.Context) (*entity.Envs, err
 		return envs, err
 	}
 
-	projectCfg, err := c.cfg.GetProjectConfigs()
+	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/logs.go
+++ b/controller/logs.go
@@ -29,22 +29,19 @@ func (c *Controller) GetActiveDeploymentLogs(ctx context.Context, numLines int32
 }
 
 func (c *Controller) GetActiveBuildLogs(ctx context.Context, numLines int32) error {
-	projectID, err := c.cfg.GetProject()
+	projectConfig, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}
-	environmentID, err := c.cfg.GetEnvironment()
-	if err != nil {
-		return err
-	}
-	deployment, err := c.gtwy.GetLatestDeploymentForEnvironment(ctx, projectID, environmentID)
+
+	deployment, err := c.gtwy.GetLatestDeploymentForEnvironment(ctx, projectConfig.Project, projectConfig.Environment)
 	if err != nil {
 		return err
 	}
 
 	return c.logsForState(ctx, &entity.DeploymentLogsRequest{
 		DeploymentID: deployment.ID,
-		ProjectID:    projectID,
+		ProjectID:    projectConfig.Project,
 		NumLines:     numLines,
 	})
 }

--- a/controller/panic.go
+++ b/controller/panic.go
@@ -11,6 +11,7 @@ import (
 
 func (c *Controller) SendPanic(ctx context.Context, panicErr string, stacktrace string, command string) (bool, error) {
 	confirmSendPanic()
+
 	projectCfg, err := c.cfg.GetProjectConfigs()
 	if err != nil {
 		return c.gtwy.SendPanic(ctx, &entity.PanicRequest{

--- a/controller/up.go
+++ b/controller/up.go
@@ -86,14 +86,11 @@ func compress(src string, buf io.Writer) error {
 }
 
 func (c *Controller) Up(ctx context.Context) (string, error) {
-	projectID, err := c.cfg.GetProject()
+	projectConfig, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return "", err
 	}
-	environmentID, err := c.cfg.GetEnvironment()
-	if err != nil {
-		return "", err
-	}
+
 	var buf bytes.Buffer
 	if err := compress(".", &buf); err != nil {
 		return "", err
@@ -101,8 +98,8 @@ func (c *Controller) Up(ctx context.Context) (string, error) {
 
 	res, err := c.gtwy.Up(ctx, &entity.UpRequest{
 		Data:          buf,
-		ProjectID:     projectID,
-		EnvironmentID: environmentID,
+		ProjectID:     projectConfig.Project,
+		EnvironmentID: projectConfig.Environment,
 	})
 	if err != nil {
 		return "", err

--- a/entity/project.go
+++ b/entity/project.go
@@ -33,3 +33,8 @@ type Project struct {
 	Plugins      []*Plugin      `json:"plugins,omitempty"`
 	Team         *string        `json:"team,omitempty"`
 }
+
+type ProjectToken struct {
+	ProjectId     string `json:"projectId"`
+	EnvironmentId string `json:"environmentId"`
+}

--- a/errors/main.go
+++ b/errors/main.go
@@ -13,6 +13,7 @@ type RailwayError error
 var (
 	UserConfigNotFound                  RailwayError = fmt.Errorf("%s\nRun %s", ui.RedText("Not logged in."), ui.Bold("railway login"))
 	ProjectConfigNotFound               RailwayError = fmt.Errorf("%s. Tip: If you haven't, do railway login\nOtherwise, run %s to get plugged into a new project, or %s to get plugged into an existing project.", ui.RedText("Project not found."), ui.Bold("railway init"), ui.Bold("railway link"))
+	ProjectTokenNotFound                RailwayError = fmt.Errorf("%s\n", ui.RedText("Project token not found"))
 	ProblemFetchingProjects             RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem fetching your projects."))
 	ProblemFetchingWritableGithubScopes RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem fetching GitHub metadata."))
 	ProjectCreateFailed                 RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem creating the project."))

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -20,14 +20,22 @@ type Gateway struct {
 
 func (g *Gateway) authorize(ctx context.Context, header http.Header) error {
 	user, err := g.cfg.GetUserConfigs()
-	if err != nil {
+
+	// Only error if no user and no project token
+	if err != nil && g.cfg.RailwayProductionToken == "" {
 		return err
 	}
-	header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
+
 	header.Add("x-source", CLI_SOURCE_HEADER)
+
+	if user != nil {
+		header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
+	}
+
 	if g.cfg.RailwayProductionToken != "" {
 		header.Add("project-access-token", g.cfg.RailwayProductionToken)
 	}
+
 	return nil
 }
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -19,22 +19,18 @@ type Gateway struct {
 }
 
 func (g *Gateway) authorize(ctx context.Context, header http.Header) error {
-	user, err := g.cfg.GetUserConfigs()
+	header.Add("x-source", CLI_SOURCE_HEADER)
+	if g.cfg.RailwayProductionToken != "" {
+		header.Add("project-access-token", g.cfg.RailwayProductionToken)
+		return nil
+	}
 
-	// Only error if no user and no project token
-	if err != nil && g.cfg.RailwayProductionToken == "" {
+	user, err := g.cfg.GetUserConfigs()
+	if err != nil {
 		return err
 	}
 
-	header.Add("x-source", CLI_SOURCE_HEADER)
-
-	if user != nil {
-		header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
-	}
-
-	if g.cfg.RailwayProductionToken != "" {
-		header.Add("project-access-token", g.cfg.RailwayProductionToken)
-	}
+	header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
 
 	return nil
 }


### PR DESCRIPTION
A lot of commands get the project and environment from the project config. This would fail if there was no project linked to the current directory. This PR lifts fetching of the project config to a controller which will use the project and environment for the project token if the RAILWAY_TOKEN is found.

Fixes #105 