### PR TITLE
Add --no-gitignore flag to up command

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -45,6 +45,10 @@ pub struct Args {
     #[clap(short, long)]
     /// Environment to deploy to (defaults to linked environment)
     environment: Option<String>,
+
+    #[clap(long)]
+    /// Don't ignore paths from .gitignore
+    no_gitignore: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -173,7 +177,9 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         let mut archive = Builder::new(&mut parz);
         let mut builder = WalkBuilder::new(path);
         builder.add_custom_ignore_filename(".railwayignore");
-        builder.add_custom_ignore_filename(".gitignore");
+        if !args.no_gitignore {
+            builder.add_custom_ignore_filename(".gitignore");
+        }
 
         let walker = builder.follow_links(true).hidden(false);
         let walked = walker.build().collect::<Vec<_>>();


### PR DESCRIPTION
This pull request adds a new flag, --no-gitignore, to the up command. When this flag is used, the command will not ignore paths specified in the .gitignore file. This allows for more flexibility when deploying to different environments.

Superceeds #481