### PR TITLE
Display aliases in help text

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! commands_enum {
             enum Commands {
                 $(
                     #[clap(
-                        $(aliases = &[$( stringify!($alias) ),*])?
+                        $(visible_aliases = &[$( stringify!($alias) ),*])?
                     )]
                     [<$module:camel>]($module::Args),
                 )*


### PR DESCRIPTION
This simple change allows aliases added to be displayed in the help text. Example:

```
environment  Change the active environment [aliases: env]
```
