### PR TITLE
Implement `down` subcommand

### DIFF
--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -1,0 +1,91 @@
+use std::time::Duration;
+
+use anyhow::bail;
+
+use crate::{
+    consts::{ABORTED_BY_USER, TICK_STRING},
+    util::prompt::prompt_confirm_with_default,
+};
+
+use super::*;
+
+/// Remove the most recent deployment
+#[derive(Parser)]
+pub struct Args {
+    /// Skip confirmation dialog
+    #[clap(short = 'y', long = "yes")]
+    bypass: bool,
+}
+
+pub async fn command(args: Args, _json: bool) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let linked_project = configs.get_linked_project().await?;
+
+    let linked_project_name = linked_project
+        .name
+        .expect("Linked project is missing the name");
+
+    let linked_environment_name = linked_project
+        .environment_name
+        .expect("Linked environment is missing the name");
+
+    let linked_project_environment = format!(
+        "{} environment of project {}",
+        linked_environment_name.bold(),
+        linked_project_name.bold()
+    );
+
+    let vars = queries::deployments::Variables {
+        project_id: linked_project.project.clone(),
+    };
+
+    let res =
+        post_graphql::<queries::Deployments, _>(&client, configs.get_backboard(), vars).await?;
+
+    let body = res.data.context("Failed to retrieve response body")?;
+
+    let mut deployments: Vec<_> = body
+        .project
+        .deployments
+        .edges
+        .into_iter()
+        .map(|deployment| deployment.node)
+        .collect();
+    deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    let latest_deployment = deployments.first().context("No deployments found")?;
+
+    if !args.bypass {
+        let confirmed = prompt_confirm_with_default(
+            format!("Delete the latest deployment for {linked_project_environment}?").as_str(),
+            false,
+        )?;
+
+        if !confirmed {
+            bail!(ABORTED_BY_USER)
+        }
+    }
+
+    let spinner = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::default_spinner()
+                .tick_chars(TICK_STRING)
+                .template("{spinner:.green} {msg}")?,
+        )
+        .with_message(format!(
+            "Deleting the latest deployment for {linked_project_environment}..."
+        ));
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let vars = mutations::deployment_remove::Variables {
+        id: latest_deployment.id.clone(),
+    };
+
+    post_graphql::<mutations::DeploymentRemove, _>(&client, configs.get_backboard(), vars).await?;
+
+    spinner.finish_with_message(format!(
+        "The latest deployment for {linked_project_environment} was deleted."
+    ));
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod completion;
 pub mod delete;
 pub mod docs;
 pub mod domain;
+pub mod down;
 pub mod environment;
 pub mod init;
 pub mod link;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use anyhow::bail;
 
 use crate::{
@@ -7,7 +5,7 @@ use crate::{
     util::prompt::{prompt_select, PromptService},
 };
 
-use super::{queries::project::ProjectProjectServicesEdgesNode, *};
+use super::*;
 
 /// Link a service to the current project
 #[derive(Parser)]

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -3,6 +3,14 @@ use graphql_client::GraphQLQuery;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/DeploymentRemove.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct DeploymentRemove;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
     query_path = "src/gql/mutations/strings/LoginSessionConsume.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -3,6 +3,22 @@ use graphql_client::GraphQLQuery;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/LoginSessionConsume.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct LoginSessionConsume;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/LoginSessionCreate.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct LoginSessionCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
     query_path = "src/gql/mutations/strings/PluginCreate.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]
@@ -19,14 +35,6 @@ pub struct PluginDelete;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.graphql",
-    query_path = "src/gql/mutations/strings/ValidateTwoFactor.graphql",
-    response_derives = "Debug, Serialize, Clone"
-)]
-pub struct ValidateTwoFactor;
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "src/gql/schema.graphql",
     query_path = "src/gql/mutations/strings/ProjectCreate.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]
@@ -35,23 +43,15 @@ pub struct ProjectCreate;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.graphql",
-    query_path = "src/gql/mutations/strings/LoginSessionCreate.graphql",
-    response_derives = "Debug, Serialize, Clone"
-)]
-pub struct LoginSessionCreate;
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "src/gql/schema.graphql",
-    query_path = "src/gql/mutations/strings/LoginSessionConsume.graphql",
-    response_derives = "Debug, Serialize, Clone"
-)]
-pub struct LoginSessionConsume;
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "src/gql/schema.graphql",
     query_path = "src/gql/mutations/strings/ServiceDomainCreate.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]
 pub struct ServiceDomainCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/ValidateTwoFactor.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ValidateTwoFactor;

--- a/src/gql/mutations/strings/DeploymentRemove.graphql
+++ b/src/gql/mutations/strings/DeploymentRemove.graphql
@@ -1,0 +1,3 @@
+mutation DeploymentRemove($id: String!) {
+	deploymentRemove(id: $id)
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! commands_enum {
     );
 }
 
-// Macro that bails if not running in a terminal
+/// Ensure running in a terminal or bail with the provided message
 #[macro_export]
 macro_rules! interact_or {
     ($message:expr) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ commands_enum!(
     delete,
     domain,
     docs,
+    down,
     environment,
     init,
     link,


### PR DESCRIPTION
## Motivation

Partially brings back `railway down --yes` command (without the possibility to specify the environment—the linked one is used instead).

```
Remove the most recent deployment

Usage: railway down [OPTIONS]

Options:
  -y, --yes      Skip confirmation dialog
```