### PR TITLE
Add volume support to the CLI

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,4 +25,5 @@ pub mod status;
 pub mod unlink;
 pub mod up;
 pub mod variables;
+pub mod volume;
 pub mod whoami;

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -1,0 +1,136 @@
+use super::*;
+use crate::{
+    controllers::project::get_project,
+    queries::project::ProjectProject,
+    util::prompt::{fake_select, prompt_text},
+};
+use anyhow::{anyhow, bail};
+use clap::Parser;
+
+/// Manage project volumes
+#[derive(Parser)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Service ID
+    #[clap(long, short)]
+    service: Option<String>,
+
+    /// Environment ID
+    #[clap(long, short)]
+    environment: Option<String>,
+}
+structstruck::strike! {
+    #[strikethrough[derive(Parser)]]
+    enum Commands {
+        /// List volumes
+        #[clap(alias = "ls")]
+        List,
+
+        /// Add a new volume
+        #[clap(alias = "create")]
+        Add(struct {
+            /// The mount path of the volume
+            #[clap(long, short)]
+            mount_path: Option<String>,
+        }),
+
+        /// Delete a volume
+        #[clap(alias = "remove", alias = "rm")]
+        Delete,
+
+        /// Update a volume
+        Update,
+    }
+}
+
+pub async fn command(args: Args, _json: bool) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let linked_project = configs.get_linked_project().await?;
+    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let service = args.service.or_else(|| linked_project.service.clone());
+    let environment = args
+        .environment
+        .clone()
+        .unwrap_or(linked_project.environment.clone());
+
+    match args.command {
+        Commands::Add(a) => add(service, environment, a.mount_path, project).await?,
+        _ => unimplemented!(),
+    }
+
+    Ok(())
+}
+
+async fn add(
+    service: Option<String>,
+    environment: String,
+    mount: Option<String>,
+    project: ProjectProject,
+) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let service = service.ok_or_else(|| anyhow!("No service found. Please link one via `railway link` or specify one via the `--service` flag."))?;
+    let mount = if let Some(mount) = mount {
+        if mount.starts_with('/') {
+            fake_select("Enter the mount path of the volume", mount.as_str());
+            mount
+        } else {
+            bail!("Mount path must start with a `/`")
+        }
+    } else {
+        prompt_text("Enter the mount path of the volume")?
+    };
+
+    let service_name = project
+        .services
+        .edges
+        .iter()
+        .find(|s| s.node.id == service)
+        .map(|s| s.node.name.clone())
+        .unwrap();
+    let environment_name = project
+        .environments
+        .edges
+        .iter()
+        .find(|e| e.node.id == environment)
+        .map(|e| e.node.name.clone())
+        .unwrap();
+
+    // check if there is a volume already mounted on the service in that environment
+    if project.volumes.edges.iter().any(|v| {
+        v.node.volume_instances.edges.iter().any(|a| {
+            a.node.service_id == Some(service.clone())
+                && a.node.environment_id == environment.clone()
+        })
+    }) {
+        bail!(
+            "A volume is already mounted on service {} in environment {}",
+            service_name.blue(),
+            environment_name.blue()
+        );
+    }
+
+    let volume = mutations::volume_create::Variables {
+        service_id: service.clone(),
+        environment_id: environment.clone(),
+        mount_path: mount.clone(),
+        project_id: project.id,
+    };
+
+    let details =
+        post_graphql::<mutations::VolumeCreate, _>(&client, configs.get_backboard(), volume)
+            .await?;
+
+    println!(
+        "Volume \"{}\" created for service {} in environment {} at mount path \"{}\"",
+        details.volume_create.name.blue(),
+        service_name.blue(),
+        environment_name.blue(),
+        mount.cyan().bold()
+    );
+
+    Ok(())
+}

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -304,17 +304,18 @@ async fn list(environment: String, project: ProjectProject) -> Result<()> {
                 .find(|a| a.node.environment_id == environment.clone())
                 .unwrap();
             println!("Volume: {}", volume.node.volume.name.green());
+            let service = project
+                .services
+                .edges
+                .iter()
+                .find(|s| s.node.id == volume.node.service_id.clone().unwrap_or_default());
             println!(
                 "Attached to: {}",
-                project
-                    .services
-                    .edges
-                    .iter()
-                    .find(|s| s.node.id == volume.node.service_id.clone().unwrap())
-                    .unwrap()
-                    .node
-                    .name
-                    .purple()
+                if let Some(service) = service {
+                    service.node.name.purple()
+                } else {
+                    "N/A".dimmed()
+                }
             );
             println!("Mount path: {}", volume.node.mount_path.yellow());
             println!(

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     controllers::project::get_project,
-    queries::project::ProjectProject,
+    queries::project::{ProjectProject, ProjectProjectVolumesEdges},
     util::prompt::{fake_select, prompt_text},
 };
 use anyhow::{anyhow, bail};
@@ -58,9 +58,74 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
 
     match args.command {
         Commands::Add(a) => add(service, environment, a.mount_path, project).await?,
+        Commands::List => list(environment, project).await?,
         _ => unimplemented!(),
     }
 
+    Ok(())
+}
+
+async fn list(environment: String, project: ProjectProject) -> Result<()> {
+    let volumes: Vec<&ProjectProjectVolumesEdges> = project
+        .volumes
+        .edges
+        .iter()
+        .filter(|v| {
+            v.node
+                .volume_instances
+                .edges
+                .iter()
+                .any(|a| a.node.environment_id == environment.clone())
+        })
+        .collect();
+    let environment_name = project
+        .environments
+        .edges
+        .iter()
+        .find(|e| e.node.id == environment)
+        .map(|e| e.node.name.clone())
+        .unwrap();
+
+    if volumes.is_empty() {
+        bail!(
+            "No volumes found in environment {}",
+            environment_name.blue()
+        );
+    } else {
+        println!("Project: {}", project.name.cyan().bold());
+        println!("Environment: {}", environment_name.cyan().bold());
+        for volume in volumes {
+            println!();
+            let volume = volume
+                .node
+                .volume_instances
+                .edges
+                .iter()
+                .find(|a| a.node.environment_id == environment.clone())
+                .unwrap();
+            println!("Volume: {}", volume.node.volume.name.green());
+            println!(
+                "Attached to: {}",
+                project
+                    .services
+                    .edges
+                    .iter()
+                    .find(|s| s.node.id == volume.node.service_id.clone().unwrap())
+                    .unwrap()
+                    .node
+                    .name
+                    .purple()
+            );
+            println!("Mount path: {}", volume.node.mount_path.yellow());
+            println!(
+                "Storage used: {}{}/{}{}",
+                volume.node.current_size_mb.round().to_string().blue(),
+                "MB".blue(),
+                volume.node.size_mb.to_string().red(),
+                "MB".red()
+            )
+        }
+    }
     Ok(())
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -49,4 +49,10 @@ pub enum RailwayError {
 
     #[error("{0}")]
     FailedToUpload(String),
+
+    #[error("Volume {0} not found.")]
+    VolumeNotFound(String),
+
+    #[error("2FA code is incorrect. Please try again.")]
+    InvalidTwoFactorCode,
 }

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -83,3 +83,21 @@ pub struct VolumeCreate;
     skip_serializing_none
 )]
 pub struct VolumeDelete;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/VolumeMountPathUpdate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct VolumeMountPathUpdate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/VolumeNameUpdate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct VolumeNameUpdate;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -101,3 +101,12 @@ pub struct VolumeMountPathUpdate;
     skip_serializing_none
 )]
 pub struct VolumeNameUpdate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/VolumeDetach.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct VolumeDetach;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -110,3 +110,12 @@ pub struct VolumeNameUpdate;
     skip_serializing_none
 )]
 pub struct VolumeDetach;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/VolumeAttach.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct VolumeAttach;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -65,3 +65,12 @@ pub struct ValidateTwoFactor;
     skip_serializing_none
 )]
 pub struct TemplateDeploy;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/VolumeCreate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct VolumeCreate;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -74,3 +74,12 @@ pub struct TemplateDeploy;
     skip_serializing_none
 )]
 pub struct VolumeCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/VolumeDelete.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct VolumeDelete;

