### PR TITLE
Up from project root

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -12,14 +12,6 @@ import (
 )
 
 func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
-	var src string
-
-	if len(req.Args) == 0 {
-		src = "."
-	} else {
-		src = "./" + req.Args[0]
-	}
-
 	isVerbose, err := req.Cmd.Flags().GetBool("verbose")
 	if err != nil {
 		// Verbose mode isn't a necessary flag; just default to false.
@@ -33,11 +25,11 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 
 	fmt.Print(ui.VerboseInfo(isVerbose, "Using verbose mode"))
 
-	fmt.Print(ui.VerboseInfo(isVerbose, "Loading project configuration"))
 	projectConfig, err := h.ctrl.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
 	}
+	fmt.Print(ui.VerboseInfo(isVerbose, fmt.Sprintf("Loaded project configuration for %s", projectConfig.ProjectPath)))
 
 	fmt.Print(ui.VerboseInfo(isVerbose, "Loading environment"))
 	environmentName, err := req.Cmd.Flags().GetString("environment")
@@ -95,7 +87,7 @@ func (h *Handler) Up(ctx context.Context, req *entity.CommandRequest) error {
 		ProjectID:     projectConfig.Project,
 		EnvironmentID: environment.Id,
 		ServiceID:     serviceId,
-		RootDir:       src,
+		RootDir:       projectConfig.ProjectPath,
 	})
 	if err != nil {
 		ui.StopSpinner("")

--- a/controller/up.go
+++ b/controller/up.go
@@ -153,7 +153,7 @@ func compress(src string, buf io.Writer) error {
 
 		// must provide real name
 		// (see https://golang.org/src/archive/tar/common.go?#L626)
-		header.Name = filepath.ToSlash(absoluteFile)
+		header.Name = filepath.ToSlash(relativeFile)
 		// size when we first observed the file
 		header.Size = int64(data.Len())
 

--- a/controller/up.go
+++ b/controller/up.go
@@ -88,7 +88,12 @@ func compress(src string, buf io.Writer) error {
 	}
 
 	// walk through every file in the folder
-	err = filepath.WalkDir(src, func(file string, de os.DirEntry, passedErr error) error {
+	err = filepath.WalkDir(src, func(absoluteFile string, de os.DirEntry, passedErr error) error {
+		relativeFile, err := filepath.Rel(src, absoluteFile)
+		if err != nil {
+			return err
+		}
+
 		if passedErr != nil {
 			return err
 		}
@@ -96,7 +101,7 @@ func compress(src string, buf io.Writer) error {
 			// skip directories if we can (for perf)
 			// e.g., want to avoid walking node_modules dir
 			for _, s := range skipDirs {
-				if filepath.Base(file) == s {
+				if filepath.Base(relativeFile) == s {
 					return filepath.SkipDir
 				}
 			}
@@ -105,8 +110,8 @@ func compress(src string, buf io.Writer) error {
 		}
 
 		for _, igf := range ignoreFiles {
-			if strings.HasPrefix(file, igf.prefix) { // if ignore file applicable
-				trimmed := strings.TrimPrefix(file, igf.prefix)
+			if strings.HasPrefix(relativeFile, igf.prefix) { // if ignore file applicable
+				trimmed := strings.TrimPrefix(relativeFile, igf.prefix)
 				if igf.ignore.MatchesPath(trimmed) {
 					return nil
 				}
@@ -114,7 +119,7 @@ func compress(src string, buf io.Writer) error {
 		}
 
 		// follow symlinks by default
-		ln, err := filepath.EvalSymlinks(file)
+		ln, err := filepath.EvalSymlinks(absoluteFile)
 		if err != nil {
 			return err
 		}
@@ -148,7 +153,7 @@ func compress(src string, buf io.Writer) error {
 
 		// must provide real name
 		// (see https://golang.org/src/archive/tar/common.go?#L626)
-		header.Name = filepath.ToSlash(file)
+		header.Name = filepath.ToSlash(absoluteFile)
 		// size when we first observed the file
 		header.Size = int64(data.Len())
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	configs "github.com/railwayapp/cli/configs"
+	"github.com/railwayapp/cli/constants"
 )
 
 const (
@@ -77,6 +78,12 @@ func (g *Gateway) authorize(header http.Header) error {
 		}
 		header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
 	}
+
+	version := constants.Version
+	if constants.IsDevVersion() {
+		version = "dev"
+	}
+	header.Set("X-Railway-Version", version)
 
 	return nil
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -67,8 +67,6 @@ type GQLResponse struct {
 }
 
 func (g *Gateway) authorize(header http.Header) error {
-	header.Add("x-source", CLI_SOURCE_HEADER)
-
 	if g.cfg.RailwayProductionToken != "" {
 		header.Add("project-access-token", g.cfg.RailwayProductionToken)
 	} else {
@@ -79,22 +77,26 @@ func (g *Gateway) authorize(header http.Header) error {
 		header.Add("authorization", fmt.Sprintf("Bearer %s", user.Token))
 	}
 
-	version := constants.Version
-	if constants.IsDevVersion() {
-		version = "dev"
-	}
-	header.Set("X-Railway-Version", version)
-
 	return nil
 }
 
 func (g *Gateway) NewRequestWithoutAuth(query string) *GQLRequest {
-	return &GQLRequest{
+	gqlReq := &GQLRequest{
 		q:          query,
 		header:     http.Header{},
 		httpClient: g.httpClient,
 		vars:       make(map[string]interface{}),
 	}
+
+	gqlReq.header.Add("x-source", CLI_SOURCE_HEADER)
+
+	version := constants.Version
+	if constants.IsDevVersion() {
+		version = "dev"
+	}
+	gqlReq.header.Set("X-Railway-Version", version)
+
+	return gqlReq
 }
 
 func (g *Gateway) NewRequestWithAuth(query string) (*GQLRequest, error) {

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -36,10 +36,9 @@ func GetHost() string {
 	return baseURL
 }
 
-type attachCommonHeadersTransport struct{}
+type AttachCommonHeadersTransport struct{}
 
-func (t *attachCommonHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Printf("FUCK\n\n")
+func (t *AttachCommonHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("x-source", CLI_SOURCE_HEADER)
 
 	version := constants.Version
@@ -53,7 +52,7 @@ func (t *attachCommonHeadersTransport) RoundTrip(req *http.Request) (*http.Respo
 func New() *Gateway {
 	httpClient := &http.Client{
 		Timeout:   time.Second * 30,
-		Transport: &attachCommonHeadersTransport{},
+		Transport: &AttachCommonHeadersTransport{},
 	}
 
 	return &Gateway{

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/railwayapp/cli/constants"
 	"github.com/railwayapp/cli/entity"
 )
 
@@ -19,12 +18,6 @@ func constructReq(ctx context.Context, req *entity.UpRequest) (*http.Request, er
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "multipart/form-data")
-
-	version := constants.Version
-	if constants.IsDevVersion() {
-		version = "dev"
-	}
-	httpReq.Header.Set("X-Railway-Version", version)
 
 	return httpReq, nil
 }

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/railwayapp/cli/constants"
 	"github.com/railwayapp/cli/entity"
 )
 
@@ -18,6 +19,13 @@ func constructReq(ctx context.Context, req *entity.UpRequest) (*http.Request, er
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "multipart/form-data")
+
+	version := constants.Version
+	if constants.IsDevVersion() {
+		version = "dev"
+	}
+	httpReq.Header.Set("X-Railway-Version", version)
+
 	return httpReq, nil
 }
 

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -31,8 +31,7 @@ func (g *Gateway) Up(ctx context.Context, req *entity.UpRequest) (*entity.UpResp
 	if err != nil {
 		return nil, err
 	}
-	client := &http.Client{}
-	resp, err := client.Do(httpReq)
+	resp, err := g.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/up.go
+++ b/gateway/up.go
@@ -31,7 +31,13 @@ func (g *Gateway) Up(ctx context.Context, req *entity.UpRequest) (*entity.UpResp
 	if err != nil {
 		return nil, err
 	}
-	resp, err := g.httpClient.Do(httpReq)
+
+	// The `up` command uses a custom HTTP Client so there is no timeout on the requests
+	client := &http.Client{
+		Transport: &AttachCommonHeadersTransport{},
+	}
+
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Set railway cli version as header on up request
- Up from the project root instead of the current directory
