### PR TITLE
Ability to Delete Project from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is the command line interface for [Railway](https://railway.app). Use it to
 
 [View the docs](https://docs.railway.app/cli)
 
+*We recommend using Brew for M1 Macs*
+
 ## Installation
 
 The Railway CLI is available through [Homebrew](https://brew.sh/), [NPM](https://www.npmjs.com/package/@railway/cli), or as a curl.
@@ -38,3 +40,4 @@ sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/cli/master/insta
 We would love to hear your feedback or suggestions. The best way to reach us is on [Discord](https://discord.gg/xAm2w6g).
 
 We also welcome pull requests into this repo. See [CONTRIBUTING.md](https://github.com/railwayapp/cli/blob/master/CONTRIBUTING.md) information on setting up this repo locally.
+

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -15,9 +15,7 @@ func (h *Handler) Delete(ctx context.Context, req *entity.CommandRequest) error 
 		arg := req.Args[0]
 
 		if uuid.IsValidUUID(arg) {
-			fmt.Printf("Looks good")
 			project, err := h.ctrl.GetProject(ctx, arg)
-			fmt.Printf(project.Id)
 			if err != nil {
 				return err
 			}
@@ -33,8 +31,6 @@ func (h *Handler) Delete(ctx context.Context, req *entity.CommandRequest) error 
 		return h.ctrl.DeleteProject(ctx, project.Id)
 	}
 
-	h.Unlink(ctx, req)
-
 	isLoggedIn, err := h.ctrl.IsLoggedIn(ctx)
 	if err != nil {
 		return err
@@ -49,7 +45,6 @@ func (h *Handler) Delete(ctx context.Context, req *entity.CommandRequest) error 
 }
 
 func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequest) error {
-	fmt.Printf("Looks good")
 	projects, err := h.ctrl.GetProjects(ctx)
 	if err != nil {
 		return err

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -76,14 +76,10 @@ func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequ
 		return nil
 	}
 	fmt.Printf("🔥 Deleting project %s\n", ui.MagentaText(name))
-
-	defer h.deleteById(ctx, project.Id)
-	{
-		if err := h.deleteById(ctx, project.Id); err != nil {
-			return err
-		}
+	err = h.deleteById(ctx, project.Id)
+	if err != nil {
+		return err
 	}
-
 	fmt.Printf("✅ Deleted project %s\n", ui.MagentaText(name))
 	return nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/railwayapp/cli/entity"
+	"github.com/railwayapp/cli/ui"
+	"github.com/railwayapp/cli/uuid"
+)
+
+func (h *Handler) Delete(ctx context.Context, req *entity.CommandRequest) error {
+	if len(req.Args) > 0 {
+		// projectID provided as argument
+		arg := req.Args[0]
+
+		if uuid.IsValidUUID(arg) {
+			project, err := h.ctrl.GetProject(ctx, arg)
+			if err != nil {
+				return err
+			}
+
+			return h.ctrl.DeleteProject(ctx, project.Id)
+		}
+
+		project, err := h.ctrl.GetProjectByName(ctx, arg)
+		if err != nil {
+			return err
+		}
+
+		return h.ctrl.DeleteProject(ctx, project.Id)
+	}
+
+	h.Unlink(ctx, req)
+
+	isLoggedIn, err := h.ctrl.IsLoggedIn(ctx)
+	if err != nil {
+		return err
+	}
+
+	if isLoggedIn {
+		return h.deleteFromAccount(ctx, req)
+	} else {
+		return h.deleteFromID(ctx, req)
+	}
+
+}
+
+func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequest) error {
+	projects, err := h.ctrl.GetProjects(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(projects) == 0 {
+		fmt.Printf("No Projects could be deleted.")
+		return nil
+	}
+
+	project, err := ui.PromptProjects(projects)
+	if err != nil {
+		return err
+	}
+	print("Looks good")
+
+	return h.ctrl.DeleteProject(ctx, project.Id)
+}
+
+func (h *Handler) deleteFromID(ctx context.Context, req *entity.CommandRequest) error {
+	projectID, err := ui.PromptText("Enter your project id")
+	if err != nil {
+		return err
+	}
+
+	project, err := h.ctrl.GetProject(ctx, projectID)
+	print("Looks good")
+
+	if err != nil {
+		return err
+	}
+
+	return h.ctrl.DeleteProject(ctx, project.Id)
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -101,11 +101,9 @@ func (h *Handler) deleteFromID(ctx context.Context, req *entity.CommandRequest) 
 		return err
 	}
 	fmt.Printf("🔥 Deleting project %s\n", ui.MagentaText(project.Name))
-	defer h.deleteById(ctx, project.Id)
-	{
-		if err := h.deleteById(ctx, project.Id); err != nil {
-			return err
-		}
+	err = h.deleteById(ctx, project.Id)
+	if err != nil {
+		return err
 	}
 	fmt.Printf("✅ Deleted project %s\n", ui.MagentaText(project.Name))
 	return nil

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -72,11 +72,13 @@ func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequ
 		return err
 	}
 	if project.Name != name {
-		fmt.Printf("You ust have mistyped the name, try again.")
+		fmt.Printf("The project name typed doesn't match the selected project to be deleted.")
 		return nil
 	}
 	fmt.Printf("🔥 Deleting project %s\n", ui.MagentaText(name))
-	return h.ctrl.DeleteProject(ctx, project.Id)
+	h.deleteById(ctx, project.Id)
+	fmt.Printf("✅ Deleted project %s\n", ui.MagentaText(name))
+	return nil
 }
 
 func (h *Handler) deleteFromID(ctx context.Context, req *entity.CommandRequest) error {
@@ -92,5 +94,15 @@ func (h *Handler) deleteFromID(ctx context.Context, req *entity.CommandRequest) 
 		return err
 	}
 	fmt.Printf("🔥 Deleting project %s\n", ui.MagentaText(project.Name))
-	return h.ctrl.DeleteProject(ctx, project.Id)
+	h.deleteById(ctx, project.Id)
+	fmt.Printf("✅ Deleted project %s\n", ui.MagentaText(project.Name))
+	return nil
+}
+
+func (h *Handler) deleteById(ctx context.Context, projectId string) error {
+	err := h.ctrl.DeleteProject(ctx, projectId)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -15,7 +15,9 @@ func (h *Handler) Delete(ctx context.Context, req *entity.CommandRequest) error 
 		arg := req.Args[0]
 
 		if uuid.IsValidUUID(arg) {
+			fmt.Printf("Looks good")
 			project, err := h.ctrl.GetProject(ctx, arg)
+			fmt.Printf(project.Id)
 			if err != nil {
 				return err
 			}
@@ -47,6 +49,7 @@ func (h *Handler) Delete(ctx context.Context, req *entity.CommandRequest) error 
 }
 
 func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequest) error {
+	fmt.Printf("Looks good")
 	projects, err := h.ctrl.GetProjects(ctx)
 	if err != nil {
 		return err
@@ -61,7 +64,6 @@ func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequ
 	if err != nil {
 		return err
 	}
-	print("Looks good")
 
 	return h.ctrl.DeleteProject(ctx, project.Id)
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -76,7 +76,14 @@ func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequ
 		return nil
 	}
 	fmt.Printf("🔥 Deleting project %s\n", ui.MagentaText(name))
-	h.deleteById(ctx, project.Id)
+
+	defer h.deleteById(ctx, project.Id)
+	{
+		if err := h.deleteById(ctx, project.Id); err != nil {
+			return err
+		}
+	}
+
 	fmt.Printf("✅ Deleted project %s\n", ui.MagentaText(name))
 	return nil
 }
@@ -94,7 +101,12 @@ func (h *Handler) deleteFromID(ctx context.Context, req *entity.CommandRequest) 
 		return err
 	}
 	fmt.Printf("🔥 Deleting project %s\n", ui.MagentaText(project.Name))
-	h.deleteById(ctx, project.Id)
+	defer h.deleteById(ctx, project.Id)
+	{
+		if err := h.deleteById(ctx, project.Id); err != nil {
+			return err
+		}
+	}
 	fmt.Printf("✅ Deleted project %s\n", ui.MagentaText(project.Name))
 	return nil
 }

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -59,7 +59,7 @@ func (h *Handler) deleteFromAccount(ctx context.Context, req *entity.CommandRequ
 	}
 
 	if len(projects) == 0 {
-		fmt.Printf("No Projects could be deleted.")
+		fmt.Printf("No Projects found.")
 		return nil
 	}
 
@@ -91,7 +91,6 @@ func (h *Handler) deleteFromID(ctx context.Context, req *entity.CommandRequest) 
 	}
 
 	project, err := h.ctrl.GetProject(ctx, projectID)
