### PR TITLE
only shortcircuit the login command if the RAILWAY_API_TOKEN is found

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -30,20 +30,22 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     interact_or!("Cannot login in non-interactive mode");
 
     let mut configs = Configs::new()?;
-    if let Ok(client) = GQLClient::new_authorized(&configs) {
-        match get_user(&client, &configs).await {
-            Ok(user) => {
-                println!("{} found", "RAILWAY_TOKEN".bold());
-                print_user(user);
-                return Ok(());
-            }
-            Err(_e) => {
-                println!("Found invalid {}", "RAILWAY_TOKEN".bold());
-                return Err(RailwayError::InvalidRailwayToken.into());
+
+    if Configs::get_railway_api_token().is_some() {
+        if let Ok(client) = GQLClient::new_authorized(&configs) {
+            match get_user(&client, &configs).await {
+                Ok(user) => {
+                    println!("{} found", "RAILWAY_TOKEN".bold());
+                    print_user(user);
+                    return Ok(());
+                }
+                Err(_e) => {
+                    println!("Found invalid {}", "RAILWAY_TOKEN".bold());
+                    return Err(RailwayError::InvalidRailwayToken.into());
+                }
             }
         }
     }
-
     if args.browserless {
         return browserless_login().await;
     }


### PR DESCRIPTION
This fixes a bug where if you have an invalid auth token, you will not be able to re login without running `railway logout` first. We only want to use the existing authenticated client if the `RAILWAY_API_TOKEN` variable is set.
