### PR TITLE
Improve `logs --help`

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -13,7 +13,7 @@ use super::{
     *,
 };
 
-/// View deployment logs from Railway services
+/// View a deploy's logs
 #[derive(Parser)]
 #[clap(after_help = "Examples:
   railway logs                                                      # Stream logs from linked service


### PR DESCRIPTION
Testing out https://github.com/railwayapp/cli/pull/669 w/ Claude Code and realized the docs could still be improved:

<img width="977" height="522" alt="image" src="https://github.com/user-attachments/assets/196f8c4f-4a24-4ff9-8ac1-324136222347" />

Clarified that `--filter` is for more than just attributes + added example w/ `AND`