### PR TITLE
Add context if terminal is TTY

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -94,10 +94,11 @@ pub async fn get_service_to_deploy(
             if std::io::stdout().is_terminal() {
                 let prompt_services: Vec<_> =
                     services.iter().map(|s| PromptService(&s.node)).collect();
-                let service = prompt_select("Select a service to deploy to", prompt_services)?;
+                let service = prompt_select("Select a service to deploy to", prompt_services)
+                    .context("Please specify a service to deploy to via the `--service` flag.")?;
                 Some(service.0.id.clone())
             } else {
-                bail!("Multiple services found. Please specify a service to deploy to.")
+                bail!("Multiple services found. Please specify a service to deploy to via the `--service` flag.")
             }
         }
     };


### PR DESCRIPTION
This fixes a [silly bug](https://discord.com/channels/713503345364697088/1164669294966231171/1164705365003341854) where the terminal thinks it is TTY. Unfortunately, we can't do anything about that but we can add extra context to the error.