### PR TITLE
Only use the pull-request-target event

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,8 +1,6 @@
 name: Release Label Check
 
 on:
-  pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 


### PR DESCRIPTION
So we don't end up with multiple actions run

![image](https://user-images.githubusercontent.com/3044853/148125296-8bd60986-36a6-4b7d-a8f0-916ccac31df0.png)
