### PR TITLE
Fix double deploys when using env new & changing configuration

### DIFF
--- a/src/commands/environment/mod.rs
+++ b/src/commands/environment/mod.rs
@@ -3,12 +3,9 @@ use std::fmt::Display;
 use crate::{
     controllers::project::get_project,
     errors::RailwayError,
-    util::{
-        prompt::{
-            PromptServiceInstance, fake_select, prompt_multi_options, prompt_options_skippable,
-            prompt_text,
-        },
-        retry::{RetryConfig, retry_with_backoff},
+    util::prompt::{
+        PromptServiceInstance, fake_select, prompt_multi_options, prompt_options_skippable,
+        prompt_text,
     },
 };
 use anyhow::bail;

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -152,14 +152,6 @@ pub struct LatestFunctionVersion;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
-    query_path = "src/gql/queries/strings/EnvironmentStagedChanges.graphql",
-    response_derives = "Debug, Serialize, Clone"
-)]
-pub struct EnvironmentStagedChanges;
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/EnvironmentConfig.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/EnvironmentStagedChanges.graphql
+++ b/src/gql/queries/strings/EnvironmentStagedChanges.graphql
@@ -1,5 +1,0 @@
-query EnvironmentStagedChanges($environmentId: String!) {
-  environmentStagedChanges(environmentId: $environmentId) {
-    status
-  }
-}


### PR DESCRIPTION
This fixes the CLI creating 2 deployments when duplicating an old environment and adding configuration changes. This works by now creating an empty environment, getting environment config from the one to be duplicated, merging with any changes requested by the user and then aplpying the whole config as a patch.
