### PR TITLE
Improve global auth token handling and errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,5 +23,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Commands use a macro system in `main.rs`. The `commands!` macro generates routing for modules in `src/commands/`.
 
 ### Authentication
-- Project tokens via `RAILWAY_TOKEN` environment variable
-- User tokens via OAuth flow stored in config directory
+- There are three auth sources:
+  - Scoped token via `RAILWAY_TOKEN`
+  - Global token via `RAILWAY_API_TOKEN`
+  - User token via OAuth from `railway login` (stored in config)

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -37,7 +37,7 @@ pub struct Args {
 
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
+    let client = GQLClient::new_authorized_with_scope(&configs, AuthScope::GlobalOnly)?;
     let is_terminal = std::io::stdout().is_terminal();
 
     let all_workspaces = workspaces().await?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -26,7 +26,7 @@ pub struct Args {
 pub async fn command(args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
 
-    let client = GQLClient::new_authorized(&configs)?;
+    let client = GQLClient::new_authorized_with_scope(&configs, AuthScope::GlobalOnly)?;
 
     let workspaces = workspaces().await?;
     let workspace = prompt_workspace(workspaces, args.workspace)?;

--- a/src/commands/whoami.rs
+++ b/src/commands/whoami.rs
@@ -27,7 +27,7 @@ struct WorkspaceJson {
 
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
+    let client = GQLClient::new_authorized_with_scope(&configs, AuthScope::GlobalOnly)?;
 
     let user: RailwayUser = get_user(&client, &configs).await?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,11 @@ pub enum RailwayError {
     UnauthorizedLogin,
 
     #[error(
+        "This command requires global authentication. Set RAILWAY_API_TOKEN or run `railway login`."
+    )]
+    GlobalAuthRequired,
+
+    #[error(
         "Invalid {0}. Please check that it is valid and has access to the resource you're trying to use."
     )]
     InvalidRailwayToken(String),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -13,7 +13,7 @@ use super::{
 pub async fn workspaces() -> Result<Vec<Workspace>> {
     let configs = Configs::new()?;
     let vars = queries::user_projects::Variables {};
-    let client = GQLClient::new_authorized(&configs)?;
+    let client = GQLClient::new_authorized_with_scope(&configs, AuthScope::GlobalOnly)?;
     let response =
         post_graphql::<queries::UserProjects, _>(&client, configs.get_backboard(), vars).await?;
 


### PR DESCRIPTION
## About this PR
This is an attempt to clear up some common DX issues that arise when trying to authorize the CLI with tokens.
Context: #699 

The CLI accepts to types of tokens as two separate env variables
- Scoped tokens via `RAILWAY_TOKEN`
- Global tokens via `RAILWAY_API_TOKEN`

The two issues addressed in this PR

1. Previously the `RAILWAY_TOKEN` was being preferred over the `RAILWAY_API_TOKEN` if both were set.

2. If the wrong token was used (eg `RAILWAY_TOKEN` for whoami) the error was a generic Unauthorized warning.

## What was changed

The commands that require a global token can now specify that. 

This enables two DX improvements

1. If both tokens are set the `RAILWAY_API_TOKEN` is used by commands that require it.
2. If `RAILWAY_TOKEN` is used incorrectly for commands that require RAILWAY_API_TOKEN a helpful error message indicates this issue.

## Possible future improvements
Ultimately the best DX would be a unified token env var and error messages that indicate if a scoped token is being used for a global command.

It would be possible to check on failure if the token is a valid scoped token and if it is indicate so to the user.

Something like this would do the trick
```

async fn check_if_token_is_scoped(token: &str) -> bool {
    let mut headers = HeaderMap::new();
    let Ok(token_header) = HeaderValue::from_str(token) else {
        return false;
    };
    headers.insert("project-access-token", token_header);
    headers.insert(
        "x-source",
        HeaderValue::from_static(consts::get_user_agent()),
    );

    let Some((client, backboard_url)) = build_probe_client(headers) else {
        return false;
    };

    let body = queries::ProjectToken::build_query(queries::project_token::Variables {});

    let Ok(response) = client.post(backboard_url).json(&body).send().await else {
        return false;
    };

    let Ok(res) = response
        .json::<GraphQLResponse<queries::project_token::ResponseData>>()
        .await
    else {
        return false;
    };

    res.data.is_some()
}
```