### PR TITLE
release binary for `i686-pc-windows-gnu`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,9 @@ jobs:
 
           - target: x86_64-pc-windows-gnu
             os: windows-latest
+            
+          - target: i686-pc-windows-gnu
+            os: windows-latest
 
     steps:
       - name: Checkout repository
@@ -114,7 +117,7 @@ jobs:
           7z a ../../../railway-${{ needs.create-release.outputs.railway_version }}-${{ matrix.target }}.zip railway.exe
           cd -
 
-      - name: Prepare binares (tar) [Windows]
+      - name: Prepare binaries (tar) [Windows]
         if: matrix.os == 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release


### PR DESCRIPTION
Fixes #347.

This is the same case as #316.