### PR TITLE
Deployment messages for `railway up`

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -235,8 +235,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     let mut url = Url::parse(&format!(
         "https://backboard.{hostname}/project/{}/environment/{}/up",
-        project_id,
-        environment_id,
+        project_id, environment_id,
     ))?;
 
     url.query_pairs_mut()


### PR DESCRIPTION
Yes, really.

`--message "text"` & `-m "text"`

It shows up in the UI the same way a commit message would.