### PR TITLE
Fix outdated `deployEnvironmentTriggers` mutation

### DIFF
--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -148,7 +148,12 @@ func (h *Handler) redeployAfterVariablesChange(ctx context.Context, environment 
 	}
 
 	ui.StopSpinner("Deploy triggered")
-	// TODO: This link is outdated and requires the ID of the deployment in progress and the service ID. Maybe DeployEnvironmentTriggers could return it to build the correct URL.
-	fmt.Printf("☁️ Deploy Logs available at %s\n", ui.GrayText(h.ctrl.GetProjectDeploymentsURL(ctx, latestDeploy.ProjectID)))
+
+	deployment, err := h.ctrl.GetLatestDeploymentForEnvironment(ctx, latestDeploy.ProjectID, environment.Id)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("☁️ Deploy Logs available at %s\n", ui.GrayText(h.ctrl.GetServiceDeploymentsURL(ctx, latestDeploy.ProjectID, *serviceID, deployment.ID)))
 	return nil
 }

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -57,6 +57,12 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 		return err
 	}
 
+	noRedeploy, err := req.Cmd.Flags().GetBool("no-redeploy")
+	if err != nil {
+		// The flag is optional; default to false.
+		noRedeploy = false
+	}
+
 	variables := &entity.Envs{}
 	updatedEnvNames := make([]string, 0)
 
@@ -86,7 +92,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 	fmt.Print(ui.Heading(fmt.Sprintf("Updated %s for \"%s\"", strings.Join(updatedEnvNames, ", "), environment.Name)))
 	fmt.Print(ui.KeyValues(*variables))
 
-	err = h.redeployAfterVariablesChange(ctx, environment, serviceID)
+	err = h.redeployAfterVariablesChange(ctx, environment, serviceID, noRedeploy)
 	if err != nil {
 		return err
 	}
@@ -98,6 +104,12 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 	serviceName, err := req.Cmd.Flags().GetString("service")
 	if err != nil {
 		return err
+	}
+
+	noRedeploy, err := req.Cmd.Flags().GetBool("no-redeploy")
+	if err != nil {
+		// The flag is optional; default to false.
+		noRedeploy = false
 	}
 
 	serviceID, err := h.ctrl.DeleteEnvs(ctx, req.Args, &serviceName)
@@ -112,7 +124,7 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 
 	fmt.Print(ui.Heading(fmt.Sprintf("Deleted %s for \"%s\"", strings.Join(req.Args, ", "), environment.Name)))
 
-	err = h.redeployAfterVariablesChange(ctx, environment, serviceID)
+	err = h.redeployAfterVariablesChange(ctx, environment, serviceID, noRedeploy)
 	if err != nil {
 		return err
 	}
@@ -120,7 +132,7 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 	return nil
 }
 
