### PR TITLE
fix: remove extra blank lines in `railway agent` REPL output

### DIFF
--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -153,7 +153,6 @@ async fn run_single_shot(
         // Show a thinking spinner while waiting for the first event
         if is_tty {
             let msg = THINKING_MESSAGES[rand::thread_rng().gen_range(0..THINKING_MESSAGES.len())];
-            println!();
             spinner = Some(create_spinner(msg.dimmed().to_string()));
         }
 
@@ -234,7 +233,6 @@ async fn run_repl(
             if is_tty {
                 let msg =
                     THINKING_MESSAGES[rand::thread_rng().gen_range(0..THINKING_MESSAGES.len())];
-                println!();
                 spinner = Some(create_spinner(msg.dimmed().to_string()));
             }
 
@@ -264,11 +262,11 @@ fn handle_event_human(
 ) {
     match event {
         ChatEvent::Chunk { text } => {
-            if let Some(s) = spinner.take() {
-                s.finish_and_clear();
-            }
+            let cleared_spinner = spinner.take().map(|s| s.finish_and_clear()).is_some();
             if !*has_printed_text {
-                println!();
+                if !cleared_spinner {
+                    println!();
+                }
                 print!("{} ", "Railway Agent:".purple().bold());
                 *has_printed_text = true;
             }
@@ -277,11 +275,11 @@ fn handle_event_human(
         }
         ChatEvent::ToolCallReady { tool_name, .. } => {
             if is_tty {
-                if let Some(s) = spinner.take() {
-                    s.finish_and_clear();
-                }
+                let cleared_spinner = spinner.take().map(|s| s.finish_and_clear()).is_some();
                 *has_printed_text = false;
-                println!();
+                if !cleared_spinner {
+                    println!();
+                }
                 *spinner = Some(create_spinner(format!(
                     "{} {}",
                     "╰─".dimmed(),


### PR DESCRIPTION
## Summary
- The `railway agent` interactive REPL was printing multiple blank lines between user input and the agent's response
- Root cause: both the thinking spinner setup and the `Chunk`/`ToolCallReady` handlers unconditionally emitted `println!()`, so each `finish_and_clear` (which already leaves the cursor on an empty line) was followed by another newline — stacking 2+ blank lines per turn, more when tool calls ran first
- Dropped the unconditional `println!()` before the initial spinner in both `run_single_shot` and `run_repl`, and made the `println!()` inside the `Chunk` and `ToolCallReady` handlers conditional on whether a spinner was just cleared

## Before
```
> You: Yes confirmed




Railway Agent: Done. All 3 services have been marked for removal:
```

## After
```
> You: Yes confirmed
Railway Agent: Done. All 3 services have been marked for removal:
```

## Test plan
- [ ] `cargo check` passes
- [ ] Run `railway agent` and confirm no extra blank lines between `> You:` and `Railway Agent:`
- [ ] Confirm tool-call spinners still render correctly and don't get overwritten by subsequent output
- [ ] Confirm single-shot mode (`railway agent -p "..."`) still renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)