### PR TITLE
Fix i686 windows target build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
     name: Build Release Assets
     needs: ["create-release"]
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
             os: windows-latest
 
           - target: i686-pc-windows-gnu
-            os: windows-latest
+            os: ubuntu-latest
             use-cross: true
 
     steps:


### PR DESCRIPTION
This PR fixes occasional railway cli install errors.

Related help threads:
https://discord.com/channels/713503345364697088/1196823606320185445
https://discord.com/channels/713503345364697088/1194757540693671978

Related issues:
https://github.com/railwayapp/cli/issues/454
https://github.com/railwayapp/cli/issues/428

The i686-windows-gnu target does not build on windows image for whatever reason, but we can cross compile it instead.

Changes:
- Updated build image for the target
- Disabled `continue-on-error` option

Build result is tested on my machine, don't see any issues with functionality.
