### PR TITLE
Remove confusing wording in `railway run`

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -156,10 +156,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         .status()
         .await?;
 
-    if exit_status.success() {
-        println!("Looking good? Run `railway up` to deploy your changes!");
-    }
-
     if let Some(code) = exit_status.code() {
         // If there is an exit code (process not terminated by signal), exit with that code
         std::process::exit(code);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -20,7 +20,7 @@ where
 {
     let configs = Configs::new()?;
     let Some(token) = configs.root_config.user.token.clone() else {
-      bail!("Unauthorized. Please login with `railway login`")
+        bail!("Unauthorized. Please login with `railway login`")
     };
     let bearer = format!("Bearer {token}");
     let hostname = configs.get_host();


### PR DESCRIPTION
This message that is printed after `railway run` often confuses people.