### PR TITLE
Add git metadata to deployments with `railway up`

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -67,20 +67,17 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 	fmt.Print(ui.VerboseInfo(isVerbose, "Getting Git information"))
 	gitInfo, err := git.GetAllMetadata(src)
 
-	if !gitInfo.IsRepo {
+	if !gitInfo.IsRepo || err != nil {
 		fmt.Print(ui.VerboseInfo(isVerbose, "No Git repository found"))
-		fmt.Print(err)
 	}
-	{
-		fmt.Print(ui.VerboseInfo(isVerbose, fmt.Sprintf(`Git information:
-   Repository name: %s
-   Branch: %s
-   Latest commit:
-	   Hash: %s
-	   Message: %s
-	   Author: %s
-		`, gitInfo.RepoName, gitInfo.Branch, gitInfo.Commit.Hash, gitInfo.Commit.Message, gitInfo.Commit.Author)))
-	}
+	fmt.Print(ui.VerboseInfo(isVerbose, fmt.Sprintf(`Git information:
+	Repository name: %s
+	Branch: %s
+	Latest commit:
+		Hash: %s
+		Message: %s
+		Author: %s
+	`, gitInfo.RepoName, gitInfo.Branch, gitInfo.Commit.Hash, gitInfo.Commit.Message, gitInfo.Commit.Author)))
 
 	ui.StartSpinner(&ui.SpinnerCfg{
 		Message: "Laying tracks in the clouds...",

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/railwayapp/cli/entity"
+	"github.com/railwayapp/cli/lib/git"
 	"github.com/railwayapp/cli/ui"
 )
 
@@ -63,6 +64,24 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 		fmt.Print(ui.VerboseInfo(isVerbose, "Using ignore file .railwayignore"))
 	}
 
+	fmt.Print(ui.VerboseInfo(isVerbose, "Getting Git information"))
+	gitInfo, err := git.GetAllMetadata(src)
+
+	if !gitInfo.IsRepo {
+		fmt.Print(ui.VerboseInfo(isVerbose, "No Git repository found"))
+		fmt.Print(err)
+	}
+	{
+		fmt.Print(ui.VerboseInfo(isVerbose, fmt.Sprintf(`Git information:
+   Repository name: %s
+   Branch: %s
+   Latest commit:
+	   Hash: %s
+	   Message: %s
+	   Author: %s
+		`, gitInfo.RepoName, gitInfo.Branch, gitInfo.Commit.Hash, gitInfo.Commit.Message, gitInfo.Commit.Author)))
+	}
+
 	ui.StartSpinner(&ui.SpinnerCfg{
 		Message: "Laying tracks in the clouds...",
 	})
@@ -71,6 +90,7 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 		EnvironmentID: environment.Id,
 		ServiceID:     service.ID,
 		RootDir:       src,
+		GitInfo:       gitInfo,
 	})
 	if err != nil {
 		return err

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/railwayapp/cli/entity"
-	"github.com/railwayapp/cli/lib/git"
 	CLIErrors "github.com/railwayapp/cli/errors"
+	"github.com/railwayapp/cli/lib/git"
 	"github.com/railwayapp/cli/ui"
 )
 
@@ -106,12 +106,18 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 	ui.StartSpinner(&ui.SpinnerCfg{
 		Message: "Laying tracks in the clouds...",
 	})
