### PR TITLE
bug(environment.ts) Split variable definitions on "=" at into at most two parts

### DIFF
--- a/src/commands/environment.rs
+++ b/src/commands/environment.rs
@@ -376,7 +376,11 @@ fn select_service_variables_new(
                                 || (s.node.name.to_lowercase() == service.to_lowercase())
                         })
                         .map(|s| (s.node.id.clone(), s.node.name.clone()));
-                    let variable = chunk.last().unwrap().split('=').collect::<Vec<&str>>();
+                    let variable = chunk.last().unwrap().splitn(2, '=').collect::<Vec<&str>>();
+                    if variable.len() != 2 || variable[1].is_empty() {
+                        println!("{}: Invalid variable format", "Error".red().bold());
+                        std::process::exit(1);
+                    }
                     if service_meta.is_none() {
                         println!(
                             "{}: Service {} not found",
@@ -428,7 +432,7 @@ fn select_service_variables_new(
                             "<KEY=VALUE, press esc to skip>",
                         )?;
                         if let Some(variable) = variable {
-                            let variable = variable.split('=').collect::<Vec<&str>>();
+                            let variable = variable.splitn(2, '=').collect::<Vec<&str>>();
                             if variable.len() != 2 || variable[1].is_empty() {
                                 println!("{}: Invalid variable format", "Warn".yellow().bold());
                                 continue;


### PR DESCRIPTION
Fixes incorrect parsing of variables whose values contain `=` when invoking `railway environment new -d foo --service-variable bar BAZ=quux=corge`.

Current behavior: in the new environment, BAZ will be set to "corge"
Desired behavior: in the new environment, BAZ will be set to "quux=corge"

Context here is that I discovered this issue while trying to set `DATABASE_URL=<URL for a new Neon branch>` and the URL ended with some query parameters ("channel_binding=require"), and to my surprise my new environment's DATABASE_URL was being set to "require".
