### PR TITLE
Types of function parameters can be combined

### DIFF
--- a/controller/logs.go
+++ b/controller/logs.go
@@ -120,7 +120,7 @@ func (c *Controller) logsForState(ctx context.Context, req *entity.DeploymentLog
 	return nil
 }
 
-func hasTransitioned(prev *entity.Deployment, curr *entity.Deployment) bool {
+func hasTransitioned(prev, curr *entity.Deployment) bool {
 	return prev != nil && curr != nil && prev.Status != curr.Status
 }
 


### PR DESCRIPTION
func(projectID string, environmentID string) error could be replaced with func(projectID, environmentID string) error