### PR TITLE
ci: Fix npm publish auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,9 +211,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: NPM publish
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   notify-release:
     name: Notify Release


### PR DESCRIPTION
## Summary
Fixes npm publish [failing](https://github.com/railwayapp/cli/actions/runs/20825584606/job/59826662418) with `ENEEDAUTH` by:
- Adding `registry-url` to `setup-node` action
- Passing `NODE_AUTH_TOKEN` env var to the publish step

## Required
Add `NPM_TOKEN` secret to the repo (npmjs.com → Access Tokens → Granular Access Token with publish permission for `@railway/cli`)

## Test plan
- [ ] Add NPM_TOKEN secret
- [ ] Re-run failed 4.18.0 npm publish job, or trigger a new release

🤖 Generated with [Claude Code](https://claude.ai/code)