### PR TITLE
feat: Add `local` alias for `railway run` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ commands!(
     logout,
     logs,
     open,
-    run,
+    run(local),
     service,
     shell,
     ssh,


### PR DESCRIPTION
## Summary
- Adds `railway local` as an alias for `railway run`
- Makes it clearer that the command runs locally with Railway env vars injected
- Addresses confusion from users coming from Heroku where `run` executes on their servers

## Example
```bash
# These are now equivalent:
railway run npm start
railway local npm start
```

## Test plan
- [ ] Test `railway local <cmd>` works the same as `railway run <cmd>`
- [ ] Test `railway local --help` shows correct help
- [ ] Test existing `railway run` behavior unchanged

Closes #715

🤖 Generated with [Claude Code](https://claude.ai/code)