### PR TITLE
Fix a couple of regressions

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -133,11 +133,12 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let me = res.data.context("No data")?.me;
 
     spinner.finish_and_clear();
-    println!(
-        "Logged in as {} ({})",
-        me.name.context("No name")?.bold(),
-        me.email
-    );
+
+    if let Some(name) = me.name {
+        println!("Logged in as {} ({})", name.bold(), me.email);
+    } else {
+        println!("Logged in as {}", me.email);
+    }
 
     Ok(())
 }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -94,10 +94,11 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let hostname = configs.get_host();
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
+    let prefix: PathBuf = configs.get_closest_linked_project_directory()?.into();
 
     let path = match args.path {
         Some(path) => path,
-        None => configs.get_closest_linked_project_directory()?.into(),
+        None => prefix.clone(),
     };
 
     let service = get_service_to_deploy(&configs, &client, args.service).await?;
@@ -144,11 +145,17 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             pg.enable_steady_tick(Duration::from_millis(100));
 
             for entry in walked.into_iter().progress_with(pg) {
-                archive.append_path(entry?.path())?;
+                let entry = entry?;
+                let path = entry.path();
+                let stripped = PathBuf::from(".").join(path.strip_prefix(&prefix)?);
+                archive.append_path_with_name(path, stripped)?;
             }
         } else {
             for entry in walked.into_iter() {
-                archive.append_path(entry?.path())?;
+                let entry = entry?;
+                let path = entry.path();
+                let stripped = PathBuf::from(".").join(path.strip_prefix(&prefix)?);
+                archive.append_path_with_name(path, stripped)?;
             }
         }
     }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -95,6 +95,11 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
 
+    let path = match args.path {
+        Some(path) => path,
+        None => configs.get_closest_linked_project_directory()?.into(),
+    };
+
     let service = get_service_to_deploy(&configs, &client, args.service).await?;
 
     let spinner = if std::io::stdout().is_terminal() {
@@ -118,7 +123,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         .from_writer(SynchronizedWriter::new(arc.clone()));
     {
         let mut archive = Builder::new(&mut parz);
-        let mut builder = WalkBuilder::new(args.path.unwrap_or_else(|| ".".into()));
+        let mut builder = WalkBuilder::new(path);
         builder.add_custom_ignore_filename(".railwayignore");
         builder.add_custom_ignore_filename(".gitignore");
         let walker = builder.follow_links(true).hidden(false);

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,11 +147,7 @@ impl Configs {
     }
 
     pub fn get_closest_linked_project_directory(&self) -> Result<String> {
-        let current_dir = std::env::current_dir()?;
-        let path = current_dir
-            .to_str()
-            .context("Unable to get current working directory")?;
-        let mut current_path = PathBuf::from(path);
+        let mut current_path = std::env::current_dir()?;
         loop {
             let path = current_path
                 .to_str()


### PR DESCRIPTION
- `railway up` now walks up to find the linked directory, and then deploys from there
  - This also fixes a bug where absolute paths would fail to deploy
- `railway login` no longer errors when a user with no name logs in