### PR TITLE
Replace no longer maintained `paste` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,10 +1969,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -2149,7 +2149,7 @@ dependencies = [
  "notify",
  "num_cpus",
  "open",
- "paste",
+ "pastey",
  "pathdiff",
  "rand",
  "reqwest 0.12.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ chrono = { version = "0.4.39", features = [
   "clock",
 ], default-features = false }
 graphql_client = { version = "0.14.0", features = ["reqwest-rustls"] }
-paste = "1.0.15"
 tokio = { version = "1.42.0", features = ["full"] }
 clap_complete = "4.5.40"
 open = "5.3.1"
@@ -97,6 +96,7 @@ croner = "2.1.0"
 tokio-util = "0.7.15"
 similar = "2.7.0"
 pathdiff = "0.2.3"
+pastey = "0.1.1"
 
 [profile.release]
 lto = "fat"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! commands {
     ($($module:ident $(($($alias:ident),*))?),*) => {
-        paste::paste! {
+        pastey::paste! {
             /// Build the global CLI (root command) and attach module subcommands.
             pub fn build_args() -> clap::Command {
                 // Use your desired root name here (for example, "railway" rather than a derived name).


### PR DESCRIPTION
Addresses [`RUSTSEC-2024-0436`](https://rustsec.org/advisories/RUSTSEC-2024-0436.html). Replaces the unmaintained `paste` crate with the `pastey` crate.

Fixes https://github.com/railwayapp/cli/issues/599