### PR TITLE
Remove a deprecated function

### DIFF
--- a/controller/up.go
+++ b/controller/up.go
@@ -45,7 +45,7 @@ func compress(src string, buf io.Writer) error {
 			return nil
 		}
 
-		if strings.HasPrefix(file, ".git") || strings.HasPrefix(file, "node_modules") {
+		if strings.Match(file, ".git") || strings.Match(file, "node_modules") {
 			return nil
 		}
 


### PR DESCRIPTION
replaced .HasPrefix (https://pkg.go.dev/path/filepath#HasPrefix) with .Match (https://pkg.go.dev/path/filepath#Match)