### PR TITLE
Fix cronSchedule being unset during function push

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -79,3 +79,45 @@ pub async fn post_graphql<Q: GraphQLQuery, U: reqwest::IntoUrl>(
         Err(RailwayError::MissingResponseData)
     }
 }
+
+/// Like post_graphql, but removes null values from the variables object before sending.
+///
+/// This is needed because graphql-client 0.14.0 has a bug where skip_serializing_none
+/// doesn't work for root-level variables (only nested ones). This causes None values
+/// to be serialized as null, which tells the Railway API to unset fields.
+///
+/// By stripping nulls from the JSON, we ensure the API receives undefined instead,
+/// which preserves existing values (e.g., cron schedules on function updates).
+pub async fn post_graphql_skip_none<Q: GraphQLQuery, U: reqwest::IntoUrl>(
+    client: &reqwest::Client,
+    url: U,
+    variables: Q::Variables,
+) -> Result<Q::ResponseData, RailwayError> {
+    let body = Q::build_query(variables);
+
+    let mut body_json =
+        serde_json::to_value(&body).expect("Failed to serialize GraphQL query body");
+
+    if let Some(obj) = body_json.as_object_mut() {
+        if let Some(vars) = obj.get_mut("variables").and_then(|v| v.as_object_mut()) {
+            vars.retain(|_, v| !v.is_null());
+        }
+    }
+
+    let response = client.post(url).json(&body_json).send().await?;
+    if response.status() == 429 {
+        return Err(RailwayError::Ratelimited);
+    }
+    let res: GraphQLResponse<Q::ResponseData> = response.json().await?;
+    if let Some(errors) = res.errors {
+        if errors[0].message.to_lowercase().contains("not authorized") {
+            Err(RailwayError::Unauthorized)
+        } else {
+            Err(RailwayError::GraphQLError(errors[0].message.clone()))
+        }
+    } else if let Some(data) = res.data {
+        Ok(data)
+    } else {
+        Err(RailwayError::MissingResponseData)
+    }
+}

--- a/src/commands/functions/new.rs
+++ b/src/commands/functions/new.rs
@@ -337,7 +337,7 @@ async fn handle_function_change(
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
 
-    post_graphql::<mutations::FunctionUpdate, _>(
+    post_graphql_skip_none::<mutations::FunctionUpdate, _>(
         &client,
         configs.get_backboard(),
         mutations::function_update::Variables {

--- a/src/commands/functions/push.rs
+++ b/src/commands/functions/push.rs
@@ -54,7 +54,7 @@ async fn update_function(
     service_id: &str,
     start_command: String,
 ) -> Result<()> {
-    post_graphql::<mutations::FunctionUpdate, _>(
+    post_graphql_skip_none::<mutations::FunctionUpdate, _>(
         client,
         configs.get_backboard(),
         mutations::function_update::Variables {

--- a/src/gql/mutations/strings/FunctionUpdate.graphql
+++ b/src/gql/mutations/strings/FunctionUpdate.graphql
@@ -1,7 +1,17 @@
-mutation FunctionUpdate($environmentId: String!, $serviceId: String!, $startCommand: String, $cronSchedule: String, $sleepApplication: Boolean) {
+mutation FunctionUpdate(
+  $environmentId: String!
+  $serviceId: String!
+  $startCommand: String
+  $cronSchedule: String
+  $sleepApplication: Boolean
+) {
   serviceInstanceUpdate(
     environmentId: $environmentId
     serviceId: $serviceId
-    input: {cronSchedule: $cronSchedule, sleepApplication: $sleepApplication, startCommand: $startCommand}
+    input: {
+      cronSchedule: $cronSchedule
+      sleepApplication: $sleepApplication
+      startCommand: $startCommand
+    }
   )
 }


### PR DESCRIPTION
Fixes cronSchedule and sleepApplication being unset when running `railway functions push`.

The graphql-client crate v0.14.0 has a bug where `skip_serializing_none` doesn't work for root-level variables (only nested ones). This caused `None` values to serialize as `null` instead of being omitted, which told the API to explicitly unset fields like cronSchedule.

Added `post_graphql_skip_none` helper that strips null values from the variables object before sending to the API, ensuring fields are omitted (undefined) rather than explicitly cleared (null).