### PR TITLE
Fix docker ci workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,10 +3,9 @@ name: Publish to GHCR
 on:
   workflow_run:
     workflows: [Release]
-    branches:
-      - master
     types:
       - completed
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -19,11 +18,11 @@ permissions:
   packages: write
 
 jobs:
-  containerize:
-    runs-on: ubuntu-latest
+  containerize-release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Download binary artifact
@@ -60,3 +59,40 @@ jobs:
           context: .
           push: true
           tags: ${{ env.IMAGE_BASE_TAG }}:${{ env.CLI_VERSION }}, ${{ env.IMAGE_BASE_TAG }}:latest
+
+  containerize-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - id: tag
+        name: Get latest release tag
+        run: |
+          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/tags | \
+          jq -r '.[-1].name' | \
+          xargs -I {} echo "tag={}" >> "$GITHUB_OUTPUT"
+
+      - name: Download the binary
+        run: |
+          wget --header='Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/railway-${{ steps.tag.outputs.tag }}-x86_64-unknown-linux-musl.tar.gz -O railway.tar.gz
+
+      - name: Extract the binary
+        run: tar -xf railway.tar.gz
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_BASE_TAG }}:${{ steps.tag.outputs.tag }}, ${{ env.IMAGE_BASE_TAG }}:latest


### PR DESCRIPTION
Revert 'only run publish workflow on changes to the master branch'; Add manual job trigger.

60547529c3cdc817c9ba4ea9de63e195c8f205d1 Introduced a logic error which caused the workflow to never be triggered.

Please keep in mind that this workflow **IS NOT TRIGGERED BY GIT EVENTS** so setting any trigger rules/filters that mention branches, tags, commits etc would quite literally brick it.