### PR TITLE
Add workspace info to list --json output

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::workspace::workspaces;
+use crate::workspace::{ProjectWithWorkspace, workspaces};
 
 /// List all projects in your Railway account
 #[derive(Parser)]
@@ -14,17 +14,14 @@ pub async fn command(args: Args) -> Result<()> {
     let linked_project = configs.get_linked_project().await.ok();
 
     let workspaces = workspaces().await?;
-    let mut all_projects = Vec::new();
+    let mut all_projects: Vec<ProjectWithWorkspace> = Vec::new();
 
     for workspace in workspaces {
         if !args.json {
             println!();
             println!("{}", workspace.name().bold());
-        }
 
-        let projects = workspace.projects();
-        if !args.json {
-            for project in &projects {
+            for project in workspace.projects() {
                 let project_name =
                     if Some(project.id()) == linked_project.as_ref().map(|p| p.project.as_str()) {
                         project.name().purple().bold()
@@ -35,7 +32,7 @@ pub async fn command(args: Args) -> Result<()> {
             }
         }
 
-        all_projects.extend(projects);
+        all_projects.extend(workspace.projects_with_workspace());
     }
 
     if args.json {

--- a/src/gql/queries/strings/UserProjects.graphql
+++ b/src/gql/queries/strings/UserProjects.graphql
@@ -42,7 +42,7 @@ query UserProjects {
       team {
         id
       }
-      projects {
+      projects(first: 500) {
         edges {
           node {
             id

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -76,6 +76,20 @@ impl Workspace {
         projects.sort_by_key(|b| std::cmp::Reverse(b.updated_at()));
         projects
     }
+
+    pub fn projects_with_workspace(&self) -> Vec<ProjectWithWorkspace> {
+        let workspace_info = WorkspaceInfo {
+            id: self.id().to_string(),
+            name: self.name().to_string(),
+        };
+        self.projects()
+            .into_iter()
+            .map(|project| ProjectWithWorkspace {
+                workspace: workspace_info.clone(),
+                project,
+            })
+            .collect()
+    }
 }
 
 impl Display for Workspace {
@@ -129,4 +143,17 @@ impl Display for Project {
             Self::External(project) => write!(f, "{}", project.name),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceInfo {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectWithWorkspace {
+    pub workspace: WorkspaceInfo,
+    #[serde(flatten)]
+    pub project: Project,
 }


### PR DESCRIPTION
Include nested workspace object (id and name) for each project in `railway list --json` output. Previously, projects were returned as a flat list with no way to identify which workspace they belonged to.

- Add `WorkspaceInfo` and `ProjectWithWorkspace` structs to workspace.rs
- Add `projects_with_workspace()` method to `Workspace`
- Update list command to use new types for JSON output
- Add pagination (first: 500) to member workspace projects query