+
+	gitInfoRef := &gitInfo
+	if gitInfo.HasLocalChanges {
+		gitInfoRef = nil
+	}
+
 	res, err := h.ctrl.Upload(ctx, &entity.UploadRequest{
 		ProjectID:     projectConfig.Project,
 		EnvironmentID: environment.Id,
 		ServiceID:     serviceId,
 		RootDir:       src,
-		GitInfo:       gitInfo,
+		GitInfo:       gitInfoRef,
 	})
 	if err != nil {
 		ui.StopSpinner("")

--- a/controller/up.go
+++ b/controller/up.go
@@ -118,6 +118,7 @@ func (c *Controller) Upload(ctx context.Context, req *entity.UploadRequest) (*en
 		ProjectID:     req.ProjectID,
 		EnvironmentID: req.EnvironmentID,
 		ServiceID:     req.ServiceID,
+		GitInfo:       req.GitInfo,
 	})
 	if err != nil {
 		return nil, err

--- a/entity/up.go
+++ b/entity/up.go
@@ -11,7 +11,7 @@ type UploadRequest struct {
 	EnvironmentID string
 	ServiceID     string
 	RootDir       string
-	GitInfo       git.GitMetadata
+	GitInfo       *git.GitMetadata
 }
 
 type UpRequest struct {
@@ -19,7 +19,7 @@ type UpRequest struct {
 	ProjectID     string
 	EnvironmentID string
 	ServiceID     string
-	GitInfo       git.GitMetadata
+	GitInfo       *git.GitMetadata
 }
 
 type UpResponse struct {

--- a/entity/up.go
+++ b/entity/up.go
@@ -1,12 +1,17 @@
 package entity
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/railwayapp/cli/lib/git"
+)
 
 type UploadRequest struct {
 	ProjectID     string
 	EnvironmentID string
 	ServiceID     string
 	RootDir       string
+	GitInfo       git.GitMetadata
 }
 
 type UpRequest struct {
@@ -14,6 +19,7 @@ type UpRequest struct {
 	ProjectID     string
 	EnvironmentID string
 	ServiceID     string
+	GitInfo       git.GitMetadata
 }
 
 type UpResponse struct {

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -40,7 +40,7 @@ func IsRepo(path string) bool {
 }
 
 func RepoName(path string) (string, error) {
-	remoteRegex := `(?:(?:.*?\@(?:.*?\.)+\:)|(?:https\:\/\/.*?\..*?\/))(?P<User>.*?)\/(?P<Repo>.*?)\.git`
+	remoteRegex := `(?:(?:.*\:)|(?:https\:\/\/.*?\..*?\/))(?P<User>.*?)\/(?P<Repo>.*?)\.git`
 	remotes, err := execGit(path, "remote")
 	useRemotes := true
 	if err != nil || strings.Trim(string(remotes), " \n") == "" {

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -40,7 +40,7 @@ func IsRepo(path string) bool {
 }
 
 func RepoName(path string) (string, error) {
-	remoteRegex := `(?:(?:.*\:)|(?:https\:\/\/.*?\..*?\/))(?P<User>.*?)\/(?P<Repo>.*?)\.git`
+	remoteRegex := `(?:(?:.*\@.*?\:)|(?:https\:\/\/.*?\..*?\/))(?P<Repo>.*?)\.git`
 	remotes, err := execGit(path, "remote")
 	useRemotes := true
 	if err != nil || strings.Trim(string(remotes), " \n") == "" {
@@ -61,7 +61,7 @@ func RepoName(path string) (string, error) {
 				if len(match) == 0 {
 					break
 				}
-				return match["User"] + "/" + match["Repo"], nil
+				return match["Repo"], nil
 			}
 		}
 	}

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -40,7 +40,7 @@ func IsRepo(path string) bool {
 }
 
 func RepoName(path string) (string, error) {
-	remoteRegex := `(?:(?:.*?\@.*?\..*?\:)|(?:https\:\/\/.*?\..*?\/))(?P<User>.*?)\/(?P<Repo>.*?)\.git`
+	remoteRegex := `(?:(?:.*?\@(?:.*?\.)+\:)|(?:https\:\/\/.*?\..*?\/))(?P<User>.*?)\/(?P<Repo>.*?)\.git`
 	remotes, err := execGit(path, "remote")
 	useRemotes := true
 	if err != nil || strings.Trim(string(remotes), " \n") == "" {

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -58,6 +58,9 @@ func RepoName(path string) (string, error) {
 					remoteUrl += ".git"
 				}
 				match := getParams(remoteRegex, remoteUrl)
+				if len(match) == 0 {
+					break
+				}
 				return match["User"] + "/" + match["Repo"], nil
 			}
 		}
@@ -72,7 +75,7 @@ func RepoName(path string) (string, error) {
 
 func GetBranch(path string) (string, error) {
 	branch, err := execGit(path, "branch", "--show-current")
-	return string(branch), err
+	return strings.Trim(string(branch), " \n"), err
 }
 
 func GetCommit(path string) (CommitInfo, error) {
@@ -90,7 +93,7 @@ func GetCommit(path string) (CommitInfo, error) {
 	}
 	return CommitInfo{
 		Hash:    string(hash),
-		Message: string(message),
+		Message: strings.Trim(string(message), " \n"),
 		Author:  string(author),
 	}, nil
 }

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -1,0 +1,120 @@
+package git
+
+import (
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+/**
+ * Parses url with the given regular expression and returns the
+ * group values defined in the expression.
+ * https://stackoverflow.com/a/39635221
+ */
+func getParams(regEx, test string) (paramsMap map[string]string) {
+
+	var compRegEx = regexp.MustCompile(regEx)
+	match := compRegEx.FindStringSubmatch(test)
+
+	paramsMap = make(map[string]string)
+	for i, name := range compRegEx.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			paramsMap[name] = match[i]
+		}
+	}
+	return paramsMap
+}
+
+func execGit(path string, cmd ...string) ([]byte, error) {
+	args := []string{}
+	args = append(args, "-C", path)
+	args = append(args, cmd...)
+	gitCmd := exec.Command("git", args...)
+	return gitCmd.Output()
+}
+
+func IsRepo(path string) bool {
+	_, err := execGit(path, "status")
+	return err == nil
+}
+
+func RepoName(path string) (string, error) {
+	remoteRegex := `(?:(?:.*?\@.*?\..*?\:)|(?:https\:\/\/.*?\..*?\/))(?P<User>.*?)\/(?P<Repo>.*?)\.git`
+	remotes, err := execGit(path, "remote")
+	useRemotes := true
+	if err != nil || strings.Trim(string(remotes), " \n") == "" {
+		useRemotes = false
+	}
+	if useRemotes {
+		for _, remote := range strings.Split(string(remotes), "\n") {
+			if remote == "origin" {
+				remoteUrlBytes, err := execGit(path, "remote", "get-url", remote)
+				if err != nil {
+					break
+				}
+				remoteUrl := strings.Trim(string(remoteUrlBytes), " \n")
+				if !strings.HasSuffix(string(remoteUrl), ".git") {
+					remoteUrl += ".git"
+				}
+				match := getParams(remoteRegex, remoteUrl)
+				return match["User"] + "/" + match["Repo"], nil
+			}
+		}
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	base := filepath.Base(abs)
+	return base, nil
+}
+
+func GetBranch(path string) (string, error) {
+	branch, err := execGit(path, "branch", "--show-current")
+	return string(branch), err
+}
+
+func GetCommit(path string) (CommitInfo, error) {
+	hash, err := execGit(path, "log", "-1", "--format=format:%h")
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	message, err := execGit(path, "log", "-1", `--format=format:%s%n%b`)
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	author, err := execGit(path, "log", "-1", "--format=format:%an <%ae>")
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	return CommitInfo{
+		Hash:    string(hash),
+		Message: string(message),
+		Author:  string(author),
+	}, nil
+}
+
+func GetAllMetadata(path string) (GitMetadata, error) {
+	name, err := RepoName(path)
+	if err != nil {
+		return GitMetadata{IsRepo: false}, err
+	}
+
+	branch, err := GetBranch(path)
+	if err != nil {
+		return GitMetadata{IsRepo: false}, err
+	}
+
+	commit, err := GetCommit(path)
+	if err != nil {
+		return GitMetadata{IsRepo: false}, err
+	}
+
+	return GitMetadata{
+		IsRepo:   IsRepo(path),
+		RepoName: name,
+		Branch:   branch,
+		Commit:   commit,
+	}, nil
+}

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -98,6 +98,15 @@ func GetCommit(path string) (CommitInfo, error) {
 	}, nil
 }
 
+func HasLocalChanges(path string) (bool, error) {
+	output, err := execGit(path, "status")
+	if err != nil {
+		return false, err
+	}
+
+	return !strings.Contains(string(output), "working tree clean"), nil
+}
+
 func GetAllMetadata(path string) (GitMetadata, error) {
 	name, err := RepoName(path)
 	if err != nil {
@@ -114,10 +123,16 @@ func GetAllMetadata(path string) (GitMetadata, error) {
 		return GitMetadata{IsRepo: false}, err
 	}
 
+	localChanges, err := HasLocalChanges(path)
+	if err != nil {
+		return GitMetadata{IsRepo: false}, err
+	}
+
 	return GitMetadata{
-		IsRepo:   IsRepo(path),
-		RepoName: name,
-		Branch:   branch,
-		Commit:   commit,
+		IsRepo:          IsRepo(path),
+		RepoName:        name,
+		Branch:          branch,
+		Commit:          commit,
+		HasLocalChanges: localChanges,
 	}, nil
 }

--- a/lib/git/metadata.go
+++ b/lib/git/metadata.go
@@ -1,0 +1,13 @@
+package git
+
+type CommitInfo struct {
+	Hash    string
+	Message string
+	Author  string
+}
+type GitMetadata struct {
+	IsRepo   bool
+	RepoName string
+	Branch   string
+	Commit   CommitInfo
+}

--- a/lib/git/metadata.go
+++ b/lib/git/metadata.go
@@ -6,8 +6,9 @@ type CommitInfo struct {
 	Author  string
 }
 type GitMetadata struct {
-	IsRepo   bool
-	RepoName string
-	Branch   string
-	Commit   CommitInfo
+	IsRepo          bool
+	RepoName        string
+	Branch          string
+	Commit          CommitInfo
+	HasLocalChanges bool
 }


### PR DESCRIPTION
Closes #178 (at least, it should)

This PR will add git metadata to deployments with `railway up` when deploying a directory with a git repository.