### PR TITLE
fix(install): tolerate compact JSON from GitHub releases API

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,7 +338,7 @@ is_build_available() {
 UNINSTALL=0
 HELP=0
 
-DEFAULT_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name": "v.*"' | cut -d'"' -f4 | cut -c2-)
+DEFAULT_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name":[[:space:]]*"v[^"]*"' | cut -d'"' -f4 | cut -c2-)
 
 if [ -z "$DEFAULT_VERSION" ]; then
   error "Failed to fetch latest version from GitHub"


### PR DESCRIPTION
## Summary

The `install.sh` one-liner aborts for every user with `x Failed to fetch latest version from GitHub`. `DEFAULT_VERSION` is extracted with `grep -o '"tag_name": "v.*"'`, which assumes pretty-printed JSON with a space after the colon — but GitHub's releases endpoint returns compact JSON (`"tag_name":"v4.42.0"`). The match comes up empty, `DEFAULT_VERSION` is unset, and the guard immediately below aborts. Relax the pattern to tolerate 0-or-more whitespace after the colon, and anchor the version capture so the greedy `.*` can no longer swallow neighbouring keys.

## Changes

- `install.sh`: change the `DEFAULT_VERSION` grep from `'"tag_name": "v.*"'` to `'"tag_name":[[:space:]]*"v[^"]*"'`. Matches both compact and pretty-printed responses; the downstream `cut -d'"' -f4 | cut -c2-` pipeline is unchanged.

## Test plan

- [x] `curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name":[[:space:]]*"v[^"]*"' | cut -d'"' -f4 | cut -c2-` → `4.42.0`
- [x] `bash install.sh --help` prints the options block instead of aborting
- [ ] After merge, re-run the published `curl … | sh` one-liner end-to-end on macOS + Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)