### PR TITLE
add `ssh` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "futures-core",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,7 +693,7 @@ checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox 0.1.3",
+ "libredox",
  "windows-sys 0.59.0",
 ]
 
@@ -1442,7 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
 dependencies = [
  "bitflags 2.6.0",
- "crossterm",
+ "crossterm 0.25.0",
  "dyn-clone",
  "fuzzy-matcher",
  "fxhash",
@@ -1533,24 +1550,13 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "redox_syscall 0.4.1",
-]
-
-[[package]]
-name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1696,12 +1702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,7 +1763,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1922,6 +1922,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "console",
+ "crossterm 0.27.0",
  "ctrlc",
  "derive-new",
  "dirs",
@@ -1954,7 +1955,6 @@ dependencies = [
  "strum",
  "synchronized-writer",
  "tar",
- "termion",
  "textwrap",
  "thiserror 2.0.9",
  "tokio",
@@ -1995,15 +1995,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
@@ -2012,19 +2003,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
- "libredox 0.1.3",
+ "libredox",
  "thiserror 1.0.69",
 ]
 
@@ -2633,18 +2618,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "termion"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
-dependencies = [
- "libc",
- "libredox 0.0.2",
- "numtoa",
- "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,7 +676,7 @@ checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
+ "libredox 0.1.3",
  "windows-sys 0.59.0",
 ]
 
@@ -774,6 +774,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +812,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1521,13 +1533,24 @@ checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.8",
 ]
 
 [[package]]
@@ -1673,6 +1696,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,7 +1763,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.8",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1897,10 +1926,12 @@ dependencies = [
  "derive-new",
  "dirs",
  "futures 0.3.31",
+ "futures-util",
  "graphql-ws-client",
  "graphql_client",
  "gzp",
  "hostname",
+ "http 0.2.12",
  "http-body-util",
  "hyper 1.5.2",
  "hyper-util",
@@ -1923,6 +1954,7 @@ dependencies = [
  "strum",
  "synchronized-writer",
  "tar",
+ "termion",
  "textwrap",
  "thiserror 2.0.9",
  "tokio",
@@ -1963,6 +1995,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
@@ -1971,13 +2012,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
- "libredox",
+ "libredox 0.1.3",
  "thiserror 1.0.69",
 ]
 
