### PR TITLE
Handle null values in service variables

### DIFF
--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
     controllers::project::{ensure_project_and_environment_exist, get_project},
+    controllers::variables::get_service_variables,
     errors::RailwayError,
     table::Table,
 };
@@ -64,13 +65,13 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         return Err(RailwayError::NoServiceLinked.into());
     };
 
-    let variables = post_graphql::<queries::VariablesForServiceDeployment, _>(
+    let variables = get_service_variables(
         &client,
-        configs.get_backboard(),
-        vars,
-    )
-    .await?
-    .variables_for_service_deployment;
+        &configs,
+        vars.project_id,
+        vars.environment_id,
+        vars.service_id,
+    ).await?;
 
     if variables.is_empty() {
         eprintln!("No variables found");

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -71,7 +71,8 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         vars.project_id,
         vars.environment_id,
         vars.service_id,
-    ).await?;
+    )
+    .await?;
 
     if variables.is_empty() {
         eprintln!("No variables found");

--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -25,11 +25,10 @@ pub async fn get_service_variables(
     )
     .await?;
 
-    let variables = response.variables_for_service_deployment
+    let variables = response
+        .variables_for_service_deployment
         .into_iter()
-        .filter_map(|(key, value)| {
-            value.map(|v| (key, v.to_string()))
-        })
+        .filter_map(|(key, value)| value.map(|v| (key, v.to_string())))
         .collect();
 
     Ok(variables)

--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -18,12 +18,19 @@ pub async fn get_service_variables(
         environment_id,
         service_id,
     };
-    let variables = post_graphql::<queries::VariablesForServiceDeployment, _>(
+    let response = post_graphql::<queries::VariablesForServiceDeployment, _>(
         client,
         configs.get_backboard(),
         vars,
     )
-    .await?
-    .variables_for_service_deployment;
+    .await?;
+
+    let variables = response.variables_for_service_deployment
+        .into_iter()
+        .filter_map(|(key, value)| {
+            value.map(|v| (key, v.to_string()))
+        })
+        .collect();
+
     Ok(variables)
 }

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -2,7 +2,7 @@ use graphql_client::GraphQLQuery;
 use serde::{Deserialize, Serialize};
 
 type DateTime = chrono::DateTime<chrono::Utc>;
-type ServiceVariables = std::collections::BTreeMap<String, String>;
+type ServiceVariables = std::collections::BTreeMap<String, Option<String>>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
This PR updates several CLI commands to not fail if a service variable value is `null`. This can happen if the variable is a sealed variable.

The core change is that `get_service_variables` filters out variables with a `null` value and the remaining changes are replacing usages of the query that didn't re-use the function to re-use the function.

Note: Leaving as a draft until reviewed by someone else from the team that actually knows Rust. ^ _ ^