### PR TITLE
Don't prompt for environment in `railway link` if only one is present

### DIFF
--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -79,7 +79,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             }
         }
     });
-
     let environment = if let Some(environment) = args.environment {
         let env = project.environments.iter().find(|e| {
             (e.name.to_lowercase() == environment.to_lowercase())
@@ -91,6 +90,8 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         } else {
             return Err(RailwayError::EnvironmentNotFound(environment).into());
         }
+    } else if project.environments.len() == 1 {
+        project.environments.first().unwrap().clone()
     } else {
         prompt_options("Select an environment", project.environments)?
     };

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -91,7 +91,9 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             return Err(RailwayError::EnvironmentNotFound(environment).into());
         }
     } else if project.environments.len() == 1 {
-        project.environments.first().unwrap().clone()
+        let env = project.environments.first().unwrap().clone();
+        fake_select("Select an environment", env.name.as_str());
+        env
     } else {
         prompt_options("Select an environment", project.environments)?
     };


### PR DESCRIPTION
If the project being linked only has one environment, we won't prompt for it and default to the only environment there is.