### PR TITLE
fix: Run release directly in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -74,22 +74,29 @@ jobs:
             sleep 30
           done
 
-      # Check if another release workflow is running
-      - name: Check for running release workflows
+      # Check if another release is in progress
+      - name: Check for running releases
+        id: check-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Check if create-release workflow is currently running
-          RUNNING=$(gh api repos/${{ github.repository }}/actions/workflows/create-release.yml/runs \
-            --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length')
+          # Check if auto-release or create-release workflow is currently running (excluding this run)
+          AUTO_RUNNING=$(gh api repos/${{ github.repository }}/actions/workflows/auto-release.yml/runs \
+            --jq "[.workflow_runs[] | select(.status == \"in_progress\" and .id != ${{ github.run_id }})] | length")
 
-          if [ "$RUNNING" -gt "0" ]; then
+          CREATE_RUNNING=$(gh api repos/${{ github.repository }}/actions/workflows/create-release.yml/runs \
+            --jq '[.workflow_runs[] | select(.status == "in_progress" or .status == "queued")] | length' 2>/dev/null || echo "0")
+
+          if [ "$AUTO_RUNNING" -gt "0" ] || [ "$CREATE_RUNNING" -gt "0" ]; then
             echo "Another release is in progress, skipping to avoid conflicts"
-            exit 0
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
       # Determine bump type from PRs merged since last release
       - name: Determine release type
+        if: steps.check-release.outputs.skip != 'true'
         id: release-type
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -150,6 +157,7 @@ jobs:
 
       # Check if there are actually changes to release
       - name: Check for unreleased changes
+        if: steps.check-release.outputs.skip != 'true'
         id: check-changes
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -168,14 +176,59 @@ jobs:
             fi
           fi
 
-      # Trigger the actual release workflow
-      - name: Trigger release
-        if: steps.check-changes.outputs.has_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: |
-          echo "Triggering ${{ steps.release-type.outputs.bump }} release..."
-          gh workflow run create-release.yml \
-            -f bump=${{ steps.release-type.outputs.bump }}
+      # Run release directly instead of triggering separate workflow
+      - name: Install Rust
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        uses: dtolnay/rust-toolchain@stable
 
-          echo "Release workflow triggered!"
+      - name: Install cargo-release
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        run: cargo install cargo-release
+
+      - name: Configure git
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and create tag
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        id: bump
+        run: |
+          # Get current version
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "Current version: $CURRENT_VERSION"
+
+          # Run cargo release (bumps version, updates package.json, commits, tags)
+          cargo release ${{ steps.release-type.outputs.bump }} --no-publish --no-push --no-confirm --execute
+
+          # Get new version
+          NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "New version: $NEW_VERSION"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Push changes and tag
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        run: |
+          git pull --rebase origin master
+          git push origin master
+          git push origin "v${{ steps.bump.outputs.version }}"
+
+      - name: Publish to crates.io
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Setup Node.js for npm publish
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
- Run release steps directly in auto-release workflow instead of triggering separate workflow
- The RELEASE_TOKEN doesn't have `workflow` scope to trigger workflow_dispatch events
- This simplifies the release process by consolidating everything in one workflow

Changes:
- Install Rust and cargo-release directly
- Run version bump, push, and publish steps inline
- Add npm publish step

## Test plan
- [ ] Merge this PR (no release label)
- [ ] Merge another PR with a release label to verify the full release flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)