### PR TITLE
Fix link command for non-terminal usage

### DIFF
--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,4 +1,5 @@
 use colored::*;
+use is_terminal::IsTerminal;
 use std::fmt::Display;
 
 use crate::{
@@ -104,8 +105,10 @@ fn select_service(
             } else {
                 return Err(RailwayError::ServiceNotFound(service).into());
             }
-        } else {
+        } else if std::io::stdout().is_terminal() {
             prompt_options_skippable("Select a service <esc to skip>", useful_services)?
+        } else {
+            None 
         }
     } else {
         None

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -108,7 +108,7 @@ fn select_service(
         } else if std::io::stdout().is_terminal() {
             prompt_options_skippable("Select a service <esc to skip>", useful_services)?
         } else {
-            None 
+            None
         }
     } else {
         None


### PR DESCRIPTION
If a service isn't provided in the command line flags and we aren't in a terminal, we will no longer prompt for it. This previously broke using it for stuff like CI when you don't want to link to a service.