### PR TITLE
Fix unused constant warning by replacing three instances of hardcoded

### DIFF
--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -4,6 +4,7 @@ use anyhow::bail;
 use is_terminal::IsTerminal;
 
 use crate::{
+    consts::TWO_FACTOR_REQUIRES_INTERACTIVE,
     errors::RailwayError,
     util::{
         progress::create_spinner_if,
@@ -81,9 +82,7 @@ pub async fn command(args: Args) -> Result<()> {
         } else if is_terminal {
             prompt_text("Enter your 2FA code")?
         } else {
-            bail!(
-                "2FA is enabled. Use --2fa-code <CODE> to provide your verification code in non-interactive mode."
-            );
+            bail!(TWO_FACTOR_REQUIRES_INTERACTIVE);
         };
         let vars = mutations::validate_two_factor::Variables { token };
 

--- a/src/commands/environment/delete.rs
+++ b/src/commands/environment/delete.rs
@@ -1,6 +1,7 @@
 use super::{Delete as Args, *};
 use crate::{
     Configs, GQLClient,
+    consts::TWO_FACTOR_REQUIRES_INTERACTIVE,
     controllers::project::get_project,
     util::{
         progress::create_spinner_if,
@@ -85,9 +86,7 @@ pub async fn delete_environment(args: Args) -> Result<()> {
         } else if is_terminal {
             prompt_text("Enter your 2FA code")?
         } else {
-            bail!(
-                "2FA is enabled. Use --2fa-code <CODE> to provide your verification code in non-interactive mode."
-            );
+            bail!(TWO_FACTOR_REQUIRES_INTERACTIVE);
         };
         let vars = mutations::validate_two_factor::Variables { token };
 

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    consts::TWO_FACTOR_REQUIRES_INTERACTIVE,
     controllers::project::{ensure_project_and_environment_exist, get_project},
     errors::RailwayError,
     queries::project::{
@@ -443,9 +444,7 @@ async fn delete(
             } else if is_terminal {
                 prompt_text("Enter your 2FA code")?
             } else {
-                bail!(
-                    "2FA is enabled. Use --2fa-code <CODE> to provide your verification code in non-interactive mode."
-                );
+                bail!(TWO_FACTOR_REQUIRES_INTERACTIVE);
             };
             let vars = mutations::validate_two_factor::Variables { token };
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -8,4 +8,4 @@ pub const RAILWAY_API_TOKEN_ENV: &str = "RAILWAY_API_TOKEN";
 pub const TICK_STRING: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ";
 pub const NON_INTERACTIVE_FAILURE: &str = "This command is only available in interactive mode";
 pub const TWO_FACTOR_REQUIRES_INTERACTIVE: &str =
-    "2FA is enabled. This operation requires interactive mode.";
+    "2FA is enabled. Use --2fa-code <CODE> to provide your verification code in non-interactive mode.";


### PR DESCRIPTION
2FA warning messages with the TWO_FACTOR_REQUIRES_INTERACTIVE constant.

This change:
- Eliminates the dead_code warning for TWO_FACTOR_REQUIRES_INTERACTIVE
- Removes code duplication across delete.rs, volume.rs, and environment/delete.rs

To reproduce:
<img width="579" height="221" alt="image" src="https://github.com/user-attachments/assets/a2526f6a-7357-40bc-8708-c7faa074ae8a" />
