### PR TITLE
Use OIDC Trusted Publisher for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,31 +199,22 @@ jobs:
     name: Publish NPM
     needs: ["create-release", "build-release", "publish-release"]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
 
-      - name: Setup Git user
-        run: |
-          git config --global user.name "Github Bot"
-          git config --global user.email "github-bot@railway.app"
-
-      - name: Create .npmrc file
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: NPM publish
-        run: npm publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
   notify-release:
     name: Notify Release


### PR DESCRIPTION
## Summary
- Replace NPM_TOKEN secret with OIDC-based Trusted Publisher authentication
- Update actions/setup-node from v1 to v4
- Add `--provenance` flag for supply chain attestation