### PR TITLE
run the release label check for forks

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,8 +1,9 @@
 name: Release Label Check
 
-# test
 on:
   pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,7 +1,8 @@
 name: Release Label Check
 
+# test
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,7 +1,7 @@
 name: Release Label Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:


### PR DESCRIPTION
Use the `pull_request_target` event so the action will work with forks.

Described here https://github.com/jesusvasquez333/verify-pr-label-action#note-when-working-with-forks
