### PR TITLE
Fix bad formatting

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -359,11 +359,11 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
                     if let Some(error) = payload.error {
                         println!(
                             "{}{}",
-                            "Build failed: {}".red().bold(),
+                            "Build failed: ".red().bold(),
                             if !error.is_empty() {
                                 format!(": {}", error.red().bold())
                             } else {
-                                String::new()
+                                "unknown".dimmed().to_string()
                             }
                         );
                         std::process::exit(1);


### PR DESCRIPTION
This pull request fixes a formatting issue in the `up.rs` file. The `Build failed` message was not being displayed correctly. This PR updates the message to display the correct error information and adds a fallback message if the error is empty.