### PR TITLE
Fix valkey "Template not found" in add command

### DIFF
--- a/src/controllers/database.rs
+++ b/src/controllers/database.rs
@@ -6,6 +6,8 @@ pub enum DatabaseType {
     PostgreSQL,
     MySQL,
     Redis,
+    KeyDB,
+    Valkey,
     MongoDB,
 }
 
@@ -15,6 +17,8 @@ impl DatabaseType {
             DatabaseType::PostgreSQL => "postgres",
             DatabaseType::MySQL => "mysql",
             DatabaseType::Redis => "redis",
+            DatabaseType::KeyDB => "keydb",
+            DatabaseType::Valkey => "valkey",
             DatabaseType::MongoDB => "mongo",
         }
     }

--- a/src/controllers/database.rs
+++ b/src/controllers/database.rs
@@ -18,7 +18,7 @@ impl DatabaseType {
             DatabaseType::MySQL => "mysql",
             DatabaseType::Redis => "redis",
             DatabaseType::KeyDB => "keydb",
-            DatabaseType::Valkey => "valkey",
+            DatabaseType::Valkey => "pQYeJx", // We set this beacuse in "add" command, the template id "valkey" does not exist. So we set it to "pQYeJx" to avoid "template not found" error.
             DatabaseType::MongoDB => "mongo",
         }
     }


### PR DESCRIPTION
So when you are using "railway add" and choose valkey, you would get "Template not found"

So i replaced "valkey" with the template id "pQYeJx"
This does not happend with keydb beacuse it's template id is keydb.