### PR TITLE
fix: make `railway docs` work in non-interactive mode

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -1,22 +1,21 @@
-use crate::{
-    consts::NON_INTERACTIVE_FAILURE, interact_or, util::prompt::prompt_confirm_with_default,
-};
-
 use super::*;
 
-/// Open Railway Documentation in default browser
+const DOCS_URL: &str = "https://docs.railway.com";
+const LLMS_TXT_URL: &str = "https://docs.railway.com/llms.txt";
+const LLMS_FULL_URL: &str = "https://docs.railway.com/llms-full.txt";
+
+/// Open Railway Documentation in default browser, or print doc URLs in non-interactive mode
 #[derive(Parser)]
 pub struct Args {}
 
 pub async fn command(_args: Args) -> Result<()> {
-    interact_or!(NON_INTERACTIVE_FAILURE);
-
-    let confirm = prompt_confirm_with_default("Open the browser?", true)?;
-
-    if !confirm {
+    if !crate::macros::is_stdout_terminal() {
+        println!("{DOCS_URL}");
+        println!("{LLMS_TXT_URL}");
+        println!("{LLMS_FULL_URL}");
         return Ok(());
     }
 
-    ::open::that("https://docs.railway.com")?;
+    ::open::that(DOCS_URL)?;
     Ok(())
 }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -10,4 +10,3 @@ pub const RAILWAY_SERVICE_ID_ENV: &str = "RAILWAY_SERVICE_ID";
 pub const RAILWAY_STAGE_UPDATE_ENV: &str = "_RAILWAY_STAGE_UPDATE";
 
 pub const TICK_STRING: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ ";
-pub const NON_INTERACTIVE_FAILURE: &str = "This command is only available in interactive mode";


### PR DESCRIPTION
## Summary

- `railway docs` no longer requires a TTY — in non-interactive mode (agents, CI, piped stdout), it prints the doc URLs instead of bailing
- Drops the confirmation prompt ("Open the browser?") in interactive mode — just opens the browser directly
- Prints all three doc URLs in non-interactive mode: the docs homepage, `llms.txt` index, and `llms-full.txt` full content
- Removes the now-unused `NON_INTERACTIVE_FAILURE` constant from `src/consts.rs`

### Before

```
$ railway docs | cat
Error: This command is only available in interactive mode
```

### After

```
$ railway docs | cat
https://docs.railway.com
https://docs.railway.com/llms.txt
https://docs.railway.com/llms-full.txt
```

## Test plan

- [ ] `railway docs | cat` prints all three URLs, exits 0
- [ ] `railway docs` in a terminal opens the browser without prompting
- [ ] `railway docs --help` shows updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)