### PR TITLE
controller/up: properly handle nested ignore files

### DIFF
--- a/controller/up.go
+++ b/controller/up.go
@@ -32,7 +32,7 @@ type ignoreFile struct {
 }
 
 func scanIgnoreFiles(src string) ([]ignoreFile, error) {
-	ret := []ignoreFile{}
+	ignoreFiles := []ignoreFile{}
 
 	if err := filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -62,7 +62,7 @@ func scanIgnoreFiles(src string) ([]ignoreFile, error) {
 				prefix = "" // Handle root dir properly.
 			}
 
-			ret = append(ret, ignoreFile{
+			ignoreFiles = append(ignoreFiles, ignoreFile{
 				prefix: prefix,
 				ignore: igf,
 			})
@@ -73,7 +73,7 @@ func scanIgnoreFiles(src string) ([]ignoreFile, error) {
 		return nil, err
 	}
 
-	return ret, nil
+	return ignoreFiles, nil
 }
 
 func compress(src string, buf io.Writer) error {
@@ -136,7 +136,9 @@ func compress(src string, buf io.Writer) error {
 		}
 
 		// close the file to avoid hitting fd limit
-		_ = f.Close()
+		if err := f.Close(); err != nil {
+			return err
+		}
 
 		// generate tar headers
 		header, err := tar.FileInfoHeader(fi, ln)

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/google/uuid v1.2.0 // indirect
-	github.com/joho/godotenv v1.4.0 // indirect
+	github.com/google/uuid v1.2.0
+	github.com/joho/godotenv v1.4.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.3 // indirect
@@ -26,7 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.61.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
Previously, we'd only consider top level ignore files (.gitignore,
.railwayignore), which led to some problems when doing `railway up`
in a monorepo environment.

For example,
```
mg@mbp operand % railway up
🚄 Laying tracks in the clouds... open web/node_modules/core-js-pure/actual/typed-array/reverse.js: too many open files
```

To fix this, we do a pre-scan to find all the relevant ignore
files in the project first, then apply them as necessary.

Some additional cleanup / fixes as well (e.g., closing files, etc).