### PR TITLE
Check stdin when checking for interactive tty in unlink

### DIFF
--- a/src/commands/unlink.rs
+++ b/src/commands/unlink.rs
@@ -34,7 +34,8 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
             service.node.name.bold(),
             project.name.bold()
         );
-        let confirmed = if std::io::stdout().is_terminal() {
+        let is_interactive_tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+        let confirmed = if is_interactive_tty {
             prompt_confirm_with_default("Are you sure you want to unlink this service?", true)?
         } else {
             true


### PR DESCRIPTION
Only checking stdout().is_terminal() means when running railway unlink in a non-interactive context, but with visible outputs (e.g. shell pipeline) the confirmation prompt fails rather than defaulting to "Yes".