### PR TITLE
CLI Project Order by Last Updated 

### DIFF
--- a/entity/project.go
+++ b/entity/project.go
@@ -29,6 +29,7 @@ type CreateProjectFromTemplateResult struct {
 type Project struct {
 	Id           string         `json:"id,omitempty"`
 	Name         string         `json:"name,omitempty"`
+	UpdatedAt    string         `json:"updatedAt,omitempty"`
 	Environments []*Environment `json:"environments,omitempty"`
 	Plugins      []*Plugin      `json:"plugins,omitempty"`
 	Team         *string        `json:"team,omitempty"`

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -107,7 +107,7 @@ func (g *Gateway) GetProjectByName(ctx context.Context, projectName string) (*en
 	}
 
 	projects := resp.Me.Projects
-	if (len(projects) == 0) {
+	if len(projects) == 0 {
 		return nil, errors.ProjectConfigNotFound
 	}
 
@@ -217,6 +217,7 @@ func (g *Gateway) DeleteProject(ctx context.Context, projectId string) error {
 func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 	projectFrag := `
 		id,
+		updatedAt,
 		name,
 		plugins {
 			id,

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -86,6 +87,10 @@ func PromptProjects(projects []*entity.Project) (*entity.Project, error) {
 			}
 		}
 	}
+
+	sort.Slice(filteredProjects, func(i int, j int) bool {
+		return filteredProjects[i].UpdatedAt > filteredProjects[j].UpdatedAt
+	})
 
 	i, _, err := selectCustom("Project", filteredProjects, func(index int) string {
 		return filteredProjects[index].Name


### PR DESCRIPTION
Projects should now return in a more convenient order. 🔢 

![image](https://user-images.githubusercontent.com/15745278/128273143-33570963-6794-485b-90b4-6006c918dd1b.png)
