### PR TITLE
Add `railway environment new` and `railway environment delete`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Interact with Railway via CLI"
 readme = "README.md"
 homepage = "https://github.com/railwayapp/cli"
 repository = "https://github.com/railwayapp/cli"
-rust-version = "1.70.0"
+rust-version = "1.77.0"
 default-run = "railway"
 include = ["src/**/*", "LICENSE", "README.md"]
 

--- a/src/commands/environment.rs
+++ b/src/commands/environment.rs
@@ -119,7 +119,12 @@ async fn new_environment(args: NewArgs) -> Result<()> {
         println!();
     }
 
-    configs.link_project(project_id, linked_project.name.clone(), env_id, Some(env_name))?;
+    configs.link_project(
+        project_id,
+        linked_project.name.clone(),
+        env_id,
+        Some(env_name),
+    )?;
 
     Ok(())
 }

--- a/src/commands/environment.rs
+++ b/src/commands/environment.rs
@@ -1,21 +1,212 @@
-use std::fmt::Display;
+use std::{collections::BTreeMap, fmt::Display, time::Duration};
 
 use crate::{
-    controllers::project::get_project, errors::RailwayError, interact_or,
-    util::prompt::prompt_options,
+    consts::TICK_STRING,
+    controllers::project::get_project,
+    errors::RailwayError,
+    interact_or,
+    util::prompt::{
+        fake_select, prompt_confirm_with_default, prompt_options, prompt_options_skippable,
+        prompt_text, prompt_text_with_placeholder_disappear_skippable, PromptService,
+    },
 };
 use anyhow::bail;
+use is_terminal::IsTerminal;
+use tokio::task::JoinHandle;
 
 use super::{queries::project::ProjectProjectEnvironmentsEdgesNode, *};
 
