### PR TITLE
Move ignore check before symlink evaluation

### DIFF
--- a/controller/up.go
+++ b/controller/up.go
@@ -104,6 +104,15 @@ func compress(src string, buf io.Writer) error {
 			return nil
 		}
 
+		for _, igf := range ignoreFiles {
+			if strings.HasPrefix(file, igf.prefix) { // if ignore file applicable
+				trimmed := strings.TrimPrefix(file, igf.prefix)
+				if igf.ignore.MatchesPath(trimmed) {
+					return nil
+				}
+			}
+		}
+
 		// follow symlinks by default
 		ln, err := filepath.EvalSymlinks(file)
 		if err != nil {
@@ -113,15 +122,6 @@ func compress(src string, buf io.Writer) error {
 		fi, err := os.Lstat(ln)
 		if err != nil {
 			return err
-		}
-
-		for _, igf := range ignoreFiles {
-			if strings.HasPrefix(file, igf.prefix) { // if ignore file applicable
-				trimmed := strings.TrimPrefix(file, igf.prefix)
-				if igf.ignore.MatchesPath(trimmed) {
-					return nil
-				}
-			}
 		}
 
 		// read file into a buffer to prevent tar overwrites


### PR DESCRIPTION
This PR fixes #224 by moving the ignore logic before the symlink check. This will ensure invalid+ignored symlinks won't break anything.