### PR TITLE
Environment config improvements

### DIFF
--- a/src/controllers/config/environment.rs
+++ b/src/controllers/config/environment.rs
@@ -19,7 +19,7 @@ pub struct EnvironmentConfig {
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub services: BTreeMap<String, ServiceInstance>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub shared_variables: BTreeMap<String, Variable>,
+    pub shared_variables: BTreeMap<String, Option<Variable>>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub volumes: BTreeMap<String, VolumeInstance>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
@@ -34,7 +34,7 @@ pub struct ServiceInstance {
     pub source: Option<ServiceSource>,
     pub networking: Option<ServiceNetworking>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    pub variables: BTreeMap<String, Variable>,
+    pub variables: BTreeMap<String, Option<Variable>>,
     pub deploy: Option<DeployConfig>,
     pub build: Option<BuildConfig>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]


### PR DESCRIPTION
Adds `environment config` subcommand and improves output formatting.

- Add `environment config` command for viewing/editing environment configuration
- Show service names instead of IDs in human output
- Improve service display with multi-line format showing root, builder, regions, domains
- Allow null variables for deletion (matches existing pattern for domains/tcp_proxies)
- Remove duplicate environment display