### PR TITLE
Fix Link Cursor

### DIFF
--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -100,8 +100,8 @@ func PromptProjects(projects []*entity.Project) (*entity.Project, error) {
 		Label: "Select Project",
 		Items: filteredProjects,
 		Templates: &promptui.SelectTemplates{
-			Active:   `{{ .Name | underline }}`,
-			Inactive: `{{ .Name }}`,
+			Active:   `▸ {{ .Name | underline }}`,
+			Inactive: `  {{ .Name }}`,
 			Selected: fmt.Sprintf("%s Project: {{ .Name | magenta | bold }} ", promptui.IconGood),
 		},
 	}


### PR DESCRIPTION
Because of the way we do templating here we override the default cursor behavior. Re-add it back manually.﻿
