### PR TITLE
Verbose mode for `railway up`

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -60,7 +60,7 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 
 	_, err = ioutil.ReadFile(".railwayignore")
 	if err == nil {
-		fmt.Print(ui.AlertInfo("Using ignore file .railwayignore"))
+		fmt.Print(ui.AlertVerbose(isVerbose, "Using ignore file .railwayignore"))
 	}
 
 	ui.StartSpinner(&ui.SpinnerCfg{

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,11 +18,22 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 		src = "./" + req.Args[0]
 	}
 
+	isVerbose, err := req.Cmd.Flags().GetBool("verbose")
+
+	if err != nil {
+		// Verbose mode isn't a necessary flag; just default to false.
+		isVerbose = false
+	}
+
+	fmt.Print(ui.AlertVerbose(isVerbose, "Using verbose mode"))
+
+	fmt.Print(ui.AlertVerbose(isVerbose, "Loading project configuration"))
 	projectConfig, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}
 
+	fmt.Print(ui.AlertVerbose(isVerbose, "Loading environment"))
 	environmentName, err := req.Cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
@@ -32,12 +43,15 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 	if err != nil {
 		return err
 	}
+	fmt.Print(ui.AlertVerbose(isVerbose, fmt.Sprintf("Using environment %s", ui.Bold(environment.Name))))
 
+	fmt.Print(ui.AlertVerbose(isVerbose, "Loading project"))
 	project, err := h.ctrl.GetProject(ctx, projectConfig.Project)
 	if err != nil {
 		return err
 	}
 
+	fmt.Print(ui.AlertVerbose(isVerbose, "Loading services"))
 	service, err := ui.PromptServices(project.Services)
 	if err != nil {
 		return err

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -26,15 +26,15 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 		isVerbose = false
 	}
 
-	fmt.Print(ui.AlertVerbose(isVerbose, "Using verbose mode"))
+	fmt.Print(ui.VerboseInfo(isVerbose, "Using verbose mode"))
 
-	fmt.Print(ui.AlertVerbose(isVerbose, "Loading project configuration"))
+	fmt.Print(ui.VerboseInfo(isVerbose, "Loading project configuration"))
 	projectConfig, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}
 
-	fmt.Print(ui.AlertVerbose(isVerbose, "Loading environment"))
+	fmt.Print(ui.VerboseInfo(isVerbose, "Loading environment"))
 	environmentName, err := req.Cmd.Flags().GetString("environment")
 	if err != nil {
 		return err
@@ -44,15 +44,15 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 	if err != nil {
 		return err
 	}
-	fmt.Print(ui.AlertVerbose(isVerbose, fmt.Sprintf("Using environment %s", ui.Bold(environment.Name))))
+	fmt.Print(ui.VerboseInfo(isVerbose, fmt.Sprintf("Using environment %s", ui.Bold(environment.Name))))
 
-	fmt.Print(ui.AlertVerbose(isVerbose, "Loading project"))
+	fmt.Print(ui.VerboseInfo(isVerbose, "Loading project"))
 	project, err := h.ctrl.GetProject(ctx, projectConfig.Project)
 	if err != nil {
 		return err
 	}
 
-	fmt.Print(ui.AlertVerbose(isVerbose, "Loading services"))
+	fmt.Print(ui.VerboseInfo(isVerbose, "Loading services"))
 	service, err := ui.PromptServices(project.Services)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 
 	_, err = ioutil.ReadFile(".railwayignore")
 	if err == nil {
-		fmt.Print(ui.AlertVerbose(isVerbose, "Using ignore file .railwayignore"))
+		fmt.Print(ui.VerboseInfo(isVerbose, "Using ignore file .railwayignore"))
 	}
 
 	ui.StartSpinner(&ui.SpinnerCfg{

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func init() {
 	// Initializes all commands
 	handler := cmd.New()
 
-	rootCmd.PersistentFlags().Bool("verbose", false, "--verbose")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Print verbose output")
 
 	loginCmd := addRootCmd(&cobra.Command{
 		Use:   "login",

--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ func init() {
 	// Initializes all commands
 	handler := cmd.New()
 
+	rootCmd.PersistentFlags().Bool("verbose", false, "--verbose")
+
 	loginCmd := addRootCmd(&cobra.Command{
 		Use:   "login",
 		Short: "Login to your Railway account",

--- a/ui/text.go
+++ b/ui/text.go
@@ -63,7 +63,7 @@ func AlertInfo(text string) string {
 	return _aurora.Sprintf(GrayText(Bold("💁 %s\n").String()), text)
 }
 
-func AlertVerbose(isVerbose bool, text string) string {
+func VerboseInfo(isVerbose bool, text string) string {
 	if isVerbose {
 		return _aurora.Sprintf(MagentaText("💁 %s\n"), text)
 	} else {

--- a/ui/text.go
+++ b/ui/text.go
@@ -2,10 +2,11 @@ package ui
 
 import (
 	"fmt"
-	_aurora "github.com/logrusorgru/aurora"
 	"math"
 	"sort"
 	"strings"
+
+	_aurora "github.com/logrusorgru/aurora"
 )
 
 var aurora = _aurora.NewAurora(true)
@@ -60,6 +61,14 @@ func AlertWarning(text string) string {
 
 func AlertInfo(text string) string {
 	return _aurora.Sprintf(GrayText(Bold("💁 %s\n").String()), text)
+}
+
+func AlertVerbose(isVerbose bool, text string) string {
+	if isVerbose {
+		return _aurora.Sprintf(MagentaText("💁 %s\n"), text)
+	} else {
+		return ""
+	}
 }
 
 func Truncate(text string, maxLength int) string {


### PR DESCRIPTION
Closes #120 

This PR adds a `--verbose` flag to the CLI. Currently, only `up` uses it, but it could be used by other commands as well.

The output from #187 would probably be counted as verbose.

Example output:
```
❯ railway up --verbose
💁 Using verbose mode
💁 Loading project configuration
💁 Loading environment
💁 Using environment production
💁 Loading project
💁 Loading services
☁️ Build logs available at https://railway.app/...

==========================
Using Buildpacks!
==========================

...