### PR TITLE
Fix npm OIDC publishing by removing registry-url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
 
       - name: NPM publish
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Remove `registry-url` from setup-node in npm publish job
- `setup-node` with `registry-url` creates an `.npmrc` expecting `NODE_AUTH_TOKEN`, which conflicts with OIDC trusted publisher flow
- Without it, npm handles OIDC authentication directly via `--provenance` flag