-/// Change the active environment
+/// Create, delete or link an environment
 #[derive(Parser)]
 pub struct Args {
     /// The environment to link to
     environment: Option<String>,
+
+    #[clap(subcommand)]
+    command: Option<EnvironmentCommand>,
+}
+
+#[derive(Subcommand)]
+pub enum EnvironmentCommand {
+    /// Create a new environment
+    New(NewArgs),
+
+    /// Delete an environment
+    #[clap(visible_aliases = &["remove", "rm"])]
+    Delete(DeleteArgs),
+}
+
+#[derive(Parser)]
+pub struct NewArgs {
+    /// The name of the environment to create
+    pub name: Option<String>,
+
+    /// The name of the environment to duplicate
+    #[clap(long, short, visible_alias = "copy", visible_short_alias = 'c')]
+    pub duplicate: Option<String>,
+
+    /// Variables to assign in the new environment
+    ///
+    /// Note: This will only work if the environment is being duplicated, and that the service specified is present in the original environment
+    ///
+    /// Examples:
+    ///
+    /// railway environment new foo --duplicate bar --service-variable <service name/service uuid> BACKEND_PORT=3000
+    #[clap(long = "service-variable", short = 'v', number_of_values = 2, value_names = &["SERVICE", "VARIABLE"])]
+    pub service_variables: Vec<String>,
+}
+
+#[derive(Parser)]
+pub struct DeleteArgs {
+    /// Skip confirmation dialog
+    #[clap(short = 'y', long = "yes")]
+    bypass: bool,
+
+    /// The environment to delete
+    environment: Option<String>,
 }
 
 pub async fn command(args: Args, _json: bool) -> Result<()> {
+    match args.command {
+        Some(EnvironmentCommand::New(args)) => new_environment(args).await,
+        Some(EnvironmentCommand::Delete(args)) => delete_environment(args).await,
+        None => link_environment(args).await,
+    }
+}
+
+async fn new_environment(args: NewArgs) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let linked_project = configs.get_linked_project().await?;
+    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let is_terminal = std::io::stdout().is_terminal();
+
+    let name = select_name_new(&args, is_terminal)?;
+    let duplicate_id = select_duplicate_id_new(&args, &project, is_terminal)?;
+    let service_variables =
+        select_service_variables_new(args, &project, is_terminal, &duplicate_id)?;
+    // create the environment!
+    let vars = mutations::environment_create::Variables {
+        project_id: project.id.clone(),
+        name,
+        source_id: duplicate_id,
+    };
+
+    let spinner = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::default_spinner()
+                .tick_chars(TICK_STRING)
+                .template("{spinner:.green} {msg}")?,
+        )
+        .with_message("Creating environment...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let response =
+        post_graphql::<mutations::EnvironmentCreate, _>(&client, &configs.get_backboard(), vars)
+            .await?;
+    spinner.finish_with_message(format!(
+        "{} {} {}",
+        "Environment".green(),
+        response.environment_create.name.magenta().bold(),
+        "created! 🎉".green()
+    ));
+    let env_id = response.environment_create.id.clone();
+
+    if !service_variables.is_empty() {
+        upsert_variables(configs, client, project, service_variables, env_id).await?;
+    }
+
+    Ok(())
+}
+
+async fn delete_environment(args: DeleteArgs) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let linked_project = configs.get_linked_project().await?;
+
+    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let is_terminal = std::io::stdout().is_terminal();
+
+    let (id, name) = if let Some(environment) = args.environment {
+        if let Some(env) = project.environments.edges.iter().find(|e| {
+            (e.node.id.to_lowercase() == environment)
+                || (e.node.name.to_lowercase() == environment.to_lowercase())
+        }) {
+            fake_select("Select the environment to delete", &env.node.name);
+            (env.node.id.clone(), env.node.name.clone())
+        } else {
+            bail!(RailwayError::EnvironmentNotFound(environment))
+        }
+    } else if is_terminal {
+        let environments = project
+            .environments
+            .edges
+            .iter()
+            .map(|env| Environment(&env.node))
+            .collect::<Vec<_>>();
+        let r = prompt_options("Select the environment to delete", environments)?;
+        (r.0.id.clone(), r.0.name.clone())
+    } else {
+        bail!("Environment must be specified when not running in a terminal");
+    };
+
+    if !args.bypass {
+        let confirmed = prompt_confirm_with_default(
+            format!(
+                r#"Are you sure you want to delete the environment "{}"?"#,
+                name.red()
+            )
+            .as_str(),
+            false,
+        )?;
+
+        if !confirmed {
+            return Ok(());
+        }
+    }
+
+    let is_two_factor_enabled = {
+        let vars = queries::two_factor_info::Variables {};
+
+        let info =
+            post_graphql::<queries::TwoFactorInfo, _>(&client, configs.get_backboard(), vars)
+                .await?
+                .two_factor_info;
+
+        info.is_verified
+    };
+    if is_two_factor_enabled {
+        let token = prompt_text("Enter your 2FA code")?;
+        let vars = mutations::validate_two_factor::Variables { token };
+
+        let valid =
+            post_graphql::<mutations::ValidateTwoFactor, _>(&client, configs.get_backboard(), vars)
+                .await?
+                .two_factor_info_validate;
+
+        if !valid {
+            return Err(RailwayError::InvalidTwoFactorCode.into());
+        }
+    }
+    let spinner = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::default_spinner()
+                .tick_chars(TICK_STRING)
+                .template("{spinner:.green} {msg}")?,
+        )
+        .with_message("Deleting environment...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+    let _r = post_graphql::<mutations::EnvironmentDelete, _>(
+        &client,
+        &configs.get_backboard(),
+        mutations::environment_delete::Variables { id },
+    )
+    .await?;
+    spinner.finish_with_message("Environment deleted!");
+    Ok(())
+}
+
+async fn link_environment(args: Args) -> std::result::Result<(), anyhow::Error> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
@@ -38,7 +229,10 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         Some(environment) => {
             let environment = environments
                 .iter()
-                .find(|env| env.0.id == environment || env.0.name == environment)
+                .find(|env| {
+                    env.0.id == environment
+                        || env.0.name.to_lowercase() == environment.to_lowercase()
+                })
                 .context("Environment not found")?;
             environment.clone()
         }
