### PR TITLE
Support alternate Dockerfile for `run`

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -146,7 +146,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 	return nil
 }
 
-func (h *Handler) runInDocker(ctx context.Context, pwd string, dockerfile string, envs *entity.Envs) error {
+func (h *Handler) runInDocker(ctx context.Context, pwd, dockerfile string, envs *entity.Envs) error {
 	// Start building the image
 	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,7 +41,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 	}
 
 	dockerfileRegex, err := regexp.Compile("--dockerfile=(.*)")
-	dockerfile := "Dockerfile.dev"
+	dockerfile := "Dockerfile"
 	if err != nil {
 		return err
 	}
@@ -102,10 +102,6 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 	hasDockerfile := true
 
 	if _, err := os.Stat(fmt.Sprintf("%s/%s", pwd, dockerfile)); os.IsNotExist(err) {
-		dockerfile = "Dockerfile"
-	}
-
-	if _, err := os.Stat(fmt.Sprintf("%s/Dockerfile", pwd)); os.IsNotExist(err) {
 		hasDockerfile = false
 	}
 


### PR DESCRIPTION
Closes #164

This PR adds support for an alternate Dockerfile (`Dockerfile.dev`) to `railway run`. If `Dockerfile.dev` is found, it will use that; otherwise, it will fall back to `Dockerfile`.