### PR TITLE
fix: remove duplicate crates.io publish from create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -54,14 +54,10 @@ jobs:
           echo "New version: $NEW_VERSION"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-      # Push BEFORE publishing to crates.io - if push fails, we haven't published yet
+      # Publishing (crates.io, npm, binaries) is handled by release.yml
+      # which triggers on the tag push below
       - name: Push changes and tag
         run: |
           git pull --rebase origin master
           git push origin master
           git push origin "v${{ steps.bump.outputs.version }}"
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish


### PR DESCRIPTION
The `create-release.yml` workflow was publishing to crates.io before pushing the tag, then the tag push triggered `release.yml` which tried to publish again, causing failures.

Removed the duplicate `cargo publish` step from `create-release.yml` since `release.yml` already handles publishing when triggered by tag push.