### PR TITLE
ci: Use RELEASE_TOKEN for branch protection bypass

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
Fixes the Create Release workflow failing to push to protected `master` branch.

`GITHUB_TOKEN` cannot bypass branch protection rules. Uses `RELEASE_TOKEN` (a PAT) instead.

## Required
Create a Personal Access Token with `repo` scope and add it as `RELEASE_TOKEN` secret:
1. https://github.com/settings/tokens → Generate new token (classic)
2. Select `repo` scope
3. Add to repo secrets as `RELEASE_TOKEN`

🤖 Generated with [Claude Code](https://claude.ai/code)