### PR TITLE
Add `--lines` / `-n` and `-f` / `--filter` options to log command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
 

--- a/shell.nix
+++ b/shell.nix
@@ -23,6 +23,7 @@ let
       (with darwin.apple_sdk.frameworks; [
         Security
         SystemConfiguration
+        CoreServices
       ]);
 in
 pkgs.mkShell

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -7,7 +7,7 @@ use crate::{
         environment::get_matched_environment,
         project::{ensure_project_and_environment_exist, get_project},
     },
-    util::logs::format_attr_log,
+    util::logs::{format_attr_log, format_query_log},
 };
 use anyhow::bail;
 use serde_json::Value;
@@ -149,7 +149,7 @@ pub async fn command(args: Args) -> Result<()> {
         if args.stream {
             stream_deploy_logs(
                 deployment.id.clone(),
-                |log: subscriptions::deployment_logs::LogFields| {
+                |log| {
                     if args.json {
                         let mut map: HashMap<String, Value> = HashMap::new();
 
@@ -194,12 +194,7 @@ pub async fn command(args: Args) -> Result<()> {
                     if args.json {
                         println!("{}", serde_json::to_string(&log).unwrap());
                     } else {
-                        // For non-JSON output, we need to format it properly
-                        if let Some(severity) = &log.severity {
-                            print!("[{}] ", severity);
-                        }
-                        print!("{} ", log.timestamp);
-                        println!("{}", log.message);
+                        format_query_log(log);
                     }
                 },
             )

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -51,51 +51,6 @@ pub struct Args {
     stream: bool,
 }
 
-impl LogLike for queries::deployment_logs::LogFields {
-    fn message(&self) -> &str {
-        &self.message
-    }
-    fn timestamp(&self) -> &str {
-        &self.timestamp
-    }
-    fn attributes(&self) -> Vec<(&str, &str)> {
-        self.attributes
-            .iter()
-            .map(|a| (a.key.as_str(), a.value.as_str()))
-            .collect()
-    }
-}
-
-impl LogLike for subscriptions::build_logs::LogFields {
-    fn message(&self) -> &str {
-        &self.message
-    }
-    fn timestamp(&self) -> &str {
-        &self.timestamp
-    }
-    fn attributes(&self) -> Vec<(&str, &str)> {
-        self.attributes
-            .iter()
-            .map(|a| (a.key.as_str(), a.value.as_str()))
-            .collect()
-    }
-}
-
-impl LogLike for queries::build_logs::LogFields {
-    fn message(&self) -> &str {
-        &self.message
-    }
-    fn timestamp(&self) -> &str {
-        &self.timestamp
-    }
-    fn attributes(&self) -> Vec<(&str, &str)> {
-        self.attributes
-            .iter()
-            .map(|a| (a.key.as_str(), a.value.as_str()))
-            .collect()
-    }
-}
-
 // Helper function to print any log type
 fn print_log<T>(log: T, json: bool, use_formatted: bool)
 where

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -288,7 +288,7 @@ pub async fn command(args: Args) -> Result<()> {
     //	Always stream build logs
     let build_deployment_id = deployment_id.clone();
     let mut tasks = vec![tokio::task::spawn(async move {
-        if let Err(e) = stream_build_logs(build_deployment_id, |log| {
+        if let Err(e) = stream_build_logs(build_deployment_id, None, |log| {
             println!("{}", log.message);
             if args.ci && log.message.starts_with("No changed files matched patterns") {
                 std::process::exit(0);
@@ -309,7 +309,7 @@ pub async fn command(args: Args) -> Result<()> {
         let deploy_deployment_id = deployment_id.clone();
         tasks.push(tokio::task::spawn(async move {
             if let Err(e) =
-                stream_deploy_logs(deploy_deployment_id, |log| format_attr_log(&log)).await
+                stream_deploy_logs(deploy_deployment_id, None, |log| format_attr_log(&log)).await
             {
                 eprintln!("Failed to stream deploy logs: {e}");
             }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -288,12 +288,15 @@ pub async fn command(args: Args) -> Result<()> {
     //	Always stream build logs
     let build_deployment_id = deployment_id.clone();
     let mut tasks = vec![tokio::task::spawn(async move {
-        if let Err(e) = stream_build_logs(build_deployment_id, |log| {
-            println!("{}", log.message);
-            if args.ci && log.message.starts_with("No changed files matched patterns") {
-                std::process::exit(0);
-            }
-        })
+        if let Err(e) = stream_build_logs(
+            build_deployment_id,
+            |log| {
+                println!("{}", log.message);
+                if args.ci && log.message.starts_with("No changed files matched patterns") {
+                    std::process::exit(0);
+                }
+            },
+        )
         .await
         {
             eprintln!("Failed to stream build logs: {e}");

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -26,7 +26,7 @@ use crate::{
     errors::RailwayError,
     subscription::subscribe_graphql,
     subscriptions::deployment::DeploymentStatus,
-    util::logs::format_attr_log,
+    util::logs::print_log,
 };
 
 use super::*;
@@ -308,8 +308,10 @@ pub async fn command(args: Args) -> Result<()> {
     if !ci_mode {
         let deploy_deployment_id = deployment_id.clone();
         tasks.push(tokio::task::spawn(async move {
-            if let Err(e) =
-                stream_deploy_logs(deploy_deployment_id, None, |log| format_attr_log(&log)).await
+            if let Err(e) = stream_deploy_logs(deploy_deployment_id, None, |log| {
+                print_log(log, false, true) // No JSON, use formatted output
+            })
+            .await
             {
                 eprintln!("Failed to stream deploy logs: {e}");
             }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -309,7 +309,7 @@ pub async fn command(args: Args) -> Result<()> {
         let deploy_deployment_id = deployment_id.clone();
         tasks.push(tokio::task::spawn(async move {
             if let Err(e) = stream_deploy_logs(deploy_deployment_id, None, |log| {
-                print_log(log, false, true) // No JSON, use formatted output
+                print_log(log, false, true)
             })
             .await
             {

--- a/src/controllers/deployment.rs
+++ b/src/controllers/deployment.rs
@@ -56,7 +56,7 @@ pub async fn fetch_deploy_logs(
     backboard: &str,
     deployment_id: String,
     limit: Option<i64>,
-    on_log: impl Fn(queries::deployment_logs::DeploymentLogsDeploymentLogs),
+    on_log: impl Fn(queries::deployment_logs::LogFields),
 ) -> Result<()> {
     // Adjust for API returning limit + 1 logs
     let api_limit = limit.map(|n| if n > 0 { n - 1 } else { 0 });

--- a/src/controllers/deployment.rs
+++ b/src/controllers/deployment.rs
@@ -36,7 +36,7 @@ pub async fn fetch_build_logs(
 
     let response = post_graphql::<queries::BuildLogs, _>(client, backboard, vars).await?;
 
-    // Take only the requested number of logs from the end (handles API returning limit+1)
+    // Take only the requested number of logs from the end (the API has a bug and returns limit+1)
     let logs = response.build_logs;
     let logs_to_process = if let Some(l) = limit {
         let l = l as usize;
@@ -72,7 +72,7 @@ pub async fn fetch_deploy_logs(
 
     let response = post_graphql::<queries::DeploymentLogs, _>(client, backboard, vars).await?;
 
-    // Take only the requested number of logs from the end (handles API returning limit+1)
+    // Take only the requested number of logs from the end (the API has a bug and returns limit+1)
     let logs = response.deployment_logs;
     let logs_to_process = if let Some(l) = limit {
         let l = l as usize;

--- a/src/gql/queries/strings/BuildLogs.graphql
+++ b/src/gql/queries/strings/BuildLogs.graphql
@@ -1,5 +1,5 @@
-query BuildLogs($deploymentId: String!, $startDate: DateTime) {
-	buildLogs(deploymentId: $deploymentId, startDate: $startDate) {
+query BuildLogs($deploymentId: String!, $limit: Int, $startDate: DateTime) {
+	buildLogs(deploymentId: $deploymentId, limit: $limit, startDate: $startDate) {
 		message
 		timestamp
 	}

--- a/src/gql/queries/strings/BuildLogs.graphql
+++ b/src/gql/queries/strings/BuildLogs.graphql
@@ -1,6 +1,14 @@
 query BuildLogs($deploymentId: String!, $limit: Int, $startDate: DateTime) {
 	buildLogs(deploymentId: $deploymentId, limit: $limit, startDate: $startDate) {
-		message
-		timestamp
+		...LogFields
+	}
+}
+
+fragment LogFields on Log {
+	timestamp
+	message
+	attributes {
+		key
+		value
 	}
 }

--- a/src/gql/queries/strings/BuildLogs.graphql
+++ b/src/gql/queries/strings/BuildLogs.graphql
@@ -1,5 +1,5 @@
-query BuildLogs($deploymentId: String!, $limit: Int, $startDate: DateTime) {
-	buildLogs(deploymentId: $deploymentId, limit: $limit, startDate: $startDate) {
+query BuildLogs($deploymentId: String!, $limit: Int, $startDate: DateTime, $filter: String) {
+	buildLogs(deploymentId: $deploymentId, limit: $limit, startDate: $startDate, filter: $filter) {
 		...LogFields
 	}
 }

--- a/src/gql/queries/strings/DeploymentLogs.graphql
+++ b/src/gql/queries/strings/DeploymentLogs.graphql
@@ -1,7 +1,14 @@
 query DeploymentLogs($deploymentId: String!, $limit: Int) {
 	deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
-		message
-		timestamp
-        severity
+		...LogFields
+	}
+}
+
+fragment LogFields on Log {
+	timestamp
+	message
+	attributes {
+		key
+		value
 	}
 }

--- a/src/gql/queries/strings/DeploymentLogs.graphql
+++ b/src/gql/queries/strings/DeploymentLogs.graphql
@@ -1,5 +1,5 @@
-query DeploymentLogs($deploymentId: String!) {
-	deploymentLogs(deploymentId: $deploymentId, limit: 500) {
+query DeploymentLogs($deploymentId: String!, $limit: Int) {
+	deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
 		message
 		timestamp
         severity

--- a/src/gql/queries/strings/DeploymentLogs.graphql
+++ b/src/gql/queries/strings/DeploymentLogs.graphql
@@ -1,5 +1,5 @@
-query DeploymentLogs($deploymentId: String!, $limit: Int) {
-	deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
+query DeploymentLogs($deploymentId: String!, $limit: Int, $filter: String) {
+	deploymentLogs(deploymentId: $deploymentId, limit: $limit, filter: $filter) {
 		...LogFields
 	}
 }

--- a/src/gql/subscriptions/strings/BuildLogs.graphql
+++ b/src/gql/subscriptions/strings/BuildLogs.graphql
@@ -1,10 +1,14 @@
 subscription BuildLogs($deploymentId: String!, $filter: String, $limit: Int) {
-	buildLogs(deploymentId: $deploymentId, filter: $filter, limit: $limit) {
-		...LogFields
-	}
+  buildLogs(deploymentId: $deploymentId, filter: $filter, limit: $limit) {
+    ...LogFields
+  }
 }
 
 fragment LogFields on Log {
-	timestamp
-	message
+  timestamp
+  message
+  attributes {
+    key
+    value
+  }
 }

--- a/src/util/logs.rs
+++ b/src/util/logs.rs
@@ -1,4 +1,4 @@
-use crate::subscriptions;
+use crate::{queries, subscriptions};
 use colored::Colorize;
 
 // Trait for log types that have common fields (matches the one in commands/logs.rs)
@@ -60,7 +60,53 @@ pub fn format_attr_log<T: LogLike>(log: &T) {
     );
 }
 
+// Implementations for all the generated GraphQL log types
 impl LogLike for subscriptions::deployment_logs::LogFields {
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn timestamp(&self) -> &str {
+        &self.timestamp
+    }
+    fn attributes(&self) -> Vec<(&str, &str)> {
+        self.attributes
+            .iter()
+            .map(|a| (a.key.as_str(), a.value.as_str()))
+            .collect()
+    }
+}
+
+impl LogLike for queries::deployment_logs::LogFields {
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn timestamp(&self) -> &str {
+        &self.timestamp
+    }
+    fn attributes(&self) -> Vec<(&str, &str)> {
+        self.attributes
+            .iter()
+            .map(|a| (a.key.as_str(), a.value.as_str()))
+            .collect()
+    }
+}
+
+impl LogLike for subscriptions::build_logs::LogFields {
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn timestamp(&self) -> &str {
+        &self.timestamp
+    }
+    fn attributes(&self) -> Vec<(&str, &str)> {
+        self.attributes
+            .iter()
+            .map(|a| (a.key.as_str(), a.value.as_str()))
+            .collect()
+    }
+}
+
+impl LogLike for queries::build_logs::LogFields {
     fn message(&self) -> &str {
         &self.message
     }

--- a/src/util/logs.rs
+++ b/src/util/logs.rs
@@ -1,4 +1,4 @@
-use crate::{queries, subscriptions};
+use crate::subscriptions;
 use colored::Colorize;
 
 // Generic function to format logs from both queries and subscriptions
@@ -52,16 +52,8 @@ pub fn format_attr_log_impl(timestamp: &str, message: &str, attributes: &[(Strin
     );
 }
 
-// Wrapper for subscription logs
+// Wrapper for subscription logs (still used by up.rs)
 pub fn format_attr_log(log: subscriptions::deployment_logs::LogFields) {
-    let attributes: Vec<(String, String)> = log.attributes.iter()
-        .map(|a| (a.key.clone(), a.value.clone()))
-        .collect();
-    format_attr_log_impl(&log.timestamp, &log.message, &attributes);
-}
-
-// Wrapper for query logs
-pub fn format_query_log(log: queries::deployment_logs::LogFields) {
     let attributes: Vec<(String, String)> = log.attributes.iter()
         .map(|a| (a.key.clone(), a.value.clone()))
         .collect();

--- a/src/util/logs.rs
+++ b/src/util/logs.rs
@@ -10,15 +10,14 @@ pub trait LogLike {
     fn attributes(&self) -> Vec<(&str, &str)>;
 }
 
-// Generic function to format logs from any type implementing LogLike
-pub fn format_attr_log<T: LogLike>(log: &T) {
+// Format log attributes into a colored string for display
+pub fn format_attr_log_string<T: LogLike>(log: &T) -> String {
     let timestamp = log.timestamp();
     let message = log.message();
     let attributes = log.attributes();
     // we love inconsistencies!
     if attributes.is_empty() || (attributes.len() == 1 && attributes[0].0 == "level") {
-        println!("{}", message);
-        return;
+        return message.to_string();
     }
 
     let mut level: Option<String> = None;
@@ -53,17 +52,22 @@ pub fn format_attr_log<T: LogLike>(log: &T) {
             .bold()
         })
         .unwrap();
-    println!(
+    format!(
         "{} {} {} {}",
         timestamp.replace('"', "").normal(),
         level,
         message,
         others.join(" ")
-    );
+    )
 }
 
-// Helper function to print any log type
-pub fn print_log<T>(log: T, json: bool, use_formatted: bool)
+// Generic function to format logs from any type implementing LogLike
+pub fn format_attr_log<T: LogLike>(log: &T) {
+    println!("{}", format_attr_log_string(log));
+}
+
+// Format a log entry as a string based on output mode
+pub fn format_log_string<T>(log: T, json: bool, use_formatted: bool) -> String
 where
     T: LogLike + serde::Serialize,
 {
@@ -89,15 +93,22 @@ where
             map.insert(key.to_string(), parsed_value);
         }
 
-        let json_string = serde_json::to_string(&map).unwrap();
-        println!("{json_string}");
+        serde_json::to_string(&map).unwrap()
     } else if use_formatted {
         // For formatted non-JSON output
-        format_attr_log(&log);
+        format_attr_log_string(&log)
     } else {
         // Simple output (just the message)
-        println!("{}", log.message());
+        log.message().to_string()
     }
+}
+
+// Helper function to print any log type
+pub fn print_log<T>(log: T, json: bool, use_formatted: bool)
+where
+    T: LogLike + serde::Serialize,
+{
+    println!("{}", format_log_string(log, json, use_formatted));
 }
 
 // Implementations for all the generated GraphQL log types
@@ -158,5 +169,118 @@ impl LogLike for queries::build_logs::LogFields {
             .iter()
             .map(|a| (a.key.as_str(), a.value.as_str()))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test struct that implements LogLike for testing
+    #[derive(serde::Serialize)]
+    struct TestLog {
+        message: String,
+        timestamp: String,
+        attributes: Vec<(String, String)>,
+    }
+
+    impl LogLike for TestLog {
+        fn message(&self) -> &str {
+            &self.message
+        }
+        fn timestamp(&self) -> &str {
+            &self.timestamp
+        }
+        fn attributes(&self) -> Vec<(&str, &str)> {
+            self.attributes
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect()
+        }
+    }
+
+    #[test]
+    fn test_format_attr_log_no_attributes() {
+        let log = TestLog {
+            message: "Test message".to_string(),
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            attributes: vec![],
+        };
+
+        // Should only return the message
+        let output = format_attr_log_string(&log);
+        assert_eq!(output, "Test message");
+    }
+
+    #[test]
+    fn test_format_attr_log_only_level() {
+        let log = TestLog {
+            message: "Test message".to_string(),
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            attributes: vec![("level".to_string(), "info".to_string())],
+        };
+
+        // Should only return message when only attribute is level
+        let output = format_attr_log_string(&log);
+        assert_eq!(output, "Test message");
+    }
+
+    #[test]
+    fn test_format_attr_log_with_attributes() {
+        let log = TestLog {
+            message: "Test message".to_string(),
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            attributes: vec![
+                ("level".to_string(), "error".to_string()),
+                ("service".to_string(), "api".to_string()),
+                ("replica".to_string(), "xyz123".to_string()),
+            ],
+        };
+
+        // Should format with all attributes
+        let output = format_attr_log_string(&log);
+        // Check that output contains expected parts
+        assert!(output.contains("Test message"));
+        assert!(output.contains("2025-01-01T00:00:00Z"));
+        // The colored output makes exact matching harder, but we can check structure
+        assert!(output.contains("service"));
+        assert!(output.contains("api"));
+        assert!(output.contains("replica"));
+        assert!(output.contains("xyz123"));
+    }
+
+    #[test]
+    fn test_print_log_json_mode() {
+        let log = TestLog {
+            message: "Test message".to_string(),
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            attributes: vec![
+                ("level".to_string(), "warn".to_string()),
+                ("count".to_string(), "42".to_string()),
+            ],
+        };
+
+        // Test JSON output mode
+        let output = format_log_string(log, true, false);
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(json["message"], "Test message");
+        assert_eq!(json["timestamp"], "2025-01-01T00:00:00Z");
+        assert_eq!(json["level"], "warn");
+        assert_eq!(json["count"], 42); // This parses as a number
+    }
+
+    #[test]
+    fn test_print_log_simple_mode() {
+        let log = TestLog {
+            message: "Test message".to_string(),
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            attributes: vec![
+                ("level".to_string(), "info".to_string()),
+            ],
+        };
+
+        // Test simple output mode (json=false, use_formatted=false)
+        let output = format_log_string(log, false, false);
+        assert_eq!(output, "Test message");
     }
 }


### PR DESCRIPTION
# Why

I've felt a couple pains when using the CLI's log command during local dev:
- `logs` CLI command isn't terribly Claude Code friendly b/c it streams by default
- I can't use filters, e.g. just get the error logs from build
- I can't grab X logs

# What Changed

- `src/util/logs.rs` - common trait + formatters for logs
- update gql calls to add queries + request attributes everywhere
- add queries in `src/controllers/deployment.rs`
- `src/commands/logs.rs` - add `--filter`, `--limit` options

# Test Plan

- `nix-shell --run "cargo run -- login"`
- `nix-shell --run "cargo run -- link"`
- `nix-shell --run "cargo run -- logs"` streams deploy + should match current version of railway CLI output
- `nix-shell --run "cargo run -- logs --build"` same thing for build logs
- `nix-shell --run "cargo run -- logs -n 1"` doesn't streams and returns the latest log line
- `nix-shell --run "cargo run -- logs -n 2"` doesn't streams and returns the latest 2x log lines
- `nix-shell --run "cargo run -- logs -n 2 --filter "@level:error" ` doesn't streams and re
- `nix-shell --run "cargo run -- logs -n 2 --filter "@userId:22222" ` doesn't streams and returns the latest 2x log lines that have the userId tag


https://github.com/user-attachments/assets/bb923c1b-cc98-4f19-ad53-0ed95141a021

- slight behavior change `nix-shell --run "cargo run -- logs --build --json` now exposes all attributes (previously just level + timestamp). I think this is probably a helpful change