### PR TITLE
fix<shell>: remove dbg! macro in windows shell detection

### DIFF
--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -186,8 +186,6 @@ async fn windows_shell_detection() -> Option<WindowsShell> {
 
     let ppname = ppname.split(".").next().unwrap_or("cmd");
 
-    dbg!(ppname);
-
     match ppname {
         "cmd" => Some(WindowsShell::Cmd),
         "powershell" => Some(WindowsShell::Powershell),


### PR DESCRIPTION
I left the dbg!() macro in by accident during the last pr. My bad