### PR TITLE
Use updated variable methods

### DIFF
--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -57,7 +57,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 		updatedEnvNames = append(updatedEnvNames, key)
 	}
 
-	err := h.ctrl.UpsertEnvsForPlugin(ctx, variables)
+	err := h.ctrl.UpsertEnvsForEnvPlugin(ctx, variables)
 
 	if err != nil {
 		return err
@@ -80,18 +80,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 }
 
 func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandRequest) error {
-	envs, err := h.ctrl.GetEnvsForEnvPlugin(ctx)
-	if err != nil {
-		return err
-	}
-
-	updatedEnvNames := make([]string, 0)
-	for _, key := range req.Args {
-		updatedEnvNames = append(updatedEnvNames, key)
-		envs.Delete(key)
-	}
-
-	_, err = h.ctrl.UpdateEnvsForEnvPlugin(ctx, envs)
+	err := h.ctrl.DeleteEnvsForEnvPlugin(ctx, req.Args)
 	if err != nil {
 		return err
 	}
@@ -101,7 +90,7 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 		return err
 	}
 
-	fmt.Print(ui.Heading(fmt.Sprintf("Deleted %s for \"%s\"", strings.Join(updatedEnvNames, ", "), environment.Name)))
+	fmt.Print(ui.Heading(fmt.Sprintf("Deleted %s for \"%s\"", strings.Join(req.Args, ", "), environment.Name)))
 
 	err = h.redeployAfterVariablesChange(ctx, environment)
 	if err != nil {

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -42,27 +42,23 @@ func (h *Handler) VariablesGet(ctx context.Context, req *entity.CommandRequest) 
 }
 
 func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) error {
-	envs, err := h.ctrl.GetEnvsForEnvPlugin(ctx)
-	if err != nil {
-		return err
-	}
-
-	updatedEnvs := &entity.Envs{}
+	variables := &entity.Envs{}
 	updatedEnvNames := make([]string, 0)
+
 	for _, kvPair := range req.Args {
 		parts := strings.SplitN(kvPair, "=", 2)
 		if len(parts) != 2 {
-			return errors.New("Invalid variables invokation. See --help")
+			return errors.New("invalid variables invocation. See --help")
 		}
 		key := parts[0]
 		value := parts[1]
 
-		envs.Set(key, value)
-		updatedEnvs.Set(key, value)
+		variables.Set(key, value)
 		updatedEnvNames = append(updatedEnvNames, key)
 	}
 
-	_, err = h.ctrl.UpdateEnvsForEnvPlugin(ctx, envs)
+	err := h.ctrl.UpsertEnvsForPlugin(ctx, variables)
+
 	if err != nil {
 		return err
 	}
@@ -73,7 +69,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 	}
 
 	fmt.Print(ui.Heading(fmt.Sprintf("Updated %s for \"%s\"", strings.Join(updatedEnvNames, ", "), environment.Name)))
-	fmt.Print(ui.KeyValues(*updatedEnvs))
+	fmt.Print(ui.KeyValues(*variables))
 
 	err = h.redeployAfterVariablesChange(ctx, environment)
 	if err != nil {

--- a/controller/config.go
+++ b/controller/config.go
@@ -2,8 +2,10 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/railwayapp/cli/entity"
+	"github.com/railwayapp/cli/ui"
 )
 
 func (c *Controller) GetProjectConfigs(ctx context.Context) (*entity.ProjectConfig, error) {
@@ -24,4 +26,24 @@ func (c *Controller) GetProjectConfigs(ctx context.Context) (*entity.ProjectConf
 	}
 
 	return c.cfg.GetProjectConfigs()
+}
+
+func (c *Controller) PromptIfProtectedEnvironment(ctx context.Context) error {
+	projectCfg, err := c.GetProjectConfigs(ctx)
+	if err != nil {
+		return err
+	}
+
+	if val, ok := projectCfg.LockedEnvsNames[projectCfg.Environment]; ok && val {
+		fmt.Println(ui.Bold(ui.RedText("Protected Environment Detected!").String()))
+		confirm, err := ui.PromptYesNo("Continue?")
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			return nil
+		}
+	}
+
+	return nil
 }

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -71,7 +71,10 @@ func (c *Controller) UpsertEnvsForEnvPlugin(ctx context.Context, envs *entity.En
 		return err
 	}
 
