### PR TITLE
fix: make –no-gitignore actually work

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -147,8 +147,8 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         let mut archive = Builder::new(&mut parz);
         let mut builder = WalkBuilder::new(path);
         builder.add_custom_ignore_filename(".railwayignore");
-        if !args.no_gitignore {
-            builder.add_custom_ignore_filename(".gitignore");
+        if args.no_gitignore {
+            builder.git_ignore(false);
         }
 
         let walker = builder.follow_links(true).hidden(false);


### PR DESCRIPTION
The ignore crate from ripgrep, by default, includes standard filters which automatically ignore files listed in .gitignore and other similar files. Simply not adding .gitignore manually through add_custom_ignore_filename has no practical effect, causing files listed in .gitignore to remain ignored.

This PR resolves this issue by explicitly disabling the git_ignore handler in the standard filters. This behavior has been tested locally to confirm that it correctly bypasses .gitignore.

See issue #608 