### PR TITLE
use `DATABASE_URL` for psql

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -73,16 +73,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let (cmd_name, args): (&str, Vec<&str>) = match &plugin.name {
         PluginType::postgresql => (
             "psql",
-            vec![
-                "-U",
-                variables.get("PGUSER").unwrap_or(default),
-                "-h",
-                variables.get("PGHOST").unwrap_or(default),
-                "-p",
-                variables.get("PGPORT").unwrap_or(default),
-                "-d",
-                variables.get("PGDATABASE").unwrap_or(default),
-            ],
+            vec![variables.get("DATABASE_URL").unwrap_or(default)],
         ),
         PluginType::redis => (
             "redis-cli",


### PR DESCRIPTION
Currently `railway connect Postgres` asks the user for the database password, this issue isn't present with the other database types when using `connect` as they either use a URI or have the password passed in as a flag.

This PR uses the `DATABASE_URL` variable as the only argument to `psql`
Specifying a connection string has been supported since [psql 9.2.0](https://www.postgresql.org/docs/release/9.2.0/#AEN114358:~:text=option%20for%20views-,Allow%20libpq%20connection%20strings%20to%20have%20the%20format%20of%20a%20URI,-Add%20a%20single)