### PR TITLE
Improving railway docs for users and LLMs

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -114,7 +114,7 @@ pub async fn command(args: Args) -> Result<()> {
         .map(|deployment| deployment.node)
         .collect();
     all_deployments.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-    let latest_deployment = all_deployments
+    let default_deployment = all_deployments
         .iter()
         .find(|d| d.status == DeploymentStatus::SUCCESS)
         .or_else(|| all_deployments.first())
@@ -124,12 +124,12 @@ pub async fn command(args: Args) -> Result<()> {
         // Use the provided deployment ID directly
         deployment_id
     } else {
-        latest_deployment.id.clone()
+        default_deployment.id.clone()
     };
 
     let show_build_logs = args.build
-        || (latest_deployment.status == DeploymentStatus::FAILED
-            && deployment_id == latest_deployment.id);
+        || (default_deployment.status == DeploymentStatus::FAILED
+            && deployment_id == default_deployment.id);
 
     if show_build_logs {
         if should_stream {


### PR DESCRIPTION
```
View build or deploy logs from a Railway deployment. This will stream logs by default, or fetch historical logs if the --lines flag is provided.

Usage: railway logs [OPTIONS] [DEPLOYMENT_ID]

Arguments:
  [DEPLOYMENT_ID]
          Deployment ID to view logs from. Defaults to most recent successful deployment, or latest deployment if none succeeded

Options:
  -s, --service <SERVICE>
          Service to view logs from (defaults to linked service). Can be service name or service ID

  -e, --environment <ENVIRONMENT>
          Environment to view logs from (defaults to linked environment). Can be environment name or environment ID

  -d, --deployment
          Show deployment logs

  -b, --build
          Show build logs

      --json
          Output logs in JSON format. Each log line becomes a JSON object with timestamp, message, and any other attributes

  -n, --lines <LINES>
          Number of log lines to fetch (disables streaming). Default when specified without value: 500 lines
          
          [aliases: tail]

  -f, --filter <FILTER>
          Filter logs using Railway's query syntax
          
          Syntax: Text search: "error message" or "user signup" Attributes: @level:error, @level:warn Operators: AND, OR, - (not)
          
          Examples: "@level:error" - Only error logs "database AND timeout" - Logs containing both words "@level:warn OR @level:error" - Warnings and errors "-@level:info" - Exclude info logs
          
          See https://docs.railway.com/guides/logs for full syntax.

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

Examples:

  railway logs                                                       # Stream live logs from latest deployment
  railway logs --build 7422c95b-c604-46bc-9de4-b7a43e1fd53d          # Stream build logs from a specific deployment
  railway logs --lines 100                                           # Pull last 100 logs without streaming
  railway logs --service backend --environment production            # Stream latest deployment logs from a specific service in a specific environment
  railway logs --lines 10 --filter "@level:error"                    # View 10 latest error logs
  railway logs --lines 10 --filter "@level:warn AND rate limit"      # View 10 latest warning logs related to rate limiting
  railway logs --json                                                # Get logs in JSON format
```