### PR TITLE
Consolidate selection prompts into helper

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -17,13 +17,18 @@ func (h *Handler) Add(ctx context.Context, req *entity.CommandRequest) error {
 	if err != nil {
 		return err
 	}
-	selection, err := ui.PromptPlugins(plugins)
+	selectedPlugin, err := ui.PromptPlugins(plugins)
 	if err != nil {
 		return err
 	}
+	ui.StartSpinner(&ui.SpinnerCfg{
+		Message: fmt.Sprintf("Adding %s plugin", selectedPlugin),
+	})
+	defer ui.StopSpinner("")
+
 	plugin, err := h.ctrl.CreatePlugin(ctx, &entity.CreatePluginRequest{
 		ProjectID: projectCfg.Project,
-		Plugin:    selection,
+		Plugin:    selectedPlugin,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR consolidates the prompt selection logic into two helper `selectString` and `selectCustom`.

- All selections now support filtering and show 10 items
- All selections now include a caret for the active item

![CleanShot 2021-06-11 at 09 54 51](https://user-images.githubusercontent.com/587576/121723334-3dc51580-ca9b-11eb-8eb5-d7d970e43eb0.gif)
