### PR TITLE
Make service optional when linking

### DIFF
--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 
 use crate::{
     errors::RailwayError,
-    util::prompt::{fake_select, prompt_options},
+    util::prompt::{fake_select, prompt_options, prompt_options_skippable},
 };
 
 use super::{
@@ -91,21 +91,22 @@ fn select_service(
         })
         .cloned()
         .collect::<Vec<NormalisedService>>();
+
     let service = if !useful_services.is_empty() {
-        Some(if let Some(service) = service {
+        if let Some(service) = service {
             let service_norm = useful_services.iter().find(|s| {
                 (s.name.to_lowercase() == service.to_lowercase())
                     || (s.id.to_lowercase() == service.to_lowercase())
             });
             if let Some(service) = service_norm {
                 fake_select("Select a service", &service.name);
-                service.clone()
+                Some(service.clone())
             } else {
                 return Err(RailwayError::ServiceNotFound(service).into());
             }
         } else {
-            prompt_options("Select a service", useful_services)?
-        })
+            prompt_options_skippable("Select a service <esc to skip>", useful_services)?
+        }
     } else {
         None
     };

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -12,6 +12,14 @@ pub fn prompt_options<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
         .context("Failed to prompt for options")
 }
 
+pub fn prompt_options_skippable<T: Display>(message: &str, options: Vec<T>) -> Result<Option<T>> {
+    let select = inquire::Select::new(message, options);
+    select
+        .with_render_config(Configs::get_render_config())
+        .prompt_skippable()
+        .context("Failed to prompt for options")
+}
+
 pub fn prompt_text(message: &str) -> Result<String> {
     let select = inquire::Text::new(message);
     select


### PR DESCRIPTION
This allows you to press escape to skip providing a service when running railway link interactively.

Why: Sometimes people may want to link to a project for a monorepo without specifically selecting one service.