### PR TITLE
feat: Add `railway delete` command for project deletion

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub fn get_dynamic_args(cmd: clap::Command) -> clap::Command {
 pub mod add;
 pub mod completion;
 pub mod connect;
+pub mod delete;
 pub mod deploy;
 pub mod deployment;
 pub mod dev;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -41,6 +41,14 @@ pub struct ProjectCreate;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/ProjectDelete.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ProjectDelete;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/ServiceDomainCreate.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/mutations/strings/ProjectDelete.graphql
+++ b/src/gql/mutations/strings/ProjectDelete.graphql
@@ -1,0 +1,3 @@
+mutation ProjectDelete($id: String!) {
+  projectDelete(id: $id)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ commands!(
     add,
     completion,
     connect,
+    delete,
     deploy,
     deployment,
     dev(develop),


### PR DESCRIPTION
## Summary
- Adds a new `delete` command that allows users to delete projects from the CLI
- Interactive project selection when no project specified
- Confirmation prompt before deletion (can be skipped with `-y`/`--yes`)
- 2FA support for users with two-factor authentication enabled

## Test plan
- [ ] Test `railway delete` with interactive project selection
- [ ] Test `railway delete --project <name>` with project name
- [ ] Test `railway delete --project <id>` with project ID
- [ ] Test `railway delete --project <name> --yes` to skip confirmation
- [ ] Test non-interactive mode requires `--project` and `--yes`
- [ ] Test 2FA prompt appears for users with 2FA enabled

Closes #695

🤖 Generated with [Claude Code](https://claude.ai/code)