### PR TITLE
Fix archive/tar: write too long in up command

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -7,9 +7,13 @@ import (
 )
 
 func (h *Handler) Logs(ctx context.Context, req *entity.CommandRequest) error {
-	numLines, err := req.Cmd.Flags().GetInt32("lines")
-	if err != nil {
-		return err
+	numLines, linesErr := req.Cmd.Flags().GetInt32("lines")
+	if linesErr != nil {
+		return linesErr
 	}
-	return h.ctrl.GetActiveDeploymentLogs(ctx, numLines)
+	shouldDownload, shouldDownloadErr := req.Cmd.Flags().GetBool("download")
+	if shouldDownloadErr != nil {
+		return shouldDownloadErr
+	}
+	return h.ctrl.GetActiveDeploymentLogs(ctx, numLines, shouldDownload)
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -62,7 +62,7 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 
 	fmt.Printf("\n\n======= Build Completed ======\n\n")
 
-	err = h.ctrl.GetActiveDeploymentLogs(ctx, 1000)
+	err = h.ctrl.GetActiveDeploymentLogs(ctx, 1000, false)
 	if err != nil {
 		return err
 	}

--- a/controller/up.go
+++ b/controller/up.go
@@ -19,21 +19,30 @@ func compress(src string, buf io.Writer) error {
 	// tar > gzip > buf
 	zr := gzip.NewWriter(buf)
 	tw := tar.NewWriter(zr)
-
 	ignore, err := gitignore.CompileIgnoreFile(".gitignore")
 
 	if err != nil {
 		return err
 	}
 
+	if err != nil {
+		return err
+	}
+
 	// walk through every file in the folder
-	err = filepath.Walk(src, func(file string, fi os.FileInfo, passedErr error) error {
+	err = filepath.WalkDir(src, func(file string, de os.DirEntry, passedErr error) error {
 		if passedErr != nil {
 			return err
 		}
-		if fi.IsDir() {
+		if de.IsDir() {
 			return nil
 		}
+
+		fi, err := de.Info()
+		if err != nil {
+			return err
+		}
+
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 			// Skip symlinks
 			// TODO: Follow em and detect cycles
@@ -48,35 +57,39 @@ func compress(src string, buf io.Writer) error {
 			return nil
 		}
 
-		// generate tar header
+		// read file into a buffer to prevent tar overwrites
+		data := bytes.NewBuffer(nil)
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(data, f)
+		if err != nil {
+			return err
+		}
+
+		// generate tar headers
 		header, err := tar.FileInfoHeader(fi, file)
 		if err != nil {
 			return err
 		}
 
-		if err != nil {
-			return err
-		}
 		// must provide real name
 		// (see https://golang.org/src/archive/tar/common.go?#L626)
 		header.Name = filepath.ToSlash(file)
+
+		// size when we first observed the file
+		header.Size = int64(data.Len())
 
 		// write header
 		if err := tw.WriteHeader(header); err != nil {
 			return err
 		}
-		// if not a dir, write file content
-		if !fi.IsDir() {
-			data, err := os.Open(file)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(tw, data); err != nil {
-				return err
-			}
+		// not a dir, write file content
+		if _, err := io.Copy(tw, data); err != nil {
+			return err
 		}
-
-		return nil
+		return err
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -223,11 +223,13 @@ func init() {
 	upCmd.Flags().BoolP("detach", "d", false, "Detach from cloud build/deploy logs")
 	upCmd.Flags().StringP("environment", "e", "", "Specify an environment to up onto")
 
-	addRootCmd(&cobra.Command{
+	logsCmd := addRootCmd(&cobra.Command{
 		Use:   "logs",
 		Short: "View the most-recent deploy's logs",
 		RunE:  contextualize(handler.Logs, handler.Panic),
-	}).Flags().Int32P("lines", "n", 0, "Output a specific number of lines")
+	})
+	logsCmd.Flags().Int32P("lines", "n", 0, "Output a specific number of lines")
+	logsCmd.Flags().BoolP("download", "d", false, "Download logs to a local file")
 
 	addRootCmd(&cobra.Command{
 		Use:   "docs",


### PR DESCRIPTION
Now copy files into a buffer before streaming them through tar to prevent overwriting the tar stream.