### PR TITLE
Add feedback after link

### DIFF
--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -56,13 +56,20 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
 
     configs.link_project(
         project.id,
-        Some(project.name),
+        Some(project.name.clone()),
         environment.id,
         Some(environment.name),
     )?;
     if let Some(service) = service {
         configs.link_service(service.id)?;
     }
+
+    println!(
+        "\n{} {} {}",
+        "Project".green(),
+        project.name.magenta().bold(),
+        "linked successfully! 🎉".green()
+    );
 
     configs.write()?;
 


### PR DESCRIPTION
This simple change adds something at the end of the link command showing that it was successful.

<img width="842" alt="image" src="https://github.com/user-attachments/assets/dc91636e-3838-4be5-9423-87e3f014d8bf">
