### PR TITLE
feat: Add railway service list and deprecate status --all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,7 +2489,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "railwayapp"
-version = "4.40.1"
+version = "4.40.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "railwayapp"
-version = "4.40.1"
+version = "4.40.2"
 edition = "2024"
 license = "MIT"
 authors = ["Railway <contact@railway.com>"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@railway/cli",
-  "version": "4.40.1",
+  "version": "4.40.2",
   "description": "Develop and deploy code with zero configuration",
   "type": "module",
   "author": "Jake Runzer",

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -1,13 +1,28 @@
 use anyhow::bail;
+use chrono::{DateTime, Utc};
 use is_terminal::IsTerminal;
+use json_dotpath::DotPaths as _;
 use serde::Serialize;
+use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::{
+    client::post_graphql,
     controllers::{
         environment::get_matched_environment,
-        project::{ensure_project_and_environment_exist, get_project, get_service_ids_in_env},
+        project::{
+            ensure_project_and_environment_exist, find_service_instance, get_project,
+            get_service_ids_in_env,
+        },
     },
     errors::RailwayError,
+    gql::queries::{
+        self,
+        project::{
+            DeploymentInstanceStatus, DeploymentStatus,
+            ProjectProjectEnvironmentsEdgesNodeServiceInstancesEdgesNode, VolumeState,
+        },
+    },
     util::prompt::{PromptService, prompt_options},
 };
 
@@ -25,6 +40,10 @@ pub struct Args {
 
 #[derive(Parser)]
 enum Commands {
+    /// List services in the current environment
+    #[clap(alias = "ls")]
+    List(ListArgs),
+
     /// Link a service to the current project
     Link(LinkArgs),
 
@@ -51,16 +70,8 @@ struct LinkArgs {
 }
 
 #[derive(Parser)]
-struct StatusArgs {
-    /// Service name or ID to show status for (defaults to linked service)
-    #[clap(short, long)]
-    service: Option<String>,
-
-    /// Show status for all services in the environment
-    #[clap(short, long)]
-    all: bool,
-
-    /// Environment to check status in (defaults to linked environment)
+struct ListArgs {
+    /// Environment to list services from (defaults to linked environment)
     #[clap(short, long)]
     environment: Option<String>,
 
@@ -71,12 +82,102 @@ struct StatusArgs {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+struct ServiceOutput {
+    id: String,
+    name: String,
+    is_linked: bool,
+    source: Option<ServiceSourceOutput>,
+    status: Option<DeploymentStatus>,
+    deployment_stopped: bool,
+    deployment_id: Option<String>,
+    latest_deployment: Option<LatestDeployment>,
+    url: Option<String>,
+    volumes: Vec<VolumeOutput>,
+    regions: Vec<RegionConfig>,
+    replicas: Option<ReplicasOutput>,
+    volume_migrating: bool,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct RegionConfig {
+    name: String,
+    location: Option<String>,
+    configured: i64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LatestDeployment {
+    id: String,
+    status: DeploymentStatus,
+    created_at: DateTime<Utc>,
+    deployment_stopped: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ServiceSourceOutput {
+    repo: Option<String>,
+    image: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VolumeOutput {
+    name: String,
+    mount_path: String,
+    current_size_mb: f64,
+    size_mb: i64,
+    state: Option<VolumeState>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReplicasOutput {
+    configured: i64,
+    running: i64,
+    crashed: i64,
+    exited: i64,
+    total: i64,
+}
+
+struct DeploymentSnapshot {
+    id: String,
+    status: DeploymentStatus,
+    deployment_stopped: bool,
+    instances: Vec<DeploymentInstanceStatus>,
+}
+
+/// Legacy `status --all` output shape. Preserved so scripts parsing the
+/// deprecated command's JSON don't break.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct ServiceStatusOutput {
     id: String,
     name: String,
     deployment_id: Option<String>,
     status: Option<String>,
     stopped: bool,
+}
+
+#[derive(Parser)]
+struct StatusArgs {
+    /// Service name or ID to show status for (defaults to linked service)
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// Deprecated: use `railway service list` instead. Kept for backwards compatibility.
+    #[clap(short, long, hide = true)]
+    all: bool,
+
+    /// Environment to check status in (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -92,6 +193,7 @@ pub async fn command(args: Args) -> Result<()> {
     }
 
     match args.command {
+        Some(Commands::List(list_args)) => list_command(list_args).await,
         Some(Commands::Link(link_args)) => link_command(link_args).await,
         Some(Commands::Status(status_args)) => status_command(status_args).await,
         Some(Commands::Logs(logs_args)) => crate::commands::logs::command(logs_args).await,
@@ -103,6 +205,642 @@ pub async fn command(args: Args) -> Result<()> {
         }
         Some(Commands::Scale(scale_args)) => crate::commands::scale::command(scale_args).await,
         None => unreachable!(),
+    }
+}
+
+async fn list_command(args: ListArgs) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let linked_project = configs.get_linked_project().await?;
+
+    let (project, region_locations) = tokio::join!(
+        get_project(&client, &configs, linked_project.project.clone()),
+        fetch_region_locations(&client, &configs),
+    );
+    let project = project?;
+
+    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
+
+    let env_id = if let Some(env_name) = args.environment {
+        get_matched_environment(&project, env_name)?.id
+    } else {
+        linked_project.environment_id()?.to_string()
+    };
+    let env_name = project
+        .environments
+        .edges
+        .iter()
+        .find(|env| env.node.id == env_id)
+        .map(|env| env.node.name.clone())
+        .expect("environment resolved above");
+
+    let service_ids_in_env = get_service_ids_in_env(&project, &env_id);
+    let linked_service_id = linked_project.service.as_deref();
+
+    let mut services: Vec<_> = project
+        .services
+        .edges
+        .iter()
+        .filter(|edge| service_ids_in_env.contains(&edge.node.id))
+        .collect();
+    services.sort_by(|a, b| a.node.name.to_lowercase().cmp(&b.node.name.to_lowercase()));
+
+    let rows: Vec<ServiceOutput> = services
+        .iter()
+        .map(|edge| {
+            build_service_output(
+                &project,
+                &env_id,
+                &edge.node,
+                linked_service_id,
+                &region_locations,
+            )
+        })
+        .collect();
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        println!("No services found in environment '{env_name}'");
+        return Ok(());
+    }
+
+    println!();
+    println!("{} {}", "Services in".bold(), env_name.blue().bold());
+    println!();
+
+    for row in &rows {
+        print_service_card(row);
+    }
+
+    Ok(())
+}
+
+fn build_service_output(
+    project: &crate::gql::queries::project::ProjectProject,
+    env_id: &str,
+    service: &crate::gql::queries::project::ProjectProjectServicesEdgesNode,
+    linked_service_id: Option<&str>,
+    region_locations: &HashMap<String, String>,
+) -> ServiceOutput {
+    let id = service.id.clone();
+    let is_linked = linked_service_id == Some(id.as_str());
+    let instance = find_service_instance(project, env_id, &id);
+
+    let volumes = volumes_for_service(project, env_id, &id);
+    let volume_migrating = volumes
+        .iter()
+        .any(|v| matches!(v.state, Some(VolumeState::MIGRATING)));
+
+    let active = instance
+        .map(|i| i.active_deployments.as_slice())
+        .unwrap_or(&[]);
+    let latest = instance.and_then(|i| i.latest_deployment.as_ref());
+
+    let stable_active = active.iter().find(|d| is_stable_status(&d.status));
+    let in_progress = active.iter().find(|d| is_in_progress_status(&d.status));
+    // Use the currently serving deployment for the primary status snapshot, but
+    // keep the latest deployment alongside it so rollouts that are still queued,
+    // waiting for approval, or have already failed remain visible.
+    let serving_snapshot = stable_active
+        .map(|d| DeploymentSnapshot {
+            id: d.id.clone(),
+            status: d.status.clone(),
+            deployment_stopped: d.deployment_stopped,
+            instances: d.instances.iter().map(|i| i.status.clone()).collect(),
+        })
+        .or_else(|| {
+            latest.map(|d| DeploymentSnapshot {
+                id: d.id.clone(),
+                status: d.status.clone(),
+                deployment_stopped: d.deployment_stopped,
+                instances: d.instances.iter().map(|i| i.status.clone()).collect(),
+            })
+        });
+
+    // Resolve region config from the deployment's service manifest, mirroring
+    // what `railway service scale` reads (and what the dashboard sums).
+    // `ServiceInstance.numReplicas` on the public API is the legacy per-region
+    // field and reports `1` for multi-region services — so we must read from meta.
+    let mut regions = stable_active
+        .and_then(|d| d.meta.as_ref())
+        .map(regions_from_meta)
+        .filter(|r| !r.is_empty())
+        .or_else(|| {
+            in_progress
+                .and_then(|d| d.meta.as_ref())
+                .map(regions_from_meta)
+                .filter(|r| !r.is_empty())
+        })
+        .or_else(|| {
+            latest
+                .and_then(|d| d.meta.as_ref())
+                .map(regions_from_meta)
+                .filter(|r| !r.is_empty())
+        })
+        .unwrap_or_default();
+
+    for r in &mut regions {
+        r.location = region_locations.get(&r.name).cloned();
+    }
+
+    let configured = if !regions.is_empty() {
+        regions.iter().map(|r| r.configured).sum()
+    } else {
+        instance.and_then(|i| i.num_replicas).unwrap_or(1)
+    };
+
+    // Snapshot fields: prefer the stable deployment from `activeDeployments`
+    // (reflects what's currently serving during rollouts), fall back to
+    // `latestDeployment` for cases where nothing stable is active.
+    let (status, deployment_stopped, deployment_id, replica_instances) = serving_snapshot
+        .map(|d| {
+            (
+                Some(d.status),
+                d.deployment_stopped,
+                Some(d.id),
+                Some(d.instances),
+            )
+        })
+        .unwrap_or((None, false, None, None));
+
+    let replicas = replica_instances.map(|s| count_replicas(configured, s.into_iter()));
+
+    let latest_deployment = latest.map(|d| LatestDeployment {
+        id: d.id.clone(),
+        status: d.status.clone(),
+        created_at: d.created_at,
+        deployment_stopped: d.deployment_stopped,
+    });
+
+    ServiceOutput {
+        source: instance.and_then(source_from_instance),
+        status,
+        deployment_stopped,
+        deployment_id,
+        latest_deployment,
+        url: instance.and_then(url_from_instance),
+        volumes,
+        regions,
+        replicas,
+        volume_migrating,
+        id,
+        name: service.name.clone(),
+        is_linked,
+    }
+}
+
+fn is_stable_status(status: &DeploymentStatus) -> bool {
+    matches!(
+        status,
+        DeploymentStatus::SUCCESS | DeploymentStatus::CRASHED | DeploymentStatus::SLEEPING
+    )
+}
+
+fn is_in_progress_status(status: &DeploymentStatus) -> bool {
+    matches!(
+        status,
+        DeploymentStatus::BUILDING
+            | DeploymentStatus::DEPLOYING
+            | DeploymentStatus::INITIALIZING
+            | DeploymentStatus::QUEUED
+            | DeploymentStatus::WAITING
+    )
+}
+
+fn is_rollout_status(status: &DeploymentStatus) -> bool {
+    is_in_progress_status(status)
+        || matches!(
+            status,
+            DeploymentStatus::NEEDS_APPROVAL | DeploymentStatus::FAILED
+        )
+}
+
+fn count_replicas(
+    configured: i64,
+    statuses: impl Iterator<Item = DeploymentInstanceStatus>,
+) -> ReplicasOutput {
+    let mut running = 0i64;
+    let mut crashed = 0i64;
+    let mut exited = 0i64;
+    let mut total = 0i64;
+    for status in statuses {
+        if matches!(
+            status,
+            DeploymentInstanceStatus::REMOVED | DeploymentInstanceStatus::REMOVING
+        ) {
+            continue;
+        }
+        total += 1;
+        match status {
+            DeploymentInstanceStatus::RUNNING => running += 1,
+            DeploymentInstanceStatus::CRASHED => crashed += 1,
+            DeploymentInstanceStatus::EXITED => exited += 1,
+            _ => {}
+        }
+    }
+    ReplicasOutput {
+        configured,
+        running,
+        crashed,
+        exited,
+        total,
+    }
+}
+
+/// Extracts per-region replica configuration from a deployment's `meta` blob.
+///
+/// Reads `serviceManifest.deploy.multiRegionConfig` (keyed by region name).
+/// Falls back to `deploy.region` + `deploy.numReplicas` for legacy single-region
+/// deployments. Returns an empty vec if the meta has neither.
+/// This is the same path `railway service scale` uses to read the config.
+fn regions_from_meta(meta: &Value) -> Vec<RegionConfig> {
+    let Some(deploy) = meta
+        .dot_get::<Value>("serviceManifest.deploy")
+        .ok()
+        .flatten()
+    else {
+        return Vec::new();
+    };
+
+    if let Some(config) = deploy
+        .dot_get::<Value>("multiRegionConfig")
+        .ok()
+        .flatten()
+        .and_then(|v| v.as_object().cloned())
+    {
+        let mut regions: Vec<RegionConfig> = config
+            .into_iter()
+            .map(|(name, v)| RegionConfig {
+                name,
+                location: None,
+                configured: v.get("numReplicas").and_then(Value::as_i64).unwrap_or(0),
+            })
+            .collect();
+        regions.sort_by(|a, b| a.name.cmp(&b.name));
+        return regions;
+    }
+
+    if let Some(region) = deploy.get("region").and_then(Value::as_str) {
+        let configured = deploy
+            .get("numReplicas")
+            .and_then(Value::as_i64)
+            .unwrap_or(1);
+        return vec![RegionConfig {
+            name: region.to_string(),
+            location: None,
+            configured,
+        }];
+    }
+
+    Vec::new()
+}
+
+/// Fetches the region directory and returns a lookup from region code (e.g.
+/// "europe-west4-drams3a") to its friendly location ("EU West").
+/// Returns an empty map on failure — callers display raw codes instead.
+async fn fetch_region_locations(
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> HashMap<String, String> {
+    match post_graphql::<queries::Regions, _>(
+        client,
+        configs.get_backboard(),
+        queries::regions::Variables,
+    )
+    .await
+    {
+        Ok(resp) => resp
+            .regions
+            .into_iter()
+            .filter(|r| !r.location.is_empty())
+            .map(|r| (r.name, r.location))
+            .collect(),
+        Err(_) => HashMap::new(),
+    }
+}
+
+const FIELD_LABEL_WIDTH: usize = 14;
+
+fn print_field(label: &str, value: &impl std::fmt::Display) {
+    let padded = format!("{label:<FIELD_LABEL_WIDTH$}");
+    println!("    {} {value}", padded.dimmed());
+}
+
+fn print_service_card(row: &ServiceOutput) {
+    if row.is_linked {
+        println!("{} {}", row.name.green().bold(), "(linked)".green());
+    } else {
+        println!("{}", row.name.bold());
+    }
+    print_field("status:", &derived_status_line(row));
+    if let Some(source) = &row.source {
+        if let Some(repo) = &source.repo {
+            print_field("repo:", repo);
+        }
+        if let Some(image) = &source.image {
+            print_field("image:", image);
+        }
+    }
+    if let Some(url) = &row.url {
+        print_field("url:", &url.clone().cyan());
+    }
+    for volume in &row.volumes {
+        print_field("volume:", &format_volume_line(volume));
+    }
+    match row.regions.len() {
+        0 => {}
+        1 => print_field("region:", &format_regions_line(&row.regions)),
+        _ => print_field("regions:", &format_regions_line(&row.regions)),
+    }
+    if let Some(r) = &row.replicas {
+        if !row.deployment_stopped
+            && (r.configured > 1 || r.crashed > 0 || r.running != r.configured)
+        {
+            print_field("replicas:", &format_replicas_line(r));
+        }
+    }
+    if let Some(dep_id) = &row.deployment_id {
+        print_field("deployment ID:", &dep_id.clone().dimmed());
+    }
+    print_field("service ID:", &row.id.clone().dimmed());
+    println!();
+}
+
+fn format_replicas_line(r: &ReplicasOutput) -> String {
+    let primary = format!("{}/{} running", r.running, r.configured);
+    if r.crashed > 0 {
+        format!("{}, {} crashed", primary, r.crashed.to_string().red())
+    } else {
+        primary
+    }
+}
+
+fn format_regions_line(regions: &[RegionConfig]) -> String {
+    if regions.len() == 1 {
+        return region_display_name(&regions[0]);
+    }
+    let sep = " · ".dimmed();
+    regions
+        .iter()
+        .map(|r| {
+            format!(
+                "{} ({})",
+                region_display_name(r),
+                r.configured.to_string().dimmed()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(&sep.to_string())
+}
+
+fn region_display_name(r: &RegionConfig) -> String {
+    r.location.clone().unwrap_or_else(|| r.name.clone())
+}
+
+fn volumes_for_service(
+    project: &crate::gql::queries::project::ProjectProject,
+    env_id: &str,
+    service_id: &str,
+) -> Vec<VolumeOutput> {
+    project
+        .environments
+        .edges
+        .iter()
+        .find(|e| e.node.id == env_id)
+        .map(|env| {
+            env.node
+                .volume_instances
+                .edges
+                .iter()
+                .filter(|vi| vi.node.service_id.as_deref() == Some(service_id))
+                .map(|vi| VolumeOutput {
+                    name: vi.node.volume.name.clone(),
+                    mount_path: vi.node.mount_path.clone(),
+                    current_size_mb: vi.node.current_size_mb,
+                    size_mb: vi.node.size_mb,
+                    state: vi.node.state.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn derived_status_line(row: &ServiceOutput) -> String {
+    if row.volume_migrating {
+        return format!(
+            "{} {}",
+            "●".dimmed(),
+            "Service temporarily offline".dimmed()
+        );
+    }
+
+    if row.status.as_ref().is_some_and(is_timed_rollout_status) {
+        if let Some(deployment) = current_status_deployment(row) {
+            let (dot, label) = rollout_status_line(deployment);
+            return format!("{dot} {label}");
+        }
+
+        let (dot, label) = style_status(row.status.as_ref(), row.deployment_stopped);
+        return format!("{dot} {label}");
+    }
+
+    let stable_line = stable_status_label(row);
+
+    match (stable_line, latest_rollout_deployment(row)) {
+        (Some(stable), Some(deployment)) => {
+            let (_, label) = rollout_status_line(deployment);
+            format!("{stable} {} {label}", "·".dimmed())
+        }
+        (Some(stable), None) => stable,
+        (None, Some(deployment)) => {
+            let (dot, label) = rollout_status_line(deployment);
+            format!("{dot} {label}")
+        }
+        (None, None) => {
+            let (dot, label) = style_status(row.status.as_ref(), row.deployment_stopped);
+            format!("{dot} {label}")
+        }
+    }
+}
+
+fn stable_status_label(row: &ServiceOutput) -> Option<String> {
+    let status = row.status.as_ref()?;
+    let some_running = row.replicas.as_ref().is_some_and(|r| r.running > 0);
+    let has_multiple = row
+        .replicas
+        .as_ref()
+        .is_some_and(|r| r.total > 1 || r.configured > 1);
+    let some_crashed = has_multiple && row.replicas.as_ref().is_some_and(|r| r.crashed > 0);
+
+    let is_online = matches!(status, DeploymentStatus::SUCCESS)
+        || (matches!(status, DeploymentStatus::CRASHED) && some_running);
+    let is_crashed_out = matches!(status, DeploymentStatus::CRASHED) && !some_running;
+
+    if is_online && row.deployment_stopped {
+        return Some(format!("{} {}", "●".green(), "Completed".green()));
+    }
+    if is_online && some_crashed {
+        let r = row
+            .replicas
+            .as_ref()
+            .expect("some_crashed implies replicas");
+        let label = format!("Online ({}/{} replicas crashed)", r.crashed, r.total);
+        return Some(format!("{} {}", "●".yellow(), label.yellow()));
+    }
+    if is_online {
+        return Some(format!("{} {}", "●".green(), "Online".green()));
+    }
+    if is_crashed_out {
+        return Some(format!("{} {}", "●".red(), "Crashed".red()));
+    }
+    let (dot, label) = style_status(Some(status), row.deployment_stopped);
+    Some(format!("{dot} {label}"))
+}
+
+fn is_timed_rollout_status(status: &DeploymentStatus) -> bool {
+    is_in_progress_status(status) || matches!(status, DeploymentStatus::NEEDS_APPROVAL)
+}
+
+fn current_status_deployment(row: &ServiceOutput) -> Option<&LatestDeployment> {
+    row.latest_deployment
+        .as_ref()
+        .filter(|d| Some(d.id.as_str()) == row.deployment_id.as_deref())
+}
+
+fn latest_rollout_deployment(row: &ServiceOutput) -> Option<&LatestDeployment> {
+    row.latest_deployment.as_ref().filter(|d| {
+        Some(d.id.as_str()) != row.deployment_id.as_deref() && is_rollout_status(&d.status)
+    })
+}
+
+fn rollout_status_line(
+    deployment: &LatestDeployment,
+) -> (colored::ColoredString, colored::ColoredString) {
+    let label = match &deployment.status {
+        DeploymentStatus::BUILDING => "Building",
+        DeploymentStatus::DEPLOYING => "Deploying",
+        DeploymentStatus::INITIALIZING => "Initializing",
+        DeploymentStatus::QUEUED => "Queued",
+        DeploymentStatus::WAITING => "Waiting for CI",
+        DeploymentStatus::NEEDS_APPROVAL => "Awaiting approval",
+        DeploymentStatus::FAILED => "Deploy failed",
+        _ => {
+            return style_status(Some(&deployment.status), deployment.deployment_stopped);
+        }
+    };
+    let label = format!("{label} ({})", format_elapsed(deployment.created_at));
+    match deployment.status {
+        DeploymentStatus::QUEUED => ("●".dimmed(), label.dimmed()),
+        DeploymentStatus::NEEDS_APPROVAL => ("●".yellow(), label.yellow()),
+        DeploymentStatus::FAILED => ("●".red(), label.red()),
+        _ => ("●".blue(), label.blue()),
+    }
+}
+
+fn format_elapsed(since: DateTime<Utc>) -> String {
+    let seconds = (Utc::now() - since).num_seconds().max(0);
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3600 {
+        format!("{}m", seconds / 60)
+    } else if seconds < 86400 {
+        let h = seconds / 3600;
+        let m = (seconds % 3600) / 60;
+        if m == 0 {
+            format!("{h}h")
+        } else {
+            format!("{h}h {m}m")
+        }
+    } else {
+        format!("{}d", seconds / 86400)
+    }
+}
+
+fn format_volume_line(volume: &VolumeOutput) -> String {
+    let total = volume.size_mb as f64;
+    let pct = if total > 0.0 {
+        volume.current_size_mb / total * 100.0
+    } else {
+        0.0
+    };
+    let usage = format_size_pair(volume.current_size_mb, total);
+    let colored_usage = if pct >= 100.0 {
+        usage.red()
+    } else if pct >= 75.0 {
+        usage.yellow()
+    } else {
+        usage.normal()
+    };
+    let sep = "·".dimmed();
+    format!(
+        "{} {sep} {} {sep} {}",
+        volume.name, volume.mount_path, colored_usage,
+    )
+}
+
+fn format_size_pair(current_mb: f64, size_mb: f64) -> String {
+    let show_gb = current_mb >= 1024.0 || size_mb >= 1024.0;
+    if show_gb {
+        format!("{:.1} GB / {:.1} GB", current_mb / 1024.0, size_mb / 1024.0)
+    } else {
+        format!("{:.0} MB / {:.0} MB", current_mb, size_mb)
+    }
+}
+
+fn source_from_instance(
+    instance: &ProjectProjectEnvironmentsEdgesNodeServiceInstancesEdgesNode,
+) -> Option<ServiceSourceOutput> {
+    let source = instance.source.as_ref()?;
+    let repo = source.repo.clone().filter(|s| !s.is_empty());
+    let image = source.image.clone().filter(|s| !s.is_empty());
+    (repo.is_some() || image.is_some()).then_some(ServiceSourceOutput { repo, image })
+}
+
+fn url_from_instance(
+    instance: &ProjectProjectEnvironmentsEdgesNodeServiceInstancesEdgesNode,
+) -> Option<String> {
+    instance
+        .domains
+        .custom_domains
+        .first()
+        .map(|d| d.domain.clone())
+        .or_else(|| {
+            instance
+                .domains
+                .service_domains
+                .first()
+                .map(|d| d.domain.clone())
+        })
+        .map(|d| format!("https://{d}"))
+}
+
+fn style_status(
+    status: Option<&DeploymentStatus>,
+    stopped: bool,
+) -> (colored::ColoredString, colored::ColoredString) {
+    let Some(status) = status else {
+        return ("○".dimmed(), "Offline".dimmed());
+    };
+    match (status, stopped) {
+        (DeploymentStatus::SUCCESS, true) => ("●".green(), "Completed".green()),
+        (DeploymentStatus::SUCCESS, false) => ("●".green(), "Online".green()),
+        (DeploymentStatus::FAILED, _) => ("●".red(), "Failed".red()),
+        (DeploymentStatus::CRASHED, _) => ("●".red(), "Crashed".red()),
+        (DeploymentStatus::BUILDING, _) => ("●".blue(), "Building".blue()),
+        (DeploymentStatus::DEPLOYING, _) => ("●".blue(), "Deploying".blue()),
+        (DeploymentStatus::INITIALIZING, _) => ("●".blue(), "Initializing".blue()),
+        (DeploymentStatus::QUEUED, _) => ("●".dimmed(), "Queued".dimmed()),
+        (DeploymentStatus::WAITING, _) => ("●".blue(), "Waiting for CI".blue()),
+        (DeploymentStatus::SLEEPING, _) => ("●".yellow(), "Sleeping".yellow()),
+        (DeploymentStatus::NEEDS_APPROVAL, _) => ("●".yellow(), "Pending".yellow()),
+        (DeploymentStatus::REMOVED, _) => ("●".dimmed(), "Removed".dimmed()),
+        (DeploymentStatus::REMOVING, _) => ("●".dimmed(), "Removing".dimmed()),
+        (DeploymentStatus::SKIPPED, _) => ("●".dimmed(), "Skipped".dimmed()),
+        (DeploymentStatus::Other(s), _) => ("●".white(), s.clone().white()),
     }
 }
 
@@ -144,6 +882,14 @@ async fn link_command(args: LinkArgs) -> Result<()> {
 }
 
 async fn status_command(args: StatusArgs) -> Result<()> {
+    if args.all {
+        eprintln!(
+            "{}",
+            "Warning: `railway service status --all` is deprecated. Please use `railway service list` instead."
+                .yellow()
+        );
+    }
+
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let linked_project = configs.get_linked_project().await?;

--- a/src/gql/queries/strings/Project.graphql
+++ b/src/gql/queries/strings/Project.graphql
@@ -29,6 +29,7 @@ query Project($id: String!) {
                 serviceId
                 serviceName
                 environmentId
+                numReplicas
                 latestDeployment {
                   canRedeploy
                   id
@@ -36,12 +37,21 @@ query Project($id: String!) {
                   status
                   createdAt
                   deploymentStopped
+                  instances {
+                    id
+                    status
+                  }
                 }
                 activeDeployments {
                   id
                   status
                   createdAt
                   meta
+                  deploymentStopped
+                  instances {
+                    id
+                    status
+                  }
                 }
                 source {
                   repo
@@ -73,6 +83,7 @@ query Project($id: String!) {
                 environmentId
                 currentSizeMB
                 sizeMB
+                state
                 volume {
                   name
                   id


### PR DESCRIPTION
## Summary

This PR adds `railway service list` as the new environment-scoped command for inspecting
multiple services at once, and deprecates `railway service status --all`.

It is designed to:

- introduce a richer multi-service overview command
- keep `railway service status --all` working for existing users and scripts
- avoid broadening the scope of single-service `railway service status`
- preserve the existing link-oriented behavior of bare `railway service`

<img width="3840" height="2160" alt="`railway service list` terminal output" src="https://github.com/user-attachments/assets/cbf83243-b208-4f37-8da0-958dd3c5a7b5" />

## Usage

```bash
railway service list
railway service ls
railway service list --environment staging
railway service list --json

# still supported, but deprecated
railway service status --all
railway service status --all --json
```

## Human-readable output

`railway service list` defaults to a card-style view optimized for quick scanning.

Example:

```text
Services in production

coming-soon (linked)
    status:        ● Online
    url:           https://coming-soon-production-fecc.up.railway.app
    regions:       Southeast Asia (1) · EU West (3) · US West (1)
    replicas:      5/5 running
    deployment ID: d1af3c31-4eef-420e-925e-ca708078fed4
    service ID:    bf2d43b4-be4f-4cc5-b445-ca8d7db2fde6

fullstack-bun
    status:        ● Online
    url:           https://fullstack-bun-production-39d5.up.railway.app
    region:        EU West
    deployment ID: 92ea5d3a-d9ee-4905-acf2-ec391acce94d
    service ID:    d4c37829-8b7a-4cf7-9bdd-19b8276560ef

json-api
    status:        ● Online
    url:           https://json-api-production-8ff3.up.railway.app
    region:        EU West
    deployment ID: de23c37c-1d59-484d-b16e-7387002d19e3
    service ID:    ec795966-8228-4d97-98b0-79b886b1fa60

Postgres
    status:        ● Online
    image:         ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni:18
    volume:        postgres-volume · /var/lib/postgresql/data · 1.2 GB / 48.8 GB
    region:        EU West
    deployment ID: 1af22886-c5d8-48a1-8ea1-32e7bd9510b9
    service ID:    47b3c39a-2378-48c3-9e17-8dd9ab341134

Redis
    status:        ● Online
    image:         redis:8.2.1
    volume:        redis-volume · /data · 1.0 GB / 48.8 GB
    region:        EU West
    deployment ID: 03554184-00ca-4e15-81e5-ee41763ce1a0
    service ID:    f8910118-c074-4b5d-9712-bead1d085f85

visitor-counter
    status:        ● Online
    url:           https://visitor-counter-production-7283.up.railway.app
    region:        EU West
    deployment ID: 43114940-21ce-40c4-9c9a-04453eceab24
    service ID:    e26a2a9c-a4d7-4aad-9ca1-a62c1462e0fe
```

The output includes:

- services sorted alphabetically
- inline `(linked)` marking for the currently linked service
- one `url:` value when available, preferring a custom domain over a generated domain
- source information when available (`repo` and/or `image`)
- volumes, regions, deployment ID, and service ID
- replica health only when it adds signal
- optional fields omitted entirely instead of rendering placeholders

Status rendering is derived in the CLI so the output can reflect both what is currently
serving and what the latest rollout is doing:

- serving deployments remain the primary status snapshot
- first-time deployments show only the rollout state
- successful stopped deployments render as `Completed`
- sleeping services remain a distinct steady state
- partially healthy multi-replica services render as degraded `Online`
- services with migrating volumes surface a degraded/offline status

## JSON output

`railway service list --json` returns a new structured JSON schema intended for scripting
and tooling.

Example:

```json
[
  {
    "id": "bf2d43b4-be4f-4cc5-b445-ca8d7db2fde6",
    "name": "coming-soon",
    "isLinked": true,
    "source": null,
    "status": "SUCCESS",
    "deploymentStopped": false,
    "deploymentId": "d1af3c31-4eef-420e-925e-ca708078fed4",
    "latestDeployment": {
      "id": "d1af3c31-4eef-420e-925e-ca708078fed4",
      "status": "SUCCESS",
      "createdAt": "2026-04-23T09:12:30Z",
      "deploymentStopped": false
    },
    "url": "https://coming-soon-production-fecc.up.railway.app",
    "volumes": [],
    "regions": [
      {
        "name": "asia-southeast1-eqsg3a",
        "location": "Southeast Asia",
        "configured": 1
      },
      {
        "name": "europe-west4-drams3a",
        "location": "EU West",
        "configured": 3
      },
      {
        "name": "us-west2",
        "location": "US West",
        "configured": 1
      }
    ],
    "replicas": {
      "configured": 5,
      "running": 5,
      "crashed": 0,
      "exited": 0,
      "total": 5
    },
    "volumeMigrating": false
  },
  {
    "id": "47b3c39a-2378-48c3-9e17-8dd9ab341134",
    "name": "Postgres",
    "isLinked": false,
    "source": {
      "repo": null,
      "image": "ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni:18"
    },
    "status": "SUCCESS",
    "deploymentStopped": false,
    "deploymentId": "1af22886-c5d8-48a1-8ea1-32e7bd9510b9",
    "latestDeployment": {
      "id": "1af22886-c5d8-48a1-8ea1-32e7bd9510b9",
      "status": "SUCCESS",
      "createdAt": "2026-04-23T09:10:11Z",
      "deploymentStopped": false
    },
    "url": null,
    "volumes": [
      {
        "name": "postgres-volume",
        "mountPath": "/var/lib/postgresql/data",
        "currentSizeMb": 1209.974784,
        "sizeMb": 50000,
        "state": "READY"
      }
    ],
    "regions": [
      {
        "name": "europe-west4-drams3a",
        "location": "EU West",
        "configured": 1
      }
    ],
    "replicas": {
      "configured": 1,
      "running": 1,
      "crashed": 0,
      "exited": 0,
      "total": 1
    },
    "volumeMigrating": false
  }
]
```

Each service entry includes:

- identity and linking state (`id`, `name`, `isLinked`)
- source metadata (`source.repo`, `source.image`), or `null` when unavailable
- the currently serving deployment snapshot (`status`, `deploymentStopped`, `deploymentId`)
- the latest deployment as `latestDeployment` when present, including:
  - `id`
  - `status`
  - `createdAt`
  - `deploymentStopped`
- `latestDeployment` may be the same deployment referenced by `deploymentId` when there is
  no rollout in progress
- `url`, or `null` when no domain exists
- `volumes`
- `regions`
- `replicas`
- `volumeMigrating`

JSON behavior:

- ordering matches the human-readable output
- output is structured and semantic, not preformatted display text
- nullable fields like `source` and `url` are emitted as `null` when unavailable
- arrays remain arrays (`[]`) rather than becoming `null`
- `latestDeployment` reflects the most recent deployment when one exists; it is not limited
  to active rollouts
- both raw region identifiers and friendly region locations are included
- volume state is preserved in JSON

If no services are present in the selected environment, `--json` returns `[]`.

## Compatibility and deprecation

`railway service status --all` remains supported for backwards compatibility.

This PR keeps the old `status --all` behavior intentionally stable:

- `--all` is hidden from help
- a deprecation warning is printed to stderr
- the existing table output is preserved
- the existing JSON shape is preserved

Single-service `railway service status` keeps its existing behavior and output contract.
Bare `railway service` also keeps its existing link-oriented behavior.

## Design notes

- `service list` is environment-scoped, not project-wide
- `service list` is the new preferred multi-service overview command
- `service ls` is supported as an alias
- linked services are marked inline rather than reordered
- multi-region configuration is derived from deployment metadata rather than the legacy
  `numReplicas` field
- friendly region names are best-effort; if region enrichment fails, raw region codes are
  still shown
- this PR expands the shared `Project` GraphQL query with the additional fields needed by
  `service list`

## Validation

- `cargo check -q`
- `cargo test -q`
