### PR TITLE
[command] [up] ignore .git and node_modules by default

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -127,6 +127,9 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         let mut builder = WalkBuilder::new(path);
         builder.add_custom_ignore_filename(".railwayignore");
         builder.add_custom_ignore_filename(".gitignore");
+
+        builder.add_ignore(".git/");
+
         let walker = builder.follow_links(true).hidden(false);
         let walked = walker.build().collect::<Vec<_>>();
         if let Some(spinner) = spinner {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -142,10 +142,8 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
 
     // list of all paths to ignore by default
     let ignore_paths = vec![".git", "node_modules"];
-    let ignore_paths: Vec<&std::ffi::OsStr> = ignore_paths
-        .iter()
-        .map(|s| std::ffi::OsStr::new(s))
-        .collect();
+    let ignore_paths: Vec<&std::ffi::OsStr> =
+        ignore_paths.iter().map(std::ffi::OsStr::new).collect();
 
     {
         let mut archive = Builder::new(&mut parz);
@@ -159,7 +157,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             spinner.finish_with_message("Indexed");
         }
         if std::io::stdout().is_terminal() {
-            //#region
             let pg = ProgressBar::new(walked.len() as u64)
                 .with_style(
                     ProgressStyle::default_bar()
@@ -170,7 +167,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
                 .with_message("Compressing")
                 .with_finish(ProgressFinish::WithMessage("Compressed".into()));
             pg.enable_steady_tick(Duration::from_millis(100));
-            //#endregion
 
             for entry in walked.into_iter().progress_with(pg) {
                 let entry = entry?;


### PR DESCRIPTION
I've written some code that ignores .git and node_modules by default. I've also added a small amount of documentation to the block that handles the actual compression of the gzipped tarball, since it is, in my opinion, quite hard to read.