-	c.PromptIfProtectedEnvironment(ctx)
+	err = c.PromptIfProtectedEnvironment(ctx)
+	if err != nil {
+		return err
+	}
 
 	project, err := c.GetProject(ctx, projectCfg.Project)
 	if err != nil {
@@ -99,7 +102,10 @@ func (c *Controller) DeleteEnvsForEnvPlugin(ctx context.Context, names []string)
 		return err
 	}
 
-	c.PromptIfProtectedEnvironment(ctx)
+	err = c.PromptIfProtectedEnvironment(ctx)
+	if err != nil {
+		return err
+	}
 
 	project, err := c.GetProject(ctx, projectCfg.Project)
 	if err != nil {
@@ -115,12 +121,16 @@ func (c *Controller) DeleteEnvsForEnvPlugin(ctx context.Context, names []string)
 
 	// Delete each variable one by one
 	for _, name := range names {
-		c.gtwy.DeleteVariable(ctx, &entity.DeleteVariableRequest{
+		err = c.gtwy.DeleteVariable(ctx, &entity.DeleteVariableRequest{
 			ProjectID:     projectCfg.Project,
 			EnvironmentID: projectCfg.Environment,
 			PluginID:      pluginID,
 			Name:          name,
 		})
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/entity/envs.go
+++ b/entity/envs.go
@@ -18,6 +18,13 @@ type UpdateEnvsRequest struct {
 	Envs          *Envs
 }
 
+type DeleteVariableRequest struct {
+	ProjectID     string
+	EnvironmentID string
+	PluginID      string
+	Name          string
+}
+
 type Envs map[string]string
 
 func (e Envs) Get(name string) string {

--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -71,31 +71,6 @@ func (g *Gateway) GetEnvsWithProjectToken(ctx context.Context) (*entity.Envs, er
 	return resp.Envs, nil
 }
 
-func (g *Gateway) UpdateEnvsForPlugin(ctx context.Context, req *entity.UpdateEnvsRequest) (*entity.Envs, error) {
-	gqlReq, err := g.NewRequestWithAuth(`
-	  	mutation($projectId: String!, $environmentId: String! $pluginId: String! $envs: Json!) {
-			updateEnvsForPlugin(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, envs: $envs)
-	  	}
-	`)
-	if err != nil {
-		return nil, err
-	}
-
-	gqlReq.Var("projectId", req.ProjectID)
-	gqlReq.Var("environmentId", req.EnvironmentID)
-	gqlReq.Var("pluginId", req.PluginID)
-	gqlReq.Var("envs", req.Envs)
-
-	var resp struct {
-		Envs *entity.Envs `json:"updateEnvsForPlugin"`
-	}
-	if err := gqlReq.Run(ctx, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Envs, nil
-}
-
 func (g *Gateway) UpsertVariablesFromObject(ctx context.Context, req *entity.UpdateEnvsRequest) error {
 	gqlReq, err := g.NewRequestWithAuth(`
 	  	mutation($projectId: String!, $environmentId: String! $pluginId: String! $variables: Json!) {
@@ -120,8 +95,8 @@ func (g *Gateway) UpsertVariablesFromObject(ctx context.Context, req *entity.Upd
 
 func (g *Gateway) DeleteVariable(ctx context.Context, req *entity.DeleteVariableRequest) error {
 	gqlReq, err := g.NewRequestWithAuth(`
-	  	mutation($projectId: String!, $environmentId: String! $pluginId: String! $variables: Json!) {
-				upsertVariablesFromObject(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, variables: $variables)
+	  	mutation($projectId: String!, $environmentId: String! $pluginId: String! $name: String!) {
+				deleteVariable(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, name: $name)
 	  	}
 	`)
 	if err != nil {

--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -9,7 +9,7 @@ import (
 func (g *Gateway) GetEnvs(ctx context.Context, req *entity.GetEnvsRequest) (*entity.Envs, error) {
 	gqlReq, err := g.NewRequestWithAuth(`
 		query ($projectId: String!, $environmentId: String!) {
-			allEnvsForEnvironment(projectId: $projectId, environmentId: $environmentId)
+			decryptedVariables(projectId: $projectId, environmentId: $environmentId)
 		}
 	`)
 	if err != nil {
@@ -20,54 +20,11 @@ func (g *Gateway) GetEnvs(ctx context.Context, req *entity.GetEnvsRequest) (*ent
 	gqlReq.Var("environmentId", req.EnvironmentID)
 
 	var resp struct {
-		Envs *entity.Envs `json:"allEnvsForEnvironment"`
+		Envs *entity.Envs `json:"decryptedVariables"`
 	}
 	if err := gqlReq.Run(ctx, &resp); err != nil {
 		return nil, err
 	}
-	return resp.Envs, nil
-}
-
-func (g *Gateway) GetEnvsForPlugin(ctx context.Context, req *entity.GetEnvsForPluginRequest) (*entity.Envs, error) {
-	gqlReq, err := g.NewRequestWithAuth(`
-		query ($projectId: String!, $environmentId: String!, $pluginId: String!) {
-			allEnvsForPlugin(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId)
-		}
-	`)
-	if err != nil {
-		return nil, err
-	}
-
-	gqlReq.Var("projectId", req.ProjectID)
-	gqlReq.Var("environmentId", req.EnvironmentID)
-	gqlReq.Var("pluginId", req.PluginID)
-
-	var resp struct {
-		Envs *entity.Envs `json:"allEnvsForPlugin"`
-	}
-	if err := gqlReq.Run(ctx, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Envs, nil
-}
-
-func (g *Gateway) GetEnvsWithProjectToken(ctx context.Context) (*entity.Envs, error) {
-	gqlReq, err := g.NewRequestWithAuth(`
-	  	query {
-			allEnvsForProjectToken
-	  	}
-	`)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp struct {
-		Envs *entity.Envs `json:"allEnvsForProjectToken"`
-	}
-	if err := gqlReq.Run(ctx, &resp); err != nil {
-		return nil, err
-	}
-
 	return resp.Envs, nil
 }
 

--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -95,3 +95,47 @@ func (g *Gateway) UpdateEnvsForPlugin(ctx context.Context, req *entity.UpdateEnv
 
 	return resp.Envs, nil
 }
+
+func (g *Gateway) UpsertVariablesFromObject(ctx context.Context, req *entity.UpdateEnvsRequest) error {
+	gqlReq, err := g.NewRequestWithAuth(`
+	  	mutation($projectId: String!, $environmentId: String! $pluginId: String! $variables: Json!) {
+				upsertVariablesFromObject(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, variables: $variables)
+	  	}
+	`)
+	if err != nil {
+		return err
+	}
+
+	gqlReq.Var("projectId", req.ProjectID)
+	gqlReq.Var("environmentId", req.EnvironmentID)
+	gqlReq.Var("pluginId", req.PluginID)
+	gqlReq.Var("variables", req.Envs)
+
+	if err := gqlReq.Run(ctx, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *Gateway) DeleteVariable(ctx context.Context, req *entity.DeleteVariableRequest) error {
+	gqlReq, err := g.NewRequestWithAuth(`
+	  	mutation($projectId: String!, $environmentId: String! $pluginId: String! $variables: Json!) {
+				upsertVariablesFromObject(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, variables: $variables)
+	  	}
+	`)
+	if err != nil {
+		return err
+	}
+
+	gqlReq.Var("projectId", req.ProjectID)
+	gqlReq.Var("environmentId", req.EnvironmentID)
+	gqlReq.Var("pluginId", req.PluginID)
+	gqlReq.Var("name", req.Name)
+
+	if err := gqlReq.Run(ctx, nil); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Use updated variable schema methods and stop using depreated methods

- allEnvsForEnvironment -> decryptedVariables
- updateEnvsForPlugin -> upsertVariablesFromObject, deleteVariable

Setting variables now upserts instead of setting all the envs for the entire plugin. Deleting variables is done one at a time.

We also no longer need a seperate query for fetching the envs with a project token.

Depends on https://github.com/railwayapp/mono/pull/1384