### PR TITLE
Write config tmp file in same directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -280,9 +280,9 @@ impl Configs {
         create_dir_all(config_dir)?;
 
         // Use temporary file to achieve atomic write:
-        //  1. Open file <CONFIG_PATH>.tmp
+        //  1. Open file ~/railway/config.tmp
         //  2. Serialize temporary file
-        //  3. Rename temporary file to <CONFIG_PATH> (atomic operation)
+        //  3. Rename temporary file to ~/railway/config.json (atomic operation)
         let tmp_file_path = self.root_config_path.with_extension("tmp");
         let tmp_file = File::options()
             .create(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,9 +272,20 @@ impl Configs {
     }
 
     pub fn write(&self) -> Result<()> {
-        let config_dir = self.root_config_path.parent().context("Failed to get parent directory")?;
-        let config_file_name = self.root_config_path.file_name().context("Failed to get file name")?;
-        let config_tmp_file_name = format!("{}.tmp", config_file_name.to_str().context("Failed to convert file name to string")?);
+        let config_dir = self
+            .root_config_path
+            .parent()
+            .context("Failed to get parent directory")?;
+        let config_file_name = self
+            .root_config_path
+            .file_name()
+            .context("Failed to get file name")?;
+        let config_tmp_file_name = format!(
+            "{}.tmp",
+            config_file_name
+                .to_str()
+                .context("Failed to convert file name to string")?
+        );
 
         // Ensure directory exists
         create_dir_all(config_dir)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,16 +275,6 @@ impl Configs {
             .root_config_path
             .parent()
             .context("Failed to get parent directory")?;
-        let config_file_name = self
-            .root_config_path
-            .file_name()
-            .context("Failed to get file name")?;
-        let config_tmp_file_name = format!(
-            "{}.tmp",
-            config_file_name
-                .to_str()
-                .context("Failed to convert file name to string")?
-        );
 
         // Ensure directory exists
         create_dir_all(config_dir)?;
@@ -293,7 +283,7 @@ impl Configs {
         //  1. Open file <CONFIG_PATH>.tmp
         //  2. Serialize temporary file
         //  3. Rename temporary file to <CONFIG_PATH> (atomic operation)
-        let tmp_file_path = config_dir.join(config_tmp_file_name);
+        let tmp_file_path = self.root_config_path.with_extension("tmp");
         let tmp_file = File::options()
             .create(true)
             .write(true)

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,7 +281,7 @@ impl Configs {
 
         // Use temporary file to achieve atomic write:
         //  1. Open file ~/railway/config.tmp
-        //  2. Serialize temporary file
+        //  2. Serialize config to temporary file
         //  3. Rename temporary file to ~/railway/config.json (atomic operation)
         let tmp_file_path = self.root_config_path.with_extension("tmp");
         let tmp_file = File::options()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use std::env::temp_dir;
 use std::{
     collections::BTreeMap,
     fs,


### PR DESCRIPTION
This fixes an issue where renaming a temporary file from system tmp folder to `~/.railway` could fail if, for example, they were on different OS partitions. This change writes the temporary file to `~/railway/config.tmp` instead, to ensure the operation is as safe as possible.