### PR TITLE
Better looking errors

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -98,6 +98,7 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 		RootDir:       src,
 	})
 	if err != nil {
+		ui.StopSpinner("")
 		return err
 	} else {
 		ui.StopSpinner(fmt.Sprintf("☁️ Build logs available at %s\n", ui.GrayText(res.URL)))

--- a/controller/up.go
+++ b/controller/up.go
@@ -188,17 +188,12 @@ func (c *Controller) Upload(
 		return nil, err
 	}
 
-	res, err := c.gtwy.Up(ctx, &entity.UpRequest{
+	return c.gtwy.Up(ctx, &entity.UpRequest{
 		Data:          buf,
 		ProjectID:     req.ProjectID,
 		EnvironmentID: req.EnvironmentID,
 		ServiceID:     req.ServiceID,
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
 }
 
 func (c *Controller) GetFullUrlFromStaticUrl(staticUrl string) string {

--- a/entity/up.go
+++ b/entity/up.go
@@ -20,3 +20,8 @@ type UpResponse struct {
 	URL              string
 	DeploymentDomain string
 }
+
+type UpErrorResponse struct {
+	Message   string `json:"message"`
+	RequestID string `json:"reqId"`
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -152,9 +152,8 @@ func (r *GQLRequest) Run(ctx context.Context, resp interface{}) error {
 		}
 		if len(gr.Errors) > 1 {
 			return fmt.Errorf("%d Errors: %s", len(gr.Errors), strings.Join(messages, ", "))
-		} else {
-			return errors.New(gr.Errors[0].Message)
 		}
+		return errors.New(gr.Errors[0].Message)
 	}
 
 	return nil

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -150,7 +150,11 @@ func (r *GQLRequest) Run(ctx context.Context, resp interface{}) error {
 		for i, err := range gr.Errors {
 			messages[i] = err.Error()
 		}
-		return fmt.Errorf("GraphQL query failed with %d errors: %s", len(gr.Errors), strings.Join(messages, ", "))
+		if len(gr.Errors) > 1 {
+			return fmt.Errorf("%d Errors: %s", len(gr.Errors), strings.Join(messages, ", "))
+		} else {
+			return errors.New(gr.Errors[0].Message)
+		}
 	}
 
 	return nil

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -40,8 +40,15 @@ func (g *Gateway) Up(ctx context.Context, req *entity.UpRequest) (*entity.UpResp
 	if err != nil {
 		return nil, err
 	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, errors.New(string(bodyBytes))
+		var res entity.UpErrorResponse
+		// Try decoding up's error response and fallback to sending body as text if decoding fails
+		if err := json.Unmarshal(bodyBytes, &res); err != nil {
+			return nil, errors.New(string(bodyBytes))
+		} else {
+			return nil, errors.New(res.Message)
+		}
 	}
 
 	var res entity.UpResponse

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -46,9 +46,8 @@ func (g *Gateway) Up(ctx context.Context, req *entity.UpRequest) (*entity.UpResp
 		// Try decoding up's error response and fallback to sending body as text if decoding fails
 		if err := json.Unmarshal(bodyBytes, &res); err != nil {
 			return nil, errors.New(string(bodyBytes))
-		} else {
-			return nil, errors.New(res.Message)
 		}
+		return nil, errors.New("This is an example message to let you know something bad happened")
 	}
 
 	var res entity.UpResponse

--- a/main.go
+++ b/main.go
@@ -55,8 +55,7 @@ func contextualize(fn entity.HandlerFunction, panicFn entity.PanicFunction) enti
 		}
 		err := fn(ctx, req)
 		if err != nil {
-			// TODO: Make it *pretty*
-			fmt.Println(err.Error())
+			fmt.Println(ui.AlertDanger(err.Error()))
 			os.Exit(1) // Set non-success exit code on error
 		}
 		return nil


### PR DESCRIPTION
This PR adds better looking error messages when GraphQL requests fail. It also has a special case for `up` deployments (since those aren't GraphQL).

<img width="494" alt="image" src="https://user-images.githubusercontent.com/587576/176566914-9fe5e756-9058-4e53-9a6c-98faa324a352.png">