### PR TITLE
Better error messages

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -14,9 +14,9 @@ func (h *Handler) Link(ctx context.Context, req *entity.CommandRequest) error {
 		// projectID provided as argument
 		arg := req.Args[0]
 
-		if (uuid.IsValidUUID(arg)) {
+		if uuid.IsValidUUID(arg) {
 			project, err := h.ctrl.GetProject(ctx, arg)
-			if (err != nil) {
+			if err != nil {
 				return err
 			}
 
@@ -24,7 +24,7 @@ func (h *Handler) Link(ctx context.Context, req *entity.CommandRequest) error {
 		}
 
 		project, err := h.ctrl.GetProjectByName(ctx, arg)
-		if (err != nil) {
+		if err != nil {
 			return err
 		}
 
@@ -69,7 +69,7 @@ func (h *Handler) linkFromID(ctx context.Context, req *entity.CommandRequest) er
 	}
 
 	project, err := h.ctrl.GetProject(ctx, projectID)
-	if (err != nil) {
+	if err != nil {
 		return err
 	}
 

--- a/configs/project.go
+++ b/configs/project.go
@@ -24,7 +24,7 @@ func (c *Configs) GetProjectConfigs() (*entity.ProjectConfig, error) {
 
 	userCfg, err := c.GetRootConfigs()
 	if err != nil {
-		return nil, errors.ProjectConfigNotFound
+		return nil, errors.RootConfigNotFound
 	}
 
 	// lookup project in global config based on pwd

--- a/configs/root.go
+++ b/configs/root.go
@@ -2,7 +2,9 @@ package configs
 
 import (
 	"encoding/json"
+	"github.com/railwayapp/cli/errors"
 	"io/ioutil"
+	"os"
 
 	"github.com/railwayapp/cli/entity"
 )
@@ -10,7 +12,9 @@ import (
 func (c *Configs) GetRootConfigs() (*entity.RootConfig, error) {
 	var cfg entity.RootConfig
 	b, err := ioutil.ReadFile(c.rootConfigs.configPath)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return nil, errors.RootConfigNotFound
+	} else if err != nil {
 		return nil, err
 	}
 	err = json.Unmarshal(b, &cfg)

--- a/errors/main.go
+++ b/errors/main.go
@@ -11,8 +11,9 @@ type RailwayError error
 // TEST
 
 var (
+	RootConfigNotFound                  RailwayError = fmt.Errorf("Run %s to get started", ui.Bold("railway login"))
 	UserConfigNotFound                  RailwayError = fmt.Errorf("%s\nRun %s", ui.RedText("Not logged in."), ui.Bold("railway login"))
-	ProjectConfigNotFound               RailwayError = fmt.Errorf("%s. Tip: If you haven't, do railway login\nOtherwise, run %s to get plugged into a new project, or %s to get plugged into an existing project.", ui.RedText("Project not found."), ui.Bold("railway init"), ui.Bold("railway link"))
+	ProjectConfigNotFound               RailwayError = fmt.Errorf("%s\nRun %s to create a new project, or %s to use an existing project", ui.RedText("Project not found"), ui.Bold("railway init"), ui.Bold("railway link"))
 	ProjectTokenNotFound                RailwayError = fmt.Errorf("%s\n", ui.RedText("Project token not found"))
 	ProblemFetchingProjects             RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem fetching your projects."))
 	ProblemFetchingWritableGithubScopes RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem fetching GitHub metadata."))

--- a/errors/main.go
+++ b/errors/main.go
@@ -14,6 +14,7 @@ var (
 	RootConfigNotFound                  RailwayError = fmt.Errorf("Run %s to get started", ui.Bold("railway login"))
 	UserConfigNotFound                  RailwayError = fmt.Errorf("%s\nRun %s", ui.RedText("Not logged in."), ui.Bold("railway login"))
 	ProjectConfigNotFound               RailwayError = fmt.Errorf("%s\nRun %s to create a new project, or %s to use an existing project", ui.RedText("Project not found"), ui.Bold("railway init"), ui.Bold("railway link"))
+	UserNotAuthorized                   RailwayError = fmt.Errorf("%s\nTry running %s", ui.RedText("Not authorized!"), ui.Bold("railway login"))
 	ProjectTokenNotFound                RailwayError = fmt.Errorf("%s\n", ui.RedText("Project token not found"))
 	ProblemFetchingProjects             RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem fetching your projects."))
 	ProblemFetchingWritableGithubScopes RailwayError = fmt.Errorf("%s\nOne of our trains probably derailed!", ui.RedText("There was a problem fetching GitHub metadata."))


### PR DESCRIPTION
## `railway up` for new users

The CLI used to return the same generic error message if the user had never used the CLI before (missing root config) and when `link` had not yet been ran. Now, it returns useful errors in each case.

<img width="486" alt="image" src="https://user-images.githubusercontent.com/587576/194535759-443c4f4f-66a6-4390-9e9f-473c6c645667.png">

**railway login...**

&nbsp;
<img width="613" alt="image" src="https://user-images.githubusercontent.com/587576/194535854-46927614-ee61-4736-9831-12dcaad93caa.png">

## Errors for expired/invalid sessions

If a GQL request returned a "Not Authorized" response, you now get a friendly error instead of something unhelpful like "Failed to fetch projects".

<img width="540" alt="image" src="https://user-images.githubusercontent.com/587576/194537949-5b7ee5e2-1eba-4552-9cf5-cdf107e1b307.png">

