### PR TITLE
fix: Improve InvalidRailwayToken error message

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ pub enum RailwayError {
     #[error("Unauthorized. Please login with `railway login`")]
     Unauthorized,
 
-    #[error("Unauthorized")]
+    #[error("Invalid RAILWAY_TOKEN. Please check that your token is valid and has not expired")]
     InvalidRailwayToken,
 
     #[error("Login state is corrupt. Please logout and login back in.")]


### PR DESCRIPTION
## Summary
- Improve the `InvalidRailwayToken` error message from generic "Unauthorized" to actionable "Invalid RAILWAY_TOKEN. Please check that your token is valid and has not expired"

## Test plan
- [ ] Verify error message is clearer when using an invalid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)