### PR TITLE
ci: add registry-url for npm OIDC trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: NPM publish
         run: npm publish --access public --provenance


### PR DESCRIPTION
The `registry-url` parameter is required for setup-node to configure `.npmrc` for OIDC token exchange with npm trusted publishers. Without it, the publish fails because npm has no way to authenticate via OIDC.