### PR TITLE
Update `open` off of yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,9 +1304,9 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "open"
-version = "3.4.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ecf2487e799604735754d2c5896106785987b441b5aee58f242e4d4963179a"
+checksum = "075c5203b3a2b698bc72c6c10b1f6263182135751d5013ea66e8a4b3d0562a43"
 dependencies = [
  "pathdiff",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ graphql_client = { version = "0.11.0", features = ["reqwest-rustls"] }
 paste = "1.0.12"
 tokio = { version = "1.26.0", features = ["full"] }
 clap_complete = "4.1.5"
-open = "3.4.0"
+open = "4.0.1"
 inquire = "0.5.3"
 hyper = { version = "1.0.0-rc.3", features = ["server", "http1"] }
 base64 = "0.21.0"


### PR DESCRIPTION
Currently, you have to `cargo install --locked`, and you get a warning about the yanked version. It seems like the only breaking change to v4 is upping the MSRV (still lower than what's declared for this project).