### PR TITLE
Fixes some typos

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -291,7 +291,7 @@ async fn create_service(
     configs.link_service(s.service_create.id)?;
     configs.write()?;
     spinner.finish_with_message(format!(
-        "Succesfully created the service \"{}\" and linked to it",
+        "Successfully created the service \"{}\" and linked to it",
         s.service_create.name.blue()
     ));
     Ok(())

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -229,7 +229,7 @@ mod test {
     fn test_is_tcp_proxy() {
         assert!(host_is_tcp_proxy("roundhouse.proxy.rlwy.net".to_string()));
         assert!(!host_is_tcp_proxy("localhost".to_string()));
-        assert!(!host_is_tcp_proxy("postgres.railway.interal".to_string()));
+        assert!(!host_is_tcp_proxy("postgres.railway.internal".to_string()));
     }
 
     #[test]

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -110,7 +110,7 @@ async fn create_service_domain(service_name: Option<String>, json: bool) -> Resu
 }
 
 fn print_existing_domains(domains: &DomainsDomains) -> Result<()> {
-    println!("Domains already exists on the service:");
+    println!("Domains already exist on the service:");
     let domain_count = domains.service_domains.len() + domains.custom_domains.len();
 
     if domain_count == 1 {

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -265,7 +265,7 @@ structstruck::strike! {
 }
 
 // unfortunately, due to the graphql client returning 3 different types for some reason (despite them all being identical)
-// we need to write 3 match arms to convert it to our normaliesd project type
+// we need to write 3 match arms to convert it to our normalised project type
 impl From<Project> for NormalisedProject {
     fn from(value: Project) -> Self {
         match value {

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -138,7 +138,7 @@ async fn attach(
                 .iter()
                 .find(|a| a.node.id == volume.service_id.clone().unwrap_or_default())
                 .ok_or(anyhow!(
-                    "The service the volume is attcahed to doesn't exist"
+                    "The service the volume is attached to doesn't exist"
                 ))?
                 .node
                 .name
@@ -200,7 +200,7 @@ async fn detach(
         .iter()
         .find(|a| a.node.id == volume.service_id.clone().unwrap_or_default())
         .ok_or(anyhow!(
-            "The service the volume is attcahed to doesn't exist"
+            "The service the volume is attached to doesn't exist"
         ))?;
     let confirm = prompt_confirm_with_default(
         format!(
@@ -268,7 +268,7 @@ async fn update(
         .await?;
 
         println!(
-            "Succesfully updated the mount path of volume \"{}\" to \"{}\"",
+            "Successfully updated the mount path of volume \"{}\" to \"{}\"",
             volume.0.volume.name.blue(),
             mount_path.purple()
         );
@@ -286,7 +286,7 @@ async fn update(
         .await?;
 
         println!(
-            "Succesfully updated the name of volume \"{}\" to \"{}\"",
+            "Successfully updated the name of volume \"{}\" to \"{}\"",
             volume.0.volume.name.blue(),
             name.purple()
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ commands!(
 
 fn spawn_update_task() -> tokio::task::JoinHandle<anyhow::Result<Option<String>>> {
     tokio::spawn(async move {
-        // outputtng would break json output on CI
+        // outputting would break json output on CI
         if !std::io::stdout().is_terminal() {
             anyhow::bail!("Stdout is not a terminal");
         }


### PR DESCRIPTION
This PR fixes some typos in:
- user-facing messages
- one proxy check - I checked that it is indeed `postgres.railway.internal` in your docs
- some comments