### PR TITLE
impl ready and stand by handshake for SSH

### DIFF
--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -57,7 +57,8 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     let spinner = create_spinner(running_command);
 
     let ws_url = format!("wss://{}", configs.get_relay_host_path());
-    let mut terminal_client = establish_connection(&ws_url, &token, &params).await?;
+    let mut terminal_client =
+        crate::commands::ssh::common::create_terminal_client(&ws_url, &token, &params).await?;
 
     if running_command {
         // Run single command
@@ -66,6 +67,6 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         // Initialize interactive shell (default to bash)
         initialize_shell(&mut terminal_client, Some("bash".to_string()), spinner).await?;
         // Run the platform-specific event loop (unix/windows implements terminals differently)
-        run_interactive_session(&mut terminal_client).await
+        run_interactive_session(terminal_client).await
     }
 }

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -6,8 +6,8 @@ use crate::config::Configs;
 
 pub const SSH_CONNECTION_TIMEOUT_SECS: u64 = 30;
 pub const SSH_MESSAGE_TIMEOUT_SECS: u64 = 10;
-pub const SSH_MAX_RECONNECT_ATTEMPTS: usize = 3;
-pub const SSH_RECONNECT_DELAY_SECS: u64 = 5;
+pub const SSH_MAX_CONNECT_ATTEMPTS: usize = 3;
+pub const SSH_CONNECT_DELAY_SECS: u64 = 5;
 pub const SSH_MAX_EMPTY_MESSAGES: usize = 100;
 
 mod common;

--- a/src/commands/ssh/platform/unix.rs
+++ b/src/commands/ssh/platform/unix.rs
@@ -3,6 +3,7 @@ use crossterm::terminal;
 use std::io::Write;
 use tokio::io::AsyncReadExt;
 use tokio::select;
+use tokio::sync::mpsc;
 
 use crate::controllers::terminal::TerminalClient;
 
@@ -19,50 +20,129 @@ pub async fn setup_signal_handlers() -> Result<(
     Ok((sigint, sigterm, sigwinch))
 }
 
+// Messages that can be sent to the UI task
+enum UiMessage {
+    // Server message handler has completed with exit code
+    ServerDone(i32),
+    // Shell is ready for input (combines ready and not in command progress)
+    ReadyForInput(bool),
+    // Shell is ready (needed for signals and window resizing)
+    ShellReady(bool),
+}
+
+// Messages that can be sent to the server task
+enum ServerMessage {
+    // Send data to the server
+    SendData(String),
+    // Send a signal to the server
+    SendSignal(u8),
+    // Resize the terminal window
+    WindowResize(u16, u16),
+}
+
 /// Run the interactive SSH session with Unix-specific event handling
