### PR TITLE
Do not lowercase cwd

### DIFF
--- a/configs/main.go
+++ b/configs/main.go
@@ -54,14 +54,6 @@ func (c *Configs) CreatePathIfNotExist(path string) error {
 	return nil
 }
 
-func (c *Configs) unmarshalConfig(config *Config, data interface{}) error {
-	err := config.viper.ReadInConfig()
-	if err != nil {
-		return err
-	}
-	return config.viper.Unmarshal(&data)
-}
-
 func (c *Configs) marshalConfig(config *Config, cfg interface{}) error {
 	reflectCfg := reflect.ValueOf(cfg)
 	for i := 0; i < reflectCfg.NumField(); i++ {

--- a/configs/project.go
+++ b/configs/project.go
@@ -14,7 +14,6 @@ func (c *Configs) getCWD() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cwd = strings.ToLower(cwd)
 
 	return cwd, nil
 }

--- a/configs/project.go
+++ b/configs/project.go
@@ -3,57 +3,11 @@ package configs
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/errors"
 )
-
-// MigrateLocalProjectConfig moves a local project config
-// to the global config and removes the local .railway directory
-// if it exists
-func (c *Configs) MigrateLocalProjectConfig() error {
-	// Get local config directory
-	projectDir, err := filepath.Abs(filepath.Dir(filepath.Dir(c.projectConfigs.configPath)))
-	if err != nil {
-		return err
-	}
-
-	// Avoid deleting ~/.railway
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	if projectDir == homeDir {
-		return nil
-	}
-
-	if _, err := os.Stat(projectDir); os.IsNotExist(err) {
-		// Local project directory does not exist
-		return nil
-	}
-
-	// Read local project config
-	var cfg entity.ProjectConfig
-	if err := c.unmarshalConfig(c.projectConfigs, &cfg); err != nil {
-		return err
-	}
-
-	// Save project config to root config
-	cfg.ProjectPath = strings.ToLower(projectDir)
-	if err = c.SetProjectConfigs(&cfg); err != nil {
-		return err
-	}
-
-	// Delete local config directory
-	if err = os.RemoveAll(fmt.Sprintf("%s/.railway", projectDir)); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func (c *Configs) getCWD() (string, error) {
 	cwd, err := os.Getwd()
@@ -66,7 +20,6 @@ func (c *Configs) getCWD() (string, error) {
 }
 
 func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
-	_ = c.MigrateLocalProjectConfig()
 	// Ignore error because the config probably doesn't exist yet
 	// TODO: Better error handling here
 


### PR DESCRIPTION
- Remove legacy project migrate. This was needed from a very early version of the CLI.
- Do not toLower(cwd). This should fix https://github.com/railwayapp/cli/issues/246. I couldn't remember why we lowercased the directory in the first place. But after some initial testing, this seems to work fine.
