### PR TITLE
Fix `railway logs` pulling from the wrong deployment

### DIFF
--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -43,22 +43,20 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let services = project.services.edges.iter().collect::<Vec<_>>();
 
     let environment_id = get_matched_environment(&project, environment)?.id;
-    let service = if let Some(service_arg) = args.service {
+    let service = match (args.service, linked_project.service) {
         // If the user specified a service, use that
-        let service_id = services
+        (Some(service_arg), _) => services
             .iter()
-            .find(|service| service.node.name == service_arg || service.node.id == service_arg);
-        if let Some(service_id) = service_id {
-            Some(service_id.node.id.to_owned())
-        } else {
-            bail!("Service not found");
-        }
-    } else if let Some(service) = linked_project.service {
-        // If the user didn't specify a service, but we have a linked service, use that
-        Some(service)
-    } else {
-        bail!("No service could be found. Please either link one with `railway service` or specify one via the `--service` flag.");
-    }.unwrap();
+            .find(|service| service.node.name == service_arg || service.node.id == service_arg)
+            .with_context(|| format!("Service '{service_arg}' not found"))?
+            .node
+            .id
+            .to_owned(),
+        // Otherwise if we have a linked service, use that
+        (_, Some(linked_service)) => linked_service,
+        // Otherwise it's a user error
+        _ => bail!("No service could be found. Please either link one with `railway service` or specify one via the `--service` flag."),
+    };
 
     let vars = queries::deployments::Variables {
         input: DeploymentListInput {

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -1,12 +1,25 @@
 use std::time::Duration;
 
-use crate::{consts::TICK_STRING, util::prompt::prompt_confirm_with_default};
+use anyhow::bail;
 
-use super::*;
+use super::{queries::deployments::DeploymentListInput, *};
+use crate::{
+    consts::TICK_STRING,
+    controllers::{environment::get_matched_environment, project::get_project},
+    util::prompt::prompt_confirm_with_default,
+};
 
 /// Remove the most recent deployment
 #[derive(Parser)]
 pub struct Args {
+    /// Service to remove the deployment from (defaults to linked service)
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// Environment to remove the deployment from (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
     /// Skip confirmation dialog
     #[clap(short = 'y', long = "yes")]
     bypass: bool,
@@ -16,6 +29,43 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
+
+    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+
+    let environment = args
+        .environment
+        .clone()
+        .unwrap_or(linked_project.environment.clone());
+
+    let services = project.services.edges.iter().collect::<Vec<_>>();
+
+    let environment_id = get_matched_environment(&project, environment)?.id;
+    let service = if let Some(service_arg) = args.service {
+        // If the user specified a service, use that
+        let service_id = services
+            .iter()
+            .find(|service| service.node.name == service_arg || service.node.id == service_arg);
+        if let Some(service_id) = service_id {
+            Some(service_id.node.id.to_owned())
+        } else {
+            bail!("Service not found");
+        }
+    } else if let Some(service) = linked_project.service {
+        // If the user didn't specify a service, but we have a linked service, use that
+        Some(service)
+    } else {
+        bail!("No service could be found. Please either link one with `railway service` or specify one via the `--service` flag.");
+    }.unwrap();
+
+    let vars = queries::deployments::Variables {
+        input: DeploymentListInput {
+            project_id: Some(linked_project.project.clone()),
+            environment_id: Some(environment_id),
+            service_id: Some(service),
+            include_deleted: None,
+            status: None,
+        },
+    };
 
     let linked_project_name = linked_project
         .name
@@ -31,14 +81,9 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         linked_project_name.bold()
     );
 
-    let vars = queries::deployments::Variables {
-        project_id: linked_project.project.clone(),
-    };
-
     let deployments =
         post_graphql::<queries::Deployments, _>(&client, configs.get_backboard(), vars)
             .await?
-            .project
             .deployments;
 
     let mut deployments: Vec<_> = deployments

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -93,11 +93,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         .edges
         .into_iter()
         .filter_map(|deployment| {
-            if deployment.node.status == DeploymentStatus::SUCCESS {
-                Some(deployment.node)
-            } else {
-                None
-            }
+            (deployment.node.status == DeploymentStatus::SUCCESS).then_some(deployment.node)
         })
         .collect();
     deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -5,7 +5,10 @@ use crate::controllers::{
 };
 use anyhow::bail;
 
-use super::{queries::deployments::DeploymentStatus, *};
+use super::{
+    queries::deployments::{DeploymentListInput, DeploymentStatus},
+    *,
+};
 
 /// View the most-recent deploy's logs
 #[derive(Parser)]
@@ -60,13 +63,18 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
     }.unwrap();
 
     let vars = queries::deployments::Variables {
-        project_id: linked_project.project.clone(),
+        input: DeploymentListInput {
+            project_id: Some(linked_project.project.clone()),
+            environment_id: Some(environment_id),
+            service_id: Some(service),
+            include_deleted: None,
+            status: None,
+        },
     };
 
     let deployments =
         post_graphql::<queries::Deployments, _>(&client, configs.get_backboard(), vars)
             .await?
-            .project
             .deployments;
 
     let mut deployments: Vec<_> = deployments

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -80,7 +80,13 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
     let mut deployments: Vec<_> = deployments
         .edges
         .into_iter()
-        .map(|deployment| deployment.node)
+        .filter_map(|deployment| {
+            if deployment.node.status == DeploymentStatus::SUCCESS {
+                Some(deployment.node)
+            } else {
+                None
+            }
+        })
         .collect();
     deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
     let latest_deployment = deployments.first().context("No deployments found")?;

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -81,11 +81,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         .edges
         .into_iter()
         .filter_map(|deployment| {
-            if deployment.node.status == DeploymentStatus::SUCCESS {
-                Some(deployment.node)
-            } else {
-                None
-            }
+            (deployment.node.status == DeploymentStatus::SUCCESS).then_some(deployment.node)
         })
         .collect();
     deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -1,10 +1,23 @@
-use crate::controllers::deployment::{stream_build_logs, stream_deploy_logs};
+use crate::controllers::{
+    deployment::{stream_build_logs, stream_deploy_logs},
+    environment::get_matched_environment,
+    project::get_project,
+};
+use anyhow::bail;
 
 use super::{queries::deployments::DeploymentStatus, *};
 
 /// View the most-recent deploy's logs
 #[derive(Parser)]
 pub struct Args {
+    /// Service to view logs from (defaults to linked service)
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// Environment to view logs from (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
     /// Show deployment logs
     #[clap(short, long, group = "log_type")]
     deployment: bool,
@@ -18,6 +31,33 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
+
+    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+
+    let environment = args
+        .environment
+        .clone()
+        .unwrap_or(linked_project.environment.clone());
+
+    let services = project.services.edges.iter().collect::<Vec<_>>();
+
+    let environment_id = get_matched_environment(&project, environment)?.id;
+    let service = if let Some(service_arg) = args.service {
+        // If the user specified a service, use that
+        let service_id = services
+            .iter()
+            .find(|service| service.node.name == service_arg || service.node.id == service_arg);
+        if let Some(service_id) = service_id {
+            Some(service_id.node.id.to_owned())
+        } else {
+            bail!("Service not found");
+        }
+    } else if let Some(service) = linked_project.service {
+        // If the user didn't specify a service, but we have a linked service, use that
+        Some(service)
+    } else {
+        bail!("No service could be found. Please either link one with `railway service` or specify one via the `--service` flag.");
+    }.unwrap();
 
     let vars = queries::deployments::Variables {
         project_id: linked_project.project.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,7 +190,7 @@ impl Configs {
                 project: data.project_token.project.id,
                 environment: data.project_token.environment.id,
                 environment_name: Some(data.project_token.environment.name),
-                service: project.cloned().and_then(|p| p.service)
+                service: project.cloned().and_then(|p| p.service),
             };
             return Ok(project);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,9 @@ impl Configs {
     }
 
     pub async fn get_linked_project(&self) -> Result<LinkedProject> {
+        let path = self.get_closest_linked_project_directory()?;
+        let project = self.root_config.projects.get(&path);
+
         if Self::get_railway_token().is_some() {
             let vars = queries::project_token::Variables {};
             let client = GQLClient::new_authorized(self)?;
@@ -187,13 +190,10 @@ impl Configs {
                 project: data.project_token.project.id,
                 environment: data.project_token.environment.id,
                 environment_name: Some(data.project_token.environment.name),
-                service: None,
+                service: project.cloned().and_then(|p| p.service)
             };
             return Ok(project);
         }
-
-        let path = self.get_closest_linked_project_directory()?;
-        let project = self.root_config.projects.get(&path);
 
         project
             .cloned()

--- a/src/gql/queries/strings/Deployments.graphql
+++ b/src/gql/queries/strings/Deployments.graphql
@@ -1,6 +1,5 @@
-query Deployments($projectId: String!) {
-  project(id: $projectId) {
-    deployments {
+query Deployments($input: DeploymentListInput!) {
+    deployments(input: $input) {
       edges {
         node {
           id
@@ -9,5 +8,4 @@ query Deployments($projectId: String!) {
         }
       }
     }
-  }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -20,7 +20,7 @@ where
 {
     let configs = Configs::new()?;
     let Some(token) = configs.root_config.user.token.clone() else {
-      bail!("Unauthorized. Please login with `railway login`")
+        bail!("Unauthorized. Please login with `railway login`")
     };
     let bearer = format!("Bearer {token}");
     let hostname = configs.get_host();


### PR DESCRIPTION
This fixes #436
This also fixes this for linked environments
This also makes sure it pulls from the latest *active* deployment, not just the latest deployment