### PR TITLE
Fix TUI tab ordering for code and image services

### DIFF
--- a/src/controllers/develop/tui/app.rs
+++ b/src/controllers/develop/tui/app.rs
@@ -235,6 +235,11 @@ impl TuiApp {
             idx -= 1;
         }
 
+        if idx < self.code_count {
+            return Some(Tab::Service(idx));
+        }
+        idx -= self.code_count;
+
         if self.show_image_tab() {
             if idx == 0 {
                 return Some(Tab::Image);
@@ -242,8 +247,9 @@ impl TuiApp {
             idx -= 1;
         }
 
-        if idx < self.services.len() {
-            Some(Tab::Service(idx))
+        let image_service_idx = self.code_count + idx;
+        if image_service_idx < self.services.len() {
+            Some(Tab::Service(image_service_idx))
         } else {
             None
         }
@@ -285,24 +291,32 @@ impl TuiApp {
     }
 
     pub fn tab_index(&self) -> usize {
-        let mut idx = 0;
-
         match self.current_tab {
-            Tab::Local => idx,
+            Tab::Local => 0,
+            Tab::Service(i) if i < self.code_count => {
+                let mut idx = i;
+                if self.show_local_tab() {
+                    idx += 1;
+                }
+                idx
+            }
             Tab::Image => {
+                let mut idx = self.code_count;
                 if self.show_local_tab() {
                     idx += 1;
                 }
                 idx
             }
             Tab::Service(i) => {
+                let mut idx = i - self.code_count;
                 if self.show_local_tab() {
                     idx += 1;
                 }
+                idx += self.code_count;
                 if self.show_image_tab() {
                     idx += 1;
                 }
-                idx + i
+                idx
             }
         }
     }

--- a/src/controllers/develop/tui/ui.rs
+++ b/src/controllers/develop/tui/ui.rs
@@ -55,12 +55,18 @@ fn render_tabs(app: &TuiApp, frame: &mut Frame, area: ratatui::layout::Rect) {
     if app.show_local_tab() {
         titles.push(Line::from("Local"));
     }
+    for service in &app.services {
+        if !service.is_docker {
+            titles.push(Line::from(service.name.clone()));
+        }
+    }
     if app.show_image_tab() {
         titles.push(Line::from("Image"));
     }
-
     for service in &app.services {
-        titles.push(Line::from(service.name.clone()));
+        if service.is_docker {
+            titles.push(Line::from(service.name.clone()));
+        }
     }
 
     let selected = app.tab_index();


### PR DESCRIPTION
## Summary
- Reorders dev command TUI tabs to display code services before the Image aggregate tab
- Fixes incorrect tab ordering when there's a single code service and multiple image services
- Tab order is now: Local (if shown) → code services → Image (if shown) → image services