### PR TITLE
Fix exec permission in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
+# This dockerfile is meant to be used in publish-docker.yml workflow which reuses artifacts created by release.yml
+# This way we can avoid rebuilding the CLI specifically for docker
+
 FROM alpine:3.20
 
-COPY ./railway /usr/bin/railway
-RUN test -f /usr/bin/railway
+# binary should be retrieved by download-artifact action by this point
+COPY --chmod=755 ./railway /usr/bin/railway


### PR DESCRIPTION
Fixes this whoopsie daisy:

![fucky-wucky](https://github.com/user-attachments/assets/eee5a505-5a2e-4380-91f9-f22b4ad300e3)


TLDR: github artifacts reset file permissions and as someone who's used to gitlab I didn't even think of checking them. Whoops! Added a chmod command and now.. now it's done.
