### PR TITLE
Fix open command

### DIFF
--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -21,8 +21,7 @@ pub async fn command(_args: Args, _json: bool) -> Result<()> {
 
     ::open::that(format!(
         "https://{hostname}/project/{}?environmentId={}",
-        linked_project.project,
-        linked_project.environment
+        linked_project.project, linked_project.environment
     ))?;
     Ok(())
 }

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -20,8 +20,9 @@ pub async fn command(_args: Args, _json: bool) -> Result<()> {
     ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
 
     ::open::that(format!(
-        "https://{hostname}/project/{}",
-        linked_project.project
+        "https://{hostname}/project/{}?environmentId={}",
+        linked_project.project,
+        linked_project.environment
     ))?;
     Ok(())
 }


### PR DESCRIPTION
Previously, the open command wouldn't open to the correct environment. This PR fixes it by providing the `environmentId` query parameter.
