### PR TITLE
fix: update version to match with latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "railwayapp"
-version = "3.5.2"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "railwayapp"
-version = "3.5.2"
+version = "3.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Railway <contact@railway.app>"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@railway/cli",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Develop and deploy code with zero configuration",
   "type": "module",
   "author": "Jake Runzer",


### PR DESCRIPTION
👋 looks like the version is still pointing to the old release, correcting it to match with the latest release.

relates to https://github.com/Homebrew/homebrew-core/pull/168599