### PR TITLE
feat: windows specific shell detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "url",
  "uuid",
  "which",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,5 @@ is-terminal = "0.4.4"
 serde_with = "2.3.1"
 ctrlc = "3.2.5"
 which = "4.4.0"
+winapi = {version="0.3.9", features = ["minwindef", "tlhelp32", "processthreadsapi", "handleapi", "winerror"]}
+

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -102,7 +102,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     }
 
     /// https://gist.github.com/mattn/253013/d47b90159cf8ffa4d92448614b748aa1d235ebe4
-    /// Only matches cmd, powershell or pwsh for safety
     /// defaults to cmd if no parent process is found
     #[cfg(target_os = "windows")]
     async fn windows_shell_detection() -> Option<WindowsShell> {

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -108,13 +108,23 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     /// defaults to cmd if no parent process is found
     #[cfg(target_os = "windows")]
     async fn windows_shell_detection() -> Option<WindowsShell> {
-        let (_, ppname) = unsafe {
+        let (ppid, mut ppname) = unsafe {
             get_parent_process_info()
                 .context("Failed to get parent process info")
                 .unwrap_or_else(|_| (0, "".to_string()))
         };
 
+        if ppname == "node.exe" {
+            (_, ppname) = unsafe {
+                node_fix(ppid)
+                    .context("Failed to get parent process info")
+                    .unwrap_or_else(|_| (0, "".to_string()))
+            }
+        }
+
         let ppname = ppname.split(".").next().unwrap_or("cmd");
+
+        dbg!(ppname);
 
         match ppname {
             "cmd" => Some(WindowsShell::Cmd),
@@ -165,12 +175,65 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     Ok(())
 }
 
+unsafe fn node_fix(process_id: u32) -> Result<(u32, String)> {
+    dbg!("node_fix");
+    let (ppid, ppname) = unsafe {
+        get_parent_process_info_with_input(process_id)
+            .context("Failed to get parent process info")
+            .unwrap_or_else(|_| (0, "".to_string()))
+    };
+
+    if ppname == "node.exe" {
+        node_fix(ppid)
+    } else {
+        Ok((ppid, ppname))
+    }
+}
+
 /// get the parent process info, translated from
 // https://gist.github.com/mattn/253013/d47b90159cf8ffa4d92448614b748aa1d235ebe4
 #[cfg(target_os = "windows")]
 unsafe fn get_parent_process_info() -> Option<(DWORD, String)> {
     let mut pe32: PROCESSENTRY32 = unsafe { zeroed() };
     let pid = unsafe { GetCurrentProcessId() };
+    let h_snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    let mut ppid = 0;
+
+    if h_snapshot == INVALID_HANDLE_VALUE {
+        return None;
+    }
+
+    pe32.dwSize = std::mem::size_of::<PROCESSENTRY32>() as u32;
+
+    if unsafe { Process32First(h_snapshot, &mut pe32) } != 0 {
+        loop {
+            if pe32.th32ProcessID == pid {
+                ppid = pe32.th32ParentProcessID;
+                break;
+            }
+            if unsafe { Process32Next(h_snapshot, &mut pe32) } == 0 {
+                break;
+            }
+        }
+    }
+
+    let mut parent_process_name = None;
+    if ppid != 0 {
+        parent_process_name = get_process_name(ppid);
+    }
+
+    unsafe { CloseHandle(h_snapshot) };
+
+    if let Some(ppname) = parent_process_name {
+        Some((ppid, ppname))
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "windows")]
+unsafe fn get_parent_process_info_with_input(pid: DWORD) -> Option<(DWORD, String)> {
+    let mut pe32: PROCESSENTRY32 = unsafe { zeroed() };
     let h_snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
     let mut ppid = 0;
 

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -73,20 +73,98 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         eprintln!("No service linked, skipping service variables");
     }
 
+    enum WindowsShell {
+        Cmd,
+        Powershell,
+        Powershell7,
+    }
+
+    async fn windows_shell_detection() -> Option<WindowsShell> {
+        let pid = std::process::id().to_string();
+
+        // https://stackoverflow.com/questions/7486717/finding-parent-process-id-on-windows
+        // runs the command "wmic process get processid,parentprocessid,executablepath|find "process id goes here"
+        // this is to determine the parent process of the current process, which should give the shell.
+        // Only matches cmd, powershell or pwsh for safety
+        let wmic = tokio::process::Command::new("wmic")
+            .args(&["process", "get", "executablepath,processid,parentprocessid"])
+            .output()
+            .await
+            .context("Failed to run wmic command")
+            .unwrap();
+        let wmic = String::from_utf8(wmic.stdout)
+            .context("Failed to convert wmic output to utf8")
+            .unwrap();
+
+        let current_process = wmic
+            .lines()
+            .find(|line| line.contains(&pid))
+            .context("Failed to find current process in wmic output")
+            .unwrap()
+            .to_string();
+
+        dbg!(&current_process);
+
+        let pids = current_process.split_whitespace().collect::<Vec<&str>>();
+        let pids = pids
+            .iter()
+            .filter(|pid| pid.parse::<u32>().is_ok())
+            .collect::<Vec<&&str>>();
+
+        let parent_pid = pids[0].to_string();
+
+        let parent_output_line = wmic
+            .lines()
+            .find(|line| line.contains(&parent_pid))
+            .context("Failed to find parent process in wmic output")
+            .unwrap()
+            .to_string();
+
+        let parent_executable = parent_output_line
+            .split("exe")
+            .next()
+            .context("Failed to find parent executable")
+            .unwrap()
+            .to_string()
+            + "exe";
+
+        if parent_executable.contains("pwsh") {
+            Some(WindowsShell::Powershell7)
+        } else if parent_executable.contains("powershell") {
+            Some(WindowsShell::Powershell)
+        } else {
+            Some(WindowsShell::Cmd)
+        }
+    }
+
     let shell = std::env::var("SHELL").unwrap_or(match std::env::consts::OS {
-        "windows" => "cmd".to_string(),
+        "windows" => match windows_shell_detection().await {
+            Some(WindowsShell::Powershell) => "powershell".to_string(),
+            Some(WindowsShell::Cmd) => "cmd".to_string(),
+            Some(WindowsShell::Powershell7) => "pwsh".to_string(),
+            None => "cmd".to_string(),
+        },
         _ => "sh".to_string(),
     });
 
-    println!("Entering subshell with Railway variables available. Type 'exit' to exit.");
+    let shell_options = match shell.as_str() {
+        "powershell" => vec!["/nologo"],
+        "pwsh" => vec!["/nologo"],
+        "cmd" => vec!["/k"],
+        _ => vec![],
+    };
+
+    println!("Entering subshell with Railway variables available. Type 'exit' to exit.\n");
 
     tokio::process::Command::new(shell)
+        .args(shell_options)
         .envs(all_variables)
         .spawn()
         .context("Failed to spawn command")?
         .wait()
         .await
         .context("Failed to wait for command")?;
+
     println!("Exited subshell, Railway variables no longer available.");
     Ok(())
 }

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -175,6 +175,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "windows")]
 unsafe fn node_fix(process_id: u32) -> Result<(u32, String)> {
     dbg!("node_fix");
     let (ppid, ppname) = unsafe {

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -108,7 +108,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     async fn windows_shell_detection() -> Option<WindowsShell> {
         let (_, ppname) = get_parent_process_info()
             .context("Failed to get parent process info")
-            .unwrap();
+            .unwrap_or_else(|_| (0, "".to_string()));
 
         if ppname.contains("pwsh") {
             Some(WindowsShell::Powershell7)

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -12,8 +12,6 @@ use winapi::shared::minwindef::DWORD;
 #[cfg(target_os = "windows")]
 use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
 #[cfg(target_os = "windows")]
-use winapi::um::processthreadsapi::GetCurrentProcessId;
-#[cfg(target_os = "windows")]
 use winapi::um::tlhelp32::{
     CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS,
 };
@@ -202,7 +200,7 @@ unsafe fn node_fix_recursive(process_id: DWORD, recursion: Option<u32>) -> Resul
 // https://gist.github.com/mattn/253013/d47b90159cf8ffa4d92448614b748aa1d235ebe4
 #[cfg(target_os = "windows")]
 unsafe fn get_parent_process_info(pid: Option<DWORD>) -> Option<(DWORD, String)> {
-    let pid = pid.unwrap_or(unsafe { GetCurrentProcessId() });
+    let pid = pid.unwrap_or(std::process::id());
 
     let mut pe32: PROCESSENTRY32 = unsafe { zeroed() };
     let h_snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -103,8 +103,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             .unwrap()
             .to_string();
 
-        dbg!(&current_process);
-
         let pids = current_process.split_whitespace().collect::<Vec<&str>>();
         let pids = pids
             .iter()

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -4,7 +4,6 @@ use crate::consts::SERVICE_NOT_FOUND;
 
 use super::*;
 
-use serde_json::from_str;
 use winapi::shared::minwindef::DWORD;
 use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
 use winapi::um::processthreadsapi::GetCurrentProcessId;


### PR DESCRIPTION
~~Uses [wmic](https://stackoverflow.com/questions/7486717/finding-parent-process-id-on-windows) and `std::process::id` to detect the parent process and therefore the correct shell to drop the user into.~~

Uses winapi syscalls and the `std::process::id` to detect the parent process of the cli. This either detects a shell listed below or defaults to `cmd`. Does nothing on non-windows platforms because of `#[cfg(target_os = "windows")]`

Supported shells:
- cmd
- Powershell 5
- Powershell 7 (pwsh)
- NuShell
- ElvSh

Edits:
- Because of brody, this now implements [this gist](https://gist.github.com/mattn/253013/d47b90159cf8ffa4d92448614b748aa1d235ebe4)