### PR TITLE
fix: show error level indicators in build logs

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -9,7 +9,10 @@ use crate::{
         environment::get_matched_environment,
         project::{ensure_project_and_environment_exist, get_project},
     },
-    util::{logs::print_log, time::parse_time},
+    util::{
+        logs::{LogFormat, print_log},
+        time::parse_time,
+    },
 };
 use anyhow::bail;
 
@@ -177,7 +180,7 @@ pub async fn command(args: Args) -> Result<()> {
     if show_build_logs {
         if should_stream {
             stream_build_logs(deployment_id.clone(), args.filter.clone(), |log| {
-                print_log(log, args.json, false) // Build logs use simple output
+                print_log(log, args.json, LogFormat::LevelOnly)
             })
             .await?;
         } else {
@@ -191,13 +194,13 @@ pub async fn command(args: Args) -> Result<()> {
                     start_date,
                     end_date,
                 },
-                |log| print_log(log, args.json, false),
+                |log| print_log(log, args.json, LogFormat::LevelOnly),
             )
             .await?;
         }
     } else if should_stream {
         stream_deploy_logs(deployment_id.clone(), args.filter.clone(), |log| {
-            print_log(log, args.json, true)
+            print_log(log, args.json, LogFormat::Full)
         })
         .await?;
     } else {
@@ -211,7 +214,7 @@ pub async fn command(args: Args) -> Result<()> {
                 start_date,
                 end_date,
             },
-            |log| print_log(log, args.json, true),
+            |log| print_log(log, args.json, LogFormat::Full),
         )
         .await?;
     }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -27,7 +27,7 @@ use crate::{
     errors::RailwayError,
     subscription::subscribe_graphql,
     subscriptions::deployment::DeploymentStatus,
-    util::logs::print_log,
+    util::logs::{LogFormat, print_log},
 };
 
 use super::*;
@@ -354,7 +354,7 @@ pub async fn command(args: Args) -> Result<()> {
             let should_exit =
                 ci_flag && log.message.starts_with("No changed files matched patterns");
             if json_mode {
-                print_log(log, true, false);
+                print_log(log, true, LogFormat::LevelOnly);
             } else {
                 println!("{}", log.message);
             }
@@ -377,7 +377,7 @@ pub async fn command(args: Args) -> Result<()> {
         let deploy_deployment_id = deployment_id.clone();
         tasks.push(tokio::task::spawn(async move {
             if let Err(e) = stream_deploy_logs(deploy_deployment_id, None, |log| {
-                print_log(log, false, true)
+                print_log(log, false, LogFormat::Full)
             })
             .await
             {


### PR DESCRIPTION
## Problem
Users reported that `railway logs -b` (build logs) doesn't show error details that are visible in the dashboard UI. Specifically, the CLI output lacked the error-level indicators shown in the dashboard for failed builds.

## Root Cause
Build logs were using simple output mode (`use_formatted=false`) which only displayed the raw message without any formatting. This meant error-level logs from the build process (like Docker build failures) didn't show the `[ERRO]` indicator.

## Solution
Added a `LogFormat` enum with three modes:
- `Simple` - raw message only
- `LevelOnly` - level indicator (`[ERRO]`, `[INFO]`, etc.) + message, no extra attributes
- `Full` - level + message + all attributes
