### PR TITLE
Docker tags cannot contain upper-case letters, so lower-case them

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -137,7 +137,7 @@ func (h *Handler) runInDocker(ctx context.Context, pwd string, envs *entity.Envs
 	}
 
 	sanitiser := regexp.MustCompile(`[^A-Za-z0-9_-]`)
-	imageNameWithoutNsOrTag := sanitiser.ReplaceAllString(project.Name, "") + "-" + sanitiser.ReplaceAllString(environment.Name, "")
+	imageNameWithoutNsOrTag := strings.ToLower(sanitiser.ReplaceAllString(project.Name, "") + "-" + sanitiser.ReplaceAllString(environment.Name, ""))
 	image := fmt.Sprintf("railway-local/%s:latest", imageNameWithoutNsOrTag)
 
 	buildArgs := []string{"build", "-q", "-t", image, pwd}


### PR DESCRIPTION
Upper-case project names were generating upper-case Docker tags, which aren't allowed by docker.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/587576/121070278-5d9ac780-c783-11eb-9647-c6e943e10da1.png">

After this change:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/587576/121070317-6a1f2000-c783-11eb-92be-9a9684645add.png">

