### PR TITLE
Log 413 reason on up

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -248,10 +248,10 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
         }
 
         if status == 413 {
+            let err = res.text().await?;
             let filesize = arc.lock().unwrap().len();
             return Err(RailwayError::FailedToUpload(format!(
-                "Failed to upload code. File too large ({} bytes)",
-                filesize
+                "Failed to upload code. File too large ({filesize} bytes): {err}",
             )))?;
         }
 


### PR DESCRIPTION
We assume it's because the file is too large, but we don't know where the limit comes from and if that's the case. A middleware we use limits multipart field size for example. Logs this so we try to narrow the cause, so we can document the upload limit.

Related to: PRO-4145