### PR TITLE
Label Guardrails

### DIFF
--- a/.github/workflows/label-check
+++ b/.github/workflows/label-check
@@ -1,0 +1,14 @@
+name: Release Label Check
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  label-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: NathanielHill/check-pr-label-action@v4.0.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: "release/patch, release/minor, release/major"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15745278/138364048-7e81dddb-d481-4535-99d6-0a416d0efea2.png)

Added a Github Action where the Github Actions bot will suggest changes to the repo if a valid label isn't added to the PR. This will also require the team to increase the approval threshold from 1 approving review to 2. 

