### PR TITLE
ci: Add automated release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,60 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  create-release:
+    name: Bump Version & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-release
+        run: cargo install cargo-release
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and create tag
+        id: bump
+        run: |
+          # Get current version
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "Current version: $CURRENT_VERSION"
+
+          # Run cargo release (bumps version, updates package.json, commits, tags)
+          cargo release ${{ inputs.bump }} --no-publish --no-push --no-confirm --execute
+
+          # Get new version
+          NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Push changes and tag
+        run: |
+          git push origin master
+          git push origin "v${{ steps.bump.outputs.version }}"


### PR DESCRIPTION
## Summary
- Adds `create-release.yml` workflow for automated CLI releases
- Trigger via workflow_dispatch with version bump type (patch/minor/major)
- Bumps version in Cargo.toml + package.json, commits, tags, publishes to crates.io, then pushes
- The tag push triggers the existing `release.yml` workflow for binary builds, GitHub release, NPM publish, etc.

## Usage
Actions → "Create Release" → Run workflow → Select bump type → Go

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with a patch release after merge

🤖 Generated with [Claude Code](https://claude.ai/code)