### PR TITLE
Add the Nixpkg to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the command line interface for [Railway](https://railway.app). Use it to
 
 ## Installation
 
-The Railway CLI is available through [Homebrew](https://brew.sh/), [NPM](https://www.npmjs.com/package/@railway/cli), or as a curl.
+The Railway CLI is available through [Homebrew](https://brew.sh/), [NPM](https://www.npmjs.com/package/@railway/cli), curl, or as a [Nixpkg](https://nixos.org).
 
 ### Brew
 
@@ -33,6 +33,15 @@ yarn global add @railway/cli
 
 ```shell
 curl -fsSL https://railway.app/install.sh | sh
+```
+
+### Nixpkg
+Note: This installation method is not supported by Railway and is maintained by the community.
+```shell
+# On NixOS
+nix-env -iA nixos.railway
+# On non-NixOS
+nix-env -iA nixpkgs.railway
 ```
 
 ### From source


### PR DESCRIPTION
I added the Railway CLI to [Nixpkgs](https://github.com/nixos/nixpkgs). [This package](https://search.nixos.org/packages?channel=22.05&show=railway&from=0&size=50&sort=relevance&type=packages&query=railway) recently hit the release-20.05 branch of NixOS. This PR adds installation instructions of the Railway CLI using Nix to the README file.