### PR TITLE
fix(cmd): Describe `railway connect` properly

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -9,7 +9,7 @@ use crate::util::prompt::{prompt_select, PromptPlugin};
 
 use super::{queries::project::PluginType, *};
 
-/// Change the active environment
+/// Connect to a plugin's shell (psql for Postgres, mongosh for MongoDB, etc.)
 #[derive(Parser)]
 pub struct Args {
     /// The name of the plugin to connect to


### PR DESCRIPTION
`railway connect` has the wrong description (likely copypaste error from `railway environment`).

```diff
- (fix/connect-desc ±) cli ツ railway --help
- Interact with Railway via CLI
- 
- Usage: railway [OPTIONS] <COMMAND>
- 
- Commands:
-   add          Add a new plugin to your project
-   completion   Generate completion script
-   connect      Change the active environment
+   connect      Connect to a plugin's shell (psql for Postgres, mongosh for MongoDB, etc.)
-   delete       Delete plugins from a project
```