### PR TITLE
update the package.json version on `cargo release`

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,6 @@
+# Automatically update version in package.json on `cargo release`
+[pre-release-replacements]
+file = "package.json"
+search = "\"version\": \"{version}\""
+replace = "\"version\": \"{new_version}\""
+version = "{version}"


### PR DESCRIPTION
When we run `cargo release patch|minor|major`, the version in `package.json` will automatically be updated
