### PR TITLE
feat: Add --restart flag to redeploy for container restart without rebuild

### DIFF
--- a/src/commands/redeploy.rs
+++ b/src/commands/redeploy.rs
@@ -1,4 +1,5 @@
 use colored::*;
+use futures::StreamExt;
 use std::time::Duration;
 
 use crate::{
@@ -7,6 +8,8 @@ use crate::{
         ensure_project_and_environment_exist, find_service_instance, get_project,
     },
     errors::RailwayError,
+    subscription::subscribe_graphql,
+    subscriptions::deployment::DeploymentStatus,
     util::prompt::prompt_confirm_with_default,
 };
 
@@ -23,6 +26,10 @@ pub struct Args {
     /// Skip confirmation dialog
     #[clap(short = 'y', long = "yes")]
     bypass: bool,
+
+    /// Restart the deployment without pulling a new image (useful for refreshing external resources)
+    #[clap(long)]
+    restart: bool,
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -49,57 +56,159 @@ pub async fn command(args: Args) -> Result<()> {
             || anyhow!("The service specified doesn't exist in the current environment"),
         )?;
 
-    if let Some(ref latest) = service_in_env.latest_deployment {
-        if latest.can_redeploy {
-            if !args.bypass {
-                let confirmed = prompt_confirm_with_default(
-                    format!(
-                        "Redeploy the latest deployment from service {} in environment {}?",
-                        service.node.name,
-                        linked_project
-                            .environment_name
-                            .unwrap_or("unknown".to_string())
-                    )
-                    .as_str(),
-                    false,
-                )?;
+    let Some(ref latest) = service_in_env.latest_deployment else {
+        bail!("No deployment found for service")
+    };
 
-                if !confirmed {
-                    return Ok(());
+    if args.restart {
+        if !args.bypass {
+            let confirmed = prompt_confirm_with_default(
+                format!(
+                    "Restart the latest deployment from service {} in environment {}?",
+                    service.node.name,
+                    linked_project
+                        .environment_name
+                        .clone()
+                        .unwrap_or("unknown".to_string())
+                )
+                .as_str(),
+                false,
+            )?;
+
+            if !confirmed {
+                return Ok(());
+            }
+        }
+
+        let spinner = indicatif::ProgressBar::new_spinner()
+            .with_style(
+                indicatif::ProgressStyle::default_spinner()
+                    .tick_chars(TICK_STRING)
+                    .template("{spinner:.green} {msg}")?,
+            )
+            .with_message(format!(
+                "Restarting the latest deployment from service {}...",
+                service.node.name
+            ));
+        spinner.enable_steady_tick(Duration::from_millis(100));
+
+        post_graphql::<mutations::DeploymentRestart, _>(
+            &client,
+            configs.get_backboard(),
+            mutations::deployment_restart::Variables {
+                id: latest.id.clone(),
+            },
+        )
+        .await?;
+
+        spinner.set_message(format!(
+            "Waiting for deployment from service {} to be healthy...",
+            service.node.name
+        ));
+
+        let mut stream =
+            subscribe_graphql::<subscriptions::Deployment>(subscriptions::deployment::Variables {
+                id: latest.id.clone(),
+            })
+            .await?;
+
+        while let Some(Ok(res)) = stream.next().await {
+            if let Some(errors) = res.errors {
+                spinner.finish_with_message(format!(
+                    "Failed to get deployment status: {}",
+                    errors
+                        .iter()
+                        .map(|err| err.to_string())
+                        .collect::<Vec<String>>()
+                        .join("; ")
+                ));
+                bail!("Failed to get deployment status");
+            }
+            if let Some(data) = res.data {
+                match data.deployment.status {
+                    DeploymentStatus::SUCCESS => {
+                        spinner.finish_with_message(format!(
+                            "The latest deployment from service {} has been restarted and is healthy",
+                            service.node.name.green()
+                        ));
+                        return Ok(());
+                    }
+                    DeploymentStatus::FAILED => {
+                        spinner.finish_with_message(format!(
+                            "Deployment from service {} failed",
+                            service.node.name.red()
+                        ));
+                        bail!("Deployment failed");
+                    }
+                    DeploymentStatus::CRASHED => {
+                        spinner.finish_with_message(format!(
+                            "Deployment from service {} crashed",
+                            service.node.name.red()
+                        ));
+                        bail!("Deployment crashed");
+                    }
+                    _ => {}
                 }
             }
-            let spinner = indicatif::ProgressBar::new_spinner()
-                .with_style(
-                    indicatif::ProgressStyle::default_spinner()
-                        .tick_chars(TICK_STRING)
-                        .template("{spinner:.green} {msg}")?,
-                )
-                .with_message(format!(
-                    "Redeploying the latest deployment from service {}...",
-                    service.node.name
-                ));
-            spinner.enable_steady_tick(Duration::from_millis(100));
-            post_graphql::<mutations::DeploymentRedeploy, _>(
-                &client,
-                configs.get_backboard(),
-                mutations::deployment_redeploy::Variables {
-                    id: latest.id.clone(),
-                },
-            )
-            .await?;
-            spinner.finish_with_message(format!(
-                "The latest deployment from service {} has been redeployed",
-                service.node.name.green()
-            ));
-        } else {
+        }
+
+        spinner.finish_with_message(format!(
+            "The latest deployment from service {} has been restarted",
+            service.node.name.green()
+        ));
+    } else {
+        if !latest.can_redeploy {
             bail!(
                 "The latest deployment for service {} cannot be redeployed. \
                 This may be because it's currently building, deploying, or was removed.",
                 service.node.name
             );
         }
-    } else {
-        bail!("No deployment found for service")
+
+        if !args.bypass {
+            let confirmed = prompt_confirm_with_default(
+                format!(
+                    "Redeploy the latest deployment from service {} in environment {}?",
+                    service.node.name,
+                    linked_project
+                        .environment_name
+                        .unwrap_or("unknown".to_string())
+                )
+                .as_str(),
+                false,
+            )?;
+
+            if !confirmed {
+                return Ok(());
+            }
+        }
+
+        let spinner = indicatif::ProgressBar::new_spinner()
+            .with_style(
+                indicatif::ProgressStyle::default_spinner()
+                    .tick_chars(TICK_STRING)
+                    .template("{spinner:.green} {msg}")?,
+            )
+            .with_message(format!(
+                "Redeploying the latest deployment from service {}...",
+                service.node.name
+            ));
+        spinner.enable_steady_tick(Duration::from_millis(100));
+
+        post_graphql::<mutations::DeploymentRedeploy, _>(
+            &client,
+            configs.get_backboard(),
+            mutations::deployment_redeploy::Variables {
+                id: latest.id.clone(),
+            },
+        )
+        .await?;
+
+        spinner.finish_with_message(format!(
+            "The latest deployment from service {} has been redeployed",
+            service.node.name.green()
+        ));
     }
+
     Ok(())
 }

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -139,6 +139,15 @@ pub struct DeploymentRedeploy;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/DeploymentRestart.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct DeploymentRestart;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/VariableCollectionUpsert.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/strings/DeploymentRestart.graphql
+++ b/src/gql/mutations/strings/DeploymentRestart.graphql
@@ -1,0 +1,3 @@
+mutation DeploymentRestart($id: String!) {
+  deploymentRestart(id: $id)
+}


### PR DESCRIPTION
## Summary
- Adds `--restart` flag to the `redeploy` command
- Restarts the container without pulling a new image (uses `deploymentRestart` API)
- Waits for the deployment to become healthy before returning
- Useful for CI/CD when external resources (like S3 files) are updated

## Usage
```bash
# Restart and wait for healthy
railway redeploy --restart

# Skip confirmation
railway redeploy --restart -y

# Specific service
railway redeploy --restart --service my-service
```

## Test plan
- [ ] Test `railway redeploy --restart` restarts without rebuild
- [ ] Test it waits for deployment to become healthy
- [ ] Test it handles FAILED/CRASHED states appropriately
- [ ] Test existing `railway redeploy` behavior unchanged

Closes #616

🤖 Generated with [Claude Code](https://claude.ai/code)