### PR TITLE
Introduce optional replace semantics for `railway variables set` as an alternative to upsert

### DIFF
--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -69,6 +69,23 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 		replace = false
 	}
 
+	yes, err := req.Cmd.Flags().GetBool("yes")
+	if err != nil {
+		// The flag is optional; default to false.
+		yes = false
+	}
+
+	if replace && !yes {
+		fmt.Println(ui.Bold(ui.RedText(fmt.Sprintf("Warning! You are about to fully replace all your variables for the service '%s'.", serviceName)).String()))
+		confirm, err := ui.PromptYesNo("Continue?")
+		if err != nil {
+			return err
+		}
+		if !confirm {
+			return nil
+		}
+	}
+
 	variables := &entity.Envs{}
 	updatedEnvNames := make([]string, 0)
 

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -191,7 +191,8 @@ func (c *Controller) UpdateEnvs(ctx context.Context, envs *entity.Envs, serviceN
 		PluginID:      pluginID,
 		ServiceID:     serviceID,
 		Envs:          envs,
-	}, replace)
+		Replace:       replace,
+	})
 }
 
 func (c *Controller) DeleteEnvs(ctx context.Context, names []string, serviceName *string) error {

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -104,7 +104,7 @@ func (c *Controller) AutoImportDotEnv(ctx context.Context) error {
 			return err
 		}
 		if len(envMap) > 0 {
-			return c.UpsertEnvs(ctx, (*entity.Envs)(&envMap), nil)
+			return c.UpdateEnvs(ctx, (*entity.Envs)(&envMap), nil, false)
 		}
 	}
 	return nil
@@ -134,7 +134,7 @@ func (c *Controller) SaveEnvsToFile(ctx context.Context) error {
 	return nil
 }
 
-func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceName *string) error {
+func (c *Controller) UpdateEnvs(ctx context.Context, envs *entity.Envs, serviceName *string, replace bool) error {
 	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
@@ -185,13 +185,13 @@ func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceN
 		}
 	}
 
-	return c.gtwy.UpsertVariablesFromObject(ctx, &entity.UpdateEnvsRequest{
+	return c.gtwy.UpdateVariablesFromObject(ctx, &entity.UpdateEnvsRequest{
 		ProjectID:     projectCfg.Project,
 		EnvironmentID: projectCfg.Environment,
 		PluginID:      pluginID,
 		ServiceID:     serviceID,
 		Envs:          envs,
-	})
+	}, replace)
 }
 
 func (c *Controller) DeleteEnvs(ctx context.Context, names []string, serviceName *string) error {

--- a/entity/envs.go
+++ b/entity/envs.go
@@ -18,6 +18,7 @@ type UpdateEnvsRequest struct {
 	PluginID      string
 	ServiceID     string
 	Envs          *Envs
+	Replace       bool
 }
 
 type DeleteVariableRequest struct {

--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -33,10 +33,11 @@ func (g *Gateway) GetEnvs(ctx context.Context, req *entity.GetEnvsRequest) (*ent
 	return resp.Envs, nil
 }
 
-func (g *Gateway) UpdateVariablesFromObject(ctx context.Context, req *entity.UpdateEnvsRequest, replace bool) error {
+func (g *Gateway) UpdateVariablesFromObject(ctx context.Context, req *entity.UpdateEnvsRequest) error {
 	queryName := "upsertVariablesFromObject"
 
-	if replace {
+	if req.Replace {
+		// When replacing, use the set query which will blow away all old variables and only set the ones in this query
 		queryName = "variablesSetFromObject"
 	}
 

--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/railwayapp/cli/entity"
 )
@@ -32,12 +33,18 @@ func (g *Gateway) GetEnvs(ctx context.Context, req *entity.GetEnvsRequest) (*ent
 	return resp.Envs, nil
 }
 
-func (g *Gateway) UpsertVariablesFromObject(ctx context.Context, req *entity.UpdateEnvsRequest) error {
-	gqlReq, err := g.NewRequestWithAuth(`
+func (g *Gateway) UpdateVariablesFromObject(ctx context.Context, req *entity.UpdateEnvsRequest, replace bool) error {
+	queryName := "upsertVariablesFromObject"
+
+	if replace {
+		queryName = "variablesSetFromObject"
+	}
+
+	gqlReq, err := g.NewRequestWithAuth(fmt.Sprintf(`
 	  	mutation($projectId: String!, $environmentId: String!, $pluginId: String, $serviceId: String, $variables: Json!) {
-				upsertVariablesFromObject(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, serviceId: $serviceId, variables: $variables)
+				%s(projectId: $projectId, environmentId: $environmentId, pluginId: $pluginId, serviceId: $serviceId, variables: $variables)
 	  	}
-	`)
+	`, queryName))
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func init() {
 	variablesSetCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
 	variablesSetCmd.Flags().Bool("skip-redeploy", false, "Skip redeploying the specified service after changing the variables")
 	variablesSetCmd.Flags().Bool("replace", false, "Fully replace previous variables instead of updating them")
+	variablesSetCmd.Flags().Bool("yes", false, "Skip questions when replacing variables")
 
 	variablesDeleteCmd := &cobra.Command{
 		Use:     "delete key",

--- a/main.go
+++ b/main.go
@@ -154,8 +154,8 @@ func init() {
 	variablesCmd.AddCommand(variablesSetCmd)
 	variablesSetCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
 	variablesSetCmd.Flags().Bool("skip-redeploy", false, "Skip redeploying the specified service after changing the variables")
-	variablesSetCmd.Flags().Bool("replace", false, "Fully replace previous variables instead of updating them")
-	variablesSetCmd.Flags().Bool("yes", false, "Skip questions when replacing variables")
+	variablesSetCmd.Flags().Bool("replace", false, "Fully replace all previous variables instead of updating them")
+	variablesSetCmd.Flags().Bool("yes", false, "Skip all confirmation dialogs")
 
 	variablesDeleteCmd := &cobra.Command{
 		Use:     "delete key",

--- a/main.go
+++ b/main.go
@@ -154,6 +154,7 @@ func init() {
 	variablesCmd.AddCommand(variablesSetCmd)
 	variablesSetCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
 	variablesSetCmd.Flags().Bool("skip-redeploy", false, "Skip redeploying the specified service after changing the variables")
+	variablesSetCmd.Flags().Bool("replace", false, "Fully replace previous variables instead of updating them")
 
 	variablesDeleteCmd := &cobra.Command{
 		Use:     "delete key",


### PR DESCRIPTION
In this PR I have added an additional flag `replace` for `variables set` that replaces all variables of a service rather than just upserting them. This is helpful for automation using another single source of truth to push a snapshot of variables; otherwise, old variables have to be deleted one-by-before before setting the current ones.

I tried to reuse as much code as possible and thus renamed functions that were prefixed with `Upsert` in favor of `Update`. Additionally I have intentionally opted out of a short-hand form for the `--replace` flag to ensure nobody triggers it by accident.

Looking forward for feedback on this one.

Closes #264