### PR TITLE
Print TXT record for custom domain creation

### DIFF
--- a/src/gql/mutations/strings/CustomDomainCreate.graphql
+++ b/src/gql/mutations/strings/CustomDomainCreate.graphql
@@ -28,6 +28,9 @@ mutation CustomDomainCreate($input: CustomDomainCreateInput!) {
         keyType
       }
       certificateStatus
+      verificationToken
+      verificationDnsHost
+      verified
     }
   }
 }


### PR DESCRIPTION
We recently added TXT records as a required verification method for custom domains. This PR updates the CLI to print those TXT records.

Solves PRO-5567