### PR TITLE
Improve login

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,6 +1,8 @@
 use std::{net::SocketAddr, time::Duration};
 
-use crate::{consts::TICK_STRING, interact_or, util::prompt::prompt_confirm_with_default};
+use crate::{
+    consts::TICK_STRING, interact_or, util::prompt::prompt_confirm_with_default_with_cancel,
+};
 
 use super::*;
 
@@ -29,10 +31,14 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         return browserless_login().await;
     }
 
-    let confirm = prompt_confirm_with_default("Open the browser?", true)?;
+    let confirm = prompt_confirm_with_default_with_cancel("Open the browser?", true)?;
 
-    if !confirm {
-        return browserless_login().await;
+    if let Some(confirm) = confirm {
+        if !confirm {
+            return browserless_login().await;
+        }
+    } else {
+        return Ok(());
     }
 
     let port = rand::thread_rng().gen_range(50000..60000);

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -32,7 +32,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let confirm = prompt_confirm_with_default("Open the browser?", true)?;
 
     if !confirm {
-        return Ok(());
+        return browserless_login().await;
     }
 
     let port = rand::thread_rng().gen_range(50000..60000);

--- a/src/config.rs
+++ b/src/config.rs
@@ -265,6 +265,9 @@ impl Configs {
                         .with_attr(Attributes::BOLD),
                 ),
             )
+            .with_canceled_prompt_indicator(
+                Styled::new("<cancelled>").with_fg(inquire::ui::Color::DarkRed),
+            )
     }
 
     pub fn write(&self) -> Result<()> {

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -31,6 +31,18 @@ pub fn prompt_confirm_with_default(message: &str, default: bool) -> Result<bool>
         .context("Failed to prompt for confirm")
 }
 
+pub fn prompt_confirm_with_default_with_cancel(
+    message: &str,
+    default: bool,
+) -> Result<Option<bool>> {
+    let confirm = inquire::Confirm::new(message);
+    confirm
+        .with_default(default)
+        .with_render_config(Configs::get_render_config())
+        .prompt_skippable()
+        .context("Failed to prompt for confirm")
+}
+
 pub fn prompt_multi_options<T: Display>(message: &str, options: Vec<T>) -> Result<Vec<T>> {
     let multi_select = inquire::MultiSelect::new(message, options);
     multi_select


### PR DESCRIPTION
If you answer no to the prompt about opening the browser, instead of just exiting, it'll now perform a browserless login instead.