### PR TITLE
Clarify `shell` command

### DIFF
--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -23,7 +23,7 @@ use std::ffi::CStr;
 #[cfg(target_os = "windows")]
 use std::mem::zeroed;
 
-/// Open a subshell with Railway variables available
+/// Open a local subshell with Railway variables available
 #[derive(Parser)]
 pub struct Args {
     /// Service to pull variables from (defaults to linked service)


### PR DESCRIPTION
Changes the description to make sure it is clear that it is a local subshell