### PR TITLE
Ignore CTRL+C on `railway run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1250,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1463,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "console",
+ "ctrlc",
  "dirs",
  "futures 0.3.27",
  "graphql-ws-client",
@@ -1866,6 +1889,12 @@ checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ async-tungstenite = { version = "0.18.0", features = [
 ] }
 is-terminal = "0.4.4"
 serde_with = "2.3.1"
+ctrlc = "3.2.5"

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -138,13 +138,19 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         }
     };
 
+    // a bit janky :/
+    ctrlc::set_handler(move || {
+        // do nothing, we just want to ignore CTRL+C
+        // this is for `rails c` and similar REPLs
+    })?;
+
     tokio::process::Command::new(args.args.first().context("No command provided")?)
         .args(args.args[1..].iter())
         .envs(variables)
-        .spawn()
-        .context("Failed to spawn command")?
-        .wait()
+        .status()
         .await
-        .context("Failed to wait for command")?;
+        .context("Failed to spawn command")?;
+
+    println!("Looking good? Run `railway up` to deploy your changes!");
     Ok(())
 }


### PR DESCRIPTION
This was causing issues where both the child and parent processes would exit at the same time, and the child process would be unable to respond to the SIGINT.

This PR ignores SIGINT on the parent process, and allows the child to handle it.

Resolves #384