### PR TITLE
Remove brew tap from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ cargo install railwayapp --locked
 ### Homebrew
 
 ```bash 
-brew tap railwayapp/railway
 brew install railway
 ```
 


### PR DESCRIPTION
A custom brew tap is no longer needed. https://formulae.brew.sh/formula/railway#default
