### PR TITLE
Add retry logic with exponential backoff for build log streaming

### DIFF
--- a/src/controllers/deployment.rs
+++ b/src/controllers/deployment.rs
@@ -1,6 +1,7 @@
 use crate::{
     commands::subscriptions::{self, build_logs, deployment_logs},
     subscription::subscribe_graphql,
+    util::retry::{retry_with_backoff, RetryConfig},
 };
 use anyhow::{Context, Result};
 use futures::StreamExt;
@@ -9,13 +10,32 @@ pub async fn stream_build_logs(
     deployment_id: String,
     on_log: impl Fn(build_logs::LogFields),
 ) -> Result<()> {
-    let vars = subscriptions::build_logs::Variables {
-        deployment_id: deployment_id.clone(),
-        filter: Some(String::new()),
-        limit: Some(500),
-    };
+    // Retry establishing connection and getting first log
+    let mut stream = retry_with_backoff(RetryConfig::default(), || async {
+        let vars = subscriptions::build_logs::Variables {
+            deployment_id: deployment_id.clone(),
+            filter: Some(String::new()),
+            limit: Some(500),
+        };
 
-    let mut stream = subscribe_graphql::<subscriptions::BuildLogs>(vars).await?;
+        let mut stream = subscribe_graphql::<subscriptions::BuildLogs>(vars).await?;
+
+        // Wait for first log to ensure stream is ready
+        if let Some(Ok(log)) = stream.next().await {
+            if let Some(data) = log.data {
+                // Process first batch of logs
+                for line in data.build_logs {
+                    on_log(line);
+                }
+                return Ok(stream);
+            }
+        }
+
+        anyhow::bail!("Build logs not yet available")
+    })
+    .await?;
+
+    // Continue processing remaining logs without retry
     while let Some(Ok(log)) = stream.next().await {
         let log = log.data.context("Failed to retrieve build log")?;
         for line in log.build_logs {
@@ -30,13 +50,32 @@ pub async fn stream_deploy_logs(
     deployment_id: String,
     on_log: impl Fn(deployment_logs::LogFields),
 ) -> Result<()> {
-    let vars = subscriptions::deployment_logs::Variables {
-        deployment_id: deployment_id.clone(),
-        filter: Some(String::new()),
-        limit: Some(500),
-    };
+    // Retry establishing connection and getting first log
+    let mut stream = retry_with_backoff(RetryConfig::default(), || async {
+        let vars = subscriptions::deployment_logs::Variables {
+            deployment_id: deployment_id.clone(),
+            filter: Some(String::new()),
+            limit: Some(500),
+        };
 
-    let mut stream = subscribe_graphql::<subscriptions::DeploymentLogs>(vars).await?;
+        let mut stream = subscribe_graphql::<subscriptions::DeploymentLogs>(vars).await?;
+
+        // Wait for first log to ensure stream is ready
+        if let Some(Ok(log)) = stream.next().await {
+            if let Some(data) = log.data {
+                // Process first batch of logs
+                for line in data.deployment_logs {
+                    on_log(line);
+                }
+                return Ok(stream);
+            }
+        }
+
+        anyhow::bail!("Deploy logs not yet available")
+    })
+    .await?;
+
+    // Continue processing remaining logs without retry
     while let Some(Ok(log)) = stream.next().await {
         let log = log.data.context("Failed to retrieve deploy log")?;
         for line in log.deployment_logs {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,4 +3,5 @@ pub mod compare_semver;
 pub mod logs;
 pub mod progress;
 pub mod prompt;
+pub mod retry;
 pub mod watcher;

--- a/src/util/retry.rs
+++ b/src/util/retry.rs
@@ -1,0 +1,164 @@
+use anyhow::Result;
+use std::future::Future;
+use std::time::Duration;
+use tokio::time::sleep;
+
+pub struct RetryConfig {
+    pub max_attempts: u32,
+    pub initial_delay_ms: u64,
+    pub max_delay_ms: u64,
+    pub backoff_multiplier: f64,
+    pub on_retry: Option<Box<dyn Fn(u32, u32, &anyhow::Error, u64) + Send + Sync>>,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            initial_delay_ms: 500, // 500ms for fast first retry
+            max_delay_ms: 10000,   // 10 seconds max
+            backoff_multiplier: 2.0,
+            on_retry: None, // Silent by default
+        }
+    }
+}
+
+pub fn default_retry_logger() -> Box<dyn Fn(u32, u32, &anyhow::Error, u64) + Send + Sync> {
+    Box::new(|attempt, max_attempts, error, delay_ms| {
+        eprintln!(
+            "Attempt {}/{} failed: {}. Retrying in {}ms...",
+            attempt, max_attempts, error, delay_ms
+        );
+    })
+}
+
+pub async fn retry_with_backoff<F, Fut, T>(config: RetryConfig, mut operation: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let mut delay_ms = config.initial_delay_ms;
+
+    for attempt in 1..=config.max_attempts {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) if attempt == config.max_attempts => {
+                return Err(e);
+            }
+            Err(e) => {
+                if let Some(ref on_retry) = config.on_retry {
+                    on_retry(attempt, config.max_attempts, &e, delay_ms);
+                }
+
+                sleep(Duration::from_millis(delay_ms)).await;
+
+                // Calculate next delay with exponential backoff, capped at max_delay_ms
+                delay_ms =
+                    ((delay_ms as f64 * config.backoff_multiplier) as u64).min(config.max_delay_ms);
+            }
+        }
+    }
+
+    unreachable!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_succeeds_after_retries() {
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+
+        let result = retry_with_backoff(
+            RetryConfig {
+                max_attempts: 3,
+                initial_delay_ms: 1,
+                ..Default::default()
+            },
+            move || {
+                let c = count_clone.clone();
+                async move {
+                    let attempt = c.fetch_add(1, Ordering::SeqCst) + 1;
+                    if attempt < 3 {
+                        anyhow::bail!("Not ready yet");
+                    }
+                    Ok::<i32, anyhow::Error>(42)
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_fails_after_max_attempts() {
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+
+        let result = retry_with_backoff(
+            RetryConfig {
+                max_attempts: 2,
+                initial_delay_ms: 1,
+                ..Default::default()
+            },
+            move || {
+                let c = count_clone.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    anyhow::bail!("Always fails");
+                    #[allow(unreachable_code)]
+                    Ok::<i32, anyhow::Error>(0)
+                }
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_succeeds_first_try() {
+        let result = retry_with_backoff(RetryConfig::default(), || async {
+            Ok::<i32, anyhow::Error>(100)
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_custom_logger() {
+        let log_count = Arc::new(AtomicU32::new(0));
+        let log_count_clone = log_count.clone();
+
+        let result = retry_with_backoff(
+            RetryConfig {
+                max_attempts: 2,
+                initial_delay_ms: 1,
+                on_retry: Some(Box::new(move |attempt, max_attempts, _error, delay_ms| {
+                    log_count_clone.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(attempt, 1);
+                    assert_eq!(max_attempts, 2);
+                    assert_eq!(delay_ms, 1);
+                })),
+                ..Default::default()
+            },
+            || async {
+                anyhow::bail!("Always fails");
+                #[allow(unreachable_code)]
+                Ok::<i32, anyhow::Error>(0)
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(log_count.load(Ordering::SeqCst), 1); // Called once for the retry
+    }
+}


### PR DESCRIPTION
Fixes the "Failed to retrieve build log" error that occurs when `railway up` tries to stream build logs before the deployment has started generating them.

- Add generic retry utility with configurable attempts and exponential backoff
- Update build/deploy log streaming to retry initial connection attempts  
- Add optional logging callback with silent retries by default for log streaming
- Comprehensive test coverage for retry functionality