### PR TITLE
fix: improve railway link non-interactive / agent mode

### DIFF
--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -149,7 +149,26 @@ fn select_service(
             }
         } else if std::io::stdout().is_terminal() {
             prompt_options_skippable("Select a service <esc to skip>", useful_services)?
+        } else if useful_services.len() == 1 {
+            let svc = useful_services.into_iter().next().unwrap();
+            eprintln!("No service specified — auto-selecting \"{}\"", svc.name);
+            Some(svc)
         } else {
+            let names: Vec<&str> = useful_services
+                .iter()
+                .take(5)
+                .map(|s| s.name.as_str())
+                .collect();
+            let suffix = if useful_services.len() > 5 {
+                format!(", +{} more", useful_services.len() - 5)
+            } else {
+                String::new()
+            };
+            eprintln!(
+                "Multiple services available — use --service <name> to link one.\nAvailable: {}{}",
+                names.join(", "),
+                suffix
+            );
             None
         }
     } else {
@@ -187,8 +206,21 @@ fn select_environment(
         env
     } else {
         if !std::io::stdout().is_terminal() {
+            let names: Vec<&str> = project
+                .environments
+                .iter()
+                .take(5)
+                .map(|e| e.name.as_str())
+                .collect();
+            let suffix = if project.environments.len() > 5 {
+                format!(", +{} more", project.environments.len() - 5)
+            } else {
+                String::new()
+            };
             bail!(
-                "--environment required in non-interactive mode (multiple environments available)"
+                "--environment required in non-interactive mode.\nAvailable: {}{}",
+                names.join(", "),
+                suffix
             );
         }
         prompt_options("Select an environment", project.environments.clone())?
@@ -277,14 +309,34 @@ fn prompt_workspaces(workspaces: Vec<Workspace>) -> Result<Workspace> {
         return Ok(workspaces[0].clone());
     }
     if !std::io::stdout().is_terminal() {
-        bail!("--workspace required in non-interactive mode (multiple workspaces available)");
+        let names: Vec<&str> = workspaces.iter().take(5).map(|w| w.name()).collect();
+        let suffix = if workspaces.len() > 5 {
+            format!(", +{} more", workspaces.len() - 5)
+        } else {
+            String::new()
+        };
+        bail!(
+            "--workspace required in non-interactive mode.\nAvailable: {}{}",
+            names.join(", "),
+            suffix
+        );
     }
     prompt_options("Select a workspace", workspaces)
 }
 
 fn prompt_workspace_projects(projects: Vec<Project>) -> Result<Project, anyhow::Error> {
     if !std::io::stdout().is_terminal() {
-        bail!("--project required in non-interactive mode");
+        let names: Vec<String> = projects.iter().take(5).map(|p| p.name().to_owned()).collect();
+        let suffix = if projects.len() > 5 {
+            format!(", +{} more", projects.len() - 5)
+        } else {
+            String::new()
+        };
+        bail!(
+            "--project required in non-interactive mode.\nAvailable: {}{}",
+            names.join(", "),
+            suffix
+        );
     }
     prompt_options("Select a project", projects)
 }

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -279,8 +279,7 @@ fn select_project(
                 fake_select("Select a project", &project.to_string());
                 project.clone()
             } else {
-                let available: Vec<&str> =
-                    projects.iter().take(5).map(|p| p.name()).collect();
+                let available: Vec<&str> = projects.iter().take(5).map(|p| p.name()).collect();
                 let suffix = if projects.len() > 5 {
                     format!(", +{} more", projects.len() - 5)
                 } else {

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -326,7 +326,11 @@ fn prompt_workspaces(workspaces: Vec<Workspace>) -> Result<Workspace> {
 
 fn prompt_workspace_projects(projects: Vec<Project>) -> Result<Project, anyhow::Error> {
     if !std::io::stdout().is_terminal() {
-        let names: Vec<String> = projects.iter().take(5).map(|p| p.name().to_owned()).collect();
+        let names: Vec<String> = projects
+            .iter()
+            .take(5)
+            .map(|p| p.name().to_owned())
+            .collect();
         let suffix = if projects.len() > 5 {
             format!(", +{} more", projects.len() - 5)
         } else {

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -145,7 +145,22 @@ fn select_service(
                 fake_select("Select a service", &service.name);
                 Some(service.clone())
             } else {
-                return Err(RailwayError::ServiceNotFound(service).into());
+                let available: Vec<&str> = useful_services
+                    .iter()
+                    .take(5)
+                    .map(|s| s.name.as_str())
+                    .collect();
+                let suffix = if useful_services.len() > 5 {
+                    format!(", +{} more", useful_services.len() - 5)
+                } else {
+                    String::new()
+                };
+                bail!(
+                    "Service \"{}\" not found.\nAvailable: {}{}",
+                    service,
+                    available.join(", "),
+                    suffix
+                );
             }
         } else if std::io::stdout().is_terminal() {
             prompt_options_skippable("Select a service <esc to skip>", useful_services)?
@@ -198,7 +213,23 @@ fn select_environment(
             fake_select("Select an environment", &env.name);
             env.clone()
         } else {
-            return Err(RailwayError::EnvironmentNotFound(environment).into());
+            let available: Vec<&str> = project
+                .environments
+                .iter()
+                .take(5)
+                .map(|e| e.name.as_str())
+                .collect();
+            let suffix = if project.environments.len() > 5 {
+                format!(", +{} more", project.environments.len() - 5)
+            } else {
+                String::new()
+            };
+            bail!(
+                "Environment \"{}\" not found.\nAvailable: {}{}",
+                environment,
+                available.join(", "),
+                suffix
+            );
         }
     } else if project.environments.len() == 1 {
         let env = project.environments[0].clone();
@@ -240,19 +271,28 @@ fn select_project(
 
     let project = NormalisedProject::from({
         if let Some(project) = project {
-            let proj = projects.into_iter().find(|pro| {
+            let proj = projects.iter().find(|pro| {
                 (pro.id().to_lowercase() == project.to_lowercase())
                     || (pro.name().to_lowercase() == project.to_lowercase())
             });
             if let Some(project) = proj {
                 fake_select("Select a project", &project.to_string());
-                project
+                project.clone()
             } else {
-                return Err(RailwayError::ProjectNotFoundInWorkspace(
+                let available: Vec<&str> =
+                    projects.iter().take(5).map(|p| p.name()).collect();
+                let suffix = if projects.len() > 5 {
+                    format!(", +{} more", projects.len() - 5)
+                } else {
+                    String::new()
+                };
+                bail!(
+                    "Project \"{}\" not found in workspace \"{}\".\nAvailable: {}{}",
                     project,
-                    workspace.name().to_owned(),
-                )
-                .into());
+                    workspace.name(),
+                    available.join(", "),
+                    suffix
+                );
             }
         } else {
             prompt_workspace_projects(projects)?

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -59,9 +59,6 @@ pub enum RailwayError {
     )]
     EnvironmentNotFound(String),
 
-    #[error("Project \"{0}\" was not found in the \"{1}\" workspace.")]
-    ProjectNotFoundInWorkspace(String, String),
-
     #[error("Workspace \"{0}\" not found.")]
     WorkspaceNotFound(String),
 


### PR DESCRIPTION
## Summary

- In non-interactive mode, errors from `railway link` now include the list of available **workspaces**, **projects**, and **environments** so agents/scripts can immediately retry with the correct `--flag value` instead of re-prompting or looping.
- Single-service environments: the service is **auto-selected** in non-interactive mode (message printed to stderr so stdout stays clean for `--json` consumers).
- Multi-service environments: a hint listing available service names is printed to stderr; the command succeeds without linking a service (callers can re-run with `--service <name>`).

## Before / After

```
# Before
Error: --environment required in non-interactive mode (multiple environments available)
Error: --workspace required in non-interactive mode (multiple workspaces available)
Error: --project required in non-interactive mode

# After
Error: --environment required in non-interactive mode.
Available: production, staging, pr-42

Error: --workspace required in non-interactive mode.
Available: acme-corp, personal-team

Error: --project required in non-interactive mode.
Available: api-server, web-app, worker
```

## Test plan

- [ ] `railway link --project <name> --environment <name>` works without a TTY
- [ ] When one workspace / one environment exists, auto-selection still proceeds silently
- [ ] Multi-workspace error includes workspace names
- [ ] Multi-project error includes project names
- [ ] Multi-environment error includes environment names
- [ ] Single service in env auto-selects and prints to stderr only
- [ ] Multi-service in env prints hint and sets no linked service
- [ ] `--json` output is unaffected by stderr messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)