### PR TITLE
Fix for `railway logs`: allow using deployment ID to look up failed build logs

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -114,7 +114,7 @@ pub async fn command(args: Args) -> Result<()> {
         .map(|deployment| deployment.node)
         .collect();
     all_deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-    let latest_deployment = all_deployments
+    let default_deployment = all_deployments
         .iter()
         .find(|d| d.status == DeploymentStatus::SUCCESS)
         .or_else(|| all_deployments.first())
@@ -124,12 +124,12 @@ pub async fn command(args: Args) -> Result<()> {
         // Use the provided deployment ID directly
         deployment_id
     } else {
-        latest_deployment.id.clone()
+        default_deployment.id.clone()
     };
 
     let show_build_logs = args.build
-        || (latest_deployment.status == DeploymentStatus::FAILED
-            && deployment_id == latest_deployment.id);
+        || (default_deployment.status == DeploymentStatus::FAILED
+            && deployment_id == default_deployment.id);
 
     if show_build_logs {
         if should_stream {


### PR DESCRIPTION
# Why

If you try to lookup logs for a failed deployment, the CLI won't let you:

<img width="687" height="85" alt="image" src="https://github.com/user-attachments/assets/ed0f571b-ce8f-438d-a152-9adf59f92d69" />

If you only have failed deploys, the CLI says there are no deployments:

<img width="984" height="89" alt="image" src="https://github.com/user-attachments/assets/78a0b72b-0ec2-4e7a-bbd7-b60ca2164c5d" />


# What Changed

- refactor the fetching logic so that we a) still have the "fallback to successful" logic, but b) we allow you to pass in whatever ID you want

# Test Plan

- `railway logs some-made-up-id` => should error w/ a 404
<img width="830" height="134" alt="image" src="https://github.com/user-attachments/assets/17f9046d-e178-4125-a644-987e94b34af1" />

- `railway logs some-real-failed-id` => should work

<img width="1058" height="165" alt="image" src="https://github.com/user-attachments/assets/f2d35e7f-a816-4e28-b384-3b3dc75a8631" />

- `railway logs ` when you only have a failed deploy => should work

<img width="992" height="307" alt="image" src="https://github.com/user-attachments/assets/ccc869c0-bd5c-4087-8977-d952a3253492" />


- `railway logs` when you only have a success + a failed deploy => should work and give you the success logs

<img width="964" height="162" alt="image" src="https://github.com/user-attachments/assets/2c34a212-6171-4af4-a578-bb8f08e6eaf7" />