@@ -71,6 +265,234 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     )?;
     configs.write()?;
     Ok(())
+}
+
+async fn upsert_variables(
+    configs: Configs,
+    client: reqwest::Client,
+    project: queries::project::ProjectProject,
+    service_variables: Vec<(String, (String, String))>,
+    env_id: String,
+) -> Result<(), anyhow::Error> {
+    let good_vars: Vec<(String, BTreeMap<String, String>)> = service_variables
+        .chunk_by(|a, b| a.0 == b.0) // group by service id
+        .map(|vars| {
+            let service = vars.first().unwrap().0.clone();
+            let variables = vars
+                .iter()
+                .map(|v| (v.1 .0.clone(), v.1 .1.clone()))
+                .collect::<BTreeMap<_, _>>();
+            (service, variables)
+        })
+        .collect();
+    let mut tasks: Vec<JoinHandle<Result<()>>> = Vec::new();
+    for (service_id, variables) in good_vars {
+        let client = client.clone();
+        let project = project.id.clone();
+        let env_id = env_id.clone();
+        let backboard = configs.get_backboard();
+        tasks.push(tokio::spawn(async move {
+            let vars = mutations::variable_collection_upsert::Variables {
+                project_id: project,
+                environment_id: env_id,
+                service_id,
+                variables,
+            };
+            let _response =
+                post_graphql::<mutations::VariableCollectionUpsert, _>(&client, backboard, vars)
+                    .await?;
+            Ok(())
+        }));
+    }
+    let spinner = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::default_spinner()
+                .tick_chars(TICK_STRING)
+                .template("{spinner:.green} {msg}")?,
+        )
+        .with_message("Inserting variables...");
+    spinner.enable_steady_tick(Duration::from_millis(100));
+    let r = futures::future::join_all(tasks).await;
+    for r in r {
+        r??;
+    }
+    spinner.finish_and_clear();
+    Ok(())
+}
+
+fn select_service_variables_new(
+    args: NewArgs,
+    project: &queries::project::ProjectProject,
+    is_terminal: bool,
+    duplicate_id: &Option<String>,
+) -> Result<Vec<(String, (String, String))>> {
+    let service_variables = if let Some(ref duplicate_id) = *duplicate_id {
+        let services = project
+            .services
+            .edges
+            .iter()
+            .filter(|s| {
+                s.node
+                    .service_instances
+                    .edges
+                    .iter()
+                    .any(|i| &i.node.environment_id == duplicate_id)
+            })
+            .collect::<Vec<_>>();
+        if !args.service_variables.is_empty() {
+            args.service_variables
+                .chunks(2)
+                .filter_map(|chunk| {
+                    // clap ensures that there will always be 2 values whenever the flag is provided
+                    let service = chunk.first().unwrap();
+                    let service_meta = services
+                        .iter()
+                        .find(|s| {
+                            (s.node.id.to_lowercase() == service.to_lowercase())
+                                || (s.node.name.to_lowercase() == service.to_lowercase())
+                        })
+                        .map(|s| (s.node.id.clone(), s.node.name.clone()));
+                    let variable = chunk.last().unwrap().split('=').collect::<Vec<&str>>();
+                    if service_meta.is_none() {
+                        println!(
+                            "{}: Service {} not found",
+                            "Error".red().bold(),
+                            service.blue()
+                        );
+                        std::process::exit(1); // returning errors in closures... oh my god...
+                    }
+                    service_meta.map(|service_meta| {
+                        let key = variable.first().unwrap().to_string();
+                        let value = variable.last().unwrap().to_string();
+                        fake_select(
+                            "Select a service to set variables for",
+                            service_meta.1.as_str(),
+                        );
+                        fake_select("Enter a variable", format!("{}={}", key, value).as_str());
+                        (
+                            service_meta.0, // id
+                            (key, value),
+                        )
+                    })
+                })
+                .collect::<Vec<(String, (String, String))>>()
+        } else if is_terminal {
+            let mut variables: Vec<(String, (String, String))> = Vec::new();
+            let p_services = services
+                .iter()
+                .map(|s| PromptService(&s.node))
+                .collect::<Vec<_>>();
+            let mut used_services: Vec<&PromptService> = Vec::new();
+            loop {
+                let prompt_services: Vec<&PromptService<'_>> = p_services
+                    .iter()
+                    .filter(|p| !used_services.contains(p))
+                    .clone()
+                    .collect();
+                if prompt_services.is_empty() {
+                    break;
+                }
+                let service = prompt_options_skippable(
+                    "Select a service to set variables for <esc to skip>",
+                    prompt_services,
+                )?;
+                if let Some(service) = service {
+                    loop {
+                        // prompt for value now
+                        let variable = prompt_text_with_placeholder_disappear_skippable(
+                            "Enter a variable",
+                            "<KEY=VALUE, press esc to skip>",
+                        )?;
+                        if let Some(variable) = variable {
+                            let variable = variable.split('=').collect::<Vec<&str>>();
+                            if variable.len() != 2 || variable[1].is_empty() {
+                                println!("{}: Invalid variable format", "Warn".yellow().bold());
+                                continue;
+                            }
+                            variables.push((
+                                service.0.id.clone(),
+                                (
+                                    variable.first().unwrap().to_string(),
+                                    variable.last().unwrap().to_string(),
+                                ),
+                            ));
+                        } else {
+                            break;
+                        }
+                    }
+                    used_services.push(service)
+                } else {
+                    break;
+                }
+            }
+            variables
+        } else {
+            vec![]
+        }
+    } else if !args.service_variables.is_empty() {
+        // if duplicate id is None and service_variables are provided, error
+        bail!("Service variables can only be set when duplicating an environment")
+    } else {
+        vec![]
+    };
+    Ok(service_variables)
+}
+
+fn select_duplicate_id_new(
+    args: &NewArgs,
+    project: &queries::project::ProjectProject,
+    is_terminal: bool,
+) -> Result<Option<String>, anyhow::Error> {
+    let duplicate_id = if let Some(ref duplicate) = args.duplicate {
+        let env = project.environments.edges.iter().find(|env| {
+            (env.node.name.to_lowercase() == duplicate.to_lowercase())
+                || (env.node.id == *duplicate)
+        });
+        if let Some(env) = env {
+            fake_select("Duplicate from", &env.node.name);
+            Some(env.node.id.clone())
+        } else {
+            bail!(RailwayError::EnvironmentNotFound(duplicate.clone()))
+        }
+    } else if is_terminal {
+        let environments = project
+            .environments
+            .edges
+            .iter()
+            .map(|env| Environment(&env.node))
+            .collect::<Vec<_>>();
+        prompt_options_skippable(
+            "Duplicate from <esc to create an empty environment>",
+            environments,
+        )?
+        .map(|e| e.0.id.clone())
+    } else {
+        None
+    };
+    Ok(duplicate_id)
+}
+
+fn select_name_new(args: &NewArgs, is_terminal: bool) -> Result<String, anyhow::Error> {
+    let name = if let Some(name) = args.name.clone() {
+        fake_select("Environment name", name.as_str());
+        name
+    } else if is_terminal {
+        loop {
+            let q = prompt_text("Environment name")?;
+            if q.is_empty() {
+                println!(
+                    "{}: Environment name cannot be empty",
+                    "Warn".yellow().bold()
+                );
+                continue;
+            } else {
+                break q;
+            }
+        }
+    } else {
+        bail!("Environment name must be specified when not running in a terminal");
+    };
+    Ok(name)
 }
 
 #[derive(Debug, Clone)]

