### PR TITLE
fix: Handle missing linked service in status command gracefully

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -35,13 +35,19 @@ pub async fn command(args: Args) -> Result<()> {
         );
 
         if let Some(linked_service) = linked_project.service {
-            let service = project
+            if let Some(service) = project
                 .services
                 .edges
                 .iter()
                 .find(|service| service.node.id == linked_service)
-                .expect("the linked service doesn't exist");
-            println!("Service: {}", service.node.name.green().bold());
+            {
+                println!("Service: {}", service.node.name.green().bold());
+            } else {
+                println!(
+                    "Service: {} (not found in project, run `railway service` to relink)",
+                    linked_service.yellow().bold()
+                );
+            }
         } else {
             println!("Service: {}", "None".red().bold())
         }


### PR DESCRIPTION
## Summary
- Fixes a panic in `railway status` when the linked service no longer exists in the project
- Now shows a helpful message instead of crashing

## Before
```
thread 'main' panicked at 'the linked service doesn't exist'
```

## After
```
Service: abc123 (not found in project, run `railway service` to relink)
```

## Test plan
- [ ] Link to a service, delete it via web UI, run `railway status`
- [ ] Verify normal status output still works

🤖 Generated with [Claude Code](https://claude.ai/code)