### PR TITLE
refactor: Move crates.io publish to release.yml for parallelization

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -214,21 +214,5 @@ jobs:
           git push origin master
           git push origin "v${{ steps.bump.outputs.version }}"
 
-      - name: Publish to crates.io
-        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish
-
-      - name: Setup Node.js for npm publish
-        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Publish to npm
-        if: steps.check-release.outputs.skip != 'true' && steps.check-changes.outputs.has_changes == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+      # Publishing (crates.io, npm, binaries) is handled by release.yml
+      # which triggers on the tag push above

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,9 +183,26 @@ jobs:
         run: |
           gh release upload "${{ needs.create-release.outputs.railway_version }}" "railway-${{ needs.create-release.outputs.railway_version }}-amd64.deb"
 
+  publish-crates:
+    name: Publish to crates.io
+    needs: ["create-release"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
   publish-release:
     name: Publish Release
-    needs: ["create-release", "build-release"]
+    needs: ["create-release", "build-release", "publish-crates"]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Move crates.io publish from auto-release.yml to release.yml
- auto-release.yml now only: debounce → CI wait → version bump → push tag (~4 min)
- release.yml handles all publishing in parallel: crates.io, npm, binaries

```
auto-release.yml: PR merge → debounce → bump → push tag
                                                  ↓
release.yml:      tag push → parallel jobs:
                             ├── build binaries (matrix)
                             ├── publish crates.io
                             └── publish npm (OIDC)
```

This prevents bottlenecking when multiple PRs are merged in quick succession.

## Test plan
- [ ] Merge this PR (no release label)
- [ ] Merge a PR with release label
- [ ] Verify auto-release completes quickly and release.yml handles publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)