### PR TITLE
Fix run command's environment flag

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -48,7 +48,7 @@ func (h *Handler) Connect(ctx context.Context, req *entity.CommandRequest) error
 	if !isPluginValid(plugin) {
 		return fmt.Errorf("Invalid plugin: %s", plugin)
 	}
-	envs, err := h.ctrl.GetEnvs(ctx)
+	envs, err := h.ctrl.GetEnvsForCurrentEnvironment(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,7 +92,7 @@ func (h *Handler) Run(ctx context.Context, req *entity.CommandRequest) error {
 		}
 		fmt.Println("Done!")
 	}
-	envs, err := h.ctrl.GetEnvsForService(ctx, targetServiceName)
+	envs, err := h.ctrl.GetEnvs(ctx, environment, targetServiceName)
 
 	if err != nil {
 		return err

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -17,7 +17,7 @@ func (h *Handler) Shell(ctx context.Context, req *entity.CommandRequest) error {
 		return err
 	}
 
-	envs, err := h.ctrl.GetEnvsForService(ctx, &serviceName)
+	envs, err := h.ctrl.GetEnvsForCurrentEnvironment(ctx, &serviceName)
 	if err != nil {
 		return err
 	}

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -17,7 +17,7 @@ func (h *Handler) Variables(ctx context.Context, req *entity.CommandRequest) err
 		return err
 	}
 
-	envs, err := h.ctrl.GetEnvsForService(ctx, &serviceName)
+	envs, err := h.ctrl.GetEnvsForCurrentEnvironment(ctx, &serviceName)
 	if err != nil {
 		return err
 	}
@@ -39,7 +39,7 @@ func (h *Handler) VariablesGet(ctx context.Context, req *entity.CommandRequest) 
 		return err
 	}
 
-	envs, err := h.ctrl.GetEnvsForService(ctx, &serviceName)
+	envs, err := h.ctrl.GetEnvsForCurrentEnvironment(ctx, &serviceName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The run command wasn't using the `--environment=<ENV>` properly when fetching variables. This PR fixes that.