### PR TITLE
Fix up from automatically selecting a service

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -90,9 +90,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
     if let Some(deployment_id) = args.deployment_id {
         deployment = deployments
             .iter()
-            .find(|deployment| {
-                deployment.id == deployment_id
-            })
+            .find(|deployment| deployment.id == deployment_id)
             .context("Deployment id does not exist")?;
     } else {
         // get the latest deloyment

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -69,13 +69,6 @@ async fn get_service_or_plugins(
                     .map(|plugin| plugin.node.id.to_owned())
                     .collect(),
             )
-        } else if services.len() == 1 {
-            // If there is only one service, use that
-            services
-                .first()
-                .map(|service| service.node.id.to_owned())
-                .map(ServiceOrPlugins::Service)
-                .unwrap()
         } else {
             // If there are multiple services, prompt the user to select one
             if std::io::stdout().is_terminal() {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -89,9 +89,6 @@ pub async fn get_service_to_deploy(
         if services.is_empty() {
             // If there are no services, backboard will generate one for us
             None
-        } else if services.len() == 1 {
-            // If there is only one service, use that
-            services.first().map(|service| service.node.id.to_owned())
         } else {
             // If there are multiple services, prompt the user to select one
             if std::io::stdout().is_terminal() {


### PR DESCRIPTION
Previously, `up` and `logs` would pick a service if only one service was in the linked project. This often caused unwanted behaviour, so this PR changes it to a prompt.

Relevant thread: https://discord.com/channels/713503345364697088/1160376027365785711