### PR TITLE
fix: skip 2FA preflight when using OAuth tokens

### DIFF
--- a/src/util/two_factor.rs
+++ b/src/util/two_factor.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 
 /// Validates 2FA if enabled for the current user.
-/// Skips check entirely for token-based auth (API tokens bypass 2FA on the backend).
+/// Skips check for token-based auth (API tokens bypass 2FA on the backend) and for
+/// OAuth tokens (backboard exempts OAuth from 2FA, and the twoFactorInfoValidate
+/// mutation requires a browser session that OAuth does not have).
 /// For session-based auth, prompts for 2FA code if enabled, or uses provided code.
 pub async fn validate_two_factor_if_enabled(
     client: &reqwest::Client,
@@ -17,8 +19,9 @@ pub async fn validate_two_factor_if_enabled(
     is_terminal: bool,
     two_factor_code: Option<String>,
 ) -> Result<()> {
-    // Skip 2FA check for token-based auth (API tokens bypass 2FA on the backend)
-    if Configs::is_using_token_auth() {
+    // Skip 2FA check for token-based auth and OAuth tokens — backboard does not
+    // enforce 2FA for either, and the validate mutation is unreachable without a session.
+    if Configs::is_using_token_auth() || configs.has_oauth_token() {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- CLI's 2FA preflight (\`validate_two_factor_if_enabled\`) fires under OAuth authentication even though backboard already exempts OAuth from 2FA (\`hasTwoFactorVerification\` scope short-circuits when \`ctx.sessionId == null\`).
- End-user symptom: for users with 2FA enabled, \`railway delete\` (and any other command that goes through the preflight) prompts for a 2FA code on fresh OAuth logins, then fails with \`Bad Access\` regardless of whether the code is correct.
- Root cause: the \`twoFactorInfoValidate\` mutation's resolver requires \`ctx.sessionId != null\` and throws \`BadAccessError\` otherwise — OAuth requests always have \`sessionId: null\`, so the validation is unreachable.

## Fix

Extend the existing \`is_using_token_auth()\` short-circuit in \`src/util/two_factor.rs::validate_two_factor_if_enabled\` to also cover OAuth tokens:

\`\`\`rust
if Configs::is_using_token_auth() || configs.has_oauth_token() {
    return Ok(());
}
\`\`\`

This mirrors the backend's behavior: token-based auth and OAuth are both 2FA-exempt, so the preflight is redundant for both and actively harmful for OAuth (since the validate mutation can't succeed).

## Context

Paired with backboard fix https://github.com/railwayapp/mono/pull/27553 (allowed OAuth tokens to query \`twoFactorInfo\` in the first place). That fix unblocked reading the 2FA status; this fix skips the prompt entirely under OAuth since the backend doesn't require it. Related escalation: https://discord.com/channels/713503345364697088/1487308685331136666

## Reproduction

Requires a Railway account with 2FA enabled.

\`\`\`bash
rm -f ~/.railway/config.json
railway login                          # browser OAuth
unset RAILWAY_TOKEN RAILWAY_API_TOKEN
railway init -n cli-2fa-oauth-repro
railway delete -p cli-2fa-oauth-repro
# Before: prompts for 2FA → "Bad Access"
# After: deletes cleanly, no 2FA prompt
\`\`\`