### PR TITLE
add help text to environment command

### DIFF
--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -57,5 +57,6 @@ func (h *Handler) Environment(ctx context.Context, req *entity.CommandRequest) e
 		return err
 	}
 
+	fmt.Printf("%s You can view the active environment by running %s\n", promptui.IconInitial, ui.BlueText("railway status"))
 	return err
 }

--- a/cmd/environment.go
+++ b/cmd/environment.go
@@ -57,6 +57,6 @@ func (h *Handler) Environment(ctx context.Context, req *entity.CommandRequest) e
 		return err
 	}
 
-	fmt.Printf("%s You can view the active environment by running %s\n", promptui.IconInitial, ui.BlueText("railway status"))
+	fmt.Printf("%s ProTip: You can view the active environment by running %s\n", promptui.IconInitial, ui.BlueText("railway status"))
 	return err
 }


### PR DESCRIPTION
Prompted by #141 as I've seen users ask this before too.

<img width="490" alt="env-help@2x" src="https://user-images.githubusercontent.com/10681116/121846820-9ff96280-ccb5-11eb-9197-b6ba4a14dae8.png">