-	print("Looks good")
 
 	if err != nil {
 		return err

--- a/controller/project.go
+++ b/controller/project.go
@@ -64,3 +64,7 @@ func (c *Controller) GetLatestDeploymentForEnvironment(ctx context.Context, proj
 func (c *Controller) OpenStaticUrlInBrowser(staticUrl string) error {
 	return c.gtwy.OpenStaticUrlInBrowser(staticUrl)
 }
+
+func (c *Controller) DeleteProject(ctx context.Context, projectID string) error {
+	return c.gtwy.DeleteProject(ctx, projectID)
+}

--- a/entity/project.go
+++ b/entity/project.go
@@ -29,6 +29,7 @@ type CreateProjectFromTemplateResult struct {
 type Project struct {
 	Id           string         `json:"id,omitempty"`
 	Name         string         `json:"name,omitempty"`
+	UpdatedAt    string         `json:"updatedAt,omitempty"`
 	Environments []*Environment `json:"environments,omitempty"`
 	Plugins      []*Plugin      `json:"plugins,omitempty"`
 	Team         *string        `json:"team,omitempty"`

--- a/entity/user.go
+++ b/entity/user.go
@@ -1,7 +1,8 @@
 package entity
 
 type User struct {
-	Id    string `json:"id,omitempty"`
-	Name  string `json:"name,omitempty"`
-	Email string `json:"email,omitempty"`
+	Id     string `json:"id,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Email  string `json:"email,omitempty"`
+	Has2FA bool
 }

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -107,7 +107,7 @@ func (g *Gateway) GetProjectByName(ctx context.Context, projectName string) (*en
 	}
 
 	projects := resp.Me.Projects
-	if (len(projects) == 0) {
+	if len(projects) == 0 {
 		return nil, errors.ProjectConfigNotFound
 	}
 
@@ -217,6 +217,7 @@ func (g *Gateway) DeleteProject(ctx context.Context, projectId string) error {
 func (g *Gateway) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 	projectFrag := `
 		id,
+		updatedAt,
 		name,
 		plugins {
 			id,

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -196,7 +196,7 @@ func (g *Gateway) UpdateProject(ctx context.Context, req *entity.UpdateProjectRe
 
 func (g *Gateway) DeleteProject(ctx context.Context, projectId string) error {
 	gqlReq, err := g.NewRequestWithAuth(`
-		mutation($projectId: ID!) {
+		mutation($projectId: String!) {
 			deleteProject(projectId: $projectId)
 		}
 	`)

--- a/gateway/user.go
+++ b/gateway/user.go
@@ -12,7 +12,8 @@ func (g *Gateway) GetUser(ctx context.Context) (*entity.User, error) {
 			me {
 				id,
 				email,
-				name
+				name,
+				has2FA
 			}
 		}
 	`)

--- a/main.go
+++ b/main.go
@@ -107,6 +107,12 @@ func init() {
 	})
 
 	addRootCmd(&cobra.Command{
+		Use:   "delete",
+		Short: "Delete Project, may specify projectId as an argument",
+		RunE:  contextualize(handler.Delete, handler.Panic),
+	})
+
+	addRootCmd(&cobra.Command{
 		Use:        "disconnect",
 		RunE:       contextualize(handler.Unlink, handler.Panic),
 		Deprecated: "Please use 'railway unlink' instead", /**/

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -158,6 +158,19 @@ func PromptProjectName() (string, error) {
 	return prompt.Run()
 }
 
+func PromptConfirmProjectName() (string, error) {
+	prompt := promptui.Prompt{
+		Label: "Confirm project name",
+		Templates: &promptui.PromptTemplates{
+			Prompt:  "{{ . }} ",
+			Valid:   fmt.Sprintf("%s {{ . | bold }}: ", promptui.IconGood),
+			Invalid: fmt.Sprintf("%s {{ . | bold }}: ", promptui.IconBad),
+			Success: fmt.Sprintf("%s {{ . | magenta | bold }}: ", promptui.IconGood),
+		},
+	}
+	return prompt.Run()
+}
+
 // PromptGitHubScopes prompts the user to select one of the provides scopes
 func PromptGitHubScopes(scopes []string) (string, error) {
 	if len(scopes) == 1 {

--- a/ui/prompt.go
+++ b/ui/prompt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -86,6 +87,10 @@ func PromptProjects(projects []*entity.Project) (*entity.Project, error) {
 			}
 		}
 	}
+
+	sort.Slice(filteredProjects, func(i int, j int) bool {
+		return filteredProjects[i].UpdatedAt > filteredProjects[j].UpdatedAt
+	})
 
 	i, _, err := selectCustom("Project", filteredProjects, func(index int) string {
 		return filteredProjects[index].Name


### PR DESCRIPTION
Added `railway delete` 

If you provide a project uuid, it will delete the project directly- if you don't it will allow you to browse your account's projects to delete.

Help appreciated on improving the copy on error/success.

Thanks to @TaroballzChen for spearheading this improvement, all I did was debugging. 