### PR TITLE
feat: Allow connecting to valkey and keydb when using 'connect' cmd

### DIFF
--- a/src/controllers/database.rs
+++ b/src/controllers/database.rs
@@ -6,6 +6,8 @@ pub enum DatabaseType {
     PostgreSQL,
     MySQL,
     Redis,
+    KeyDB,
+    Valkey,
     MongoDB,
 }
 
@@ -15,6 +17,8 @@ impl DatabaseType {
             DatabaseType::PostgreSQL => "postgres",
             DatabaseType::MySQL => "mysql",
             DatabaseType::Redis => "redis",
+            DatabaseType::KeyDB => "keydb",
+            DatabaseType::Valkey => "valkey",
             DatabaseType::MongoDB => "mongo",
         }
     }


### PR DESCRIPTION
I normally use keydb or valkey. So therefore i made some changes that allows you to also connect with the **redis-cli** via the keydb or valkey public url. 