### PR TITLE
fix: remove npm self-upgrade step that breaks release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,9 +230,6 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
-
       - name: NPM publish
         run: npm publish --access public --provenance
 


### PR DESCRIPTION
## Summary
- Removes the `npm install -g npm@latest` step from the "Publish NPM" job in the release workflow
- This step started failing because `npm@latest` now resolves to npm 11.x, which causes a fatal cross-major self-upgrade when the runner bundles npm 10.x (Node 22). npm removes its own dependencies (like `promise-retry`) mid-install, leaving itself corrupted.
- The step is no longer needed — Node 22 ships with npm 10.9.7, which has had OIDC/provenance support since npm 9.5.0

## Context
- Last successful release: v4.36.1 (Apr 3) — runner had Node 22.22.1 / npm 10.9.4, `npm@latest` still resolved to 10.x
- First failure: v4.37.0 (Apr 6) — `npm@latest` now resolves to 11.12.1, cross-major self-upgrade breaks
- Failing job: https://github.com/railwayapp/cli/actions/runs/24237101439/job/70772180416

## Test plan
- [ ] Verify next release tag triggers a successful "Publish NPM" job

🤖 Generated with [Claude Code](https://claude.com/claude-code)