### PR TITLE
Remove .gitignore from ignore files in `up`

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -173,7 +173,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         let mut archive = Builder::new(&mut parz);
         let mut builder = WalkBuilder::new(path);
         builder.add_custom_ignore_filename(".railwayignore");
-        builder.add_custom_ignore_filename(".gitignore");
 
         let walker = builder.follow_links(true).hidden(false);
         let walked = walker.build().collect::<Vec<_>>();


### PR DESCRIPTION
This removes the searching of .gitignore in the up command. This previously caused some unknown behaviour.

