### PR TITLE
Fix osx compilation

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,8 +24,6 @@ let
         Security
         SystemConfiguration
         CoreServices
-        CoreFoundation
-        IOKit
       ]);
 in
 pkgs.mkShell


### PR DESCRIPTION
# Why

On OSX Tahoe, `nix-shell --run "cargo clean && cargo build"` fails on this linking error:

```
  = note: ld: framework not found CoreServices
          clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `railwayapp` (bin "railway") due to 1 previous error
```

# What Changed

- add CoreServices to the OSX nix config

# Test Plan

- `nix-shell --run "cargo clean && cargo build"` works
