### PR TITLE
handle `railway login` when api token is set

### DIFF
--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -13,6 +13,12 @@ pub async fn command(_args: Args, _json: bool) -> Result<()> {
 
     let user: RailwayUser = get_user(&client, &configs).await?;
 
+    print_user(user);
+
+    Ok(())
+}
+
+pub fn print_user(user: RailwayUser) {
     if let Some(name) = user.name {
         println!(
             "Logged in as {} ({}) 👋",
@@ -22,6 +28,4 @@ pub async fn command(_args: Args, _json: bool) -> Result<()> {
     } else {
         println!("Logged in as {} 👋", user.email.bright_magenta().bold())
     }
-
-    Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,6 +130,7 @@ impl Configs {
             .clone()
             .filter(|t| !t.is_empty()))
     }
+
     pub fn get_environment_id() -> Environment {
         match std::env::var("RAILWAY_ENV")
             .map(|env| env.to_lowercase())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,9 @@ pub enum RailwayError {
     #[error("Unauthorized. Please login with `railway login`")]
     Unauthorized,
 
+    #[error("Unauthorized")]
+    InvalidRailwayToken,
+
     #[error("Login state is corrupt. Please logout and login back in.")]
     InvalidHeader(#[from] InvalidHeaderValue),
 


### PR DESCRIPTION
If the `RAILWAY_API_TOKEN` is set, `railway login` doesn't really make sense. This PR shows the user that is already logged in.

![screenshot-2024-09-20-20 34 26](https://github.com/user-attachments/assets/27b8255c-9a19-478a-9505-3306d286b9fc)
