### PR TITLE
Fix the behavior of the `railway completion` command

### DIFF
--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -12,12 +12,7 @@ pub struct Args {
 pub async fn command(args: Args) -> Result<()> {
     let mut railway = crate::build_args();
 
-    generate(
-        args.shell,
-        &mut railway,
-        "railway",
-        &mut io::stdout(),
-    );
+    generate(args.shell, &mut railway, "railway", &mut io::stdout());
 
     Ok(())
 }


### PR DESCRIPTION
Fixes the behavior of `railway completion <shell>` to actually generate the completions from the entire CLI and not from `railway completion` itself.