### PR TITLE
Add String! to service variables query

### DIFF
--- a/gateway/envs.go
+++ b/gateway/envs.go
@@ -9,7 +9,7 @@ import (
 
 func (g *Gateway) GetEnvs(ctx context.Context, req *entity.GetEnvsRequest) (*entity.Envs, error) {
 	gqlReq, err := g.NewRequestWithAuth(`
-		query ($projectId: String!, $environmentId: String!, $serviceId: String) {
+		query ($projectId: String!, $environmentId: String!, $serviceId: String!) {
 			decryptedVariablesForService(projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId)
 		}
 	`)


### PR DESCRIPTION
`serviceId` is always required to fetch service variables, so update query accordingly. This will allow us to update the server-side nullability later.