--- a/src/commands/environment.rs
+++ b/src/commands/environment.rs
@@ -114,6 +114,8 @@ async fn new_environment(args: NewArgs) -> Result<()> {
 
     if !service_variables.is_empty() {
         upsert_variables(configs, client, project, service_variables, env_id).await?;
+    } else {
+        println!();
     }
 
     Ok(())

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 pub(super) use crate::{client::*, config::*, gql::*};
 pub(super) use anyhow::{Context, Result};
-pub(super) use clap::Parser;
+pub(super) use clap::{Parser, Subcommand};
 pub(super) use colored::Colorize;
 
 pub mod add;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -21,7 +21,7 @@ pub enum RailwayError {
     #[error("Failed to fetch: {0}")]
     FetchError(#[from] reqwest::Error),
 
-    #[error("No linked project found. Run railway link to connect to a project, and a service.")]
+    #[error("No linked project found. Run railway link to connect to a project")]
     NoLinkedProject,
 
     #[error("Project not found. Run `railway link` to connect to a project.")]

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -161,6 +161,24 @@ pub struct ServiceCreate;
 )]
 pub struct CustomDomainCreate;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/EnvironmentCreate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct EnvironmentCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/EnvironmentDelete.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct EnvironmentDelete;
+
 impl std::fmt::Display for custom_domain_create::DNSRecordType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/gql/mutations/strings/EnvironmentCreate.graphql
+++ b/src/gql/mutations/strings/EnvironmentCreate.graphql
@@ -1,0 +1,8 @@
+mutation EnvironmentCreate($projectId: String!, $name: String!, $sourceId: String) {
+  environmentCreate(
+    input: {projectId: $projectId, name: $name, sourceEnvironmentId: $sourceId}
+  ) {
+    name,
+    id
+  }
+}

--- a/src/gql/mutations/strings/EnvironmentDelete.graphql
+++ b/src/gql/mutations/strings/EnvironmentDelete.graphql
@@ -1,0 +1,3 @@
+mutation EnvironmentDelete($id: String!) {
+  environmentDelete(id: $id)
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -61,7 +61,7 @@ pub struct TemplateServiceConfigIcon {
 #[graphql(
     schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/Project.graphql",
-    response_derives = "Debug, Serialize, Clone"
+    response_derives = "Debug, Serialize, Clone, PartialEq"
 )]
 pub struct Project;
 pub type RailwayProject = project::ProjectProject;

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -57,6 +57,18 @@ pub fn prompt_text_with_placeholder_disappear(message: &str, placeholder: &str) 
         .context("Failed to prompt for options")
 }
 
