### PR TITLE
Allow for configFile in environment patch

### DIFF
--- a/src/controllers/config/environment.rs
+++ b/src/controllers/config/environment.rs
@@ -35,6 +35,7 @@ pub struct ServiceInstance {
     pub networking: Option<ServiceNetworking>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub variables: BTreeMap<String, Option<Variable>>,
+    pub config_file: Option<String>,
     pub deploy: Option<DeployConfig>,
     pub build: Option<BuildConfig>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/controllers/config/patch.rs
+++ b/src/controllers/config/patch.rs
@@ -453,6 +453,7 @@ mod tests {
     #[test]
     fn test_validate_service_path_valid() {
         assert!(validate_service_path("source.image").is_ok());
+        assert!(validate_service_path("configFile").is_ok());
         assert!(validate_service_path("deploy.startCommand").is_ok());
         assert!(validate_service_path("deploy.restartPolicyType").is_ok());
         assert!(validate_service_path("build.builder").is_ok());
@@ -477,6 +478,9 @@ mod tests {
         // String fields should accept strings
         let (_, value) = parse_service_value("source.image", "nginx:latest").unwrap();
         assert_eq!(value, serde_json::json!("nginx:latest"));
+
+        let (_, value) = parse_service_value("configFile", "railway.json").unwrap();
+        assert_eq!(value, serde_json::json!("railway.json"));
 
         let (_, value) = parse_service_value("deploy.startCommand", "npm start").unwrap();
         assert_eq!(value, serde_json::json!("npm start"));


### PR DESCRIPTION
Add config_file to the service config model so environment updates can set the configFile

Addresses https://github.com/railwayapp/cli/issues/790