### PR TITLE
release binary for `x86_64-pc-windows-gnu`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,9 @@ jobs:
 
           - target: i686-pc-windows-msvc
             os: windows-latest
+            
+          - target: x86_64-pc-windows-gnu
+            os: windows-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fixes https://github.com/railwayapp/cli/issues/316

[`3.0.5`](https://github.com/railwayapp/cli/releases/tag/v3.0.5) does **not** fix the aforementioned issue. As mentioned in the issue the error includes `npm ERR! https://github.com/railwayapp/cli/releases/download/v3.0.3/railway-v3.0.3-x86_64-pc-windows-gnu.tar.gz`. 

The error states that `railway-v3.0.3-x86_64-pc-windows-gnu.tar.gz` can't be fetched since the CLI does not provide a binary for `x86_64-pc-windows-gnu`.