### PR TITLE
fix<run>: allows `railway run` to run batch scripts on windows, including pnpm and npm.

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -144,8 +144,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         // this is for `rails c` and similar REPLs
     })?;
 
-    let slash_c = "/C".to_owned();
-    let mut args = args.args.iter().collect::<Vec<_>>();
+    let mut args = args.args.iter().map(|s| s.as_str()).collect::<Vec<_>>();
     if args.is_empty() {
         bail!("No command provided");
     }
@@ -154,7 +153,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
 
     match std::env::consts::OS {
         "windows" => {
-            args.insert(0, &slash_c);
+            args.insert(0, "/C");
             child_process_name = "cmd"
         }
         _ => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -154,9 +154,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             args.insert(0, "/C");
             "cmd"
         }
-        _ => {
-            args.remove(0)
-        }
+        _ => args.remove(0),
     };
 
     let exit_status = tokio::process::Command::new(child_process_name)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -155,8 +155,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             "cmd"
         }
         _ => {
-            args.remove(0);
-            args.first().context("No command provided")?
+            args.remove(0)
         }
     };
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -149,18 +149,17 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         bail!("No command provided");
     }
 
-    let child_process_name: &str;
-
-    match std::env::consts::OS {
+    // So the linter doesn't get mad. I think this is pretty ugly.
+    let child_process_name = match std::env::consts::OS {
         "windows" => {
             args.insert(0, "/C");
-            child_process_name = "cmd"
+            "cmd"
         }
         _ => {
             args.remove(0);
-            child_process_name = args.first().context("No command provided")?
+            args.first().context("No command provided")?
         }
-    }
+    };
 
     let exit_status = tokio::process::Command::new(child_process_name)
         .args(args)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -149,7 +149,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         bail!("No command provided");
     }
 
-    // So the linter doesn't get mad. I think this is pretty ugly.
     let child_process_name = match std::env::consts::OS {
         "windows" => {
             args.insert(0, "/C");


### PR DESCRIPTION
Fixes #386
Allows `railway run` to run other batch script windows programs, such as pnpm and npm.

- one match statement that sets the child proc and does all the argument handling
- moved command spawning away from the match statemnt
- handles no argument passed