### PR TITLE
Add ignore file

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"time"
 
 	"github.com/railwayapp/cli/entity"
@@ -41,6 +42,11 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 	service, err := ui.PromptServices(project.Services)
 	if err != nil {
 		return err
+	}
+
+	_, err = ioutil.ReadFile(".railwayignore")
+	if err == nil {
+		fmt.Print(ui.AlertInfo("Using ignore file .railwayignore"))
 	}
 
 	ui.StartSpinner(&ui.SpinnerCfg{

--- a/controller/up.go
+++ b/controller/up.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/railwayapp/cli/entity"
 	gitignore "github.com/railwayapp/cli/gateway"
@@ -23,6 +22,15 @@ func compress(src string, buf io.Writer) error {
 
 	if err != nil {
 		return err
+	}
+
+	rwIgnore, err := gitignore.CompileIgnoreFile(".railwayignore")
+
+	if err != nil {
+		rwIgnore, err = gitignore.CompileIgnoreLines(".git/", "node_modules/")
+		if err != nil {
+			return err
+		}
 	}
 
 	// walk through every file in the folder
@@ -45,11 +53,7 @@ func compress(src string, buf io.Writer) error {
 			return nil
 		}
 
-		if strings.HasPrefix(file, ".git") || strings.HasPrefix(file, "node_modules") {
-			return nil
-		}
-
-		if ignore.MatchesPath(file) {
+		if rwIgnore.MatchesPath(file) || ignore.MatchesPath(file) {
 			return nil
 		}
 


### PR DESCRIPTION
Closes #181

This adds support for a .railwayignore file as suggested in #181. If this file is found in the current directory, the CLI will print out `Using ignore file .railwayignore` and use it in addition to `.gitignore` (using the same gitignore parser). If the file isn't found, then it will fall back to using `node_modules/` and `.git/` (the current functionality).