### PR TITLE
Allow service to be selected in `railway link`

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -90,9 +90,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
     if let Some(deployment_id) = args.deployment_id {
         deployment = deployments
             .iter()
-            .find(|deployment| {
-                deployment.id == deployment_id
-            })
+            .find(|deployment| deployment.id == deployment_id)
             .context("Deployment id does not exist")?;
     } else {
         // get the latest deloyment

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,7 @@ pub enum RailwayError {
     #[error("Failed to fetch: {0}")]
     FetchError(#[from] reqwest::Error),
 
-    #[error("No linked project found. Run `railway link` to connect to a project.")]
+    #[error("No linked project found. Run railway link to connect to a project, and a service.")]
     NoLinkedProject,
 
     #[error("Project not found. Run `railway link` to connect to a project.")]

--- a/src/gql/queries/strings/Projects.graphql
+++ b/src/gql/queries/strings/Projects.graphql
@@ -17,6 +17,14 @@ query Projects($teamId: String) {
 						}
 					}
 				}
+            	services {
+      				edges {
+        				node {
+          					id
+							name
+        				}
+      				}
+    			}
 			}
 		}
 	}

--- a/src/gql/queries/strings/UserProjects.graphql
+++ b/src/gql/queries/strings/UserProjects.graphql
@@ -19,6 +19,14 @@ query UserProjects {
 							}
 						}
 					}
+                    services {
+                        edges {
+                            node {
+                                id
+                                name
+                            }
+                        }
+                    }
 				}
 			}
 		}


### PR DESCRIPTION
This adds a new prompt in the `railway link` command allowing you to select a service.

Some notes:
- The links command internal code is a mess (and needs to be cleaned up)
- Logic is often being implemented 3x for the same thing
- This is the same with some other commands, but this is one of the worst