### PR TITLE
Tag and Release on Merge to Master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Check version
-        run: echo "Version ${{ steps.vars.outputs.tag }}"
+        run: echo "Version ${{ github.event.client_payload.new-tag }}"
 
       - name: Use Node.js 12
         uses: actions/setup-node@v1
@@ -62,7 +62,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Bump NPM version
-        run: npm --no-git-tag-version --allow-same-version version ${{ steps.vars.outputs.tag }}
+        run: npm --no-git-tag-version --allow-same-version version ${{ github.event.client_payload.new-tag }}
 
       - name: NPM publish
         run: npm publish --access public
@@ -75,7 +75,7 @@ jobs:
           webhook: ${{ secrets.DEPLOY_WEBHOOK }}
           status: ${{ job.status }}
           title: "Published CLI"
-          description: "Published CLI version ${{ steps.vars.outputs.tag }} to Brew and NPM"
+          description: "Published CLI version ${{ github.event.client_payload.new-tag }} to Brew and NPM"
           nofail: false
           nodetail: false
           username: Github Actions

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,21 +8,19 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.PAT }}
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions-ecosystem/action-get-merged-pull-request@v1
         id: get-merged-pull-request
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ secrets.GH_PAT }}
 
       - uses: actions-ecosystem/action-release-label@v1
         id: release-label
         if: ${{ steps.get-merged-pull-request.outputs.title != null }}
         with:
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ secrets.GH_PAT }}
           labels: ${{ steps.get-merged-pull-request.outputs.labels }}
 
       - uses: actions-ecosystem/action-get-latest-tag@v1
@@ -54,7 +52,7 @@ jobs:
       - uses: peter-evans/repository-dispatch@v1
         if: ${{ steps.bump-semver.outputs.new_version != null }}
         with:
-          token: ${{ secrets.PAT }}
-          repository: ndneighbor/expressjs-postgres
+          token: ${{ secrets.GH_PAT }}
+          repository: railwayapp/cli
           event-type: publish-event
           client-payload: '{"new-tag": "${{ steps.bump-semver.outputs.new_version }}", "release-notes": "${{ steps.regex-match.outputs.group1 }}"}'


### PR DESCRIPTION
Added a new tagging workflow and a dispatch event to trigger a release.

Releases will only be triggered if there is a label applied to a PR. For more info see: https://github.com/marketplace/actions/actions-ecosystem-action-release-label#inputs

