### PR TITLE
Remove comment step and just fail CI

### DIFF
--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -13,4 +13,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: "release/patch, release/minor, release/major"
           pull-request-number: '${{ github.event.pull_request.number }}'
-          disable-reviews: true
+          disable-reviews: 'true'

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -13,4 +13,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: "release/patch, release/minor, release/major"
           pull-request-number: '${{ github.event.pull_request.number }}'
-          disable-reviews: 'true'
+          disable-reviews: true

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -13,3 +13,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: "release/patch, release/minor, release/major"
           pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: true


### PR DESCRIPTION
To prevent the bot from commenting and flooding our Discord, just have the exit code returned vs commenting