### PR TITLE
Inject mkcert CA env vars for code services when HTTPS enabled

### DIFF
--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -19,9 +19,9 @@ use crate::{
             build_slug_port_mapping, certs_exist, check_docker_compose_installed,
             check_mkcert_installed, ensure_mkcert_ca, generate_caddyfile, generate_certs,
             generate_port, generate_random_port, get_compose_path as develop_get_compose_path,
-            get_develop_dir, get_existing_certs, is_port_443_available, is_project_proxy_on_443,
-            override_railway_vars, print_context_info, print_domain_info, print_log_line,
-            resolve_path, slugify, volume_name,
+            get_develop_dir, get_existing_certs, inject_mkcert_ca_vars, is_port_443_available,
+            is_project_proxy_on_443, override_railway_vars, print_context_info, print_domain_info,
+            print_log_line, resolve_path, slugify, volume_name,
         },
         project::{self, ensure_project_and_environment_exist},
         variables::get_service_variables,
@@ -1194,6 +1194,10 @@ async fn up_command(args: UpArgs) -> Result<()> {
         // Only set PORT if service has networking configured
         if let Some(port) = internal_port {
             vars.insert("PORT".to_string(), port.to_string());
+        }
+
+        if ctx.https_enabled() {
+            inject_mkcert_ca_vars(&mut vars);
         }
 
         print_code_service_summary(

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,6 +3,7 @@ use is_terminal::IsTerminal;
 
 use crate::{
     controllers::{
+        develop::variables::inject_mkcert_ca_vars,
         environment::get_matched_environment,
         local_override::{
             apply_local_overrides, build_local_override_context, is_local_develop_active,
@@ -116,6 +117,9 @@ pub async fn command(args: Args) -> Result<()> {
             build_local_override_context(&client, &configs, &project, &environment_id).await?;
 
         variables = apply_local_overrides(variables, &service, &ctx);
+        if ctx.https_enabled() {
+            inject_mkcert_ca_vars(&mut variables);
+        }
         eprintln!("{}", "Using local develop services".yellow());
     }
 

--- a/src/controllers/develop/https_proxy.rs
+++ b/src/controllers/develop/https_proxy.rs
@@ -67,6 +67,21 @@ pub fn ensure_mkcert_ca() -> Result<()> {
     Ok(())
 }
 
+/// Get the mkcert CA root directory if available.
+/// Returns None if mkcert is not installed or the CA root doesn't exist.
+pub fn get_mkcert_ca_root() -> Option<PathBuf> {
+    Command::new("mkcert")
+        .arg("-CAROOT")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| {
+            let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            let path = PathBuf::from(path);
+            path.join("rootCA.pem").exists().then_some(path)
+        })
+}
+
 /// Check if certs already exist for a project with the required type
 pub fn certs_exist(output_dir: &Path, use_port_443: bool) -> bool {
     let cert_path = output_dir.join("cert.pem");


### PR DESCRIPTION
Node, Python, and other runtimes bundle their own CA stores instead of using the system store. This injects CA environment variables for code services when HTTPS is enabled, allowing these runtimes to trust mkcert certificates.

- Adds `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `SSL_CERT_DIR` pointing to mkcert's root CA
- Only injects when HTTPS is enabled and mkcert is installed
- Uses `.entry().or_insert()` to avoid overwriting user-defined vars
- Silently falls back if mkcert unavailable or CA root doesn't exist