### PR TITLE
don't use `$module:tt` in macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! commands_enum {
-    ($($module:tt),*) => (
+    ($($module:ident),*) => (
       paste::paste! {
         #[derive(Subcommand)]
         enum Commands {


### PR DESCRIPTION
Using `tt` can lead to this being valid input for the macro:

```rs
commands_enum!(println!("a"));
```