### PR TITLE
feat: add check updates command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,10 @@ reqwest = { version = "0.12.12", default-features = false, features = [
   "rustls-tls",
   "json",
 ] }
-chrono = { version = "0.4.39", features = ["serde"], default-features = false }
+chrono = { version = "0.4.39", features = [
+  "serde",
+  "clock",
+], default-features = false }
 graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
 paste = "1.0.15"
 tokio = { version = "1.42.0", features = ["full"] }

--- a/src/commands/check_updates.rs
+++ b/src/commands/check_updates.rs
@@ -1,4 +1,4 @@
-use crate::check_update;
+use crate::util::check_update::check_update;
 
 use super::*;
 use serde_json::json;
@@ -23,7 +23,7 @@ pub async fn command(_args: Args, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    let is_latest = check_update!(configs, true);
+    let is_latest = check_update(&mut configs, true).await?;
     if is_latest {
         println!(
             "You are on the latest version of the CLI, v{}",

--- a/src/commands/check_updates.rs
+++ b/src/commands/check_updates.rs
@@ -13,22 +13,22 @@ pub async fn command(_args: Args, json: bool) -> Result<()> {
     if json {
         let result = configs.check_update(true).await;
 
-        if let Ok(Some(latest_version)) = result {
-            let json = json!({
-                "latest_version": latest_version,
-                "current_version": env!("CARGO_PKG_VERSION"),
-            });
-            println!("{}", serde_json::to_string_pretty(&json)?);
-        } else {
-            let json = json!({
-                "latest_version": None::<String>,
-                "current_version": env!("CARGO_PKG_VERSION"),
-            });
-            println!("{}", serde_json::to_string_pretty(&json)?);
-        }
+        let json = json!({
+            "latest_version": result.ok().flatten().as_ref(),
+            "current_version": env!("CARGO_PKG_VERSION"),
+        });
+
+        println!("{}", serde_json::to_string_pretty(&json)?);
+
         return Ok(());
     }
 
-    check_update!(configs, true);
+    let is_latest = check_update!(configs, true);
+    if is_latest {
+        println!(
+            "You are on the latest version of the CLI, v{}",
+            env!("CARGO_PKG_VERSION")
+        );
+    }
     Ok(())
 }

--- a/src/commands/check_updates.rs
+++ b/src/commands/check_updates.rs
@@ -1,0 +1,34 @@
+use crate::check_update;
+
+use super::*;
+use serde_json::json;
+
+/// Test the update check
+#[derive(Parser)]
+pub struct Args {}
+
+pub async fn command(_args: Args, json: bool) -> Result<()> {
+    let mut configs = Configs::new()?;
+
+    if json {
+        let result = configs.check_update(true).await;
+
+        if let Ok(Some(latest_version)) = result {
+            let json = json!({
+                "latest_version": latest_version,
+                "current_version": env!("CARGO_PKG_VERSION"),
+            });
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        } else {
+            let json = json!({
+                "latest_version": None::<String>,
+                "current_version": env!("CARGO_PKG_VERSION"),
+            });
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        return Ok(());
+    }
+
+    check_update!(configs, true);
+    Ok(())
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::util::{check_update::check_update_command, prompt::prompt_select};
+use crate::util::prompt::prompt_select;
 
 use super::{queries::user_projects::UserProjectsMeTeamsEdgesNode, *};
 
@@ -15,8 +15,6 @@ pub struct Args {
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let mut configs = Configs::new()?;
-
-    check_update_command(&mut configs).await?;
 
     let client = GQLClient::new_authorized(&configs)?;
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::util::prompt::prompt_select;
+use crate::{check_update, util::prompt::prompt_select};
 
 use super::{queries::user_projects::UserProjectsMeTeamsEdgesNode, *};
 
@@ -15,6 +15,9 @@ pub struct Args {
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let mut configs = Configs::new()?;
+
+    check_update!(configs);
+
     let client = GQLClient::new_authorized(&configs)?;
 
     let vars = queries::user_projects::Variables {};

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use crate::{check_update, util::prompt::prompt_select};
+use crate::util::{check_update::check_update_command, prompt::prompt_select};
 
 use super::{queries::user_projects::UserProjectsMeTeamsEdgesNode, *};
 
@@ -16,7 +16,7 @@ pub struct Args {
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let mut configs = Configs::new()?;
 
-    check_update!(configs);
+    check_update_command(&mut configs).await?;
 
     let client = GQLClient::new_authorized(&configs)?;
 

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -3,6 +3,7 @@ use is_terminal::IsTerminal;
 use std::fmt::Display;
 
 use crate::{
+    check_update,
     errors::RailwayError,
     util::prompt::{fake_select, prompt_options, prompt_options_skippable},
 };
@@ -38,6 +39,9 @@ pub struct Args {
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let mut configs = Configs::new()?;
+
+    check_update!(configs);
+
     let client = GQLClient::new_authorized(&configs)?;
     let me = post_graphql::<queries::UserProjects, _>(
         &client,

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -4,10 +4,7 @@ use std::fmt::Display;
 
 use crate::{
     errors::RailwayError,
-    util::{
-        check_update::check_update_command,
-        prompt::{fake_select, prompt_options, prompt_options_skippable},
-    },
+    util::prompt::{fake_select, prompt_options, prompt_options_skippable},
 };
 
 use super::{
@@ -41,8 +38,6 @@ pub struct Args {
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let mut configs = Configs::new()?;
-
-    check_update_command(&mut configs).await?;
 
     let client = GQLClient::new_authorized(&configs)?;
     let me = post_graphql::<queries::UserProjects, _>(

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -3,9 +3,11 @@ use is_terminal::IsTerminal;
 use std::fmt::Display;
 
 use crate::{
-    check_update,
     errors::RailwayError,
-    util::prompt::{fake_select, prompt_options, prompt_options_skippable},
+    util::{
+        check_update::check_update_command,
+        prompt::{fake_select, prompt_options, prompt_options_skippable},
+    },
 };
 
 use super::{
@@ -40,7 +42,7 @@ pub struct Args {
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let mut configs = Configs::new()?;
 
-    check_update!(configs);
+    check_update_command(&mut configs).await?;
 
     let client = GQLClient::new_authorized(&configs)?;
     let me = post_graphql::<queries::UserProjects, _>(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,3 +29,5 @@ pub mod up;
 pub mod variables;
 pub mod volume;
 pub mod whoami;
+
+pub mod check_updates;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -2,6 +2,7 @@ use anyhow::bail;
 use is_terminal::IsTerminal;
 
 use crate::{
+    check_update,
     controllers::{
         environment::get_matched_environment,
         project::{ensure_project_and_environment_exist, get_project},
@@ -73,7 +74,11 @@ async fn get_service(
 }
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
-    let configs = Configs::new()?;
+    // only needs to be mutable for the update check
+    let mut configs = Configs::new()?;
+    check_update!(configs);
+    let configs = configs; // so we make it immutable again
+
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -8,10 +8,7 @@ use crate::{
         variables::get_service_variables,
     },
     errors::RailwayError,
-    util::{
-        check_update::check_update_command,
-        prompt::{prompt_select, PromptService},
-    },
+    util::prompt::{prompt_select, PromptService},
 };
 
 use super::{queries::project::ProjectProject, *};
@@ -77,9 +74,7 @@ async fn get_service(
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     // only needs to be mutable for the update check
-    let mut configs = Configs::new()?;
-    check_update_command(&mut configs).await?;
-    let configs = configs; // so we make it immutable again
+    let configs = Configs::new()?;
 
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -2,14 +2,16 @@ use anyhow::bail;
 use is_terminal::IsTerminal;
 
 use crate::{
-    check_update,
     controllers::{
         environment::get_matched_environment,
         project::{ensure_project_and_environment_exist, get_project},
         variables::get_service_variables,
     },
     errors::RailwayError,
-    util::prompt::{prompt_select, PromptService},
+    util::{
+        check_update::check_update_command,
+        prompt::{prompt_select, PromptService},
+    },
 };
 
 use super::{queries::project::ProjectProject, *};
@@ -76,7 +78,7 @@ async fn get_service(
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     // only needs to be mutable for the update check
     let mut configs = Configs::new()?;
-    check_update!(configs);
+    check_update_command(&mut configs).await?;
     let configs = configs; // so we make it immutable again
 
     let client = GQLClient::new_authorized(&configs)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,7 +352,7 @@ impl Configs {
 
         self.root_config.last_update_check = Some(Utc::now());
         self.write()
-            .context("Failed to write config in should_update")?;
+            .context("Failed to save time since last update check")?;
 
         let response = response.json::<GithubApiRelease>().await?;
         let latest_version = response.tag_name.trim_start_matches('v');

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,7 @@ pub struct RailwayConfig {
     pub projects: BTreeMap<String, LinkedProject>,
     pub user: RailwayUser,
     pub last_update_check: Option<DateTime<Utc>>,
+    pub new_version_available: Option<String>,
 }
 
 #[derive(Debug)]
@@ -90,6 +91,7 @@ impl Configs {
                         projects: BTreeMap::new(),
                         user: RailwayUser { token: None },
                         last_update_check: None,
+                        new_version_available: None,
                     }
                 });
 
@@ -107,6 +109,7 @@ impl Configs {
                 projects: BTreeMap::new(),
                 user: RailwayUser { token: None },
                 last_update_check: None,
+                new_version_available: None,
             },
         })
     }
@@ -116,6 +119,7 @@ impl Configs {
             projects: BTreeMap::new(),
             user: RailwayUser { token: None },
             last_update_check: None,
+            new_version_available: None,
         };
         Ok(())
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,25 +42,3 @@ macro_rules! interact_or {
         }
     };
 }
-
-#[macro_export]
-macro_rules! check_update {
-    ($obj:expr, $force:expr) => {{
-        let result = $obj.check_update($force).await;
-
-        if let Ok(Some(latest_version)) = result {
-            println!(
-                "{} v{} visit {} for more info",
-                "New version available:".green().bold(),
-                latest_version.yellow(),
-                "https://docs.railway.com/guides/cli".purple(),
-            );
-            false
-        } else {
-            true
-        }
-    }};
-    ($configs:expr) => {{
-        check_update!($configs, false);
-    }};
-}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,6 +55,9 @@ macro_rules! check_update {
                 latest_version.yellow(),
                 "https://docs.railway.com/guides/cli".purple(),
             );
+            false
+        } else {
+            true
         }
     }};
     ($configs:expr) => {{

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -57,4 +57,7 @@ macro_rules! check_update {
             );
         }
     }};
+    ($configs:expr) => {{
+        check_update!($configs, false);
+    }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,3 +42,19 @@ macro_rules! interact_or {
         }
     };
 }
+
+#[macro_export]
+macro_rules! check_update {
+    ($obj:expr, $force:expr) => {{
+        let result = $obj.check_update($force).await;
+
+        if let Ok(Some(latest_version)) = result {
+            println!(
+                "{} v{} visit {} for more info",
+                "New version available:".green().bold(),
+                latest_version.yellow(),
+                "https://docs.railway.com/guides/cli".purple(),
+            );
+        }
+    }};
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod macros;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
+// #[clap(author, about, long_about = None)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -64,6 +65,23 @@ commands_enum!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // intercept the args
+    {
+        let args: Vec<String> = std::env::args().collect();
+
+        let flags: Vec<String> = vec!["--version", "-V", "-h", "--help", "help"]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let check_version = args.into_iter().any(|arg| flags.contains(&arg));
+
+        if check_version {
+            let mut configs = Configs::new()?;
+            check_update!(configs, false);
+        }
+    }
+
     let cli = Args::parse();
 
     match Commands::exec(cli).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,8 @@ commands_enum!(
     variables,
     whoami,
     volume,
-    redeploy
+    redeploy,
+    check_updates
 );
 
 #[tokio::main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ mod macros;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
-// #[clap(author, about, long_about = None)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
+use std::cmp::Ordering;
+
 use anyhow::Result;
 use clap::{error::ErrorKind, Parser, Subcommand};
 
 mod commands;
 use commands::*;
 use is_terminal::IsTerminal;
+use util::compare_semver::compare_semver;
 
 mod client;
 mod config;
@@ -63,13 +66,12 @@ commands_enum!(
     check_updates
 );
 
-fn spawn_update_task() -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
-    tokio::spawn(async {
+fn spawn_update_task(mut configs: Configs) -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
+    tokio::spawn(async move {
         if !std::io::stdout().is_terminal() {
             return Ok::<(), anyhow::Error>(());
         }
 
-        let mut configs = Configs::new()?;
         let result = configs.check_update(false).await;
         if let Ok(Some(latest_version)) = result {
             configs.root_config.new_version_available = Some(latest_version);
@@ -79,39 +81,48 @@ fn spawn_update_task() -> tokio::task::JoinHandle<Result<(), anyhow::Error>> {
     })
 }
 
-async fn handle_update_task(handle: tokio::task::JoinHandle<Result<(), anyhow::Error>>) {
-    match handle.await {
-        Ok(Ok(_)) => {} // Task completed successfully
-        Ok(Err(e)) => {
-            if !std::io::stdout().is_terminal() {
-                eprintln!("Failed to check for updates (not fatal)");
+async fn handle_update_task(handle: Option<tokio::task::JoinHandle<Result<(), anyhow::Error>>>) {
+    if let Some(handle) = handle {
+        match handle.await {
+            Ok(Ok(_)) => {} // Task completed successfully
+            Ok(Err(e)) => {
+                if !std::io::stdout().is_terminal() {
+                    eprintln!("Failed to check for updates (not fatal)");
+                    eprintln!("{}", e);
+                }
+            }
+            Err(e) => {
+                eprintln!("Check Updates: Task panicked or failed to execute.");
                 eprintln!("{}", e);
             }
-        }
-        Err(e) => {
-            eprintln!("Check Updates: Task panicked or failed to execute.");
-            eprintln!("{}", e);
         }
     }
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Avoid grabbing configs multiple times, and avoid grabbing configs if we're not in a terminal
+    let mut check_updates_handle: Option<tokio::task::JoinHandle<Result<(), anyhow::Error>>> = None;
     if std::io::stdout().is_terminal() {
         let mut configs = Configs::new()?;
-        if let Some(new_version_available) = configs.root_config.new_version_available {
-            println!(
-                "{} v{} visit {} for more info",
-                "New version available:".green().bold(),
-                new_version_available.yellow(),
-                "https://docs.railway.com/guides/cli".purple(),
-            );
-            configs.root_config.new_version_available = None;
-            configs.write()?;
+        if let Some(new_version_available) = &configs.root_config.new_version_available {
+            match compare_semver(env!("CARGO_PKG_VERSION"), &new_version_available) {
+                Ordering::Less => {
+                    println!(
+                        "{} v{} visit {} for more info",
+                        "New version available:".green().bold(),
+                        new_version_available.yellow(),
+                        "https://docs.railway.com/guides/cli".purple(),
+                    );
+                }
+                _ => {
+                    configs.root_config.new_version_available = None;
+                    configs.write()?;
+                }
+            }
         }
+        check_updates_handle = Some(spawn_update_task(configs));
     }
-
-    let check_updates_handle = spawn_update_task();
 
     // Trace from where Args::parse() bubbles an error to where it gets caught
     // and handled.

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,12 +147,6 @@ async fn main() -> Result<()> {
 
     let cli = match Args::try_parse() {
         Ok(args) => args,
-        // Cases where Clap usually exits the process with and prints to stdout.
-        Err(e) if e.kind() == ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
-            eprintln!("{}", e);
-            handle_update_task(check_updates_handle).await;
-            std::process::exit(2); // Exit 2 (default)
-        }
         // Clap's source code specifically says that these errors should be
         // printed to stdout and exit with a status of 0.
         Err(e) if e.kind() == ErrorKind::DisplayHelp || e.kind() == ErrorKind::DisplayVersion => {
@@ -161,7 +155,7 @@ async fn main() -> Result<()> {
             std::process::exit(0); // Exit 0 (because of error kind)
         }
         Err(e) => {
-            eprintln!("Error parsing arguments: {}", e);
+            eprintln!("{}", e);
             handle_update_task(check_updates_handle).await;
             std::process::exit(2); // Exit 2 (default)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,27 +124,7 @@ async fn main() -> Result<()> {
         check_updates_handle = Some(spawn_update_task(configs));
     }
 
-    // Trace from where Args::parse() bubbles an error to where it gets caught
-    // and handled.
-    //
-    // https://github.com/clap-rs/clap/blob/cb2352f84a7663f32a89e70f01ad24446d5fa1e2/clap_builder/src/derive.rs#L30-L42
-    // https://github.com/clap-rs/clap/blob/cb2352f84a7663f32a89e70f01ad24446d5fa1e2/clap_builder/src/error/mod.rs#L233-L237
-    //
-    // This code tells us what exit code to use:
-    // https://github.com/clap-rs/clap/blob/cb2352f84a7663f32a89e70f01ad24446d5fa1e2/clap_builder/src/error/mod.rs#L221-L227
-    //
-    // https://github.com/clap-rs/clap/blob/cb2352f84a7663f32a89e70f01ad24446d5fa1e2/clap_builder/src/error/mod.rs#L206-L208
-    //
-    // This code tells us what stream to print the error to:
     // https://github.com/clap-rs/clap/blob/cb2352f84a7663f32a89e70f01ad24446d5fa1e2/clap_builder/src/error/mod.rs#L210-L215
-    //
-    // pub(crate) fn stream(&self) -> Stream {
-    //     match self.kind() {
-    //         ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => Stream::Stdout,
-    //         _ => Stream::Stderr,
-    //     }
-    // }
-
     let cli = match Args::try_parse() {
         Ok(args) => args,
         // Clap's source code specifically says that these errors should be
@@ -152,12 +132,12 @@ async fn main() -> Result<()> {
         Err(e) if e.kind() == ErrorKind::DisplayHelp || e.kind() == ErrorKind::DisplayVersion => {
             println!("{}", e);
             handle_update_task(check_updates_handle).await;
-            std::process::exit(0); // Exit 0 (because of error kind)
+            std::process::exit(0);
         }
         Err(e) => {
             eprintln!("{}", e);
             handle_update_task(check_updates_handle).await;
-            std::process::exit(2); // Exit 2 (default)
+            std::process::exit(2); // The default behavior is exit 2
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Parser, Subcommand};
 
 mod commands;
 use commands::*;
+use util::check_update::check_update_command;
 
 mod client;
 mod config;
@@ -68,17 +69,12 @@ async fn main() -> Result<()> {
     // intercept the args
     {
         let args: Vec<String> = std::env::args().collect();
-
-        let flags: Vec<String> = vec!["--version", "-V", "-h", "--help", "help"]
-            .into_iter()
-            .map(|s| s.to_string())
-            .collect();
-
-        let check_version = args.into_iter().any(|arg| flags.contains(&arg));
+        let flags = ["--version", "-V", "-h", "--help", "help"];
+        let check_version = args.into_iter().any(|arg| flags.contains(&arg.as_str()));
 
         if check_version {
             let mut configs = Configs::new()?;
-            check_update!(configs, false);
+            check_update_command(&mut configs).await?;
         }
     }
 

--- a/src/util/check_update.rs
+++ b/src/util/check_update.rs
@@ -1,0 +1,21 @@
+use colored::Colorize;
+
+pub async fn check_update(configs: &mut crate::Configs, force: bool) -> anyhow::Result<bool> {
+    let result = configs.check_update(force).await;
+    if let Ok(Some(latest_version)) = result {
+        println!(
+            "{} v{} visit {} for more info",
+            "New version available:".green().bold(),
+            latest_version.yellow(),
+            "https://docs.railway.com/guides/cli".purple(),
+        );
+        Ok(false)
+    } else {
+        Ok(true)
+    }
+}
+
+pub async fn check_update_command(configs: &mut crate::Configs) -> anyhow::Result<()> {
+    check_update(configs, false).await?;
+    Ok(())
+}

--- a/src/util/check_update.rs
+++ b/src/util/check_update.rs
@@ -14,8 +14,3 @@ pub async fn check_update(configs: &mut crate::Configs, force: bool) -> anyhow::
         Ok(true)
     }
 }
-
-pub async fn check_update_command(configs: &mut crate::Configs) -> anyhow::Result<()> {
-    check_update(configs, false).await?;
-    Ok(())
-}

--- a/src/util/compare_semver.rs
+++ b/src/util/compare_semver.rs
@@ -1,0 +1,228 @@
+use std::cmp::Ordering;
+
+#[cfg(test)]
+mod tests {
+    use super::compare_semver;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn test_equal_versions() {
+        assert_eq!(compare_semver("1.0.0", "1.0.0"), Ordering::Equal);
+        assert_eq!(compare_semver("2.3.4", "2.3.4"), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_major_version_comparison() {
+        assert_eq!(compare_semver("2.0.0", "1.9.9"), Ordering::Greater);
+        assert_eq!(compare_semver("1.0.0", "2.0.0"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_minor_version_comparison() {
+        assert_eq!(compare_semver("1.2.0", "1.1.9"), Ordering::Greater);
+        assert_eq!(compare_semver("1.1.0", "1.2.0"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_patch_version_comparison() {
+        assert_eq!(compare_semver("1.0.2", "1.0.1"), Ordering::Greater);
+        assert_eq!(compare_semver("1.0.1", "1.0.2"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_pre_release_versions() {
+        assert_eq!(compare_semver("1.0.0-alpha", "1.0.0"), Ordering::Less);
+        assert_eq!(
+            compare_semver("1.0.0-beta", "1.0.0-alpha"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("1.0.0-alpha.1", "1.0.0-alpha"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("4.2.1-beta.2", "4.2.1-beta.3"),
+            Ordering::Less
+        );
+        assert_eq!(compare_semver("5.0.0-rc.1", "5.0.0"), Ordering::Less);
+        assert_eq!(
+            compare_semver("7.0.0-alpha.5", "7.0.0-alpha.4"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("8.2.0-beta.10", "8.2.0-beta.2"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("12.0.0-rc.3", "12.0.0-rc.2"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("14.5.6-beta.4", "14.5.6-beta.3"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("18.2.3-alpha.1", "18.2.3-alpha.2"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_semver("22.1.0-rc.5", "22.1.0-rc.4"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_semver("27.9.0-alpha.9", "27.9.0-alpha.8"),
+            Ordering::Greater
+        );
+        assert_eq!(compare_semver("29.1.8-rc.8", "29.1.8-rc.9"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_numeric_pre_release_alpha() {
+        assert_eq!(
+            compare_semver("1.0.0-alpha", "1.0.0-alpha.1"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_semver("1.0.0-beta", "1.0.0-alpha.1"),
+            Ordering::Greater
+        );
+        assert_eq!(compare_semver("1.0-alpha", "1.0.0-alpha.1"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_build_metadata_ignored() {
+        assert_eq!(
+            compare_semver("1.0.0+20130313144700", "1.0.0"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_semver("1.0.0-beta+exp.sha.5114f85", "1.0.0-beta"),
+            Ordering::Equal
+        );
+        assert_eq!(compare_semver("6.1.3+build.456", "6.1.3"), Ordering::Equal);
+        assert_eq!(compare_semver("16.3.1+exp.data", "16.3.1"), Ordering::Equal);
+        assert_eq!(
+            compare_semver("20.10.5-beta.6", "20.10.5-beta.6+hotfix.1001"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_alternating_build_metadata() {
+        assert_eq!(compare_semver("11.4.3", "11.4.3+meta.789"), Ordering::Equal);
+        assert_eq!(
+            compare_semver("15.0.0+final.release", "15.0.0"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_semver("19.0.0", "19.0.0+build.100"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_semver("23.7.9+commit.abc", "23.7.9"),
+            Ordering::Equal
+        );
+        assert_eq!(
+            compare_semver("28.0.0+revision.1", "28.0.0"),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn test_build_metadata_vs_regular() {
+        assert_eq!(compare_semver("5.0.0+build.1", "4.9.9"), Ordering::Greater);
+        assert_eq!(compare_semver("7.1.0+build.123", "7.1.1"), Ordering::Less);
+        assert_eq!(
+            compare_semver("9.3.2+xyz", "9.3.2-alpha"),
+            Ordering::Greater
+        );
+        assert_eq!(compare_semver("12.4.0+meta.1", "12.5.0"), Ordering::Less);
+        assert_eq!(
+            compare_semver("14.2.1+patch.9", "14.2.1-rc.1"),
+            Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn test_precedence_ordering() {
+        assert_eq!(
+            compare_semver("1.0.0-alpha", "1.0.0-alpha.1"),
+            Ordering::Less
+        );
+        assert_eq!(compare_semver("1.0.0-beta", "1.0.0-beta.2"), Ordering::Less);
+        assert_eq!(
+            compare_semver("1.0.0-beta.2", "1.0.0-beta.11"),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_semver("1.0.0-beta.11", "1.0.0-rc.1"),
+            Ordering::Less
+        );
+        assert_eq!(compare_semver("1.0.0-rc.1", "1.0.0"), Ordering::Less);
+    }
+}
+
+// N=3, much faster than BTreeMap
+fn get_precedence(a: &str) -> u8 {
+    match a {
+        "" => 5,
+        "rc" => 4,
+        "beta" => 3,
+        "alpha" => 2,
+        _ => 1,
+    }
+}
+
+fn compare_precedence(a: &str, b: &str) -> Ordering {
+    if a == b {
+        return Ordering::Equal;
+    }
+
+    let (a_major, a_numeric) = a.split_once('.').unwrap_or((a, ""));
+    let (b_major, b_numeric) = b.split_once('.').unwrap_or((b, ""));
+
+    let a_precedence = get_precedence(a_major.trim());
+    let b_precedence = get_precedence(b_major.trim());
+
+    if a_precedence != b_precedence {
+        return a_precedence.cmp(&b_precedence);
+    }
+
+    a_numeric
+        .parse::<u8>()
+        .unwrap_or(0)
+        .cmp(&b_numeric.parse::<u8>().unwrap_or(0))
+}
+
+pub fn compare_semver(a: &str, b: &str) -> Ordering {
+    let (a, _) = a.split_once('+').unwrap_or((a, ""));
+    let (b, _) = b.split_once('+').unwrap_or((b, ""));
+
+    if a == b {
+        return Ordering::Equal;
+    }
+
+    let (a_version, a_build) = a.split_once('-').unwrap_or((a, ""));
+    let (b_version, b_build) = b.split_once('-').unwrap_or((b, ""));
+
+    let a_version: Vec<u8> = a_version
+        .split('.')
+        .filter_map(|s| s.parse().ok())
+        .collect();
+    let b_version: Vec<u8> = b_version
+        .split('.')
+        .filter_map(|s| s.parse().ok())
+        .collect();
+
+    for (a, b) in a_version.iter().zip(b_version.iter()) {
+        match a.cmp(b) {
+            Ordering::Equal => continue,
+            x => return x,
+        }
+    }
+
+    a_build
+        .is_empty()
+        .cmp(&b_build.is_empty())
+        .then(compare_precedence(a_build, b_build))
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod logs;
 pub mod prompt;
+pub mod check_update;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,3 @@
+pub mod check_update;
 pub mod logs;
 pub mod prompt;
-pub mod check_update;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod check_update;
+pub mod compare_semver;
 pub mod logs;
 pub mod prompt;


### PR DESCRIPTION
This PR adds automatic (daily) checks for new updates for the CLI, only in interactive mode. Alternatively, a user may manually check for updates using the `railway check-updates` command. 

Automatic daily checks run in interactive mode, in the background, for any command called. If a new version is detected, the CLI will push a message to the user (similar to NPM) that requests they update their CLI. 

Manual checks can be run as follows:
```bash
railway check-updates
```

This is what the check-updates command looks like when the version has changed:
![image](https://github.com/user-attachments/assets/002cd67b-4766-4e1f-b8fa-d91f958c4ca6)

This is what the check-updates command looks like when the version has not changed:
![image](https://github.com/user-attachments/assets/d1e28e48-7d49-42a2-b2dd-21420f958177)

This is what the automatic check looks like when the check detects that the version has changed:
![image](https://github.com/user-attachments/assets/8126e049-815d-42ed-aae9-2547f52e42fe)

The data is grabbed (rather slowly) via the GitHub API (endpoint https://api.github.com/repos/railwayapp/cli/releases/latest), which takes around 700ms to process. This is why we run the check in the background, and even then, we only run it daily.

First run:
![image](https://github.com/user-attachments/assets/74c5c091-e698-43ca-950d-37d7b0674bdc)
Second run:
![image](https://github.com/user-attachments/assets/f1d97b1e-76bd-4266-9c33-2e0e5a276036)
