### PR TITLE
Fix CI mode immediate exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yay -S railwayapp-cli
 
 ### Docker
 
-Before using CLI in non-interactive environment make sure that you have created an access token (account or project scoped) and made it available via the `RAILWAY_TOKEN` environment variable.
+Before using the CLI in a non-interactive environment, ensure you have created an access token (account or project-scoped) and set it as the `RAILWAY_TOKEN` environment variable. CI environments are automatically detected by the presence of `CI=true` variable. In these environments, only build logs will be streamed, and the CLI will exit with an appropriate code indicating success or failure.
 
 Install from the command line
 ```bash
@@ -81,7 +81,7 @@ deploy-job:
     RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
   steps:
     - uses: actions/checkout@v3
-    - run: railway up --service=${{ env.SVC_ID }} -d
+    - run: railway up --service=${{ env.SVC_ID }}
 ```
 
 Use in GitLab CICD
@@ -91,7 +91,7 @@ deploy-job:
   variables:
     SVC_ID: my-service
   script:
-    - railway up --service=$SVC_ID -d
+    - railway up --service=$SVC_ID
 ```
 
 \* GitLab can access a protected (secret) variable directly, all you need to do is to add it in CI/CD settings.

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -44,7 +44,7 @@ pub struct Args {
     detach: bool,
 
     #[clap(short, long)]
-    /// Only stream build logs and exit after it's done
+    /// Stream build logs only, then exit (equivalent to setting $CI=true).
     ci: bool,
 
     #[clap(short, long)]
@@ -319,8 +319,13 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         return Ok(());
     }
 
-    // If the user is not in a terminal, don't stream logs
-    if !std::io::stdout().is_terminal() {
+    let ci_mode = Configs::env_is_ci() || args.ci;
+    if ci_mode {
+        println!("{}", "CI mode enabled".green().bold());
+    }
+
+    // If the user is not in a terminal AND if we are not in CI mode, don't stream logs
+    if !std::io::stdout().is_terminal() && !ci_mode {
         return Ok(());
     }
 
@@ -334,11 +339,15 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             stream_build_logs(build_deployment_id, |log| println!("{}", log.message)).await
         {
             eprintln!("Failed to stream build logs: {}", e);
+
+            if ci_mode {
+                std::process::exit(1);
+            }
         }
     })];
 
-    // Stream deploy logs only if ci flag is not set
-    if !args.ci {
+    // Stream deploy logs only if is not in ci mode
+    if !ci_mode {
         tasks.push(tokio::task::spawn(async move {
             if let Err(e) = stream_deploy_logs(deploy_deployment_id, format_attr_log).await {
                 eprintln!("Failed to stream deploy logs: {}", e);
@@ -371,7 +380,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
                 }
                 if (data.deployment_events.step == DeploymentEventStep::DRAIN_INSTANCES)
                     && data.deployment_events.completed_at.is_some()
-                    && args.ci
+                    && ci_mode
                 {
                     println!("{}", "Deploy complete".green().bold());
                     std::process::exit(0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,12 @@ impl Configs {
         std::env::var("RAILWAY_API_TOKEN").ok()
     }
 
+    pub fn env_is_ci() -> bool {
+        std::env::var("CI")
+            .map(|val| val.trim().to_lowercase() == "true")
+            .unwrap_or(false)
+    }
+
     /// tries the environment variable and the config file
     pub fn get_railway_auth_token(&self) -> Option<String> {
         Self::get_railway_api_token().or(self


### PR DESCRIPTION
Fixes premature "up" command exit in non-interactive environemnts

## Cause:
An `if` statement at:
https://github.com/railwayapp/cli/blob/f2d2b07238d2814fa2f85807bbfb6ee61bb2d64a/src/commands/up.rs#L323
doesn't take into account that CI environments would be detected as "not terminal" which in turn short circuits the CI mode.

## Changes

1. Check for CI mode as well before exiting if "not in terminal".
2. Detect `CI=true` env variable that is set by every major CI provider/runner.
3. Log "CI mode enabled" message to clearly indicate current command behavior.
4. CLI in CI mode will exit with error if it can't stream build logs
5. Updated readme and help strings to reflect changes to CI mode
