### PR TITLE
Added arm in build for

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,11 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - 386
 
 brews:
   - tap:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,13 +8,14 @@ before:
 builds:
   - binary: railway
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     ldflags:
       - -s -w -X github.com/railwayapp/cli/constants.Version={{.Version}}
     goos:
       - linux
       - windows
       - darwin
+      - android
     goarch:
       - amd64
       - arm


### PR DESCRIPTION
Added arm in build for environment. It defaults to 386, amd64 and arm64. Thus, it wasn't able to work in arm devices.

