### PR TITLE
fix: Show error when deployment cannot be redeployed

### DIFF
--- a/src/commands/redeploy.rs
+++ b/src/commands/redeploy.rs
@@ -91,6 +91,12 @@ pub async fn command(args: Args) -> Result<()> {
                 "The latest deployment from service {} has been redeployed",
                 service.node.name.green()
             ));
+        } else {
+            bail!(
+                "The latest deployment for service {} cannot be redeployed. \
+                This may be because it's currently building, deploying, or was removed.",
+                service.node.name
+            );
         }
     } else {
         bail!("No deployment found for service")


### PR DESCRIPTION
## Summary
- Fixes silent failure in `railway redeploy` when `can_redeploy` is false
- Now shows a helpful error message explaining the deployment cannot be redeployed

**Before:** Command silently exits with success
**After:** Shows error: "The latest deployment for service X cannot be redeployed. This may be because it's currently building, deploying, or was removed."

## Test plan
- [x] Build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)