### PR TITLE
Connect to public database URLs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -55,4 +55,10 @@ pub enum RailwayError {
 
     #[error("2FA code is incorrect. Please try again.")]
     InvalidTwoFactorCode,
+
+    #[error("Could not find a variable to connect to service with. Looking for {0}")]
+    ConnectionVariableNotFound(String),
+
+    #[error("Connection URL should point to the Railway TCP proxy")]
+    InvalidConnectionVariable,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,7 +56,7 @@ pub enum RailwayError {
     #[error("2FA code is incorrect. Please try again.")]
     InvalidTwoFactorCode,
 
-    #[error("Could not find a variable to connect to service with. Looking for {0}")]
+    #[error("Could not find a variable to connect to the service with. Looking for \"{0}\".")]
     ConnectionVariableNotFound(String),
 
     #[error("Connection URL should point to the Railway TCP proxy")]


### PR DESCRIPTION
The default `DATABASE_URL` variable now points to the private network. This PR updates the connect command to first look for the public db url and connect with that if it exists.
