### PR TITLE
feat: Handle 2FA enforcement error gracefully

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -76,6 +76,9 @@ pub enum RailwayError {
     #[error("2FA code is incorrect. Please try again.")]
     InvalidTwoFactorCode,
 
+    #[error("Two-factor authentication is required for workspace \"{0}\".\nEnable 2FA at: {1}")]
+    TwoFactorEnforcementRequired(String, String),
+
     #[error("Could not find a variable to connect to the service with. Looking for \"{0}\".")]
     ConnectionVariableNotFound(String),
 


### PR DESCRIPTION
When a workspace has 2FA enforcement enabled and the user hasn't set up 2FA, display a user-friendly error message with the workspace name and a direct link to the account security page.

<img width="1578" height="150" alt="CleanShot 2026-01-12 at 18 05 28@2x" src="https://github.com/user-attachments/assets/98b51b65-3685-4f6a-8626-eafd5c6e3be3" />
