### PR TITLE
allow user to select service on `up`

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -78,11 +78,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             project_id: linked_project.project.clone(),
             name: plugin.to_lowercase(),
         };
-        if !std::io::stdout().is_terminal() {
-            println!("Creating {}...", plugin);
-            post_graphql::<mutations::PluginCreate, _>(&client, configs.get_backboard(), vars)
-                .await?;
-        } else {
+        if std::io::stdout().is_terminal() {
             let spinner = indicatif::ProgressBar::new_spinner()
                 .with_style(
                     indicatif::ProgressStyle::default_spinner()
@@ -94,6 +90,10 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             post_graphql::<mutations::PluginCreate, _>(&client, configs.get_backboard(), vars)
                 .await?;
             spinner.finish_with_message(format!("Created {plugin}"));
+        } else {
+            println!("Creating {}...", plugin);
+            post_graphql::<mutations::PluginCreate, _>(&client, configs.get_backboard(), vars)
+                .await?;
         }
     }
 

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -5,6 +5,7 @@ use is_terminal::IsTerminal;
 
 use crate::{
     consts::{ABORTED_BY_USER, TICK_STRING},
+    interact_or,
     util::prompt::{prompt_confirm, prompt_multi_options, prompt_text},
 };
 
@@ -15,9 +16,8 @@ use super::{queries::project_plugins::PluginType, *};
 pub struct Args {}
 
 pub async fn command(_args: Args, _json: bool) -> Result<()> {
-    if !std::io::stdout().is_terminal() {
-        bail!("Cannot delete plugins in non-interactive mode");
-    }
+    interact_or!("Cannot delete plugins in non-interactive mode");
+
     let configs = Configs::new()?;
 
     let client = GQLClient::new_authorized(&configs)?;

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -3,6 +3,7 @@ use is_terminal::IsTerminal;
 
 use crate::{
     consts::{ABORTED_BY_USER, NON_INTERACTIVE_FAILURE},
+    interact_or,
     util::prompt::prompt_confirm_with_default,
 };
 
@@ -13,9 +14,8 @@ use super::*;
 pub struct Args {}
 
 pub async fn command(_args: Args, _json: bool) -> Result<()> {
-    if !std::io::stdout().is_terminal() {
-        bail!(NON_INTERACTIVE_FAILURE);
-    }
+    interact_or!(NON_INTERACTIVE_FAILURE);
+
     let confirm = prompt_confirm_with_default("Open the browser?", true)?;
 
     if !confirm {

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -72,21 +72,7 @@ pub async fn command(_args: Args, _json: bool) -> Result<()> {
         environment_id: linked_project.environment.clone(),
     };
 
-    if !std::io::stdout().is_terminal() {
-        println!("Creating domain...");
-
-        let res = post_graphql::<mutations::ServiceDomainCreate, _>(
-            &client,
-            configs.get_backboard(),
-            vars,
-        )
-        .await?;
-
-        let body = res.data.context("Failed to create service domain.")?;
-        let domain = body.service_domain_create.domain;
-
-        println!("Service Domain created: {}", domain.bold());
-    } else {
+    if std::io::stdout().is_terminal() {
         let spinner = indicatif::ProgressBar::new_spinner()
             .with_style(
                 indicatif::ProgressStyle::default_spinner()
@@ -107,6 +93,20 @@ pub async fn command(_args: Args, _json: bool) -> Result<()> {
         let domain = body.service_domain_create.domain;
 
         spinner.finish_and_clear();
+
+        println!("Service Domain created: {}", domain.bold());
+    } else {
+        println!("Creating domain...");
+
+        let res = post_graphql::<mutations::ServiceDomainCreate, _>(
+            &client,
+            configs.get_backboard(),
+            vars,
+        )
+        .await?;
+
+        let body = res.data.context("Failed to create service domain.")?;
+        let domain = body.service_domain_create.domain;
 
         println!("Service Domain created: {}", domain.bold());
     }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -2,6 +2,7 @@ use std::{net::SocketAddr, time::Duration};
 
 use crate::{
     consts::{ABORTED_BY_USER, TICK_STRING},
+    interact_or,
     util::prompt::prompt_confirm_with_default,
 };
 
@@ -24,9 +25,7 @@ pub struct Args {
 }
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
-    if !std::io::stdout().is_terminal() {
-        bail!("Cannot login in non-interactive mode");
-    }
+    interact_or!("Cannot login in non-interactive mode");
 
     let mut configs = Configs::new()?;
 

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use is_terminal::IsTerminal;
 
-use crate::consts::NON_INTERACTIVE_FAILURE;
+use crate::{consts::NON_INTERACTIVE_FAILURE, interact_or};
 
 use super::*;
 
@@ -10,9 +10,7 @@ use super::*;
 pub struct Args {}
 
 pub async fn command(_args: Args, _json: bool) -> Result<()> {
-    if !std::io::stdout().is_terminal() {
-        bail!(NON_INTERACTIVE_FAILURE);
-    }
+    interact_or!(NON_INTERACTIVE_FAILURE);
 
     let configs = Configs::new()?;
     let hostname = configs.get_host();

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -2,7 +2,10 @@ use std::fmt::Display;
 
 use anyhow::bail;
 
-use crate::{consts::SERVICE_NOT_FOUND, util::prompt::prompt_select};
+use crate::{
+    consts::SERVICE_NOT_FOUND,
+    util::prompt::{prompt_select, PromptService},
+};
 
 use super::{queries::project::ProjectProjectServicesEdgesNode, *};
 
@@ -31,7 +34,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         .services
         .edges
         .iter()
-        .map(|s| Service(&s.node))
+        .map(|s| PromptService(&s.node))
         .collect();
 
     if let Some(service) = args.service {
@@ -54,13 +57,4 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     configs.link_service(service.0.id.clone())?;
     configs.write()?;
     Ok(())
-}
-
-#[derive(Debug, Clone)]
-struct Service<'a>(&'a ProjectProjectServicesEdgesNode);
-
-impl<'a> Display for Service<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0.name)
-    }
 }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -4,11 +4,13 @@ use std::{
     time::Duration,
 };
 
+use anyhow::bail;
 use futures::StreamExt;
 use gzp::{deflate::Gzip, ZBuilder};
 use ignore::WalkBuilder;
 use indicatif::{ProgressBar, ProgressFinish, ProgressIterator, ProgressStyle};
 use is_terminal::IsTerminal;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use synchronized_writer::SynchronizedWriter;
 use tar::Builder;
@@ -25,6 +27,55 @@ pub struct Args {
     #[clap(short, long)]
     /// Don't attach to the log stream
     detach: bool,
+
+    #[clap(short, long)]
+    /// Service to deploy to (defaults to linked service)
+    service: Option<String>,
+}
+
+pub async fn get_service_to_deploy(
+    configs: &Configs,
+    client: &Client,
+    service_arg: Option<String>,
+) -> Result<Option<String>> {
+    let linked_project = configs.get_linked_project().await?;
+
+    let vars = queries::project::Variables {
+        id: linked_project.project.to_owned(),
+    };
+    let res = post_graphql::<queries::Project, _>(client, configs.get_backboard(), vars).await?;
+    let body = res.data.context("Failed to get project (query project)")?;
+
+    let services = body.project.services.edges.iter().collect::<Vec<_>>();
+
+    let service = if let Some(service_arg) = service_arg {
+        // If the user specified a service, use that
+        let service_id = services
+            .iter()
+            .find(|service| service.node.name == service_arg || service.node.id == service_arg);
+        if let Some(service_id) = service_id {
+            Some(service_id.node.id.to_owned())
+        } else {
+            bail!("Service not found");
+        }
+    } else if let Some(service) = linked_project.service {
+        // If the user didn't specify a service, but we have a linked service, use that
+        Some(service)
+    } else {
+        // If the user didn't specify a service, and we don't have a linked service, get the first service
+
+        if services.is_empty() {
+            // If there are no services, backboard will generate one for us
+            None
+        } else if services.len() == 1 {
+            // If there is only one service, use that
+            services.first().map(|service| service.node.id.to_owned())
+        } else {
+            // If there are multiple services, bail
+            bail!("Multiple services found. Please specify a service to deploy to.")
+        }
+    };
+    Ok(service)
 }
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
@@ -32,7 +83,10 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let hostname = configs.get_host();
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
-    let spinner = if !std::io::stdout().is_terminal() {
+
+    let service = get_service_to_deploy(&configs, &client, args.service).await?;
+
+    let spinner = if std::io::stdout().is_terminal() {
         let spinner = ProgressBar::new_spinner()
             .with_style(
                 ProgressStyle::default_spinner()
@@ -61,7 +115,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         if let Some(spinner) = spinner {
             spinner.finish_with_message("Indexed");
         }
-        if !std::io::stdout().is_terminal() {
+        if std::io::stdout().is_terminal() {
             let pg = ProgressBar::new(walked.len() as u64)
                 .with_style(
                     ProgressStyle::default_bar()
@@ -85,10 +139,12 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     parz.finish()?;
 
     let builder = client.post(format!(
-        "https://backboard.{hostname}/project/{}/environment/{}/up",
-        linked_project.project, linked_project.environment
+        "https://backboard.{hostname}/project/{}/environment/{}/up?serviceId={}",
+        linked_project.project,
+        linked_project.environment,
+        service.unwrap_or_default(),
     ));
-    let spinner = if !std::io::stdout().is_terminal() {
+    let spinner = if std::io::stdout().is_terminal() {
         let spinner = ProgressBar::new_spinner()
             .with_style(
                 ProgressStyle::default_spinner()
@@ -117,6 +173,11 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     }
     println!("  {}: {}", "Build Logs".green().bold(), body.logs_url);
     if args.detach {
+        return Ok(());
+    }
+
+    // If the user is not in a terminal, don't stream logs
+    if !std::io::stdout().is_terminal() {
         return Ok(());
     }
 

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -5,6 +5,7 @@ use is_terminal::IsTerminal;
 
 use crate::{
     consts::{NO_SERVICE_LINKED, SERVICE_NOT_FOUND},
+    interact_or,
     table::Table,
     util::prompt::prompt_select,
 };
@@ -142,9 +143,8 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
 }
 
 fn prompt_plugin(plugins: Vec<Plugin>) -> Result<Plugin> {
-    if !std::io::stdout().is_terminal() {
-        bail!("Plugin must be provided when not running in a terminal")
-    }
+    interact_or!("Plugin must be provided when not running in a terminal");
+
     let plugin = prompt_select("Select a plugin", plugins)?;
 
     Ok(plugin)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,8 +27,8 @@ macro_rules! commands_enum {
 #[macro_export]
 macro_rules! interact_or {
     ($message:expr) => {
-        use anyhow::bail;
         if !std::io::stdout().is_terminal() {
+            use anyhow::bail;
             bail!($message);
         }
     };

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::commands::Configs;
+use crate::commands::{queries::project::ProjectProjectServicesEdgesNode, Configs};
 use anyhow::{Context, Result};
 
 pub fn prompt_options<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
@@ -48,4 +48,13 @@ pub fn prompt_select<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
         .with_render_config(Configs::get_render_config())
         .prompt()
         .context("Failed to prompt for select")
+}
+
+#[derive(Debug, Clone)]
+pub struct PromptService<'a>(pub &'a ProjectProjectServicesEdgesNode);
+
+impl<'a> Display for PromptService<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.name)
+    }
 }


### PR DESCRIPTION
fix 409 errors on projects with mutiple services
fix non-interactive checks

usage
```bash
railway up --service <SERVICE_NAME> [PATH]
```
or
```bash
railway up --service <SERVICE_ID> [PATH]
```