### PR TITLE
Add `railway env` as an alias for `railway environment`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,9 +27,6 @@ macro_rules! commands_enum {
     );
 }
 
-
-
-
 /// Ensure running in a terminal or bail with the provided message
 #[macro_export]
 macro_rules! interact_or {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ commands_enum!(
     domain,
     docs,
     down,
-    environment,
+    environment(env),
     init,
     link,
     list,


### PR DESCRIPTION
Alias' can now be created like this:

```rs
commands_enum!(
 actual_name(aliases, goes, here)
)
```