@@ -2586,6 +2633,18 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "termion"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
+dependencies = [
+ "libc",
+ "libredox 0.0.2",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ futures = { version = "0.3.31", default-features = false, features = [
   "compat",
   "io-compat",
 ] }
+futures-util = "0.3"
 names = { version = "0.14.0", default-features = false }
 graphql-ws-client = { version = "0.11.1", features = [
   "client-graphql-client",
@@ -66,6 +67,8 @@ async-tungstenite = { version = "0.28.2", features = [
   "tokio-runtime",
   "tokio-rustls-native-certs",
 ] }
+termion = "2.0"
+http = "0.2"
 is-terminal = "0.4.13"
 serde_with = "3.12.0"
 ctrlc = "3.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ async-tungstenite = { version = "0.28.2", features = [
   "tokio-runtime",
   "tokio-rustls-native-certs",
 ] }
-termion = "2.0"
+crossterm = { version = "0.27.0", features = ["event-stream"] }
 http = "0.2"
 is-terminal = "0.4.13"
 serde_with = "3.12.0"

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod redeploy;
 pub mod run;
 pub mod service;
 pub mod shell;
+pub mod ssh;
 pub mod starship;
 pub mod status;
 pub mod unlink;

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -1,0 +1,124 @@
+use anyhow::{Context, Result};
+use is_terminal::IsTerminal;
+use tokio::io::AsyncReadExt;
+use tokio::select;
+
+use super::*;
+use crate::{consts::TICK_STRING, controllers::terminal::TerminalClient};
+
+/// Connect to a service via SSH
+#[derive(Parser)]
+pub struct Args {
+    /// Project to connect to
+    #[arg(value_name = "project-name")]
+    project: String,
+
+    /// Service to connect to
+    #[arg(value_name = "service-name")]
+    service: String,
+
+    /// Deployment instance ID to connect to
+    #[arg(long = "deployment-instance", value_name = "deployment-instance-id")]
+    deployment_instance: Option<String>,
+}
+
+pub async fn command(args: Args, _json: bool) -> Result<()> {
+    let configs = Configs::new()?;
+    let token = configs
+        .get_railway_auth_token()
+        .context("No authentication token found. Please login first with 'railway login'")?;
+
+    let spinner = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::default_spinner()
+                .tick_chars(TICK_STRING)
+                .template("{spinner:.green} {msg}")?,
+        )
+        .with_message("Connecting to service...");
+
+    spinner.enable_steady_tick(std::time::Duration::from_millis(100));
+
+    let ws_url = format!("wss://{}", configs.get_relay_host_path());
+
+    let mut client = TerminalClient::new(
+        &ws_url,
+        &token,
+        &args.project,
+        &args.service,
+        args.deployment_instance.as_deref(),
+    )
+    .await?;
+
+    if !std::io::stdout().is_terminal() {
+        anyhow::bail!("SSH connection requires a terminal");
+    }
+
+    let size = termion::terminal_size()?;
+    client.send_window_size(size.0, size.1).await?;
+
+    let mut stdin = tokio::io::stdin();
+    let mut stdin_buf = [0u8; 1024];
+
+    let raw_mode = termion::raw::IntoRawMode::into_raw_mode(std::io::stdout())?;
+
+    spinner.finish();
+
+    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    let mut sigwinch =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())?;
+
+    // Main event loop
+    loop {
+        select! {
+            // Handle window resizes
+            _ = sigwinch.recv() => {
+                if let Ok(size) = termion::terminal_size() {
+                    client.send_window_size(size.0, size.1).await?;
+                }
+                continue;
+            }
+            // Handle signals
+            _ = sigint.recv() => {
+                client.send_signal(2).await?; // SIGINT
+                continue;
+            }
+            _ = sigterm.recv() => {
+                client.send_signal(15).await?; // SIGTERM
+                break;
+            }
+            // Handle input from terminal
+            result = stdin.read(&mut stdin_buf) => {
+                match result {
+                    Ok(0) => break, // EOF
+                    Ok(n) => {
+                        let data = String::from_utf8_lossy(&stdin_buf[..n]);
+                        client.send_data(&data).await?;
+                    }
+                    Err(e) => {
+                        eprintln!("Error reading from stdin: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // Handle messages from server
+            result = client.handle_server_messages() => {
+                match result {
+                   Ok(()) => {
+                        // PTY session has ended, exit immediately
+                        drop(raw_mode);
+                        std::process::exit(0);
+                    }
+                    Err(e) => {
+                        eprintln!("Error handling server messages: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    drop(raw_mode);
+    Ok(())
+}

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -111,8 +111,8 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
                         std::process::exit(0);
                     }
                     Err(e) => {
-                        eprintln!("Error handling server messages: {}", e);
-                        break;
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
                     }
                 }
             }

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use is_terminal::IsTerminal;
 use reqwest::Client;
 use tokio::io::AsyncReadExt;
 use tokio::select;
@@ -87,10 +86,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let ws_url = format!("wss://{}", configs.get_relay_host_path());
 
     let mut client = TerminalClient::new(&ws_url, &token, &params).await?;
-
-    if !std::io::stdout().is_terminal() {
-        anyhow::bail!("SSH connection requires a terminal");
-    }
 
     let size = termion::terminal_size()?;
     client.send_window_size(size.0, size.1).await?;

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -1,4 +1,7 @@
 use anyhow::{Context, Result};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{self, disable_raw_mode, enable_raw_mode};
+use futures_util::FutureExt;
 use reqwest::Client;
 use tokio::io::AsyncReadExt;
 use tokio::select;
@@ -63,6 +66,25 @@ async fn get_ssh_connect_params(
     })
 }
 
+#[cfg(unix)]
+async fn setup_signal_handlers() -> Result<(
+    tokio::signal::unix::Signal,
+    tokio::signal::unix::Signal,
+    tokio::signal::unix::Signal,
+)> {
+    let sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+    let sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    let sigwinch = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())?;
+
+    Ok((sigint, sigterm, sigwinch))
+}
+
+#[cfg(not(unix))]
+async fn setup_signal_handlers() -> Result<()> {
+    // On Windows, we don't have these Unix signals
+    Ok(())
+}
+
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
@@ -87,75 +109,232 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
 
     let mut client = TerminalClient::new(&ws_url, &token, &params).await?;
 
-    let size = termion::terminal_size()?;
-    client.send_window_size(size.0, size.1).await?;
+    // Wait a moment for the connection to stabilize before sending terminal size
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let (cols, rows) = terminal::size()?;
+    client.send_window_size(cols, rows).await?;
 
     let mut stdin = tokio::io::stdin();
     let mut stdin_buf = [0u8; 1024];
 
-    let raw_mode = termion::raw::IntoRawMode::into_raw_mode(std::io::stdout())?;
+    enable_raw_mode()?;
 
     spinner.finish();
 
-    let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
-    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
-    let mut sigwinch =
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::window_change())?;
+    // Send window size again after connection is fully established and spinner is finished
+    if let Ok((cols, rows)) = terminal::size() {
+        client.send_window_size(cols, rows).await?;
+    }
+
+    // Signal handling is platform-specific
+    #[cfg(unix)]
+    let (mut sigint, mut sigterm, mut sigwinch) = setup_signal_handlers().await?;
+
+    #[cfg(not(unix))]
+    let _ = setup_signal_handlers().await?;
+
+    // For Windows, we'll use crossterm's event stream if available
+    #[cfg(all(not(unix), feature = "event-stream"))]
+    let mut event_stream = crossterm::event::EventStream::new();
+
+    // Fallback to polling if event-stream is not available
+    #[cfg(all(not(unix), not(feature = "event-stream")))]
+    let event_poll_timeout = std::time::Duration::from_millis(100);
 
     let mut exit_code = None;
 
     // Main event loop
     loop {
-        select! {
-            // Handle window resizes
-            _ = sigwinch.recv() => {
-                if let Ok(size) = termion::terminal_size() {
-                    client.send_window_size(size.0, size.1).await?;
-                }
-                continue;
-            }
-            // Handle signals
-            _ = sigint.recv() => {
-                client.send_signal(2).await?; // SIGINT
-                continue;
-            }
-            _ = sigterm.recv() => {
-                client.send_signal(15).await?; // SIGTERM
-                break;
-            }
-            // Handle input from terminal
-            result = stdin.read(&mut stdin_buf) => {
-                match result {
-                    Ok(0) => break, // EOF
-                    Ok(n) => {
-                        let data = String::from_utf8_lossy(&stdin_buf[..n]);
-                        client.send_data(&data).await?;
+        #[cfg(unix)]
+        {
+            select! {
+                // Handle window resizes
+                _ = sigwinch.recv() => {
+                    if let Ok((cols, rows)) = terminal::size() {
+                        client.send_window_size(cols, rows).await?;
                     }
-                    Err(e) => {
-                        eprintln!("Error reading from stdin: {}", e);
-                        break;
+                    continue;
+                }
+                // Handle signals
+                _ = sigint.recv() => {
+                    client.send_signal(2).await?; // SIGINT
+                    continue;
+                }
+                _ = sigterm.recv() => {
+                    client.send_signal(15).await?; // SIGTERM
+                    break;
+                }
+                // Handle input from terminal
+                result = stdin.read(&mut stdin_buf) => {
+                    match result {
+                        Ok(0) => break, // EOF
+                        Ok(n) => {
+                            let data = String::from_utf8_lossy(&stdin_buf[..n]);
+                            client.send_data(&data).await?;
+                        }
+                        Err(e) => {
+                            eprintln!("Error reading from stdin: {}", e);
+                            break;
+                        }
+                    }
+                }
+
+                // Handle messages from server
+                result = client.handle_server_messages() => {
+                    match result {
+                       Ok(()) => {
+                            exit_code = Some(0);
+                            break;
+                        }
+                        Err(e) => {
+                            eprintln!("Error: {}", e);
+                            exit_code = Some(1);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            // We need to handle Windows event handling differently based on whether the
+            // event-stream feature is enabled
+            #[cfg(feature = "event-stream")]
+            {
+                select! {
+                    // Handle crossterm events for Windows with event-stream
+                    maybe_event = event_stream.next().fuse() => {
+                        match maybe_event {
+                            Some(Ok(Event::Key(KeyEvent { code: KeyCode::Char('c'), modifiers, .. }))) if modifiers.contains(KeyModifiers::CONTROL) => {
+                                // Handle Ctrl+C like SIGINT
+                                client.send_signal(2).await?;
+                                continue;
+                            },
+                            Some(Ok(Event::Resize(width, height))) => {
+                                // Handle terminal resize
+                                client.send_window_size(width, height).await?;
+                                continue;
+                            },
+                            Some(Ok(Event::Key(key))) => {
+                                // Handle regular key input
+                                // Convert the key event to a string and send it
+                                let input = match key.code {
+                                    KeyCode::Char(c) => c.to_string(),
+                                    KeyCode::Enter => "\r".to_string(),
+                                    KeyCode::Backspace => "\x08".to_string(),
+                                    KeyCode::Esc => "\x1b".to_string(),
+                                    _ => continue,
+                                };
+                                client.send_data(&input).await?;
+                            },
+                            Some(Err(e)) => {
+                                eprintln!("Error reading events: {}", e);
+                                break;
+                            },
+                            None => break,
+                        }
+                    },
+
+                    result = stdin.read(&mut stdin_buf) => {
+                        match result {
+                            Ok(0) => break, // EOF
+                            Ok(n) => {
+                                let data = String::from_utf8_lossy(&stdin_buf[..n]);
+                                client.send_data(&data).await?;
+                            }
+                            Err(e) => {
+                                eprintln!("Error reading from stdin: {}", e);
+                                break;
+                            }
+                        }
+                    }
+
+                    // Handle messages from server
+                    result = client.handle_server_messages() => {
+                        match result {
+                           Ok(()) => {
+                                exit_code = Some(0);
+                                break;
+                            }
+                            Err(e) => {
+                                eprintln!("Error: {}", e);
+                                exit_code = Some(1);
+                                break;
+                            }
+                        }
                     }
                 }
             }
 
-            // Handle messages from server
-            result = client.handle_server_messages() => {
-                match result {
-                   Ok(()) => {
-                        exit_code = Some(0);
-                        break;
+            // Use polling-based approach when event-stream is not available
+            #[cfg(not(feature = "event-stream"))]
+            {
+                select! {
+                    result = stdin.read(&mut stdin_buf) => {
+                        match result {
+                            Ok(0) => break, // EOF
+                            Ok(n) => {
+                                let data = String::from_utf8_lossy(&stdin_buf[..n]);
+                                client.send_data(&data).await?;
+                            }
+                            Err(e) => {
+                                eprintln!("Error reading from stdin: {}", e);
+                                break;
+                            }
+                        }
                     }
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit_code = Some(1);
-                        break;
+
+                    // Handle messages from server
+                    result = client.handle_server_messages() => {
+                        match result {
+                           Ok(()) => {
+                                exit_code = Some(0);
+                                break;
+                            }
+                            Err(e) => {
+                                eprintln!("Error: {}", e);
+                                exit_code = Some(1);
+                                break;
+                            }
+                        }
+                    }
+
+                    // Poll for crossterm events
+                    _ = tokio::time::sleep(event_poll_timeout) => {
+                        if event::poll(std::time::Duration::from_millis(0))? {
+                            match event::read()? {
+                                Event::Key(KeyEvent { code: KeyCode::Char('c'), modifiers, .. }) if modifiers.contains(KeyModifiers::CONTROL) => {
+                                    // Handle Ctrl+C like SIGINT
+                                    client.send_signal(2).await?;
+                                },
+                                Event::Resize(width, height) => {
+                                    // Handle terminal resize
+                                    client.send_window_size(width, height).await?;
+                                },
+                                Event::Key(key) => {
+                                    // Handle regular key input
+                                    // Convert the key event to a string and send it
+                                    let input = match key.code {
+                                        KeyCode::Char(c) => c.to_string(),
+                                        KeyCode::Enter => "\r".to_string(),
+                                        KeyCode::Backspace => "\x08".to_string(),
+                                        KeyCode::Esc => "\x1b".to_string(),
+                                        _ => continue,
+                                    };
+                                    client.send_data(&input).await?;
+                                },
+                                _ => {}
+                            }
+                        }
                     }
                 }
             }
         }
     }
 
-    drop(raw_mode);
+    let _ = disable_raw_mode();
 
     if let Some(code) = exit_code {
         std::process::exit(code);

--- a/src/commands/ssh.rs
+++ b/src/commands/ssh.rs
@@ -11,8 +11,10 @@ use super::{
 use crate::{
     consts::TICK_STRING,
     controllers::{
-        environment::get_matched_environment, project::get_project, service::get_or_prompt_service,
-        terminal::TerminalClient,
+        environment::get_matched_environment,
+        project::get_project,
+        service::get_or_prompt_service,
+        terminal::{SSHConnectParams, TerminalClient},
     },
     util::prompt::{prompt_select, PromptService},
 };
@@ -36,14 +38,6 @@ pub struct Args {
     /// Deployment instance ID to connect to (defaults to first active instance)
     #[arg(long = "deployment-instance", value_name = "deployment-instance-id")]
     deployment_instance: Option<String>,
-}
-
-#[derive(Clone, Debug)]
-struct SSHConnectParams {
-    project_id: String,
-    environment_id: String,
-    service_id: String,
-    deployment_instance_id: Option<String>,
 }
 
 async fn get_ssh_connect_params(
@@ -96,14 +90,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
 
     let ws_url = format!("wss://{}", configs.get_relay_host_path());
 
-    let mut client = TerminalClient::new(
-        &ws_url,
-        &token,
-        &params.project_id,
-        &params.service_id,
-        params.deployment_instance_id.as_deref(),
-    )
-    .await?;
+    let mut client = TerminalClient::new(&ws_url, &token, &params).await?;
 
     if !std::io::stdout().is_terminal() {
         anyhow::bail!("SSH connection requires a terminal");

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,12 @@ pub enum Environment {
     Dev,
 }
 
+pub const SSH_CONNECTION_TIMEOUT_SECS: u64 = 10;
+pub const SSH_MESSAGE_TIMEOUT_SECS: u64 = 5;
+pub const SSH_RECONNECT_DELAY_SECS: u64 = 1;
+pub const SSH_MAX_RECONNECT_ATTEMPTS: u32 = 3;
+pub const SSH_MAX_EMPTY_MESSAGES: u32 = 5;
+
 impl Configs {
     pub fn new() -> Result<Self> {
         let environment = Self::get_environment_id();
@@ -150,6 +156,12 @@ impl Configs {
             Environment::Staging => "railway-staging.com",
             Environment::Dev => "railway-develop.com",
         }
+    }
+
+    /// Returns the host and path for relay server without protocol (e.g. "backboard.railway.com/relay")
+    /// Protocol is omitted to allow flexibility between https:// and wss:// usage
+    pub fn get_relay_host_path(&self) -> String {
+        format!("backboard.{}/relay", self.get_host())
     }
 
     pub fn get_backboard(&self) -> String {

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -2,5 +2,6 @@ pub mod database;
 pub mod deployment;
 pub mod environment;
 pub mod project;
+pub mod terminal;
 pub mod user;
 pub mod variables;

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -2,6 +2,7 @@ pub mod database;
 pub mod deployment;
 pub mod environment;
 pub mod project;
+pub mod service;
 pub mod terminal;
 pub mod user;
 pub mod variables;

--- a/src/controllers/service.rs
+++ b/src/controllers/service.rs
@@ -38,11 +38,11 @@ pub async fn get_or_prompt_service(
             if std::io::stdout().is_terminal() {
                 let prompt_services: Vec<_> =
                     services.iter().map(|s| PromptService(&s.node)).collect();
-                let service = prompt_select("Select a service to deploy to", prompt_services)
-                    .context("Please specify a service to deploy to via the `--service` flag.")?;
+                let service = prompt_select("Select a service", prompt_services)
+                    .context("Please specify a service via the `--service` flag.")?;
                 Some(service.0.id.clone())
             } else {
-                bail!("Multiple services found. Please specify a service to deploy to via the `--service` flag.")
+                bail!("Multiple services found. Please specify a service via the `--service` flag.")
             }
         }
     };

--- a/src/controllers/service.rs
+++ b/src/controllers/service.rs
@@ -1,0 +1,51 @@
+use anyhow::{bail, Context, Result};
+use is_terminal::IsTerminal;
+
+use crate::{
+    config::LinkedProject,
+    queries::project::ProjectProject,
+    util::prompt::{prompt_select, PromptService},
+};
+
+pub async fn get_or_prompt_service(
+    linked_project: LinkedProject,
+    project: ProjectProject,
+    service_arg: Option<String>,
+) -> Result<Option<String>> {
+    let services = project.services.edges.iter().collect::<Vec<_>>();
+
+    let service_id = if let Some(service_arg) = service_arg {
+        // If the user specified a service, use that
+        let service_id = services
+            .iter()
+            .find(|service| service.node.name == service_arg || service.node.id == service_arg);
+        if let Some(service_id) = service_id {
+            Some(service_id.node.id.to_owned())
+        } else {
+            bail!("Service not found");
+        }
+    } else if let Some(service) = linked_project.service {
+        // If the user didn't specify a service, but we have a linked service, use that
+        Some(service)
+    } else {
+        // If the user didn't specify a service, and we don't have a linked service, get the first service
+
+        if services.is_empty() {
+            // If there are no services, backboard will generate one for us
+            None
+        } else {
+            // If there are multiple services, prompt the user to select one
+            if std::io::stdout().is_terminal() {
+                let prompt_services: Vec<_> =
+                    services.iter().map(|s| PromptService(&s.node)).collect();
+                let service = prompt_select("Select a service to deploy to", prompt_services)
+                    .context("Please specify a service to deploy to via the `--service` flag.")?;
+                Some(service.0.id.clone())
+            } else {
+                bail!("Multiple services found. Please specify a service to deploy to via the `--service` flag.")
+            }
+        }
+    };
+
+    Ok(service_id)
+}

--- a/src/controllers/terminal.rs
+++ b/src/controllers/terminal.rs
@@ -115,7 +115,7 @@ impl TerminalClient {
             .header("X-Railway-Environment-Id", params.environment_id.clone());
 
         if let Some(instance_id) = params.deployment_instance_id.as_ref() {
-            request = request.header("X-Railway-Deployment-Instance", instance_id);
+            request = request.header("X-Railway-Deployment-Instance-Id", instance_id);
         }
 
         let request = request.body(())?;

--- a/src/controllers/terminal.rs
+++ b/src/controllers/terminal.rs
@@ -221,7 +221,7 @@ impl TerminalClient {
                             }
                         },
                         "error" => {
-                            bail!("Server error: {}", server_msg.payload.message);
+                            bail!(server_msg.payload.message);
                         }
                         "pty_closed" => {
                             return Ok(());

--- a/src/controllers/terminal.rs
+++ b/src/controllers/terminal.rs
@@ -1,0 +1,259 @@
+use anyhow::{bail, Result};
+use async_tungstenite::tungstenite::handshake::client::generate_key;
+use async_tungstenite::tungstenite::http::Request;
+use async_tungstenite::{tungstenite::Message, WebSocketStream};
+use futures_util::stream::StreamExt;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use tokio::time::{sleep, timeout, Duration};
+use url::Url;
+
+use crate::commands::{
+    SSH_CONNECTION_TIMEOUT_SECS, SSH_MAX_EMPTY_MESSAGES, SSH_MAX_RECONNECT_ATTEMPTS,
+    SSH_MESSAGE_TIMEOUT_SECS, SSH_RECONNECT_DELAY_SECS,
+};
+
+#[derive(Debug, Serialize)]
+pub struct ClientMessage {
+    pub r#type: String,
+    pub payload: ClientPayload,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum ClientPayload {
+    Data { data: String },
+    WindowSize { cols: u16, rows: u16 },
+    Signal { signal: u8 },
+}
+
+#[derive(Debug, Deserialize)]
+struct ServerMessage {
+    r#type: String,
+    payload: ServerPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct ServerPayload {
+    #[serde(default)]
+    data: DataPayload,
+    #[serde(default)]
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum DataPayload {
+    String(String),
+    Buffer { data: Vec<u8> },
+    Empty {},
+}
+
+impl Default for DataPayload {
+    fn default() -> Self {
+        DataPayload::Empty {}
+    }
+}
+
+pub struct TerminalClient {
+    ws_stream: WebSocketStream<async_tungstenite::tokio::ConnectStream>,
+}
+
+impl TerminalClient {
+    pub async fn new(
+        url: &str,
+        token: &str,
+        project: &str,
+        service: &str,
+        deployment_instance: Option<&str>,
+    ) -> Result<Self> {
+        let url = Url::parse(url)?;
+
+        for attempt in 1..=SSH_MAX_RECONNECT_ATTEMPTS {
+            match Self::attempt_connection(&url, token, project, service, deployment_instance).await
+            {
+                Ok(ws_stream) => {
+                    return Ok(Self { ws_stream });
+                }
+                Err(e) => {
+                    if attempt == SSH_MAX_RECONNECT_ATTEMPTS {
+                        bail!(
+                            "Failed to establish connection after {} attempts: {}",
+                            SSH_MAX_RECONNECT_ATTEMPTS,
+                            e
+                        );
+                    }
+                    eprintln!(
+                        "Connection attempt {} failed: {}. Retrying in {} seconds...",
+                        attempt, e, SSH_RECONNECT_DELAY_SECS
+                    );
+                    sleep(Duration::from_secs(SSH_RECONNECT_DELAY_SECS)).await;
+                }
+            }
+        }
+
+        bail!("Failed to establish connection after all attempts");
+    }
+    async fn attempt_connection(
+        url: &Url,
+        token: &str,
+        project: &str,
+        service: &str,
+        deployment_instance: Option<&str>,
+    ) -> Result<WebSocketStream<async_tungstenite::tokio::ConnectStream>> {
+        let key = generate_key();
+
+        let mut request = Request::builder()
+            .uri(url.as_str())
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Sec-WebSocket-Key", key)
+            .header("Upgrade", "websocket")
+            .header("Connection", "Upgrade")
+            .header("Sec-WebSocket-Version", "13")
+            .header("Host", url.host_str().unwrap_or(""))
+            .header("X-Railway-Project-Id", project)
+            .header("X-Railway-Service-Id", service);
+
+        if let Some(instance) = deployment_instance {
+            request = request.header("X-Railway-Deployment-Instance", instance);
+        }
+
+        let request = request.body(())?;
+
+        let (ws_stream, response) = timeout(
+            Duration::from_secs(SSH_CONNECTION_TIMEOUT_SECS),
+            async_tungstenite::tokio::connect_async_with_config(request, None),
+        )
+        .await??;
+
+        if response.status().as_u16() == 101 {
+            Ok(ws_stream)
+        } else {
+            bail!(
+                "Server did not upgrade to WebSocket. Status: {}",
+                response.status()
+            );
+        }
+    }
+    async fn send_message(&mut self, msg: Message) -> Result<()> {
+        timeout(
+            Duration::from_secs(SSH_MESSAGE_TIMEOUT_SECS),
+            self.ws_stream.send(msg),
+        )
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "Message send timed out after {} seconds",
+                SSH_MESSAGE_TIMEOUT_SECS
+            )
+        })??;
+        Ok(())
+    }
+
+    pub async fn send_data(&mut self, data: &str) -> Result<()> {
+        let message = ClientMessage {
+            r#type: "session_data".to_string(),
+            payload: ClientPayload::Data {
+                data: data.to_string(),
+            },
+        };
+
+        let msg = serde_json::to_string(&message)?;
+        self.send_message(Message::Text(msg))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to send data: {}", e))?;
+        Ok(())
+    }
+
+    pub async fn send_window_size(&mut self, cols: u16, rows: u16) -> Result<()> {
+        let message = ClientMessage {
+            r#type: "window_resize".to_string(),
+            payload: ClientPayload::WindowSize { cols, rows },
+        };
+
+        let msg = serde_json::to_string(&message)?;
+        self.send_message(Message::Text(msg))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to send window size: {}", e))?;
+        Ok(())
+    }
+
+    pub async fn send_signal(&mut self, signal: u8) -> Result<()> {
+        let message = ClientMessage {
+            r#type: "signal".to_string(),
+            payload: ClientPayload::Signal { signal },
+        };
+
+        let msg = serde_json::to_string(&message)?;
+        self.send_message(Message::Text(msg))
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to send signal: {}", e))?;
+        Ok(())
+    }
+    pub async fn handle_server_messages(&mut self) -> Result<()> {
+        let mut consecutive_empty_messages = 0;
+
+        while let Some(msg) = self.ws_stream.next().await {
+            let msg = msg.map_err(|e| anyhow::anyhow!("WebSocket error: {}", e))?;
+
+            match msg {
+                Message::Text(text) => {
+                    let server_msg: ServerMessage = serde_json::from_str(&text)
+                        .map_err(|e| anyhow::anyhow!("Failed to parse server message: {}", e))?;
+
+                    match server_msg.r#type.as_str() {
+                        "session_data" => match server_msg.payload.data {
+                            DataPayload::String(text) => {
+                                consecutive_empty_messages = 0;
+                                print!("{}", text);
+                                std::io::stdout().flush()?;
+                            }
+                            DataPayload::Buffer { data } => {
+                                consecutive_empty_messages = 0;
+                                std::io::stdout().write_all(&data)?;
+                                std::io::stdout().flush()?;
+                            }
+                            DataPayload::Empty {} => {
+                                consecutive_empty_messages += 1;
+                                if consecutive_empty_messages >= SSH_MAX_EMPTY_MESSAGES {
+                                    bail!("Received too many empty messages in a row, connection may be stale");
+                                }
+                            }
+                        },
+                        "error" => {
+                            bail!("Server error: {}", server_msg.payload.message);
+                        }
+                        "pty_closed" => {
+                            return Ok(());
+                        }
+                        unknown_type => {
+                            eprintln!("Warning: Received unknown message type: {}", unknown_type);
+                        }
+                    }
+                }
+                Message::Close(frame) => {
+                    if let Some(frame) = frame {
+                        bail!(
+                            "WebSocket closed with code {}: {}",
+                            frame.code,
+                            frame.reason
+                        );
+                    } else {
+                        bail!("WebSocket closed unexpectedly");
+                    }
+                }
+                Message::Ping(_) | Message::Pong(_) => {
+                    // Just acknowledge these silently...they keep the connection alive
+                }
+                Message::Binary(_) => {
+                    eprintln!("Warning: Unexpected binary message received");
+                }
+                Message::Frame(_) => {
+                    eprintln!("Warning: Unexpected raw frame received");
+                }
+            }
+        }
+
+        bail!("WebSocket connection closed unexpectedly");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ commands_enum!(
     run,
     service,
     shell,
+    ssh,
     starship,
     status,
     unlink,


### PR DESCRIPTION
This adds a `railway ssh` command that creates a websocket connect to a relay server that will provide SSH capabilities to deployment instances.

`<project-name>` and `<service-name>` are required and deployment instance id is not because they are the minimum data required to find a deployment instance. `--deployment-instance` is only necessary if you have multiple replicas.

```sh
$ railway ssh --help
Connect to a service via SSH

Usage: railway ssh [OPTIONS]

Options:
  -p, --project <PROJECT>
          Project to connect to (defaults to linked project)
  -s, --service <SERVICE>
          Service to connect to (defaults to linked service)
  -e, --environment <ENVIRONMENT>
          Environment to connect to (defaults to linked environment)
  -d, --deployment-instance <deployment-instance-id>
          Deployment instance ID to connect to (defaults to first active instance)
      --json
          Output in JSON format
  -h, --help
          Print help
  -V, --version
          Print version

$ railway ssh
  Connecting to service...
root@07e29b7e760a:/app#
```