### PR TITLE
Fix manual docker ci tag

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -3,10 +3,9 @@ name: Publish to GHCR
 on:
   workflow_run:
     workflows: [Release]
-    branches:
-      - master
     types:
       - completed
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -19,11 +18,11 @@ permissions:
   packages: write
 
 jobs:
-  containerize:
-    runs-on: ubuntu-latest
+  containerize-release:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
     steps:
-      - name: "Checkout"
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Download binary artifact
@@ -60,3 +59,40 @@ jobs:
           context: .
           push: true
           tags: ${{ env.IMAGE_BASE_TAG }}:${{ env.CLI_VERSION }}, ${{ env.IMAGE_BASE_TAG }}:latest
+
+  containerize-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - id: tag
+        name: Get latest release tag
+        run: |
+          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/tags | \
+          jq -r '.[-1].name' | \
+          xargs -I {} echo "tag={}" >> "$GITHUB_OUTPUT"
+
+      - name: Download the binary
+        run: |
+          wget --header='Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/railway-${{ steps.tag.outputs.tag }}-x86_64-unknown-linux-musl.tar.gz -O railway.tar.gz
+
+      - name: Extract the binary
+        run: tar -xf railway.tar.gz
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_BASE_TAG }}:${{ steps.tag.outputs.tag }}, ${{ env.IMAGE_BASE_TAG }}:latest

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,11 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: Release tag to containerize
+        required: true
 
 env:
   REGISTRY: ghcr.io
@@ -64,23 +69,16 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout'
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - id: tag
-        name: Get latest release tag
-        run: |
-          curl -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/tags | \
-          jq -r '.[-1].name' | \
-          xargs -I {} echo "tag={}" >> "$GITHUB_OUTPUT"
-
-      - name: Download the binary
+      - name: Download release binary
         run: |
           wget --header='Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/railway-${{ steps.tag.outputs.tag }}-x86_64-unknown-linux-musl.tar.gz -O railway.tar.gz
+          https://github.com/${{ github.repository }}/releases/download/${{ github.event.inputs.tag }}/railway-${{ github.event.inputs.tag }}-x86_64-unknown-linux-musl.tar.gz -O - | tar xvfz -
 
-      - name: Extract the binary
-        run: tar -xf railway.tar.gz
+      - name: Test run the binary
+        run: ./railway --version
 
       - name: Login to ghcr
         uses: docker/login-action@v3
@@ -95,4 +93,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE_BASE_TAG }}:${{ steps.tag.outputs.tag }}, ${{ env.IMAGE_BASE_TAG }}:latest
+          tags: ${{ env.IMAGE_BASE_TAG }}:${{ github.event.inputs.tag }}, ${{ env.IMAGE_BASE_TAG }}:latest


### PR DESCRIPTION
Since there was a problem with element order returned by GitHub's tags endpoint, this PR replaces that API request with a "tag" input field, which also makes possible to push any tag as the latest.