### PR TITLE
Fix sealed variables

### DIFF
--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -28,6 +28,13 @@ pub async fn get_service_variables(
     let variables = response
         .variables_for_service_deployment
         .into_iter()
+        .filter_map(|var| {
+            if let Some(value) = var.1 {
+                Some((var.0, value))
+            } else {
+                None
+            }
+        })
         .collect();
 
     Ok(variables)

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -2,7 +2,7 @@ use graphql_client::GraphQLQuery;
 use serde::{Deserialize, Serialize};
 
 type DateTime = chrono::DateTime<chrono::Utc>;
-type EnvironmentVariables = std::collections::BTreeMap<String, String>;
+type EnvironmentVariables = std::collections::BTreeMap<String, Option<String>>;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -109,7 +109,8 @@ pub struct UserProjects;
 #[graphql(
     schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/VariablesForServiceDeployment.graphql",
-    response_derives = "Debug, Serialize, Clone"
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
 )]
 pub struct VariablesForServiceDeployment;
 


### PR DESCRIPTION
Previously, if a service linked to had a sealed variable and you tried to use the variables or run command, it would exit with an error. This fixes it.