--- a/src/gql/mutations/strings/VolumeAttach.graphql
+++ b/src/gql/mutations/strings/VolumeAttach.graphql
@@ -1,0 +1,7 @@
+mutation VolumeAttach($environmentId: String!, $volumeId: String!, $serviceId: String!) {
+  volumeInstanceUpdate(
+    input: { serviceId: $serviceId }
+    environmentId: $environmentId
+    volumeId: $volumeId
+  )
+}

--- a/src/gql/mutations/strings/VolumeCreate.graphql
+++ b/src/gql/mutations/strings/VolumeCreate.graphql
@@ -1,0 +1,7 @@
+mutation VolumeCreate($projectId: String!, $environmentId: String!, $serviceId: String!, $mountPath: String!) {
+  volumeCreate(
+    input: {projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId, mountPath: $mountPath}
+  ) {
+    name
+  }
+}

--- a/src/gql/mutations/strings/VolumeDelete.graphql
+++ b/src/gql/mutations/strings/VolumeDelete.graphql
@@ -1,0 +1,3 @@
+mutation VolumeDelete($id: String!) {
+  volumeDelete(volumeId: $id)
+}

--- a/src/gql/mutations/strings/VolumeDetach.graphql
+++ b/src/gql/mutations/strings/VolumeDetach.graphql
@@ -1,0 +1,7 @@
+mutation VolumeDetach($environmentId: String!, $volumeId: String!) {
+  volumeInstanceUpdate(
+    input: { serviceId: null }
+    environmentId: $environmentId
+    volumeId: $volumeId
+  )
+}

