### PR TITLE
get latest version from GitHub release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,16 +338,12 @@ is_build_available() {
 UNINSTALL=0
 HELP=0
 
-CARGOTOML="$(curl -fsSL https://raw.githubusercontent.com/railwayapp/cli/master/Cargo.toml)"
-ALL_VERSIONS="$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' <<EOH
-"$CARGOTOML"
-EOH
-)"
-IFS=$'\n' read -r VERSION <<EOH
-$ALL_VERSIONS
-EOH
+DEFAULT_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name": "v.*"' | cut -d'"' -f4 | cut -c2-)
 
-DEFAULT_VERSION="$VERSION"
+if [ -z "$DEFAULT_VERSION" ]; then
+  error "Failed to fetch latest version from GitHub"
+  exit 1
+fi
 
 
 # defaults

--- a/install.sh
+++ b/install.sh
@@ -462,7 +462,7 @@ if [ "$UNINSTALL" = 1 ]; then
 
   info "$msg"
   ${sudo} rm "$(which railway)"
-  ${sudo} rm /tmp/railway
+  ${sudo} rm -f /tmp/railway 2>/dev/null || true
 
   info "Removed railway"
   exit 0


### PR DESCRIPTION
We currently get the latest version of the CLI for the install.sh script from looking at the `Cargo.toml` file in the repo. This is a problem since there is a brief period of time when the Cargo.toml file is updated to the newest version, but we haven't published a new release on GitHub yet. If you try to install during this time, it will fail. This PR instead gets the latest version from the GitHub releases which should always work.
