### PR TITLE
fix: include build.rs in crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/railwayapp/cli"
 repository = "https://github.com/railwayapp/cli"
 rust-version = "1.85.0"
 default-run = "railway"
-include = ["src/**/*", "LICENSE", "README.md"]
+include = ["src/**/*", "build.rs", "LICENSE", "README.md"]
 
 [[bin]]
 name = "railway"


### PR DESCRIPTION
## Summary
- The `include` field in `Cargo.toml` was missing `build.rs`, so `cargo publish` verification failed with `environment variable BUILD_TARGET not defined at compile time`
- `build.rs` sets `BUILD_TARGET` via `cargo:rustc-env`, which is required by the self-update module

## Test plan
- [x] `cargo publish --dry-run` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)