### PR TITLE
Prompt to link on up command

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -51,7 +51,7 @@ func (h *Handler) linkFromAccount(ctx context.Context, _ *entity.CommandRequest)
 	}
 
 	if len(projects) == 0 {
-		fmt.Printf(ui.AlertWarning("No projects found"))
+		fmt.Print(ui.AlertWarning("No projects found"))
 		fmt.Printf("Create one with %s\n", ui.GreenText("railway init"))
 		os.Exit(1)
 	}

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/ui"
@@ -43,15 +44,16 @@ func (h *Handler) Link(ctx context.Context, req *entity.CommandRequest) error {
 	}
 }
 
-func (h *Handler) linkFromAccount(ctx context.Context, req *entity.CommandRequest) error {
+func (h *Handler) linkFromAccount(ctx context.Context, _ *entity.CommandRequest) error {
 	projects, err := h.ctrl.GetProjects(ctx)
 	if err != nil {
 		return err
 	}
 
 	if len(projects) == 0 {
-		fmt.Printf("No Projects. Create one with %s\n", ui.GreenText("railway init"))
-		return nil
+		fmt.Printf(ui.AlertWarning("No projects found"))
+		fmt.Printf("Create one with %s\n", ui.GreenText("railway init"))
+		os.Exit(1)
 	}
 
 	project, err := ui.PromptProjects(projects)
@@ -62,7 +64,7 @@ func (h *Handler) linkFromAccount(ctx context.Context, req *entity.CommandReques
 	return h.setProject(ctx, project)
 }
 
-func (h *Handler) linkFromID(ctx context.Context, req *entity.CommandRequest) error {
+func (h *Handler) linkFromID(ctx context.Context, _ *entity.CommandRequest) error {
 	projectID, err := ui.PromptText("Enter your project id")
 	if err != nil {
 		return err

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -13,7 +13,7 @@ import (
 func (h *Handler) Unlink(ctx context.Context, _ *entity.CommandRequest) error {
 	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
 	if err == errors.ProjectConfigNotFound {
-		fmt.Printf(ui.AlertWarning("No project is currently linked"))
+		fmt.Print(ui.AlertWarning("No project is currently linked"))
 		os.Exit(1)
 	} else if err != nil {
 		return err

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -3,13 +3,21 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/railwayapp/cli/errors"
+	"os"
 
 	"github.com/railwayapp/cli/entity"
 	"github.com/railwayapp/cli/ui"
 )
 
-func (h *Handler) Unlink(ctx context.Context, req *entity.CommandRequest) error {
-	projectCfg, _ := h.ctrl.GetProjectConfigs(ctx)
+func (h *Handler) Unlink(ctx context.Context, _ *entity.CommandRequest) error {
+	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
+	if err == errors.ProjectConfigNotFound {
+		fmt.Printf(ui.AlertWarning("No project links found"))
+		os.Exit(1)
+	} else if err != nil {
+		return err
+	}
 
 	project, err := h.ctrl.GetProject(ctx, projectCfg.Project)
 	if err != nil {

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -13,7 +13,7 @@ import (
 func (h *Handler) Unlink(ctx context.Context, _ *entity.CommandRequest) error {
 	projectCfg, err := h.ctrl.GetProjectConfigs(ctx)
 	if err == errors.ProjectConfigNotFound {
-		fmt.Printf(ui.AlertWarning("No project links found"))
+		fmt.Printf(ui.AlertWarning("No project is currently linked"))
 		os.Exit(1)
 	} else if err != nil {
 		return err


### PR DESCRIPTION
If no project is linked on `railway up`, prompt the user to do so inline.

<img width="460" alt="CleanShot 2022-12-16 at 12 35 57@2x" src="https://user-images.githubusercontent.com/587576/208184778-5623da77-b0ef-4e49-8bf6-8f443abbc39c.png">

And fix panic for non-linked project during unlink

<img width="339" alt="CleanShot 2022-12-16 at 12 38 41@2x" src="https://user-images.githubusercontent.com/587576/208185095-20197634-bde9-4b62-9887-43684b6ce5b5.png">

And shows a better error when linking with no projects

<img width="403" alt="CleanShot 2022-12-16 at 12 38 04@2x" src="https://user-images.githubusercontent.com/587576/208185003-f1e2c61d-3d26-4b0b-b708-0c37ff29f097.png">
