### PR TITLE
feat: Add --print flag to open command

### DIFF
--- a/src/commands/open.rs
+++ b/src/commands/open.rs
@@ -1,17 +1,17 @@
-use crate::{
-    consts::NON_INTERACTIVE_FAILURE, controllers::project::ensure_project_and_environment_exist,
-    interact_or,
-};
+use crate::controllers::project::ensure_project_and_environment_exist;
+use is_terminal::IsTerminal;
 
 use super::*;
 
 /// Open your project dashboard
 #[derive(Parser)]
-pub struct Args {}
+pub struct Args {
+    /// Print the URL instead of opening it
+    #[clap(long, short)]
+    print: bool,
+}
 
-pub async fn command(_args: Args) -> Result<()> {
-    interact_or!(NON_INTERACTIVE_FAILURE);
-
+pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let hostname = configs.get_host();
     let linked_project = configs.get_linked_project().await?;
@@ -19,9 +19,15 @@ pub async fn command(_args: Args) -> Result<()> {
 
     ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
 
-    ::open::that(format!(
+    let url = format!(
         "https://{hostname}/project/{}?environmentId={}",
         linked_project.project, linked_project.environment
-    ))?;
+    );
+
+    if args.print || !std::io::stdout().is_terminal() {
+        println!("{url}");
+    } else {
+        ::open::that(&url)?;
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add `--print`/`-p` flag to print the URL instead of opening it in a browser
- Automatically print (instead of open) when stdout is not a terminal (CI/scripts)

## Test plan
- [ ] `railway open -p` prints the URL
- [ ] `railway open` in terminal opens browser
- [ ] `railway open | cat` prints URL (non-terminal detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)