### PR TITLE
fix: Update README Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ cargo install railwayapp --locked
 ### Homebrew
 
 ```bash 
-brew tap railwayapp/tap
-brew install rlwy
+brew tap railwayapp/railway
+brew install railway
 ```
 
 ### NPM


### PR DESCRIPTION
This is a simple update to the Homebrew installation section in this README. Seems like `rlwy` is outdated now.