--- a/src/gql/mutations/strings/VolumeMountPathUpdate.graphql
+++ b/src/gql/mutations/strings/VolumeMountPathUpdate.graphql
@@ -1,0 +1,7 @@
+mutation VolumeMountPathUpdate($serviceId: String, $environmentId: String!, $volumeId: String!, $mountPath: String!) {
+  volumeInstanceUpdate(
+    input: {serviceId: $serviceId, mountPath: $mountPath}
+    environmentId: $environmentId
+    volumeId: $volumeId
+  )
+}

--- a/src/gql/mutations/strings/VolumeNameUpdate.graphql
+++ b/src/gql/mutations/strings/VolumeNameUpdate.graphql
@@ -1,0 +1,5 @@
+mutation VolumeNameUpdate($volumeId: String!, $name: String!) {
+  volumeUpdate(volumeId: $volumeId, input: {name: $name}) {
+    name
+  }
+}

--- a/src/gql/queries/strings/Project.graphql
+++ b/src/gql/queries/strings/Project.graphql
@@ -43,6 +43,8 @@ query Project($id: String!) {
                 serviceId
                 mountPath
                 environmentId
+                currentSizeMB
+                sizeMB
                 volume {
                   name
                   id

--- a/src/gql/queries/strings/Project.graphql
+++ b/src/gql/queries/strings/Project.graphql
@@ -3,7 +3,7 @@ query Project($id: String!) {
     id
     name
     team {
-        name
+      name
     }
     environments {
       edges {
@@ -18,7 +18,6 @@ query Project($id: String!) {
         node {
           id
           name
-
           serviceInstances {
             edges {
               node {
@@ -28,6 +27,25 @@ query Project($id: String!) {
                 source {
                   repo
                   image
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    volumes {
+      edges {
+        node {
+          volumeInstances {
+            edges {
+              node {
+                serviceId
+                mountPath
+                environmentId
+                volume {
+                  name
+                  id
                 }
               }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ commands_enum!(
     unlink,
     up,
     variables,
-    whoami
+    whoami,
+    volume
 );
 
 #[tokio::main]

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -12,6 +12,14 @@ pub fn prompt_options<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
         .context("Failed to prompt for options")
 }
 
+pub fn prompt_text(message: &str) -> Result<String> {
+    let select = inquire::Text::new(message);
+    select
+        .with_render_config(Configs::get_render_config())
+        .prompt()
+        .context("Failed to prompt for options")
+}
+
 pub fn prompt_confirm_with_default(message: &str, default: bool) -> Result<bool> {
     let confirm = inquire::Confirm::new(message);
     confirm


### PR DESCRIPTION
This PR adds the ability to update, list, create and delete volumes in a project.

A new command has been added, `railway volume` with various subcommands (create, delete, update, list, attach, detach).

Fixes #499 
