### PR TITLE
Fix auto-release to checkout master instead of PR ref

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 


### PR DESCRIPTION
The auto-release workflow was checking out the PR's merge ref instead of master. This could cause issues when master moves after a PR merges, since the workflow operates on a stale commit.

Adds explicit `ref: master` to the checkout step.