### PR TITLE
release tarfiles for windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           args: --release --locked --target ${{ matrix.target }}
           use-cross: ${{ matrix.os == 'ubuntu-latest' }}
 
-      - name: Prepare binaries [Windows]
+      - name: Prepare binaries (zip) [Windows]
         if: matrix.os == 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
@@ -111,7 +111,16 @@ jobs:
           7z a ../../../railway-${{ needs.create-release.outputs.railway_version }}-${{ matrix.target }}.zip railway.exe
           cd -
 
+      - name: Prepare binares (tar) [Windows]
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          strip railway.exe
+          7z a ../../../railway-${{ needs.create-release.outputs.railway_version }}-${{ matrix.target }}.tar.gz railway.exe
+          cd -
+
       - name: Prepare binaries [-linux]
+        if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
           strip railway || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,6 @@ jobs:
           cd -
 
       - name: Prepare binaries [-linux]
-        if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
           strip railway || true

--- a/bin/railway.js
+++ b/bin/railway.js
@@ -6,9 +6,9 @@ import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
+const binName = process.platform === "win32" ? "railway.exe" : "railway";
 try {
-	execFileSync(path.resolve(`${__dirname}/railway`), process.argv.slice(2), {
+	execFileSync(path.resolve(`${__dirname}/${binName}`), process.argv.slice(2), {
 		stdio: "inherit",
 	});
 } catch (e) {

--- a/npm-install/config.js
+++ b/npm-install/config.js
@@ -6,7 +6,7 @@ export const CONFIG = {
 	 * The name of the binary
 	 * @type {string}
 	 */
-	name: "railway",
+	name: "railway{{ext}}",
 
 	/**
 	 * Where to save the unzipped files

--- a/npm-install/postinstall.js
+++ b/npm-install/postinstall.js
@@ -20,6 +20,12 @@ async function install() {
 	// Fetch Static Config
 	let { name: binName, path: binPath, url } = CONFIG;
 	let triple = triples.platformArchTriples[process.platform][process.arch][0];
+	if (process.platform === "win32") {
+		triple.ext = ".exe";
+	} else {
+		triple.ext = "";
+	}
+	binName = binName.replace(/{{ext}}/g, triple.ext);
 	url = url.replace(/{{triple}}/g, triple.raw);
 	url = url.replace(/{{version}}/g, version);
 	url = url.replace(/{{bin_name}}/g, binName);


### PR DESCRIPTION
Resolves #201 

Releases tarfiles for both Windows and Linux, so the NPM installer can fetch them.