### PR TITLE
fix: honor --json flag in variables and deployment list commands

### DIFF
--- a/src/commands/deployment.rs
+++ b/src/commands/deployment.rs
@@ -160,41 +160,42 @@ async fn list_deployments(
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&output)?);
-    } else {
-        if deployments.is_empty() {
-            println!("No deployments found");
-            return Ok(());
-        }
+        return Ok(());
+    }
 
-        println!("{}", "Recent Deployments".bold());
+    if deployments.is_empty() {
+        println!("No deployments found");
+        return Ok(());
+    }
 
-        for deployment in deployments {
-            let status_colored = match deployment.status {
-                DeploymentStatus::SUCCESS => format!("{:?}", deployment.status).green(),
-                DeploymentStatus::FAILED | DeploymentStatus::CRASHED => {
-                    format!("{:?}", deployment.status).red()
-                }
-                DeploymentStatus::BUILDING
-                | DeploymentStatus::DEPLOYING
-                | DeploymentStatus::INITIALIZING
-                | DeploymentStatus::WAITING
-                | DeploymentStatus::QUEUED => format!("{:?}", deployment.status).blue(),
-                DeploymentStatus::REMOVED | DeploymentStatus::REMOVING => {
-                    format!("{:?}", deployment.status).dimmed()
-                }
-                _ => format!("{:?}", deployment.status).white(),
-            };
+    println!("{}", "Recent Deployments".bold());
 
-            // Convert UTC time to local timezone
-            let local_time: DateTime<Local> = DateTime::from(deployment.created_at);
-            let created_at = local_time.format("%Y-%m-%d %H:%M:%S %Z");
-            println!(
-                "  {} | {} | {}",
-                deployment.id,
-                status_colored,
-                created_at.to_string().dimmed()
-            );
-        }
+    for deployment in deployments {
+        let status_colored = match deployment.status {
+            DeploymentStatus::SUCCESS => format!("{:?}", deployment.status).green(),
+            DeploymentStatus::FAILED | DeploymentStatus::CRASHED => {
+                format!("{:?}", deployment.status).red()
+            }
+            DeploymentStatus::BUILDING
+            | DeploymentStatus::DEPLOYING
+            | DeploymentStatus::INITIALIZING
+            | DeploymentStatus::WAITING
+            | DeploymentStatus::QUEUED => format!("{:?}", deployment.status).blue(),
+            DeploymentStatus::REMOVED | DeploymentStatus::REMOVING => {
+                format!("{:?}", deployment.status).dimmed()
+            }
+            _ => format!("{:?}", deployment.status).white(),
+        };
+
+        // Convert UTC time to local timezone
+        let local_time: DateTime<Local> = DateTime::from(deployment.created_at);
+        let created_at = local_time.format("%Y-%m-%d %H:%M:%S %Z");
+        println!(
+            "  {} | {} | {}",
+            deployment.id,
+            status_colored,
+            created_at.to_string().dimmed()
+        );
     }
 
     Ok(())

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -97,11 +97,6 @@ pub async fn command(args: Args) -> Result<()> {
     )
     .await?;
 
-    if variables.is_empty() {
-        eprintln!("No variables found");
-        return Ok(());
-    }
-
     if args.kv {
         for (key, value) in variables {
             println!("{key}={value}");
@@ -111,6 +106,11 @@ pub async fn command(args: Args) -> Result<()> {
 
     if args.json {
         println!("{}", serde_json::to_string_pretty(&variables)?);
+        return Ok(());
+    }
+
+    if variables.is_empty() {
+        eprintln!("No variables found");
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
- `variables`: output `{}` when empty in json mode  
- `deployment list`: output `[]` when empty in json mode


Partially addresses #722 (domain already fixed in #727)