### PR TITLE
Disable colors if no TTY detected

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,8 @@ require (
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.3 // indirect
 	github.com/manifoldco/promptui v0.7.0
-	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/mattn/go-colorable v0.1.7
+	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4

--- a/ui/spinner.go
+++ b/ui/spinner.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -10,8 +11,6 @@ import (
 type TrainSpinner []string
 
 var (
-	TrainRight  TrainSpinner = []string{"🚅", "🚅🚋", "🚅🚋🚋", "🚅🚋🚋🚋", "🚅🚋🚋🚋🚋", "🚅🚋🚋🚋🚋🚋", "🚅🚋🚋🚋🚋🚋🚋", "🚅🚋🚋🚋🚋🚋🚋🚋", "🚅🚋🚋🚋🚋🚋🚋🚋🚋"}
-	TrainLeft   TrainSpinner = []string{"       🚅", "      🚅🚋", "     🚅🚋🚋", "    🚅🚋🚋🚋", "   🚅🚋🚋🚋🚋", "  🚅🚋🚋🚋🚋🚋", " 🚅🚋🚋🚋🚋🚋🚋", " 🚅🚋🚋🚋🚋🚋🚋🚋", "🚅🚋🚋🚋🚋🚋🚋🚋🚋"}
 	TrainEmojis TrainSpinner = []string{"🚝", "🚅", "🚄", "🚇", "🚞", "🚈", "🚉", "🚂", "🚃", "🚊", "🚋"}
 )
 
@@ -27,6 +26,11 @@ type SpinnerCfg struct {
 var s = &spinner.Spinner{}
 
 func StartSpinner(cfg *SpinnerCfg) {
+	if !SupportsANSICodes() {
+		fmt.Println(cfg.Message)
+		return
+	}
+
 	if cfg.Tokens == nil {
 		cfg.Tokens = TrainEmojis
 	}

--- a/ui/text.go
+++ b/ui/text.go
@@ -2,7 +2,9 @@ package ui
 
 import (
 	"fmt"
+	"github.com/mattn/go-isatty"
 	"math"
+	"os"
 	"sort"
 	"strings"
 
@@ -10,6 +12,13 @@ import (
 )
 
 var aurora = _aurora.NewAurora(true)
+
+func init() {
+	// Disable colors if no TTY detected
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		DisableTextStyles()
+	}
+}
 
 func DisableTextStyles() {
 	aurora = _aurora.NewAurora(false)

--- a/ui/text.go
+++ b/ui/text.go
@@ -11,17 +11,12 @@ import (
 	_aurora "github.com/logrusorgru/aurora"
 )
 
-var aurora = _aurora.NewAurora(true)
+var aurora _aurora.Aurora
 
 func init() {
-	// Disable colors if no TTY detected
-	if !isatty.IsTerminal(os.Stdout.Fd()) {
-		DisableTextStyles()
-	}
-}
-
-func DisableTextStyles() {
-	aurora = _aurora.NewAurora(false)
+	// Disable colors automatically if no TTY detected
+	enableColors := isatty.IsTerminal(os.Stdout.Fd())
+	aurora = _aurora.NewAurora(enableColors)
 }
 
 func Bold(payload string) _aurora.Value {

--- a/ui/text.go
+++ b/ui/text.go
@@ -2,9 +2,7 @@ package ui
 
 import (
 	"fmt"
-	"github.com/mattn/go-isatty"
 	"math"
-	"os"
 	"sort"
 	"strings"
 
@@ -15,7 +13,7 @@ var aurora _aurora.Aurora
 
 func init() {
 	// Disable colors automatically if no TTY detected
-	enableColors := isatty.IsTerminal(os.Stdout.Fd())
+	enableColors := SupportsANSICodes()
 	aurora = _aurora.NewAurora(enableColors)
 }
 

--- a/ui/text_test.go
+++ b/ui/text_test.go
@@ -199,7 +199,6 @@ var prefixTest = []struct {
 }
 
 func TestKeyValues(t *testing.T) {
-	ui.DisableTextStyles()
 	for _, tt := range keyValuesTest {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.out, ui.KeyValues(tt.in))
@@ -208,7 +207,6 @@ func TestKeyValues(t *testing.T) {
 }
 
 func TestUnorderedList(t *testing.T) {
-	ui.DisableTextStyles()
 	for _, tt := range unorderedListTest {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.out, ui.UnorderedList(tt.in))
@@ -217,7 +215,6 @@ func TestUnorderedList(t *testing.T) {
 }
 
 func TestOrderedList(t *testing.T) {
-	ui.DisableTextStyles()
 	for _, tt := range orderedListTest {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.out, ui.OrderedList(tt.in))
@@ -226,7 +223,6 @@ func TestOrderedList(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
-	ui.DisableTextStyles()
 	for _, tt := range truncateTest {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.out, ui.Truncate(tt.inStr, tt.inLen))
@@ -235,7 +231,6 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestParagraph(t *testing.T) {
-	ui.DisableTextStyles()
 	for _, tt := range paragraphTest {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.out, ui.Paragraph(tt.in))
@@ -244,7 +239,6 @@ func TestParagraph(t *testing.T) {
 }
 
 func TestPrefixLines(t *testing.T) {
-	ui.DisableTextStyles()
 	for _, tt := range prefixTest {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.out, ui.PrefixLines(tt.inStr, tt.inPrefix))

--- a/ui/tty.go
+++ b/ui/tty.go
@@ -1,0 +1,10 @@
+package ui
+
+import (
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+func SupportsANSICodes() bool {
+	return isatty.IsTerminal(os.Stdout.Fd())
+}


### PR DESCRIPTION
ANSI formatting codes are not always supported. For example, when piping to a file or when running in some CI environments. This PR checks on `init()` for a TTY and enables colors accordingly.

- [x] Disable ANSI colors when no TTY is present
- [x] Disable spinner when no TTY is present

Tested with `railway up > output.txt` and `railway status > output.txt`