### PR TITLE
remove global json flag

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -44,7 +44,7 @@ pub struct Args {
     variables: Vec<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/check_updates.rs
+++ b/src/commands/check_updates.rs
@@ -5,12 +5,16 @@ use serde_json::json;
 
 /// Test the update check
 #[derive(Parser)]
-pub struct Args {}
+pub struct Args {
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
+}
 
-pub async fn command(_args: Args, json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
 
-    if json {
+    if args.json {
         let result = configs.check_update(true).await;
 
         let json = json!({

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -10,7 +10,7 @@ pub struct Args {
     shell: Shell,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     generate(
         args.shell,
         &mut self::Args::command(),

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -31,7 +31,7 @@ impl Display for ProjectProjectServicesEdgesNode {
     }
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -28,7 +28,7 @@ pub struct Args {
     variable: Vec<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
 
     let client = GQLClient::new_authorized(&configs)?;

--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -8,7 +8,7 @@ use super::*;
 #[derive(Parser)]
 pub struct Args {}
 
-pub async fn command(_args: Args, _json: bool) -> Result<()> {
+pub async fn command(_args: Args) -> Result<()> {
     interact_or!(NON_INTERACTIVE_FAILURE);
 
     let confirm = prompt_confirm_with_default("Open the browser?", true)?;

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -32,13 +32,17 @@ pub struct Args {
     /// Specifying a custom domain will also return the required DNS records
     /// to add to your DNS settings
     domain: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
 }
 
-pub async fn command(args: Args, json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     if let Some(domain) = args.domain {
-        create_custom_domain(domain, args.port, args.service, json).await?;
+        create_custom_domain(domain, args.port, args.service, args.json).await?;
     } else {
-        create_service_domain(args.service, json).await?;
+        create_service_domain(args.service, args.json).await?;
     }
     Ok(())
 }

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -29,7 +29,7 @@ pub struct Args {
     bypass: bool,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/environment.rs
+++ b/src/commands/environment.rs
@@ -66,7 +66,7 @@ pub struct DeleteArgs {
     environment: Option<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     match args.command {
         Some(EnvironmentCommand::New(args)) => new_environment(args).await,
         Some(EnvironmentCommand::Delete(args)) => delete_environment(args).await,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -12,7 +12,7 @@ pub struct Args {
     name: Option<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
 
     let client = GQLClient::new_authorized(&configs)?;

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -31,7 +31,7 @@ pub struct Args {
     team: Option<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
 
     let workspaces = workspaces().await?;

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -3,9 +3,13 @@ use crate::workspace::workspaces;
 
 /// List all projects in your Railway account
 #[derive(Parser)]
-pub struct Args {}
+pub struct Args {
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
+}
 
-pub async fn command(_args: Args, json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let linked_project = configs.get_linked_project().await.ok();
 
@@ -13,13 +17,13 @@ pub async fn command(_args: Args, json: bool) -> Result<()> {
     let mut all_projects = Vec::new();
 
     for workspace in workspaces {
-        if !json {
+        if !args.json {
             println!();
             println!("{}", workspace.name().bold());
         }
 
         let projects = workspace.projects();
-        if !json {
+        if !args.json {
             for project in &projects {
                 let project_name =
                     if Some(project.id()) == linked_project.as_ref().map(|p| p.project.as_str()) {
@@ -34,7 +38,7 @@ pub async fn command(_args: Args, json: bool) -> Result<()> {
         all_projects.extend(projects);
     }
 
-    if json {
+    if args.json {
         println!("{}", serde_json::to_string_pretty(&all_projects)?);
     }
     Ok(())

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -24,7 +24,7 @@ pub struct Args {
     browserless: bool,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     interact_or!("Cannot login in non-interactive mode");
 
     let mut configs = Configs::new()?;

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -4,7 +4,7 @@ use super::*;
 #[derive(Parser)]
 pub struct Args {}
 
-pub async fn command(_args: Args, _json: bool) -> Result<()> {
+pub async fn command(_args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
     configs.reset()?;
     configs.write()?;

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -37,9 +37,13 @@ pub struct Args {
 
     /// Deployment ID to pull logs from. Omit to pull from latest deloy
     deployment_id: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
 }
 
-pub async fn command(args: Args, json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
@@ -108,7 +112,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
 
     if (args.build || deployment.status == DeploymentStatus::FAILED) && !args.deployment {
         stream_build_logs(deployment.id.clone(), |log| {
-            if json {
+            if args.json {
                 println!("{}", serde_json::to_string(&log).unwrap());
             } else {
                 println!("{}", log.message);
@@ -119,7 +123,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         stream_deploy_logs(
             deployment.id.clone(),
             |log: subscriptions::deployment_logs::LogFields| {
-                if json {
+                if args.json {
                     let mut map: HashMap<String, Value> = HashMap::new();
 
                     // Insert fixed attributes

--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -9,7 +9,7 @@ use super::*;
 #[derive(Parser)]
 pub struct Args {}
 
-pub async fn command(_args: Args, _json: bool) -> Result<()> {
+pub async fn command(_args: Args) -> Result<()> {
     interact_or!(NON_INTERACTIVE_FAILURE);
 
     let configs = Configs::new()?;

--- a/src/commands/redeploy.rs
+++ b/src/commands/redeploy.rs
@@ -23,7 +23,7 @@ pub struct Args {
     bypass: bool,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -72,7 +72,7 @@ async fn get_service(
     Ok(service)
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     // only needs to be mutable for the update check
     let configs = Configs::new()?;
 

--- a/src/commands/scale.rs
+++ b/src/commands/scale.rs
@@ -35,7 +35,7 @@ pub struct Args {
     environment: Option<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -15,7 +15,7 @@ pub struct Args {
     service: Option<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -39,7 +39,7 @@ pub struct Args {
     silent: bool,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -50,7 +50,7 @@ pub struct Args {
     command: Vec<String>,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
 

--- a/src/commands/starship.rs
+++ b/src/commands/starship.rs
@@ -5,7 +5,7 @@ use super::*;
 #[clap(hide = true)]
 pub struct Args {}
 
-pub async fn command(_args: Args, _json: bool) -> Result<()> {
+pub async fn command(_args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let linked_project = configs.get_linked_project().await?;
     println!("{}", serde_json::to_string(&linked_project)?);

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -4,9 +4,13 @@ use super::*;
 
 /// Show information about the current project
 #[derive(Parser)]
-pub struct Args;
+pub struct Args {
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
+}
 
-pub async fn command(_args: Args, json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
@@ -14,7 +18,7 @@ pub async fn command(_args: Args, json: bool) -> Result<()> {
 
     ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
 
-    if !json {
+    if !args.json {
         println!("Project: {}", project.name.purple().bold());
         println!(
             "Environment: {}",

--- a/src/commands/unlink.rs
+++ b/src/commands/unlink.rs
@@ -12,7 +12,7 @@ pub struct Args {
     service: bool,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -79,7 +79,7 @@ pub struct UpErrorResponse {
     pub message: String,
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let hostname = configs.get_host();
     let client = GQLClient::new_authorized(&configs)?;

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -33,9 +33,13 @@ pub struct Args {
     /// railway variables --set "MY_SPECIAL_ENV_VAR=1" --set "BACKEND_PORT=3000"
     #[clap(long)]
     set: Vec<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
 }
 
-pub async fn command(args: Args, json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;
@@ -100,7 +104,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    if json {
+    if args.json {
         println!("{}", serde_json::to_string_pretty(&variables)?);
         return Ok(());
     }

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -84,7 +84,7 @@ structstruck::strike! {
     }
 }
 
-pub async fn command(args: Args, _json: bool) -> Result<()> {
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -7,7 +7,7 @@ use super::*;
 #[derive(Parser)]
 pub struct Args {}
 
-pub async fn command(_args: Args, _json: bool) -> Result<()> {
+pub async fn command(_args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,14 +11,7 @@ macro_rules! commands {
                     .propagate_version(true)
                     .about(clap::crate_description!())
                     .long_about(None)
-                    .version(clap::crate_version!())
-                    .arg(
-                        clap::Arg::new("json")
-                            .long("json")
-                            .action(clap::ArgAction::SetTrue)
-                            .global(true)
-                            .help("Output in JSON format")
-                    );
+                    .version(clap::crate_version!());
                 $(
                     {
                         // Get the subcommand as defined by the module.
@@ -51,13 +44,12 @@ macro_rules! commands {
 
             /// Dispatches the selected subcommand (after parsing) to its handler.
             pub async fn exec_cli(matches: clap::ArgMatches) -> anyhow::Result<()> {
-                let json = matches.get_flag("json");
                 match matches.subcommand() {
                     $(
                         Some((stringify!([<$module:snake>]), sub_matches)) => {
                                let args = <$module::Args as ::clap::FromArgMatches>::from_arg_matches(sub_matches)
                                    .map_err(anyhow::Error::from)?;
-                            $module::command(args, json).await?;
+                            $module::command(args).await?;
                         },
                     )*
                     _ => {


### PR DESCRIPTION
The `--json` flag is currently global and can be added to all commands, but it is only actually used in a few. This PR moves the flag to the specific commands where it is used.
