### PR TITLE
fix: Remove redundant npm publish from auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -220,15 +220,5 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish
 
-      - name: Setup Node.js for npm publish
-        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Publish to npm
-        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+      # Note: npm publish is handled by release.yml which triggers on tag push
+      # It uses OIDC (id-token: write) for authentication


### PR DESCRIPTION
## Summary
Remove npm publish steps from auto-release.yml - they're already handled by release.yml via OIDC when the tag is pushed.

The flow is:
1. auto-release.yml bumps version, commits, pushes tag, publishes to crates.io
2. release.yml triggers on tag push, builds binaries, publishes npm with OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)