### PR TITLE
Skip 2FA prompt for token-based auth

### DIFF
--- a/src/commands/environment/mod.rs
+++ b/src/commands/environment/mod.rs
@@ -77,13 +77,13 @@ structstruck::strike! {
             /// The environment to delete
             pub environment: Option<String>,
 
-            /// 2FA code for verification (required if 2FA is enabled in non-interactive mode)
-            #[clap(long = "2fa-code")]
-            pub two_factor_code: Option<String>,
-
             /// Output in JSON format
             #[clap(long)]
             pub json: bool,
+
+            /// 2FA code for verification (required if 2FA is enabled in non-interactive mode)
+            #[clap(long = "2fa-code")]
+            pub two_factor_code: Option<String>,
         }),
 
         /// Edit an environment's configuration

--- a/src/commands/functions/mod.rs
+++ b/src/commands/functions/mod.rs
@@ -67,7 +67,11 @@ structstruck::strike! {
 
             /// Skip confirmation for deleting
             #[clap(long, short, action = clap::ArgAction::Set, num_args = 0..=1, default_missing_value = "true")]
-            yes: Option<bool>
+            yes: Option<bool>,
+
+            /// 2FA code for verification (required if 2FA is enabled in non-interactive mode)
+            #[clap(long = "2fa-code")]
+            two_factor_code: Option<String>
         }),
 
         /// Push a new change to the function

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,13 @@ impl Configs {
         std::env::var(consts::RAILWAY_API_TOKEN_ENV).ok()
     }
 
+    /// Returns true if using token-based auth (RAILWAY_TOKEN or RAILWAY_API_TOKEN)
+    /// rather than session-based auth from `railway login`.
+    /// Token-based auth bypasses 2FA on the backend, so client-side 2FA checks are unnecessary.
+    pub fn is_using_token_auth() -> bool {
+        Self::get_railway_token().is_some() || Self::get_railway_api_token().is_some()
+    }
+
     pub fn env_is_ci() -> bool {
         std::env::var("CI")
             .map(|val| val.trim().to_lowercase() == "true")

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -86,11 +86,6 @@ pub enum RailwayError {
     #[error("2FA code is incorrect. Please try again.")]
     InvalidTwoFactorCode,
 
-    #[error(
-        "2FA is enabled. Use --2fa-code <CODE> to provide your verification code in non-interactive mode."
-    )]
-    TwoFactorRequiresInteractive,
-
     #[error("Two-factor authentication is required for workspace \"{0}\".\nEnable 2FA at: {1}")]
     TwoFactorEnforcementRequired(String, String),
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,4 +5,5 @@ pub mod progress;
 pub mod prompt;
 pub mod retry;
 pub mod time;
+pub mod two_factor;
 pub mod watcher;

--- a/src/util/two_factor.rs
+++ b/src/util/two_factor.rs
@@ -1,0 +1,57 @@
+use anyhow::{Result, bail};
+
+use crate::{
+    Configs,
+    client::post_graphql,
+    errors::RailwayError,
+    gql::{mutations, queries},
+    util::prompt::prompt_text,
+};
+
+/// Validates 2FA if enabled for the current user.
+/// Skips check entirely for token-based auth (API tokens bypass 2FA on the backend).
+/// For session-based auth, prompts for 2FA code if enabled, or uses provided code.
+pub async fn validate_two_factor_if_enabled(
+    client: &reqwest::Client,
+    configs: &Configs,
+    is_terminal: bool,
+    two_factor_code: Option<String>,
+) -> Result<()> {
+    // Skip 2FA check for token-based auth (API tokens bypass 2FA on the backend)
+    if Configs::is_using_token_auth() {
+        return Ok(());
+    }
+
+    let is_two_factor_enabled = {
+        let vars = queries::two_factor_info::Variables {};
+        let info = post_graphql::<queries::TwoFactorInfo, _>(client, configs.get_backboard(), vars)
+            .await?
+            .two_factor_info;
+        info.is_verified
+    };
+
+    if is_two_factor_enabled {
+        let token = if let Some(code) = two_factor_code {
+            code
+        } else if is_terminal {
+            prompt_text("Enter your 2FA code")?
+        } else {
+            bail!(
+                "2FA is enabled and requires interactive mode. Use --2fa-code <CODE> or an API token for non-interactive operations."
+            );
+        };
+
+        let vars = mutations::validate_two_factor::Variables { token };
+
+        let valid =
+            post_graphql::<mutations::ValidateTwoFactor, _>(client, configs.get_backboard(), vars)
+                .await?
+                .two_factor_info_validate;
+
+        if !valid {
+            return Err(RailwayError::InvalidTwoFactorCode.into());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Token-based auth (RAILWAY_TOKEN, RAILWAY_API_TOKEN) is non-interactive and bypasses 2FA on the backend. Only prompt for 2FA when using session-based auth from railway login.

https://discord.com/channels/713503345364697088/1467957064595800156

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/2FA behavior across multiple destructive commands (project/environment/function/volume delete), so incorrect branching could weaken safeguards or break CI/non-interactive usage.
> 
> **Overview**
> Deletion flows now share a centralized 2FA gate via new `util::two_factor::validate_two_factor_if_enabled`, and the function delete command gains `--2fa-code` support.
> 
> The new helper skips 2FA entirely when using `RAILWAY_TOKEN`/`RAILWAY_API_TOKEN` (token auth), and otherwise prompts/accepts a provided code for session auth; the old `TwoFactorRequiresInteractive` error is removed in favor of a direct non-interactive bail message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a42d19aaafd10f23387662dbcdccfad5690cc38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->