### PR TITLE
Properly show external workspaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,6 @@ dependencies = [
  "open",
  "paste",
  "rand",
- "regex",
  "reqwest 0.12.12",
  "serde",
  "serde_json",
@@ -2011,18 +2010,6 @@ dependencies = [
  "getrandom",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ winapi = { version = "0.3.9", features = [
 strum = { version = "0.26.3", features = ["derive"] }
 structstruck = "0.4.1"
 derive-new = "0.7.0"
-regex = "1.11.1"
 
 [profile.release]
 lto = "fat"

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use colored::*;
 use is_terminal::IsTerminal;
 use std::fmt::Display;
@@ -185,6 +186,8 @@ fn select_workspace(
             }) {
                 fake_select("Select a workspace", workspace.name());
                 workspace.clone()
+            } else if team_arg.to_lowercase() == "personal" {
+                bail!(RailwayError::NoPersonalWorkspace);
             } else {
                 return Err(RailwayError::TeamNotFound(team_arg.clone()).into());
             }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,11 +1,5 @@
-use serde::Serialize;
-
-use super::{
-    queries::user_projects::{
-        UserProjectsExternalWorkspacesProjects, UserProjectsMeWorkspacesTeamProjectsEdgesNode,
-    },
-    *,
-};
+use super::*;
+use crate::workspace::workspaces;
 
 /// List all projects in your Railway account
 #[derive(Parser)]
@@ -13,80 +7,35 @@ pub struct Args {}
 
 pub async fn command(_args: Args, json: bool) -> Result<()> {
     let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await.ok();
 
-    let vars = queries::user_projects::Variables {};
-    let mut response =
-        post_graphql::<queries::UserProjects, _>(&client, configs.get_backboard(), vars).await?;
-
+    let workspaces = workspaces().await?;
     let mut all_projects = Vec::new();
 
-    response.me.workspaces.sort_by(|a, b| b.id.cmp(&a.id));
-    for workspace in response.me.workspaces {
+    for workspace in workspaces {
         if !json {
             println!();
-            println!("{}", workspace.name.bold());
+            println!("{}", workspace.name().bold());
         }
 
-        if let Some(mut team) = workspace.team {
-            team.projects
-                .edges
-                .sort_by(|a, b| b.node.updated_at.cmp(&a.node.updated_at));
-            if !json {
-                for project in &team.projects.edges {
-                    let project_name = if linked_project.is_some()
-                        && project.node.id == linked_project.as_ref().unwrap().project
-                    {
-                        project.node.name.purple().bold()
+        let projects = workspace.projects();
+        if !json {
+            for project in &projects {
+                let project_name =
+                    if Some(project.id()) == linked_project.as_ref().map(|p| p.project.as_str()) {
+                        project.name().purple().bold()
                     } else {
-                        project.node.name.white()
+                        project.name().white()
                     };
-                    println!("  {project_name}");
-                }
-            }
-
-            all_projects.extend(
-                team.projects
-                    .edges
-                    .into_iter()
-                    .map(|edge| Project::Team(edge.node)),
-            );
-        }
-    }
-
-    response.external_workspaces.sort_by(|a, b| b.id.cmp(&a.id));
-    for mut workspace in response.external_workspaces {
-        workspace
-            .projects
-            .sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-
-        if !json {
-            println!();
-            println!("{}", workspace.name.bold());
-
-            for project in &workspace.projects {
-                let project_name = if linked_project.is_some()
-                    && project.id == linked_project.as_ref().unwrap().project
-                {
-                    project.name.purple().bold()
-                } else {
-                    project.name.white()
-                };
                 println!("  {project_name}");
             }
         }
-        all_projects.extend(workspace.projects.into_iter().map(|p| Project::External(p)));
+
+        all_projects.extend(projects);
     }
+
     if json {
         println!("{}", serde_json::to_string_pretty(&all_projects)?);
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
-enum Project {
-    External(UserProjectsExternalWorkspacesProjects),
-    Team(UserProjectsMeWorkspacesTeamProjectsEdgesNode),
 }

--- a/src/commands/ssh/common.rs
+++ b/src/commands/ssh/common.rs
@@ -1,5 +1,5 @@
 // src/commands/ssh/common.rs
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 use tokio::time::Duration;
@@ -113,7 +113,6 @@ pub async fn establish_connection(
     ws_url: &str,
     token: &str,
     params: &SSHConnectParams,
-    spinner: &ProgressBar,
 ) -> Result<TerminalClient> {
     let mut client = TerminalClient::new(ws_url, token, params).await?;
 

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 
 use crate::client::GQLClient;
 use crate::config::Configs;
-use crate::controllers::terminal::SSHConnectParams;
 
 pub const SSH_CONNECTION_TIMEOUT_SECS: u64 = 30;
 pub const SSH_MESSAGE_TIMEOUT_SECS: u64 = 10;
@@ -58,7 +57,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let spinner = create_spinner(running_command);
 
     let ws_url = format!("wss://{}", configs.get_relay_host_path());
-    let mut terminal_client = establish_connection(&ws_url, &token, &params, &spinner).await?;
+    let mut terminal_client = establish_connection(&ws_url, &token, &params).await?;
 
     if running_command {
         // Run single command

--- a/src/commands/ssh/platform/unix.rs
+++ b/src/commands/ssh/platform/unix.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use crossterm::terminal;
-use futures_util::FutureExt;
 use tokio::io::AsyncReadExt;
 use tokio::select;
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -4,14 +4,13 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use futures::StreamExt;
 use gzp::{deflate::Gzip, ZBuilder};
 use ignore::WalkBuilder;
 use indicatif::{ProgressBar, ProgressFinish, ProgressIterator, ProgressStyle};
 use is_terminal::IsTerminal;
-use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use synchronized_writer::SynchronizedWriter;
 use tar::Builder;
@@ -21,16 +20,13 @@ use crate::{
     controllers::{
         deployment::{stream_build_logs, stream_deploy_logs},
         environment::get_matched_environment,
-        project::{ensure_project_and_environment_exist, get_project},
+        project::get_project,
         service::get_or_prompt_service,
     },
     errors::RailwayError,
     subscription::subscribe_graphql,
     subscriptions::deployment::DeploymentStatus,
-    util::{
-        logs::format_attr_log,
-        prompt::{prompt_select, PromptService},
-    },
+    util::logs::format_attr_log,
 };
 
 use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,12 +69,6 @@ struct GithubApiRelease {
 
 const GITHUB_API_RELEASE_URL: &str = "https://api.github.com/repos/railwayapp/cli/releases/latest";
 
-pub const SSH_CONNECTION_TIMEOUT_SECS: u64 = 10;
-pub const SSH_MESSAGE_TIMEOUT_SECS: u64 = 5;
-pub const SSH_RECONNECT_DELAY_SECS: u64 = 1;
-pub const SSH_MAX_RECONNECT_ATTEMPTS: u32 = 3;
-pub const SSH_MAX_EMPTY_MESSAGES: u32 = 5;
-
 impl Configs {
     pub fn new() -> Result<Self> {
         let environment = Self::get_environment_id();

--- a/src/controllers/terminal/client.rs
+++ b/src/controllers/terminal/client.rs
@@ -169,7 +169,6 @@ impl TerminalClient {
     /// Process incoming messages from the server
     pub async fn handle_server_messages(&mut self) -> Result<()> {
         let mut consecutive_empty_messages = 0;
-        let mut exit_code: Option<i32> = None;
 
         let mut ping_interval = interval(Duration::from_secs(SSH_PING_INTERVAL_SECS));
 

--- a/src/controllers/terminal/connection.rs
+++ b/src/controllers/terminal/connection.rs
@@ -2,13 +2,11 @@ use anyhow::{bail, Result};
 use async_tungstenite::tungstenite::handshake::client::generate_key;
 use async_tungstenite::tungstenite::http::Request;
 use async_tungstenite::WebSocketStream;
-use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, timeout, Duration};
 use url::Url;
 
 use crate::commands::ssh::{
-    SSH_CONNECTION_TIMEOUT_SECS, SSH_MAX_RECONNECT_ATTEMPTS, SSH_MESSAGE_TIMEOUT_SECS,
-    SSH_RECONNECT_DELAY_SECS,
+    SSH_CONNECTION_TIMEOUT_SECS, SSH_MAX_RECONNECT_ATTEMPTS, SSH_RECONNECT_DELAY_SECS,
 };
 use crate::consts::get_user_agent;
 

--- a/src/controllers/terminal/mod.rs
+++ b/src/controllers/terminal/mod.rs
@@ -3,7 +3,6 @@ mod connection;
 mod messages;
 
 pub use client::TerminalClient;
-pub use connection::{attempt_connection, establish_connection, SSHConnectParams};
-pub use messages::{ClientMessage, ClientPayload, DataPayload, ServerMessage, ServerPayload};
+pub use connection::SSHConnectParams;
 
 pub const SSH_PING_INTERVAL_SECS: u64 = 10;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,11 @@ pub enum RailwayError {
     #[error("No linked project found. Run railway link to connect to a project")]
     NoLinkedProject,
 
+    #[error(
+        "Personal workspaces are no longer supported. Please specify a workspace by id or name"
+    )]
+    NoPersonalWorkspace,
+
     #[error("Project not found. Run `railway link` to connect to a project.")]
     ProjectNotFound,
 

--- a/src/gql/queries/strings/UserProjects.graphql
+++ b/src/gql/queries/strings/UserProjects.graphql
@@ -1,35 +1,34 @@
 query UserProjects {
-  me {
+  externalWorkspaces {
+    id
+    name
+    teamId
     projects {
-      edges {
-        node {
-          id
-          name
-          createdAt
-          updatedAt
-          team {
+      id
+      name
+      createdAt
+      updatedAt
+      team {
+        id
+        name
+      }
+      environments {
+        edges {
+          node {
             id
             name
           }
-          environments {
-            edges {
-              node {
-                id
-                name
-              }
-            }
-          }
-          services {
-            edges {
-              node {
-                id
-                name
-                serviceInstances {
-                  edges {
-                    node {
-                      environmentId
-                    }
-                  }
+        }
+      }
+      services {
+        edges {
+          node {
+            id
+            name
+            serviceInstances {
+              edges {
+                node {
+                  environmentId
                 }
               }
             }
@@ -37,40 +36,41 @@ query UserProjects {
         }
       }
     }
-    teams {
-      edges {
-        node {
-          id
-          name
-          projects {
-            edges {
-              node {
+  }
+  me {
+    workspaces {
+      id
+      name
+      team {
+        id
+        projects {
+          edges {
+            node {
+              id
+              name
+              createdAt
+              updatedAt
+              team {
                 id
                 name
-                createdAt
-                updatedAt
-                team {
-                  id
-                  name
-                }
-                environments {
-                  edges {
-                    node {
-                      id
-                      name
-                    }
+              }
+              environments {
+                edges {
+                  node {
+                    id
+                    name
                   }
                 }
-                services {
-                  edges {
-                    node {
-                      id
-                      name
-                      serviceInstances {
-                        edges {
-                          node {
-                            environmentId
-                          }
+              }
+              services {
+                edges {
+                  node {
+                    id
+                    name
+                    serviceInstances {
+                      edges {
+                        node {
+                          environmentId
                         }
                       }
                     }

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -138,13 +138,31 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "NEW_SERVICE_GROUPS_UX"
+              "name": "CEPH_VOLUMES"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "DEFAULT_TO_RAILPACK"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "METAL_VOLUME_CREATION"
             },
             {
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "PRIORITY_BOARDING"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "V2_NEW_PROJECT_PAGE"
             }
           ],
           "fields": null,
@@ -161,13 +179,19 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "BACKUPS"
+              "name": "BETTER_CRON_WORKFLOW"
             },
             {
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "OLD_CRON_EXPERIENCE"
+              "name": "COPY_VOLUME_TO_ENVIRONMENT"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "LEGACY_CRONS"
             },
             {
               "deprecationReason": null,
@@ -999,6 +1023,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "PAKETO"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "RAILPACK"
             }
           ],
           "fields": null,
@@ -1164,6 +1194,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "CERTIFICATE_STATUS_TYPE_VALID"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "CERTIFICATE_STATUS_TYPE_VALIDATING_OWNERSHIP"
             },
             {
               "deprecationReason": null,
@@ -1689,6 +1725,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "edgeId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {
@@ -2302,18 +2350,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "teamId",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "usageLimit",
               "type": {
                 "kind": "OBJECT",
@@ -2326,11 +2362,15 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "userId",
+              "name": "workspace",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Workspace",
+                  "ofType": null
+                }
               }
             }
           ],
@@ -3137,6 +3177,22 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Check if a deployment's instances have all stopped",
+              "isDeprecated": false,
+              "name": "deploymentStopped",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
               "name": "environment",
@@ -3508,6 +3564,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "PRE_DEPLOY_COMMAND"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "PUBLISH_IMAGE"
             },
             {
@@ -3515,6 +3577,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "SNAPSHOT_CODE"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "WAIT_FOR_DEPENDENCIES"
             }
           ],
           "fields": null,
@@ -3794,6 +3862,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "SKIPPED"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "STOPPED"
             }
           ],
           "fields": null,
@@ -4553,6 +4627,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "edgeId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {
@@ -6093,6 +6179,41 @@
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "errors",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Errors",
+          "possibleTypes": null
+        },
+        {
           "description": "The estimated usage of a single measurement.",
           "enumValues": null,
           "fields": [
@@ -6494,19 +6615,218 @@
               "description": "The type of owner",
               "name": "type",
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "ResourceOwnerType",
-                  "ofType": null
-                }
+                "kind": "ENUM",
+                "name": "ResourceOwnerType",
+                "ofType": null
               }
             }
           ],
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "ExplicitOwnerInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "avatar",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "banReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "customerState",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SubscriptionState",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "discordRole",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hasBAA",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "preferredRegion",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "projects",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Project",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "subscriptionModel",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SubscriptionModel",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "supportTierOverride",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "teamId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ExternalWorkspace",
           "possibleTypes": null
         },
         {
@@ -6826,11 +7146,60 @@
         {
           "description": null,
           "enumValues": null,
-          "fields": null,
-          "inputFields": [
+          "fields": [
             {
-              "defaultValue": null,
+              "args": [],
+              "deprecationReason": null,
               "description": null,
+              "isDeprecated": false,
+              "name": "defaultBranch",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fullName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "isPrivate",
               "type": {
                 "kind": "NON_NULL",
@@ -6843,37 +7212,11 @@
               }
             },
             {
-              "defaultValue": null,
+              "args": [],
+              "deprecationReason": null,
               "description": null,
-              "name": "message",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "subject",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "topic",
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6885,9 +7228,10 @@
               }
             }
           ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "HelpStationFormInput",
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GitHubRepoWithoutInstallation",
           "possibleTypes": null
         },
         {
@@ -8535,6 +8879,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "CPU_USAGE_2"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "DISK_USAGE_GB"
             },
             {
@@ -8607,6 +8957,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "ENVIRONMENT_ID"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "HOST_TYPE"
             },
             {
               "deprecationReason": null,
@@ -9074,37 +9430,6 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "id",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Migrate a customer to the hobby plan",
-              "isDeprecated": false,
-              "name": "customerMigrateToHobbyPlan",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "customerId",
                   "type": {
                     "kind": "NON_NULL",
@@ -9377,6 +9702,37 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Stops a deployment.",
+              "isDeprecated": false,
+              "name": "deploymentStop",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "input",
                   "type": {
                     "kind": "NON_NULL",
@@ -9475,6 +9831,65 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "DeploymentTrigger",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "projectId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "yaml",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Create services and volumes from docker compose",
+              "isDeprecated": false,
+              "name": "dockerComposeImport",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Errors",
                   "ofType": null
                 }
               }
@@ -9962,37 +10377,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "input",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "HelpStationFormInput",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Creates a new help station thread",
-              "isDeprecated": false,
-              "name": "helpStationCreateThread",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
                   "ofType": null
                 }
               }
@@ -10817,6 +11201,68 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "PreferenceOverridesCreateUpdateData",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Create/Updates preferences overrides for a specific resource belonging to a user",
+              "isDeprecated": false,
+              "name": "preferenceOverridesCreateUpdate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "PreferenceOverridesDestroyData",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Destroy preferences overrides for a specific resource belonging to a user",
+              "isDeprecated": false,
+              "name": "preferenceOverridesDestroyForResource",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "PreferencesUpdateData",
                       "ofType": null
                     }
@@ -11026,6 +11472,20 @@
                   "defaultValue": null,
                   "description": null,
                   "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "workspaceId",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -11402,6 +11862,99 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Deletes a project with a 48 hour grace period.",
+              "isDeprecated": false,
+              "name": "projectScheduleDelete",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Cancel scheduled deletion of a project",
+              "isDeprecated": false,
+              "name": "projectScheduleDeleteCancel",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Force delete a scheduled deletion of a project (skips the grace period)",
+              "isDeprecated": false,
+              "name": "projectScheduleDeleteForce",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "input",
                   "type": {
                     "kind": "NON_NULL",
@@ -11556,37 +12109,6 @@
               "description": "Transfer a project to a team",
               "isDeprecated": false,
               "name": "projectTransferToTeam",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "id",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Transfer a project to a user",
-              "isDeprecated": false,
-              "name": "projectTransferToUser",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -12114,6 +12636,16 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "latestCommit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "serviceId",
                   "type": {
                     "kind": "NON_NULL",
@@ -12136,6 +12668,61 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "commitSha",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "serviceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Deploy a service instance. Returns a deployment ID",
+              "isDeprecated": false,
+              "name": "serviceInstanceDeployV2",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -12513,37 +13100,6 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "TeamCreateInput",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Create a team",
-              "isDeprecated": false,
-              "name": "teamCreate",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Team",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "input",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
                       "name": "TeamCreateAndSubscribeInput",
                       "ofType": null
                     }
@@ -12560,37 +13116,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "TeamCreateAndSubscribeResponse",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "id",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Delete a team and all data associated with it",
-              "isDeprecated": false,
-              "name": "teamDelete",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
                   "ofType": null
                 }
               }
@@ -12738,6 +13263,37 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "TeamTrustedDomainCreateInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Create a new team trusted domain for this team",
+              "isDeprecated": false,
+              "name": "teamTrustedDomainCreate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "id",
                   "type": {
                     "kind": "NON_NULL",
@@ -12748,32 +13304,18 @@
                       "ofType": null
                     }
                   }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "input",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "TeamUpdateInput",
-                      "ofType": null
-                    }
-                  }
                 }
               ],
               "deprecationReason": null,
-              "description": "Update a team by id",
+              "description": "Delete a team trusted domain",
               "isDeprecated": false,
-              "name": "teamUpdate",
+              "name": "teamTrustedDomainDelete",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Team",
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               }
@@ -13824,6 +14366,51 @@
               "args": [
                 {
                   "defaultValue": null,
+                  "description": "The id of the backup to lock",
+                  "name": "volumeInstanceBackupId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "The id of the volume instance to be restored from",
+                  "name": "volumeInstanceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Removes backup expiration date",
+              "isDeprecated": false,
+              "name": "volumeInstanceBackupLock",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
                   "description": "The id of the backup to be restored from",
                   "name": "volumeInstanceBackupId",
                   "type": {
@@ -13861,6 +14448,59 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "WorkflowId",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "The frequency/retention of the backups",
+                  "name": "kinds",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "ENUM",
+                          "name": "VolumeInstanceBackupScheduleKind",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "The id of the volume instance to create a backup of",
+                  "name": "volumeInstanceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Manage schedule for backups of a volume instance",
+              "isDeprecated": false,
+              "name": "volumeInstanceBackupScheduleUpdate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               }
@@ -14071,6 +14711,144 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Delete a workspace and all data associated with it",
+              "isDeprecated": false,
+              "name": "workspaceDelete",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Leave a workspace",
+              "isDeprecated": false,
+              "name": "workspaceLeave",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "WorkspaceUpdateInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Update a workspace by id",
+              "isDeprecated": false,
+              "name": "workspaceUpdate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Generate a Slack channel for a workspace",
+              "isDeprecated": false,
+              "name": "workspaceUpsertSlackChannel",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -14212,6 +14990,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "PreferenceOverride",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Preferences",
               "ofType": null
             },
@@ -14277,6 +15060,11 @@
             },
             {
               "kind": "OBJECT",
+              "name": "TeamTrustedDomain",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Template",
               "ofType": null
             },
@@ -14317,12 +15105,22 @@
             },
             {
               "kind": "OBJECT",
+              "name": "VolumeInstanceBackupSchedule",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Withdrawal",
               "ofType": null
             },
             {
               "kind": "OBJECT",
               "name": "WithdrawalAccount",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Workspace",
               "ofType": null
             }
           ]
@@ -14906,6 +15704,73 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "ObservabilityDashboardUpdateInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "enabled",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "resource",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "resourceId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "OverrideInput",
           "possibleTypes": null
         },
         {
@@ -15826,6 +16691,175 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "enabled",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "resource",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "resourceId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "PreferenceOverride",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "overrides",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "OverrideInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "PreferenceOverridesCreateUpdateData",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "resource",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "resourceId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "PreferenceOverridesDestroyData",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "buildFailedEmail",
               "type": {
                 "kind": "NON_NULL",
@@ -15930,6 +16964,26 @@
                   "kind": "SCALAR",
                   "name": "Boolean",
                   "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "preferenceOverrides",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PreferenceOverride",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -17004,6 +18058,22 @@
               "description": null,
               "isDeprecated": false,
               "name": "prDeploys",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "prEnvCopyVolData",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -18919,6 +19989,16 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "destinationWorkspaceId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "ownershipTransferId",
               "type": {
                 "kind": "NON_NULL",
@@ -19073,6 +20153,16 @@
               "defaultValue": null,
               "description": null,
               "name": "prDeploys",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "Enable/disable copying volume data to PR environment from the base environment",
+              "name": "prEnvCopyVolData",
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
@@ -19236,6 +20326,26 @@
           "description": null,
           "enumValues": null,
           "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "filters",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
             {
               "args": [],
               "deprecationReason": null,
@@ -20643,6 +21753,105 @@
               "args": [
                 {
                   "defaultValue": null,
+                  "description": "Latest date to look for logs after the anchor",
+                  "name": "afterDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit the number of logs returned after the anchor",
+                  "name": "afterLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Target date time to look for logs",
+                  "name": "anchorDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Oldest date to look for logs before the anchor",
+                  "name": "beforeDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit the number of logs returned before the anchor",
+                  "name": "beforeLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Filter logs using a query syntax",
+                  "name": "filter",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Fetch logs for a project environment. Build logs are excluded unless a snapshot ID is explicitly provided in the filter",
+              "isDeprecated": false,
+              "name": "environmentLogs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Log",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
                   "description": null,
                   "name": "after",
                   "type": {
@@ -20844,16 +22053,6 @@
                     "name": "String",
                     "ofType": null
                   }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "userId",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
                 }
               ],
               "deprecationReason": null,
@@ -20974,6 +22173,41 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "projectId",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get the workspaces the user doesn't belong to, but needs access (like when invited to a project)",
+              "isDeprecated": false,
+              "name": "externalWorkspaces",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ExternalWorkspace",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "fullRepoName",
                   "type": {
                     "kind": "NON_NULL",
@@ -21027,6 +22261,37 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "fullRepoName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Checks if user has access to GitHub repository",
+              "isDeprecated": false,
+              "name": "githubRepo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GitHubRepoWithoutInstallation",
                   "ofType": null
                 }
               }
@@ -21160,6 +22425,56 @@
               "args": [
                 {
                   "defaultValue": null,
+                  "description": "Latest date to look for logs after the anchor",
+                  "name": "afterDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit the number of logs returned after the anchor",
+                  "name": "afterLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Target date time to look for logs",
+                  "name": "anchorDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Oldest date to look for logs before the anchor",
+                  "name": "beforeDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit the number of logs returned before the anchor",
+                  "name": "beforeLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
                   "description": null,
                   "name": "deploymentId",
                   "type": {
@@ -21184,7 +22499,7 @@
                 },
                 {
                   "defaultValue": null,
-                  "description": "Filter logs by a string. Providing an empty value will match all logs.",
+                  "description": "Filter logs using a query syntax",
                   "name": "filter",
                   "type": {
                     "kind": "SCALAR",
@@ -21604,7 +22919,7 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "userId",
+                  "name": "volumeId",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -21614,7 +22929,7 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "volumeId",
+                  "name": "workspaceId",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -21781,68 +23096,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "QueryObservabilityDashboardsConnection",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "discordId",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Get a user's Plain Customer ID given their Discord ID.",
-              "isDeprecated": false,
-              "name": "plainCustomerIdForDiscordId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "discordId",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Get a user JWT token for a Discord id",
-              "isDeprecated": false,
-              "name": "plainJWTForDiscordId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
                   "ofType": null
                 }
               }
@@ -22574,7 +23827,22 @@
               }
             },
             {
-              "args": [],
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "workspaceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
               "deprecationReason": null,
               "description": "Gets the ReferralInfo for the authenticated user.",
               "isDeprecated": false,
@@ -22631,9 +23899,13 @@
                   "description": null,
                   "name": "explicitResourceOwner",
                   "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "ExplicitOwnerInput",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ExplicitOwnerInput",
+                      "ofType": null
+                    }
                   }
                 }
               ],
@@ -23098,33 +24370,6 @@
                 {
                   "defaultValue": null,
                   "description": null,
-                  "name": "discordId",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Fetch Discord info associated with Direct Support-eligible team members, given a Discord UID",
-              "isDeprecated": false,
-              "name": "teamDirectSupportDiscordInfoForDiscordId",
-              "type": {
-                "kind": "OBJECT",
-                "name": "TeamDirectSupportDiscordInfo",
-                "ofType": null
-              }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
                   "name": "after",
                   "type": {
                     "kind": "SCALAR",
@@ -23187,6 +24432,77 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "QueryTeamTemplatesConnection",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "teamId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get all team trusted domains",
+              "isDeprecated": false,
+              "name": "teamTrustedDomains",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "QueryTeamTrustedDomainsConnection",
                   "ofType": null
                 }
               }
@@ -23375,6 +24691,22 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": "Count all published templates.",
+              "isDeprecated": false,
+              "name": "templatesCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Gets the TwoFactorInfo for the authenticated user.",
               "isDeprecated": false,
               "name": "twoFactorInfo",
@@ -23474,16 +24806,6 @@
                   "defaultValue": null,
                   "description": null,
                   "name": "teamId",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "userId",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -23676,9 +24998,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "Users don't have personal templates anymore, they belong to their team now",
               "description": "Get all templates for the current user.",
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "userTemplates",
               "type": {
                 "kind": "NON_NULL",
@@ -23914,6 +25236,45 @@
               "args": [
                 {
                   "defaultValue": null,
+                  "description": "The id of the volume instance to list the schedules of",
+                  "name": "volumeInstanceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "List backups schedules of a volume instance",
+              "isDeprecated": false,
+              "name": "volumeInstanceBackupScheduleList",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "VolumeInstanceBackupSchedule",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
                   "description": null,
                   "name": "after",
                   "type": {
@@ -24008,6 +25369,37 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "WorkflowResult",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "workspaceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get the workspace",
+              "isDeprecated": false,
+              "name": "workspace",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Workspace",
                   "ofType": null
                 }
               }
@@ -25434,6 +26826,100 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
+                      "name": "QueryTeamTrustedDomainsConnectionEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "QueryTeamTrustedDomainsConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TeamTrustedDomain",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "QueryTeamTrustedDomainsConnectionEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
                       "name": "QueryTemplatesConnectionEdge",
                       "ofType": null
                     }
@@ -25699,6 +27185,16 @@
           "description": null,
           "enumValues": null,
           "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "RailpackInfo",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
           "inputFields": [
             {
               "defaultValue": null,
@@ -25855,6 +27351,20 @@
               "defaultValue": null,
               "description": null,
               "name": "code",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "workspaceId",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -26099,7 +27609,7 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "teamId",
+              "name": "userId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -26111,13 +27621,13 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "userId",
+              "name": "workspace",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
+                  "kind": "OBJECT",
+                  "name": "Workspace",
                   "ofType": null
                 }
               }
@@ -26503,12 +28013,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "TEAM"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "USER"
             }
           ],
           "fields": null,
@@ -27273,6 +28777,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "edgeId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "environmentId",
               "type": {
                 "kind": "NON_NULL",
@@ -27751,6 +29267,30 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "preDeployCommand",
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "railpackInfo",
+              "type": {
+                "kind": "SCALAR",
+                "name": "RailpackInfo",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "railwayConfigFile",
               "type": {
                 "kind": "SCALAR",
@@ -27982,7 +29522,7 @@
               "name": "memoryGB",
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             },
@@ -28006,7 +29546,7 @@
               "name": "vCPUs",
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "Float",
                 "ofType": null
               }
             }
@@ -28074,6 +29614,16 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "multiRegionConfig",
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "nixpacksPlan",
               "type": {
                 "kind": "SCALAR",
@@ -28089,6 +29639,24 @@
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "preDeployCommand",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               }
             },
             {
@@ -29172,6 +30740,105 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Filter logs using a query syntax",
+                  "name": "filter",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Stream logs for a project environment",
+              "isDeprecated": false,
+              "name": "environmentLogs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Log",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "Latest date to look for logs after the anchor",
+                  "name": "afterDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit the number of logs returned after the anchor",
+                  "name": "afterLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Target date time to look for logs",
+                  "name": "anchorDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Oldest date to look for logs before the anchor",
+                  "name": "beforeDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit the number of logs returned before the anchor",
+                  "name": "beforeLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "deploymentId",
                   "type": {
                     "kind": "NON_NULL",
@@ -29396,6 +31063,35 @@
         },
         {
           "description": null,
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "FREE"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "TEAM"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "USER"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "SubscriptionModel",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
           "enumValues": null,
           "fields": null,
           "inputFields": null,
@@ -29407,6 +31103,12 @@
         {
           "description": null,
           "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "free"
+            },
             {
               "deprecationReason": null,
               "description": null,
@@ -29472,6 +31174,29 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "SubscriptionState",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "BUSINESS_CLASS"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "BUSINESS_CLASS_TRIAL"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "SupportTierOverride",
           "possibleTypes": null
         },
         {
@@ -29716,22 +31441,10 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "This property is not part of Teams anymore, go through the Workspace to access it",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "avatar",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "banReason",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -29756,9 +31469,9 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "Access the customer through the workspace",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "customer",
               "type": {
                 "kind": "NON_NULL",
@@ -29775,18 +31488,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "discordRole",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "id",
               "type": {
                 "kind": "NON_NULL",
@@ -29794,22 +31495,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isEligibleForDirectSupport",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
                   "ofType": null
                 }
               }
@@ -29840,9 +31525,9 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "This property is not part of Teams anymore, go through the Workspace to access it",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "name",
               "type": {
                 "kind": "NON_NULL",
@@ -29856,9 +31541,9 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "This property is not part of Teams anymore, go through the Workspace to access it",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "preferredRegion",
               "type": {
                 "kind": "SCALAR",
@@ -29925,13 +31610,25 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "This property is not part of Teams anymore, go through the Workspace to access it",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "slackChannelId",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "This property is not part of Teams anymore, go through the Workspace to access it",
+              "description": null,
+              "isDeprecated": true,
+              "name": "supportTierOverride",
+              "type": {
+                "kind": "ENUM",
+                "name": "SupportTierOverride",
                 "ofType": null
               }
             },
@@ -29971,6 +31668,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "DateTime",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "workspace",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Workspace",
                   "ofType": null
                 }
               }
@@ -30137,108 +31850,6 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "TeamCreateAndSubscribeResponse",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "avatar",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            {
-              "defaultValue": null,
-              "description": null,
-              "name": "name",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "interfaces": null,
-          "kind": "INPUT_OBJECT",
-          "name": "TeamCreateInput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "memberDiscordIds",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "teamId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "teamName",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "TeamDirectSupportDiscordInfo",
           "possibleTypes": null
         },
         {
@@ -30643,6 +32254,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "MEMBER"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "VIEWER"
             }
           ],
           "fields": null,
@@ -30655,42 +32272,167 @@
         {
           "description": null,
           "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "domainName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "teamId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "teamRole",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "verificationData",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TrustedDomainVerificationData",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "verificationType",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "TeamTrustedDomain",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
               "defaultValue": null,
               "description": null,
-              "name": "avatar",
+              "name": "domainName",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             {
               "defaultValue": null,
               "description": null,
-              "name": "name",
+              "name": "teamId",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             {
               "defaultValue": null,
               "description": null,
-              "name": "preferredRegion",
+              "name": "teamRole",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             }
           ],
           "interfaces": null,
           "kind": "INPUT_OBJECT",
-          "name": "TeamUpdateInput",
+          "name": "TeamTrustedDomainCreateInput",
           "possibleTypes": null
         },
         {
@@ -31300,18 +33042,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "userId",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             }
           ],
           "inputFields": null,
@@ -31507,9 +33237,13 @@
               "description": null,
               "name": "teamId",
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               }
             },
             {
@@ -31644,6 +33378,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "preDeployCommand",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               }
             },
             {
@@ -31822,6 +33574,16 @@
           "enumValues": null,
           "fields": null,
           "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "environmentId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
             {
               "defaultValue": null,
               "description": null,
@@ -32361,6 +34123,41 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "domainMatch",
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Domain",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "domainStatus",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomDomainStatus",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "TrustedDomainVerificationData",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "hasRecoveryCodes",
               "type": {
                 "kind": "NON_NULL",
@@ -32883,22 +34680,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "cost",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "UserCost",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "createdAt",
               "type": {
                 "kind": "NON_NULL",
@@ -32906,22 +34687,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "DateTime",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "customer",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Customer",
                   "ofType": null
                 }
               }
@@ -33059,54 +34824,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "isDevPlan",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isEligibleForFreeHobbyPlan",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "isOnHobbyPlan",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "isVerified",
               "type": {
                 "kind": "NON_NULL",
@@ -33201,9 +34918,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "This field will not return anything anymore, go through the workspace's projects",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "projects",
               "type": {
                 "kind": "NON_NULL",
@@ -33269,30 +34986,6 @@
                   "kind": "OBJECT",
                   "name": "UserProviderAuthsConnection",
                   "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "referredUsers",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "ReferralUser",
-                      "ofType": null
-                    }
-                  }
                 }
               }
             },
@@ -33367,9 +35060,9 @@
                   }
                 }
               ],
-              "deprecationReason": null,
+              "deprecationReason": "Use the workspaces relation to access the teams",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "teams",
               "type": {
                 "kind": "NON_NULL",
@@ -33404,6 +35097,42 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use user.workspaces instead, no user are associated to a workspace",
+              "description": null,
+              "isDeprecated": true,
+              "name": "workspace",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Workspace",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Workspaces user is member of",
+              "isDeprecated": false,
+              "name": "workspaces",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Workspace",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -33416,49 +35145,6 @@
           ],
           "kind": "OBJECT",
           "name": "User",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "current",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "estimated",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "UserCost",
           "possibleTypes": null
         },
         {
@@ -33801,9 +35487,9 @@
             },
             {
               "args": [],
-              "deprecationReason": null,
+              "deprecationReason": "There are no personal templates anymore, they all belong to a workspace",
               "description": null,
-              "isDeprecated": false,
+              "isDeprecated": true,
               "name": "publishedTemplates",
               "type": {
                 "kind": "NON_NULL",
@@ -35349,6 +37035,22 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "VolumeInstanceType",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "volume",
               "type": {
                 "kind": "NON_NULL",
@@ -35404,6 +37106,46 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "creatorId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "expiresAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "externalId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
                 }
@@ -35423,6 +37165,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             },
             {
@@ -35459,6 +37213,167 @@
         {
           "description": null,
           "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cron",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "kind",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "VolumeInstanceBackupScheduleKind",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "retentionSeconds",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "VolumeInstanceBackupSchedule",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "DAILY"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "MONTHLY"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "WEEKLY"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "VolumeInstanceBackupScheduleKind",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "CLOUD"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "METAL"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "VolumeInstanceType",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
           "fields": null,
           "inputFields": [
             {
@@ -35488,6 +37403,16 @@
               "type": {
                 "kind": "ENUM",
                 "name": "VolumeState",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": "The type of the volume instance. If not provided, the type will not be updated.",
+              "name": "type",
+              "type": {
+                "kind": "ENUM",
+                "name": "VolumeInstanceType",
                 "ofType": null
               }
             }
@@ -35673,6 +37598,24 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "filters",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "projectId",
               "type": {
                 "kind": "NON_NULL",
@@ -35709,6 +37652,24 @@
           "enumValues": null,
           "fields": null,
           "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "filters",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
             {
               "defaultValue": null,
               "description": null,
@@ -36098,6 +38059,252 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "WorkflowStatus",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "avatar",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "banReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "customer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "discordRole",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "preferredRegion",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "referredUsers",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ReferralUser",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "slackChannelId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "subscriptionModel",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SubscriptionModel",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "supportTierOverride",
+              "type": {
+                "kind": "ENUM",
+                "name": "SupportTierOverride",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "team",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Team",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "Workspace",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "avatar",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "preferredRegion",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "WorkspaceUpdateInput",
           "possibleTypes": null
         },
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod gql;
 mod subscription;
 mod table;
 mod util;
+mod workspace;
 
 #[macro_use]
 mod macros;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,131 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::fmt::Display;
+
+use super::{
+    queries::user_projects::{
+        UserProjectsExternalWorkspaces, UserProjectsExternalWorkspacesProjects,
+        UserProjectsMeWorkspaces, UserProjectsMeWorkspacesTeamProjectsEdgesNode,
+    },
+    *,
+};
+
+pub async fn workspaces() -> Result<Vec<Workspace>> {
+    let configs = Configs::new()?;
+    let vars = queries::user_projects::Variables {};
+    let client = GQLClient::new_authorized(&configs)?;
+    let response =
+        post_graphql::<queries::UserProjects, _>(&client, configs.get_backboard(), vars).await?;
+
+    let mut workspaces: Vec<Workspace> = response
+        .me
+        .workspaces
+        .into_iter()
+        .map(|w| Workspace::Member(w))
+        .collect();
+    workspaces.extend(
+        response
+            .external_workspaces
+            .into_iter()
+            .map(|w| Workspace::External(w)),
+    );
+    workspaces.sort_by(|a, b| b.id().cmp(&a.id()));
+    Ok(workspaces)
+}
+
+#[derive(Debug, Clone)]
+pub enum Workspace {
+    External(UserProjectsExternalWorkspaces),
+    Member(UserProjectsMeWorkspaces),
+}
+
+impl Workspace {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::External(w) => w.id.as_str(),
+            Self::Member(w) => w.id.as_str(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::External(w) => w.name.as_str(),
+            Self::Member(w) => w.name.as_str(),
+        }
+    }
+
+    pub fn team_id(&self) -> Option<String> {
+        match self {
+            Self::External(w) => w.team_id.clone(),
+            Self::Member(w) => w.team.as_ref().map(|t| t.id.clone()),
+        }
+    }
+
+    pub fn projects(&self) -> Vec<Project> {
+        let mut projects = match self {
+            Self::External(w) => w
+                .projects
+                .iter()
+                .cloned()
+                .map(|p| Project::External(p))
+                .collect(),
+            Self::Member(w) => w.team.as_ref().map_or_else(Vec::new, |t| {
+                t.projects
+                    .edges
+                    .iter()
+                    .cloned()
+                    .map(|e| Project::Team(e.node))
+                    .collect()
+            }),
+        };
+        projects.sort_by(|a, b| b.updated_at().cmp(&a.updated_at()));
+        projects
+    }
+}
+
+impl Display for Workspace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::External(w) => w.name.as_str(),
+            Self::Member(w) => w.name.as_str(),
+        };
+        write!(f, "{name}")
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum Project {
+    External(UserProjectsExternalWorkspacesProjects),
+    Team(UserProjectsMeWorkspacesTeamProjectsEdgesNode),
+}
+
+impl Project {
+    pub fn id(&self) -> &str {
+        match self {
+            Self::External(w) => &w.id,
+            Self::Team(w) => &w.id,
+        }
+    }
+    pub fn name(&self) -> &str {
+        match self {
+            Self::External(w) => &w.name,
+            Self::Team(w) => &w.name,
+        }
+    }
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        match self {
+            Self::External(w) => w.updated_at,
+            Self::Team(w) => w.updated_at,
+        }
+    }
+}
+
+impl Display for Project {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Team(team_project) => write!(f, "{}", team_project.name),
+            Self::External(team_project) => write!(f, "{}", team_project.name),
+        }
+    }
+}


### PR DESCRIPTION
We are going away with the concept of a personal workspace. Right now personal workspaces in the CLI have both projects the user is a member of and projects owned by the workspace created for the user when they signed up.

And that workspace created for the user when they signup now has a team, so it appears twice in the selector.

To solve this we stop using `me.projects` and go throught he externalWorkspaces query, displaying each external project in its workspace.