-func (h *Handler) redeployAfterVariablesChange(ctx context.Context, environment *entity.Environment, serviceID *string) error {
+func (h *Handler) redeployAfterVariablesChange(ctx context.Context, environment *entity.Environment, serviceID *string, noRedeploy bool) error {
 	deployments, err := h.ctrl.GetDeployments(ctx)
 	if err != nil {
 		return err
@@ -133,7 +145,7 @@ func (h *Handler) redeployAfterVariablesChange(ctx context.Context, environment 
 
 	// Don't redeploy if the latest deploy for environment came from up
 	latestDeploy := deployments[0]
-	if latestDeploy.Meta == nil || latestDeploy.Meta.Repo == "" {
+	if latestDeploy.Meta == nil || latestDeploy.Meta.Repo == "" || noRedeploy {
 		fmt.Printf(ui.AlertInfo("Run %s to redeploy your project"), ui.MagentaText("railway up").Underline())
 		return nil
 	}

--- a/cmd/variables.go
+++ b/cmd/variables.go
@@ -78,7 +78,7 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 		updatedEnvNames = append(updatedEnvNames, key)
 	}
 
-	serviceID, err := h.ctrl.UpsertEnvs(ctx, variables, &serviceName)
+	err = h.ctrl.UpsertEnvs(ctx, variables, &serviceName)
 
 	if err != nil {
 		return err
@@ -93,6 +93,11 @@ func (h *Handler) VariablesSet(ctx context.Context, req *entity.CommandRequest) 
 	fmt.Print(ui.KeyValues(*variables))
 
 	if !skipRedeploy {
+		serviceID, err := h.ctrl.GetServiceIdByName(ctx, &serviceName)
+		if err != nil {
+			return err
+		}
+
 		err = h.redeployAfterVariablesChange(ctx, environment, serviceID)
 		if err != nil {
 			return err
@@ -114,7 +119,7 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 		skipRedeploy = false
 	}
 
-	serviceID, err := h.ctrl.DeleteEnvs(ctx, req.Args, &serviceName)
+	err = h.ctrl.DeleteEnvs(ctx, req.Args, &serviceName)
 	if err != nil {
 		return err
 	}
@@ -127,6 +132,11 @@ func (h *Handler) VariablesDelete(ctx context.Context, req *entity.CommandReques
 	fmt.Print(ui.Heading(fmt.Sprintf("Deleted %s for \"%s\"", strings.Join(req.Args, ", "), environment.Name)))
 
 	if !skipRedeploy {
+		serviceID, err := h.ctrl.GetServiceIdByName(ctx, &serviceName)
+		if err != nil {
+			return err
+		}
+
 		err = h.redeployAfterVariablesChange(ctx, environment, serviceID)
 		if err != nil {
 			return err

--- a/controller/deployment_trigger.go
+++ b/controller/deployment_trigger.go
@@ -6,7 +6,7 @@ import (
 	"github.com/railwayapp/cli/entity"
 )
 
-func (c *Controller) DeployEnvironmentTriggers(ctx context.Context) error {
+func (c *Controller) DeployEnvironmentTriggers(ctx context.Context, serviceID *string) error {
 	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
 		return err
@@ -15,5 +15,6 @@ func (c *Controller) DeployEnvironmentTriggers(ctx context.Context) error {
 	return c.gtwy.DeployEnvironmentTriggers(ctx, &entity.DeployEnvironmentTriggersRequest{
 		ProjectID:     projectCfg.Project,
 		EnvironmentID: projectCfg.Environment,
+		ServiceID:     *serviceID,
 	})
 }

--- a/controller/envs.go
+++ b/controller/envs.go
@@ -104,8 +104,7 @@ func (c *Controller) AutoImportDotEnv(ctx context.Context) error {
 			return err
 		}
 		if len(envMap) > 0 {
-			_, err := c.UpsertEnvs(ctx, (*entity.Envs)(&envMap), nil)
-			return err
+			return c.UpsertEnvs(ctx, (*entity.Envs)(&envMap), nil)
 		}
 	}
 	return nil
@@ -135,20 +134,20 @@ func (c *Controller) SaveEnvsToFile(ctx context.Context) error {
 	return nil
 }
 
-func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceName *string) (*string, error) {
+func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceName *string) error {
 	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	err = c.PromptIfProtectedEnvironment(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	project, err := c.GetProject(ctx, projectCfg.Project)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Get service id from name
@@ -161,14 +160,14 @@ func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceN
 		}
 
 		if serviceID == "" {
-			return nil, CLIErrors.ServiceNotFound
+			return CLIErrors.ServiceNotFound
 		}
 	}
 
 	if serviceID == "" {
 		service, err := ui.PromptServices(project.Services)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if service != nil {
 			serviceID = service.ID
@@ -186,7 +185,7 @@ func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceN
 		}
 	}
 
-	return &serviceID, c.gtwy.UpsertVariablesFromObject(ctx, &entity.UpdateEnvsRequest{
+	return c.gtwy.UpsertVariablesFromObject(ctx, &entity.UpdateEnvsRequest{
 		ProjectID:     projectCfg.Project,
 		EnvironmentID: projectCfg.Environment,
 		PluginID:      pluginID,
@@ -195,20 +194,20 @@ func (c *Controller) UpsertEnvs(ctx context.Context, envs *entity.Envs, serviceN
 	})
 }
 
-func (c *Controller) DeleteEnvs(ctx context.Context, names []string, serviceName *string) (*string, error) {
+func (c *Controller) DeleteEnvs(ctx context.Context, names []string, serviceName *string) error {
 	projectCfg, err := c.GetProjectConfigs(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	err = c.PromptIfProtectedEnvironment(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	project, err := c.GetProject(ctx, projectCfg.Project)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Get service id from name
@@ -221,14 +220,14 @@ func (c *Controller) DeleteEnvs(ctx context.Context, names []string, serviceName
 		}
 
 		if serviceID == "" {
-			return nil, CLIErrors.ServiceNotFound
+			return CLIErrors.ServiceNotFound
 		}
 	}
 
 	if serviceID == "" {
 		service, err := ui.PromptServices(project.Services)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if service != nil {
 			serviceID = service.ID
@@ -257,9 +256,9 @@ func (c *Controller) DeleteEnvs(ctx context.Context, names []string, serviceName
 		})
 
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return &serviceID, nil
+	return nil
 }

--- a/controller/project.go
+++ b/controller/project.go
@@ -71,7 +71,12 @@ func (c *Controller) GetProjectDeploymentsURL(ctx context.Context, projectID str
 	return c.gtwy.GetProjectDeploymentsURL(projectID)
 }
 
-// GetProjectDeploymentsURL returns the URL to access project deployment in browser
+// GetServiceDeploymentsURL returns the URL to access service deployments in the browser
+func (c *Controller) GetServiceDeploymentsURL(ctx context.Context, projectID string, serviceID string, deploymentID string) string {
+	return c.gtwy.GetServiceDeploymentsURL(projectID, serviceID, deploymentID)
+}
+
+// GetLatestDeploymentForEnvironment returns the URL to access project deployment in browser
 func (c *Controller) GetLatestDeploymentForEnvironment(ctx context.Context, projectID string, environmentID string) (*entity.Deployment, error) {
 	return c.gtwy.GetLatestDeploymentForEnvironment(ctx, projectID, environmentID)
 }

--- a/entity/deployment_trigger.go
+++ b/entity/deployment_trigger.go
@@ -3,4 +3,5 @@ package entity
 type DeployEnvironmentTriggersRequest struct {
 	ProjectID     string
 	EnvironmentID string
+	ServiceID     string
 }

--- a/gateway/deployment_trigger.go
+++ b/gateway/deployment_trigger.go
@@ -8,8 +8,8 @@ import (
 
 func (g *Gateway) DeployEnvironmentTriggers(ctx context.Context, req *entity.DeployEnvironmentTriggersRequest) error {
 	gqlReq, err := g.NewRequestWithAuth(`
-	  	mutation($projectId: String!, $environmentId: String!) {
-			deployEnvironmentTriggers(projectId: $projectId, environmentId: $environmentId)
+	  	mutation($projectId: ID!, $environmentId: ID!, $serviceId: ID!) {
+			deployEnvironmentTriggers(projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId)
 	  	}
 	`)
 	if err != nil {
@@ -18,6 +18,7 @@ func (g *Gateway) DeployEnvironmentTriggers(ctx context.Context, req *entity.Dep
 
 	gqlReq.Var("projectId", req.ProjectID)
 	gqlReq.Var("environmentId", req.EnvironmentID)
+	gqlReq.Var("serviceId", req.ServiceID)
 
 	var resp struct {
 		// Nothing useful here

--- a/gateway/project.go
+++ b/gateway/project.go
@@ -303,6 +303,10 @@ func (g *Gateway) GetProjectDeploymentsURL(projectID string) string {
 	return fmt.Sprintf("%s/project/%s/deployments?open=true", configs.GetRailwayURL(), projectID)
 }
 
+func (g *Gateway) GetServiceDeploymentsURL(projectID string, serviceID string, deploymentID string) string {
+	return fmt.Sprintf("%s/project/%s/service/%s?id=%s", configs.GetRailwayURL(), projectID, serviceID, deploymentID)
+}
+
 func (g *Gateway) OpenStaticUrlInBrowser(staticUrl string) error {
 	return browser.OpenURL(fmt.Sprintf("https://%s", staticUrl))
 }

--- a/main.go
+++ b/main.go
@@ -134,15 +134,15 @@ func init() {
 	})
 	variablesCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
 
-	variablesAddCmd := &cobra.Command{
+	variablesGetCmd := &cobra.Command{
 		Use:     "get key",
 		Short:   "Get the value of a variable",
 		RunE:    contextualize(handler.VariablesGet, handler.Panic),
 		Args:    cobra.MinimumNArgs(1),
 		Example: "  railway variables get MY_KEY",
 	}
-	variablesCmd.AddCommand(variablesAddCmd)
-	variablesAddCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
+	variablesCmd.AddCommand(variablesGetCmd)
+	variablesGetCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
 
 	variablesSetCmd := &cobra.Command{
 		Use:     "set key=value",
@@ -153,6 +153,7 @@ func init() {
 	}
 	variablesCmd.AddCommand(variablesSetCmd)
 	variablesSetCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
+	variablesSetCmd.Flags().Bool("no-redeploy", false, "Skip redeploying the specified service after changing the variables")
 
 	variablesDeleteCmd := &cobra.Command{
 		Use:     "delete key",
@@ -162,6 +163,7 @@ func init() {
 	}
 	variablesCmd.AddCommand(variablesDeleteCmd)
 	variablesDeleteCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
+	variablesDeleteCmd.Flags().Bool("no-redeploy", false, "Skip redeploying the specified service after changing the variables")
 
 	addRootCmd(&cobra.Command{
 		Use:   "status",

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func init() {
 	}
 	variablesCmd.AddCommand(variablesSetCmd)
 	variablesSetCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
-	variablesSetCmd.Flags().Bool("no-redeploy", false, "Skip redeploying the specified service after changing the variables")
+	variablesSetCmd.Flags().Bool("skip-redeploy", false, "Skip redeploying the specified service after changing the variables")
 
 	variablesDeleteCmd := &cobra.Command{
 		Use:     "delete key",
@@ -163,7 +163,7 @@ func init() {
 	}
 	variablesCmd.AddCommand(variablesDeleteCmd)
 	variablesDeleteCmd.Flags().StringP("service", "s", "", "Fetch variables accessible to a specific service")
-	variablesDeleteCmd.Flags().Bool("no-redeploy", false, "Skip redeploying the specified service after changing the variables")
+	variablesDeleteCmd.Flags().Bool("skip-redeploy", false, "Skip redeploying the specified service after changing the variables")
 
 	addRootCmd(&cobra.Command{
 		Use:   "status",


### PR DESCRIPTION
This draft attempts to fix an outdated mutation to trigger a redeploy. I attempted to reuse the inferred `serviceID` and return it to the original callsite causing some changes here and there.

Unfortunately during local testing the mutation was successfully invoked but no redeployment was initiated server-side. I guess this is just filtered based on the headers disallowing CLI redeployments which may be intended for now or just a bug. The very same mutation fired from the UI by updating any variable does work though. As such this probably requires somebody to check that on your end.

Another observation I made is the type of mutation parameters. The server returns a 400 status code when the types are declared as `String!` instead of `ID!`. This is highly inconsistent with other queries and mutations expecting `String!` instead. My assumption is that this is a very old endpoint you exposed and haven't updated it yet.

I'll keep this a draft until the open questions are resolved and the correctness of the implementation has been confirmed.

Closes #266 