### PR TITLE
exit with the same exit code as process for railway run

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -144,13 +144,22 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         // this is for `rails c` and similar REPLs
     })?;
 
-    tokio::process::Command::new(args.args.first().context("No command provided")?)
-        .args(args.args[1..].iter())
-        .envs(variables)
-        .status()
-        .await
-        .context("Failed to spawn command")?;
+    let exit_status =
+        tokio::process::Command::new(args.args.first().context("No command provided")?)
+            .args(args.args[1..].iter())
+            .envs(variables)
+            .status()
+            .await
+            .context("Failed to spawn command")?;
 
-    println!("Looking good? Run `railway up` to deploy your changes!");
+    if exit_status.success() {
+        println!("Looking good? Run `railway up` to deploy your changes!");
+    }
+
+    if let Some(code) = exit_status.code() {
+        // If there is an exit code (process not terminated by signal), exit with that code
+        std::process::exit(code);
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Exit the `railway run` process with the same exit code that the command being run exits with. This is important when using `railway run` to run tests and the tests exit with a non-zero exit code.

![image](https://user-images.githubusercontent.com/3044853/227656879-2454198d-cdb3-47f9-ab82-5a820f9d1b6f.png)
