### PR TITLE
Add `--workspace` option to `railway init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,15 +1816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "names"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
-dependencies = [
- "rand",
-]
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,7 +2146,6 @@ dependencies = [
  "inquire",
  "is-terminal",
  "json_dotpath",
- "names",
  "notify",
  "num_cpus",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ futures = { version = "0.3.31", default-features = false, features = [
   "executor"
 ] }
 futures-util = "0.3"
-names = { version = "0.14.0", default-features = false }
 graphql-ws-client = { version = "0.11.1", features = [
   "client-graphql-client",
   "tungstenite",

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ The Railway CLI allows you to
 - Pull down environment variables for your project locally to run
 - Create services and databases right from the comfort of your fingertips
 
-## Status
-
-Currently pre-release. We are looking for feedback and suggestions. Please join our [Discord](https://discord.gg/railway) to provide feedback.
-
 ## Installation
 
 ### Cargo

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -83,7 +83,7 @@ fn prompt_workspace(workspaces: Vec<Workspace>, workspace: Option<String>) -> Re
     if let Some(input) = workspace {
         return workspaces
             .iter()
-            .find(|w| w.id() == input || w.name() == input)
+            .find(|w| w.id().eq_ignore_ascii_case(&input) || w.name().eq_ignore_ascii_case(&input))
             .map(select)
             .ok_or_else(|| RailwayError::WorkspaceNotFound(input).into());
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
+use crate::errors::RailwayError;
 use crate::util::prompt::{fake_select, prompt_select, prompt_text_with_placeholder_if_blank};
 use crate::workspace::{workspaces, Workspace};
-use crate::errors::RailwayError;
 
 use super::*;
 
@@ -29,7 +29,11 @@ pub async fn command(args: Args) -> Result<()> {
 
     let vars = mutations::project_create::Variables {
         // Railway's API will automatically generate a name if one is not provided
-        name: if project_name.is_empty() { None } else { Some(project_name) },
+        name: if project_name.is_empty() {
+            None
+        } else {
+            Some(project_name)
+        },
         description: None,
         team_id: workspace.team_id(),
     };

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,6 +52,9 @@ pub enum RailwayError {
     #[error("Project \"{0}\" was not found in the \"{1}\" team.")]
     ProjectNotFoundInTeam(String, String),
 
+    #[error("Workspace \"{0}\" not found.")]
+    WorkspaceNotFound(String),
+
     #[error("Service \"{0}\" not found.")]
     ServiceNotFound(String),
 


### PR DESCRIPTION
Allows this command to create a project headlessly without any input prompts.

- Accepts a case-insensitive environment name or a case-insensitive UUID.
- Cleans up some very old code.