-pub async fn run_interactive_session(client: &mut TerminalClient) -> Result<()> {
+pub async fn run_interactive_session(mut client: TerminalClient) -> Result<()> {
     let mut stdin = tokio::io::stdin();
     let mut stdin_buf = [0u8; 1024];
     let mut exit_code = None;
 
+    let (ui_tx, mut ui_rx) = mpsc::channel::<UiMessage>(100);
+    let (server_tx, mut server_rx) = mpsc::channel::<ServerMessage>(100);
+
+    let mut shell_ready = client.is_ready();
+    let mut ready_for_input = client.is_ready_for_input();
+
+    tokio::spawn(async move {
+        loop {
+            select! {
+                // Handle incoming messages from the UI task
+                Some(msg) = server_rx.recv() => {
+                    match msg {
+                        ServerMessage::SendData(data) => {
+                            if let Err(e) = client.send_data(&data).await {
+                                eprintln!("Error sending data: {}", e);
+                                let _ = ui_tx.send(UiMessage::ServerDone(1)).await;
+                                break;
+                            }
+                        },
+                        ServerMessage::SendSignal(signal) => {
+                            if let Err(e) = client.send_signal(signal).await {
+                                eprintln!("Error sending signal: {}", e);
+                            }
+                        },
+                        ServerMessage::WindowResize(cols, rows) => {
+                            if let Err(e) = client.send_window_size(cols, rows).await {
+                                eprintln!("Error resizing window: {}", e);
+                            }
+                        }
+                    }
+                },
+
+                // Process messages from the server
+                result = client.handle_server_messages() => {
+                    match result {
+                        Ok(()) => {
+                            let _ = ui_tx.send(UiMessage::ServerDone(0)).await;
+                        },
+                        Err(e) => {
+                            eprintln!("Error in server messages: {}", e);
+                            let _ = ui_tx.send(UiMessage::ServerDone(1)).await;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if shell_ready != client.is_ready() {
+                shell_ready = client.is_ready();
+                let _ = ui_tx.send(UiMessage::ShellReady(shell_ready)).await;
+            }
+
+            if ready_for_input != client.is_ready_for_input() {
+                ready_for_input = client.is_ready_for_input();
+                let _ = ui_tx.send(UiMessage::ReadyForInput(ready_for_input)).await;
+            }
+        }
+    });
+
     let (mut sigint, mut sigterm, mut sigwinch) = setup_signal_handlers().await?;
 
-    // Main event loop
+    // Main event loop for input and signals
     loop {
-        // Check if shell is ready for input
-        let is_ready = client.is_ready();
-
         select! {
             // Handle window resizes
             _ = sigwinch.recv() => {
                 if let Ok((cols, rows)) = terminal::size() {
-                   if is_ready {
-                        client.send_window_size(cols, rows).await?;
-                    }
+                   if shell_ready {
+                        let _ = server_tx.send(ServerMessage::WindowResize(cols, rows)).await;
+                   }
                 }
                 continue;
             }
+
             // Handle signals
             _ = sigint.recv() => {
-                if is_ready {
-                    client.send_signal(2).await?; // SIGINT
+                if shell_ready {
+                    let _ = server_tx.send(ServerMessage::SendSignal(2)).await; // SIGINT
                 }
                 continue;
             }
+
             _ = sigterm.recv() => {
-                if is_ready {
-                    client.send_signal(15).await?; // SIGTERM
+                if shell_ready {
+                    let _ = server_tx.send(ServerMessage::SendSignal(15)).await; // SIGTERM
                 }
                 break;
             }
-            // Handle input from terminal
+
+            // Handle input from terminal - only send if ready for input
             result = stdin.read(&mut stdin_buf) => {
-                if is_ready {
+                if ready_for_input {
                     match result {
                         Ok(0) => break, // EOF
                         Ok(n) => {
-                            let data = String::from_utf8_lossy(&stdin_buf[..n]);
-                            client.send_data(&data).await?;
+                            let data = String::from_utf8_lossy(&stdin_buf[..n]).to_string();
+                            let _ = server_tx.send(ServerMessage::SendData(data)).await;
                         }
                         Err(e) => {
                             eprintln!("Error reading from stdin: {}", e);
@@ -71,17 +151,19 @@ pub async fn run_interactive_session(client: &mut TerminalClient) -> Result<()> 
                     }
                 }
             }
-            // Handle messages from server
-            result = client.handle_server_messages() => {
-                match result {
-                   Ok(()) => {
-                        exit_code = Some(0);
+
+            // Process messages from server task
+            Some(msg) = ui_rx.recv() => {
+                match msg {
+                    UiMessage::ServerDone(code) => {
+                        exit_code = Some(code);
                         break;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        exit_code = Some(1);
-                        break;
+                    },
+                    UiMessage::ShellReady(ready) => {
+                        shell_ready = ready;
+                    },
+                    UiMessage::ReadyForInput(input_ready) => {
+                        ready_for_input = input_ready;
                     }
                 }
             }
@@ -94,6 +176,7 @@ pub async fn run_interactive_session(client: &mut TerminalClient) -> Result<()> 
     // Ensure cursor is visible with ANSI escape sequence
     print!("\x1b[?25h");
     std::io::stdout().flush()?;
+
     if let Some(code) = exit_code {
         std::process::exit(code);
     }

--- a/src/commands/ssh/platform/windows.rs
+++ b/src/commands/ssh/platform/windows.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use crossterm::terminal;
-use futures_util::stream::StreamExt;
+use futures_util::future::FutureExt;
 use std::io::Write;
 use tokio::io::AsyncReadExt;
 use tokio::select;
+use tokio::sync::mpsc;
 use tokio::time::Duration;
 
 use crate::controllers::terminal::TerminalClient;
@@ -14,21 +15,33 @@ pub async fn setup_signal_handlers() -> Result<()> {
     Ok(())
 }
 
-// Windows-specific event handling for the SSH session
-pub async fn run_interactive_session(client: &mut TerminalClient) -> Result<()> {
-    let mut stdin = tokio::io::stdin();
-    let mut stdin_buf = [0u8; 1024];
-    let mut exit_code = None;
+// Messages that can be sent to the UI task
+enum UiMessage {
+    // Server message handler has completed with exit code
+    ServerDone(i32),
+    // Shell is ready for input (combines ready and not in command progress)
+    ReadyForInput(bool),
+    // Shell is ready (needed for signals and window resizing)
+    ShellReady(bool),
+}
 
-    let _ = setup_signal_handlers().await?;
+// Messages that can be sent to the server task
+enum ServerMessage {
+    // Send data to the server
+    SendData(String),
+    // Send a signal to the server
+    SendSignal(u8),
+    // Resize the terminal window
+    WindowResize(u16, u16),
+}
 
-    // Event handling differs based on available features
+/// Windows-specific event handling for the SSH session
+pub async fn run_interactive_session(client: TerminalClient) -> Result<()> {
     #[cfg(feature = "event-stream")]
-    let run_result =
-        run_with_event_stream(client, &mut stdin, &mut stdin_buf, &mut exit_code).await;
+    let result = run_with_event_stream(client).await;
 
     #[cfg(not(feature = "event-stream"))]
-    let run_result = run_with_polling(client, &mut stdin, &mut stdin_buf, &mut exit_code).await;
+    let result = run_with_polling(client).await;
 
     // Clean up terminal
     let _ = terminal::disable_raw_mode();
@@ -37,80 +50,136 @@ pub async fn run_interactive_session(client: &mut TerminalClient) -> Result<()> 
     print!("\x1b[?25h");
     std::io::stdout().flush()?;
 
-    if let Some(code) = exit_code {
-        std::process::exit(code);
-    }
-
-    run_result
+    result
 }
 
 #[cfg(feature = "event-stream")]
-async fn run_with_event_stream(
-    client: &mut TerminalClient,
-    stdin: &mut tokio::io::Stdin,
-    stdin_buf: &mut [u8; 1024],
-    exit_code: &mut Option<i32>,
-) -> Result<()> {
-    let mut event_stream = crossterm::event::EventStream::new();
+async fn run_with_event_stream(mut client: TerminalClient) -> Result<()> {
+    let mut stdin = tokio::io::stdin();
+    let mut stdin_buf = [0u8; 1024];
     let mut exit_code = None;
+    let mut event_stream = crossterm::event::EventStream::new();
 
+    let (ui_tx, mut ui_rx) = mpsc::channel::<UiMessage>(100);
+    let (server_tx, mut server_rx) = mpsc::channel::<ServerMessage>(100);
+
+    let mut shell_ready = client.is_ready();
+    let mut ready_for_input = client.is_ready_for_input();
+
+    tokio::spawn(async move {
+        loop {
+            select! {
+                // Handle incoming messages from the UI task
+                Some(msg) = server_rx.recv() => {
+                    match msg {
+                        ServerMessage::SendData(data) => {
+                            if let Err(e) = client.send_data(&data).await {
+                                eprintln!("Error sending data: {}", e);
+                                let _ = ui_tx.send(UiMessage::ServerDone(1)).await;
+                                break;
+                            }
+                        },
+                        ServerMessage::SendSignal(signal) => {
+                            if let Err(e) = client.send_signal(signal).await {
+                                eprintln!("Error sending signal: {}", e);
+                            }
+                        },
+                        ServerMessage::WindowResize(cols, rows) => {
+                            if let Err(e) = client.send_window_size(cols, rows).await {
+                                eprintln!("Error resizing window: {}", e);
+                            }
+                        }
+                    }
+                },
+
+                // Process messages from the server
+                result = client.handle_server_messages() => {
+                    match result {
+                        Ok(()) => {
+                            let _ = ui_tx.send(UiMessage::ServerDone(0)).await;
+                        },
+                        Err(e) => {
+                            eprintln!("Error in server messages: {}", e);
+                            let _ = ui_tx.send(UiMessage::ServerDone(1)).await;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if shell_ready != client.is_ready() {
+                shell_ready = client.is_ready();
+                let _ = ui_tx.send(UiMessage::ShellReady(shell_ready)).await;
+            }
+
+            if ready_for_input != client.is_ready_for_input() {
+                ready_for_input = client.is_ready_for_input();
+                let _ = ui_tx.send(UiMessage::ReadyForInput(ready_for_input)).await;
+            }
+        }
+    });
+
+    // Main event loop for input and events
     loop {
-        // Check if the shell is ready for input
-        let is_ready = client.is_ready();
-
         select! {
             // Handle crossterm events for Windows with event-stream
-            maybe_event = event_stream.next().fuse(), if is_ready => {
-                match maybe_event {
-                    Some(Ok(Event::Key(KeyEvent { code: KeyCode::Char('c'), modifiers, .. }))) if modifiers.contains(KeyModifiers::CONTROL) => {
-                        // Handle Ctrl+C like SIGINT
-                        client.send_signal(2).await?;
-                        continue;
-                    },
-                    Some(Ok(Event::Resize(width, height))) => {
-                        // Handle terminal resize
-                        client.send_window_size(width, height).await?;
-                        continue;
-                    },
-                    Some(Ok(Event::Key(key))) => {
-                        // Handle key input
-                        if let Some(input) = key_event_to_string(key) {
-                            client.send_data(&input).await?;
-                        }
-                    },
-                    Some(Err(e)) => {
-                        eprintln!("Error reading events: {}", e);
-                        break;
-                    },
-                    None => break,
+            maybe_event = event_stream.next().fuse() => {
+                if let Some(Ok(event)) = maybe_event {
+                    match event {
+                        Event::Key(KeyEvent { code: KeyCode::Char('c'), modifiers, .. }) if modifiers.contains(KeyModifiers::CONTROL) => {
+                            // Handle Ctrl+C like SIGINT
+                            if shell_ready {
+                                let _ = server_tx.send(ServerMessage::SendSignal(2)).await;
+                            }
+                        },
+                        Event::Resize(width, height) => {
+                            // Handle terminal resize
+                            if shell_ready {
+                                let _ = server_tx.send(ServerMessage::WindowResize(width, height)).await;
+                            }
+                        },
+                        Event::Key(key) => {
+                            // Only handle key input if ready for input
+                            if ready_for_input {
+                                if let Some(input) = key_event_to_string(key) {
+                                    let _ = server_tx.send(ServerMessage::SendData(input)).await;
+                                }
+                            }
+                        },
+                        _ => {}
+                    }
                 }
             },
 
-            result = stdin.read(stdin_buf), if is_ready => {
-                match result {
-                    Ok(0) => break, // EOF
-                    Ok(n) => {
-                        let data = String::from_utf8_lossy(&stdin_buf[..n]);
-                        client.send_data(&data).await?;
-                    }
-                    Err(e) => {
-                        eprintln!("Error reading from stdin: {}", e);
-                        break;
+            // Handle input from stdin (if using both stdin and events)
+            result = stdin.read(&mut stdin_buf) => {
+                if ready_for_input {
+                    match result {
+                        Ok(0) => break, // EOF
+                        Ok(n) => {
+                            let data = String::from_utf8_lossy(&stdin_buf[..n]).to_string();
+                            let _ = server_tx.send(ServerMessage::SendData(data)).await;
+                        }
+                        Err(e) => {
+                            eprintln!("Error reading from stdin: {}", e);
+                            break;
+                        }
                     }
                 }
             }
 
-            // Handle messages from server
-            result = client.handle_server_messages() => {
-                match result {
-                   Ok(()) => {
-                        *exit_code = Some(0);
+            // Process messages from server task
+            Some(msg) = ui_rx.recv() => {
+                match msg {
+                    UiMessage::ServerDone(code) => {
+                        exit_code = Some(code);
                         break;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        *exit_code = Some(1);
-                        break;
+                    },
+                    UiMessage::ShellReady(ready) => {
+                        shell_ready = ready;
+                    },
+                    UiMessage::ReadyForInput(input_ready) => {
+                        ready_for_input = input_ready;
                     }
                 }
             }
@@ -125,65 +194,129 @@ async fn run_with_event_stream(
 }
 
 #[cfg(not(feature = "event-stream"))]
-async fn run_with_polling(
-    client: &mut TerminalClient,
-    stdin: &mut tokio::io::Stdin,
-    stdin_buf: &mut [u8; 1024],
-    exit_code: &mut Option<i32>,
-) -> Result<()> {
-    let event_poll_timeout = Duration::from_millis(100);
+async fn run_with_polling(mut client: TerminalClient) -> Result<()> {
+    let mut stdin = tokio::io::stdin();
+    let mut stdin_buf = [0u8; 1024];
     let mut exit_code = None;
+    let event_poll_timeout = Duration::from_millis(100);
 
-    loop {
-        // Check if the shell is ready for input
-        let is_ready = client.is_ready();
+    let (ui_tx, mut ui_rx) = mpsc::channel::<UiMessage>(100);
+    let (server_tx, mut server_rx) = mpsc::channel::<ServerMessage>(100);
 
-        select! {
-            result = stdin.read(stdin_buf), if is_ready => {
-                match result {
-                    Ok(0) => break, // EOF
-                    Ok(n) => {
-                        let data = String::from_utf8_lossy(&stdin_buf[..n]);
-                        client.send_data(&data).await?;
+    let mut shell_ready = client.is_ready();
+    let mut ready_for_input = client.is_ready_for_input();
+
+    tokio::spawn(async move {
+        loop {
+            select! {
+                // Handle incoming messages from the UI task
+                Some(msg) = server_rx.recv() => {
+                    match msg {
+                        ServerMessage::SendData(data) => {
+                            if let Err(e) = client.send_data(&data).await {
+                                eprintln!("Error sending data: {}", e);
+                                let _ = ui_tx.send(UiMessage::ServerDone(1)).await;
+                                break;
+                            }
+                        },
+                        ServerMessage::SendSignal(signal) => {
+                            if let Err(e) = client.send_signal(signal).await {
+                                eprintln!("Error sending signal: {}", e);
+                            }
+                        },
+                        ServerMessage::WindowResize(cols, rows) => {
+                            if let Err(e) = client.send_window_size(cols, rows).await {
+                                eprintln!("Error resizing window: {}", e);
+                            }
+                        }
                     }
-                    Err(e) => {
-                        eprintln!("Error reading from stdin: {}", e);
-                        break;
+                },
+
+                // Process messages from the server
+                result = client.handle_server_messages() => {
+                    match result {
+                        Ok(()) => {
+                            let _ = ui_tx.send(UiMessage::ServerDone(0)).await;
+                        },
+                        Err(e) => {
+                            eprintln!("Error in server messages: {}", e);
+                            let _ = ui_tx.send(UiMessage::ServerDone(1)).await;
+                        }
+                    }
+                    break;
+                }
+            }
+
+            if shell_ready != client.is_ready() {
+                shell_ready = client.is_ready();
+                let _ = ui_tx.send(UiMessage::ShellReady(shell_ready)).await;
+            }
+
+            if ready_for_input != client.is_ready_for_input() {
+                ready_for_input = client.is_ready_for_input();
+                let _ = ui_tx.send(UiMessage::ReadyForInput(ready_for_input)).await;
+            }
+        }
+    });
+
+    // Main event loop for input and polling events
+    loop {
+        select! {
+            // Handle input from stdin
+            result = stdin.read(&mut stdin_buf) => {
+                if ready_for_input {
+                    match result {
+                        Ok(0) => break, // EOF
+                        Ok(n) => {
+                            let data = String::from_utf8_lossy(&stdin_buf[..n]).to_string();
+                            let _ = server_tx.send(ServerMessage::SendData(data)).await;
+                        }
+                        Err(e) => {
+                            eprintln!("Error reading from stdin: {}", e);
+                            break;
+                        }
                     }
                 }
             }
 
-            // Handle messages from server
-            result = client.handle_server_messages() => {
-                match result {
-                   Ok(()) => {
-                        *exit_code = Some(0);
+            // Process messages from server task
+            Some(msg) = ui_rx.recv() => {
+                match msg {
+                    UiMessage::ServerDone(code) => {
+                        exit_code = Some(code);
                         break;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: {}", e);
-                        *exit_code = Some(1);
-                        break;
+                    },
+                    UiMessage::ShellReady(ready) => {
+                        shell_ready = ready;
+                    },
+                    UiMessage::ReadyForInput(input_ready) => {
+                        ready_for_input = input_ready;
                     }
                 }
             }
 
             // Poll for crossterm events
             _ = tokio::time::sleep(event_poll_timeout) => {
-                if is_ready && event::poll(Duration::from_millis(0))? {
+                if event::poll(Duration::from_millis(0))? {
                     match event::read()? {
                         Event::Key(KeyEvent { code: KeyCode::Char('c'), modifiers, .. }) if modifiers.contains(KeyModifiers::CONTROL) => {
                             // Handle Ctrl+C like SIGINT
-                            client.send_signal(2).await?;
+                            if shell_ready {
+                                let _ = server_tx.send(ServerMessage::SendSignal(2)).await;
+                            }
                         },
                         Event::Resize(width, height) => {
                             // Handle terminal resize
-                            client.send_window_size(width, height).await?;
+                            if shell_ready {
+                                let _ = server_tx.send(ServerMessage::WindowResize(width, height)).await;
+                            }
                         },
                         Event::Key(key) => {
-                            // Handle key input
-                            if let Some(input) = key_event_to_string(key) {
-                                client.send_data(&input).await?;
+                            // Only handle key input if ready for input
+                            if ready_for_input {
+                                if let Some(input) = key_event_to_string(key) {
+                                    let _ = server_tx.send(ServerMessage::SendData(input)).await;
+                                }
                             }
                         },
                         _ => {}

--- a/src/controllers/terminal/client.rs
+++ b/src/controllers/terminal/client.rs
@@ -3,6 +3,7 @@ use async_tungstenite::tungstenite::Message;
 use async_tungstenite::WebSocketStream;
 use futures_util::stream::StreamExt;
 use std::io::Write;
+use tokio::sync::mpsc;
 use tokio::time::{interval, timeout, Duration};
 
 use crate::commands::ssh::{SSH_MAX_EMPTY_MESSAGES, SSH_MESSAGE_TIMEOUT_SECS};
@@ -15,16 +16,21 @@ pub struct TerminalClient {
     ws_stream: WebSocketStream<async_tungstenite::tokio::ConnectStream>,
     initialized: bool,
     ready: bool,
+    in_command_progress: bool,
+    ready_tx: Option<mpsc::Sender<bool>>,
 }
 
 impl TerminalClient {
     pub async fn new(url: &str, token: &str, params: &SSHConnectParams) -> Result<Self> {
+        // Use the correct establish_connection function that handles authentication
         let ws_stream = establish_connection(url, token, params).await?;
 
         let mut client = Self {
             ws_stream,
             initialized: false,
             ready: false,
+            in_command_progress: false,
+            ready_tx: None,
         };
 
         // Wait for the initial welcome message from the server
@@ -83,57 +89,6 @@ impl TerminalClient {
         self.initialized = true;
         self.ready = false;
 
-        // Wait for the ready response
-        let timeout_duration = Duration::from_secs(10); // 10 seconds timeout
-        let mut wait_time = Duration::from_secs(0);
-        let tick_duration = Duration::from_millis(100);
-
-        while !self.ready {
-            if wait_time >= timeout_duration {
-                bail!("Timed out waiting for ready response from server");
-            }
-
-            if let Some(msg_result) = timeout(tick_duration, self.ws_stream.next()).await? {
-                let msg = msg_result.map_err(|e| anyhow::anyhow!("WebSocket error: {}", e))?;
-
-                if let Message::Text(text) = msg {
-                    let server_msg: ServerMessage = serde_json::from_str(&text)
-                        .map_err(|e| anyhow::anyhow!("Failed to parse server message: {}", e))?;
-
-                    match server_msg.r#type.as_str() {
-                        "ready" => {
-                            self.ready = true;
-                            break;
-                        }
-                        "session_data" => {
-                            // Echo any data received while waiting for ready
-                            match server_msg.payload.data {
-                                DataPayload::String(text) => {
-                                    print!("{}", text);
-                                    std::io::stdout().flush()?;
-                                }
-                                DataPayload::Buffer { data } => {
-                                    std::io::stdout().write_all(&data)?;
-                                    std::io::stdout().flush()?;
-                                }
-                                DataPayload::Empty {} => {}
-                            }
-                        }
-                        "error" => {
-                            bail!("Error initializing shell: {}", server_msg.payload.message);
-                        }
-                        _ => {
-                            // Ignore other message types while waiting for ready
-                        }
-                    }
-                }
-            } else {
-                bail!("Connection closed while waiting for ready response");
-            }
-
-            wait_time += tick_duration;
-        }
-
         Ok(())
     }
 
@@ -173,6 +128,11 @@ impl TerminalClient {
             bail!("Shell not ready yet");
         }
 
+        // Do not send data when in command progress (stand_by) mode
+        if self.in_command_progress {
+            return Ok(());
+        }
+
         let message = ClientMessage {
             r#type: "session_data".to_string(),
             payload: ClientPayload::Data {
@@ -189,6 +149,8 @@ impl TerminalClient {
 
     /// Updates the terminal window size
     pub async fn send_window_size(&mut self, cols: u16, rows: u16) -> Result<()> {
+        // Allow window resize before initialization (needed for initial setup)
+        // But block it when initialized but not yet ready
         if self.initialized && !self.ready {
             bail!("Shell not ready yet");
         }
@@ -255,14 +217,20 @@ impl TerminalClient {
                                     match server_msg.r#type.as_str() {
                                         "session_data" => match server_msg.payload.data {
                                             DataPayload::String(text) => {
-                                                consecutive_empty_messages = 0;
-                                                print!("{}", text);
-                                                std::io::stdout().flush()?;
+                                                if !text.trim().is_empty() {
+                                                    print!("{}", text);
+                                                    std::io::stdout().flush()?;
+                                                } else {
+                                                    consecutive_empty_messages = 0;
+                                                }
                                             }
                                             DataPayload::Buffer { data } => {
-                                                consecutive_empty_messages = 0;
-                                                std::io::stdout().write_all(&data)?;
-                                                std::io::stdout().flush()?;
+                                                if !data.is_empty() {
+                                                    std::io::stdout().write_all(&data)?;
+                                                    std::io::stdout().flush()?;
+                                                } else {
+                                                    consecutive_empty_messages = 0;
+                                                }
                                             }
                                             DataPayload::Empty {} => {
                                                 consecutive_empty_messages += 1;
@@ -274,10 +242,22 @@ impl TerminalClient {
                                         "ready" => {
                                             // Client can start sending data/events
                                             self.ready = true;
+                                            self.in_command_progress = false;
+
+                                            // Notify waiting functions that the shell is ready
+                                            if let Some(tx) = &self.ready_tx {
+                                                let _ = tx.send(true).await;
+                                            }
                                         },
                                         "stand_by" => {
                                             // This indicates command is in progress
                                             self.ready = true;
+                                            self.in_command_progress = true;
+
+                                            // Notify waiting functions that the shell is ready
+                                            if let Some(tx) = &self.ready_tx {
+                                                let _ = tx.send(true).await;
+                                            }
                                         },
                                         "command_exit" => {
                                             if let Some(code) = server_msg.payload.code {
@@ -290,6 +270,10 @@ impl TerminalClient {
                                             }
                                         },
                                         "error" => {
+                                            // Notify waiting functions that the shell initialization failed
+                                            if let Some(tx) = &self.ready_tx {
+                                                let _ = tx.send(false).await;
+                                            }
                                             bail!(server_msg.payload.message);
                                         }
                                         "welcome" => {
@@ -304,6 +288,9 @@ impl TerminalClient {
                                     }
                                 }
                                 Message::Close(frame) => {
+                                    if let Some(tx) = &self.ready_tx {
+                                        let _ = tx.send(false).await;
+                                    }
                                     if let Some(frame) = frame {
                                         bail!(
                                             "WebSocket closed with code {}: {}",
@@ -341,9 +328,85 @@ impl TerminalClient {
         }
     }
 
+    /// Directly waits for a ready or stand_by message from the server
+    pub async fn wait_for_shell_ready(&mut self, timeout_secs: u64) -> Result<()> {
+        let timeout_future = tokio::time::sleep(Duration::from_secs(timeout_secs));
+        tokio::pin!(timeout_future);
+
+        loop {
+            tokio::select! {
+                msg_option = self.ws_stream.next() => {
+                    match msg_option {
+                        Some(msg_result) => {
+                            let msg = msg_result.map_err(|e| anyhow::anyhow!("WebSocket error: {}", e))?;
+                            match msg {
+                                Message::Text(text) => {
+                                    let server_msg: ServerMessage = serde_json::from_str(&text)
+                                        .map_err(|e| anyhow::anyhow!("Failed to parse server message: {}", e))?;
+
+                                    if server_msg.r#type == "ready" || server_msg.r#type == "stand_by" {
+                                        self.ready = true;
+                                        self.in_command_progress = server_msg.r#type == "stand_by";
+                                        return Ok(());
+                                    }
+
+                                    // Handle specially recognized messages
+                                    match server_msg.r#type.as_str() {
+                                        "session_data" => match server_msg.payload.data {
+                                            DataPayload::String(text) => {
+                                                if !text.trim().is_empty() {
+                                                    print!("{}", text);
+                                                    std::io::stdout().flush()?;
+                                                }
+                                            }
+                                            DataPayload::Buffer { data } => {
+                                                if !data.is_empty() {
+                                                    std::io::stdout().write_all(&data)?;
+                                                    std::io::stdout().flush()?;
+                                                }
+                                            }
+                                            DataPayload::Empty {} => {}
+                                        },
+                                        "error" => {
+                                            bail!("Error from server: {}", server_msg.payload.message);
+                                        }
+                                        _ => {}
+                                    }
+                                },
+                                // Handle other message types
+                                Message::Ping(data) => {
+                                    self.send_message(Message::Pong(data)).await?;
+                                }
+                                Message::Close(frame) => {
+                                    if let Some(frame) = frame {
+                                        bail!("WebSocket closed with code {}: {}", frame.code, frame.reason);
+                                    } else {
+                                        bail!("WebSocket closed unexpectedly");
+                                    }
+                                }
+                                // Ignore other message types
+                                _ => {}
+                            }
+                        },
+                        None => {
+                            bail!("WebSocket connection closed unexpectedly");
+                        }
+                    }
+                },
+                _ = &mut timeout_future => {
+                    bail!("Timed out waiting for shell to be ready");
+                }
+            }
+        }
+    }
+
     /// Check if the shell is ready for input
     pub fn is_ready(&self) -> bool {
         self.ready
     }
-}
 
+    /// Check if the shell is ready and not currently processing a command
+    pub fn is_ready_for_input(&self) -> bool {
+        self.ready && !self.in_command_progress
+    }
+}

--- a/src/controllers/terminal/client.rs
+++ b/src/controllers/terminal/client.rs
@@ -42,7 +42,7 @@ impl TerminalClient {
                     .map_err(|e| anyhow::anyhow!("Failed to parse server message: {}", e))?;
 
                 if server_msg.r#type != "welcome" {
-                    bail!("Expected welcome message, received: {}", server_msg.r#type);
+                    bail!("Expected welcome message, received: {:?}", server_msg);
                 }
 
                 return Ok(client);

--- a/src/controllers/terminal/connection.rs
+++ b/src/controllers/terminal/connection.rs
@@ -6,7 +6,7 @@ use tokio::time::{sleep, timeout, Duration};
 use url::Url;
 
 use crate::commands::ssh::{
-    SSH_CONNECTION_TIMEOUT_SECS, SSH_MAX_RECONNECT_ATTEMPTS, SSH_RECONNECT_DELAY_SECS,
+    SSH_CONNECTION_TIMEOUT_SECS, SSH_CONNECT_DELAY_SECS, SSH_MAX_CONNECT_ATTEMPTS,
 };
 use crate::consts::get_user_agent;
 
@@ -26,24 +26,24 @@ pub async fn establish_connection(
 ) -> Result<WebSocketStream<async_tungstenite::tokio::ConnectStream>> {
     let url = Url::parse(url)?;
 
-    for attempt in 1..=SSH_MAX_RECONNECT_ATTEMPTS {
+    for attempt in 1..=SSH_MAX_CONNECT_ATTEMPTS {
         match attempt_connection(&url, token, params).await {
             Ok(ws_stream) => {
                 return Ok(ws_stream);
             }
             Err(e) => {
-                if attempt == SSH_MAX_RECONNECT_ATTEMPTS {
+                if attempt == SSH_MAX_CONNECT_ATTEMPTS {
                     bail!(
                         "Failed to establish connection after {} attempts: {}",
-                        SSH_MAX_RECONNECT_ATTEMPTS,
+                        SSH_MAX_CONNECT_ATTEMPTS,
                         e
                     );
                 }
                 eprintln!(
                     "Connection attempt {} failed: {}. Retrying in {} seconds...",
-                    attempt, e, SSH_RECONNECT_DELAY_SECS
+                    attempt, e, SSH_CONNECT_DELAY_SECS
                 );
-                sleep(Duration::from_secs(SSH_RECONNECT_DELAY_SECS)).await;
+                sleep(Duration::from_secs(SSH_CONNECT_DELAY_SECS)).await;
             }
         }
     }


### PR DESCRIPTION
The SSH logic has required more and more functionality that requires the client and server communicating when they are ready to send or receive data. This PR takes the welcome event handshake further by waiting for a response after starting a session or knowing that a command is being executed.

Today the client waits for a welcome after connecting before starting an interactive shell or sending a command to execute. The client doesn't know if the command is being executed or when data can start to be sent (such as key inputs or window size).

Now the client will get the `welcome` and after sending `init_shell` or `exec_command` the client will wait for `ready` if interactive shell or `stand_by` if waiting for a command to complete. 