+pub fn prompt_text_with_placeholder_disappear_skippable(
+    message: &str,
+    placeholder: &str,
+) -> Result<Option<String>> {
+    let select = inquire::Text::new(message);
+    select
+        .with_render_config(Configs::get_render_config())
+        .with_placeholder(placeholder)
+        .prompt_skippable()
+        .context("Failed to prompt for options")
+}
+
 pub fn prompt_confirm_with_default(message: &str, default: bool) -> Result<bool> {
     let confirm = inquire::Confirm::new(message);
     confirm
@@ -97,7 +109,7 @@ pub fn fake_select(message: &str, selected: &str) {
     println!("{} {} {}", ">".green(), message, selected.cyan().bold());
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PromptService<'a>(pub &'a ProjectProjectServicesEdgesNode);
 
 impl Display for PromptService<'_> {


### PR DESCRIPTION
This pull request adds 2 new commands:
- `railway environment new`
- `railway environment delete`


# `railway environment new`

railway environment new is a command for creating new environments. It supports duplicating pre-existing environments, injecting variables for services that are being duplicated, and works fully in non-interactive mode (whilst also having an interactive mode).

# `railway environment delete`

This command allows you to delete environments. It will work in non interactive mode completely if you do not have 2FA on your account. If you do, then it won't, but this is the same case with any command that requires 2fa.