### PR TITLE
feat(redeploy): add --from-source flag to pull latest commit or image

### DIFF
--- a/src/commands/redeploy.rs
+++ b/src/commands/redeploy.rs
@@ -26,6 +26,10 @@ pub struct Args {
     /// Output in JSON format
     #[clap(long)]
     json: bool,
+
+    /// Pull and deploy the latest commit or image from the configured source, instead of redeploying the existing deployment
+    #[clap(long)]
+    from_source: bool,
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -36,9 +40,20 @@ pub async fn command(args: Args) -> Result<()> {
     ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
 
     let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-    let is_terminal = std::io::stdout().is_terminal();
+    let environment_id = linked_project.environment_id()?.to_string();
+    let environment_name = linked_project
+        .environment_name
+        .as_deref()
+        .unwrap_or("unknown");
 
-    let service_id = args.service.or_else(|| linked_project.service.clone()).ok_or_else(|| anyhow!("No service found. Please link one via `railway link` or specify one via the `--service` flag."))?;
+    let service_id = args
+        .service
+        .or_else(|| linked_project.service.clone())
+        .ok_or_else(|| {
+            anyhow!(
+                "No service found. Please link one via `railway link` or specify one via the `--service` flag."
+            )
+        })?;
     let service = project
         .services
         .edges
@@ -47,40 +62,55 @@ pub async fn command(args: Args) -> Result<()> {
             s.node.id == service_id || s.node.name.to_lowercase() == service_id.to_lowercase()
         })
         .ok_or_else(|| anyhow!(RailwayError::ServiceNotFound(service_id)))?;
+    let service_name = &service.node.name;
 
-    let service_in_env =
-        find_service_instance(&project, linked_project.environment_id()?, &service.node.id)
-            .ok_or_else(|| {
-                anyhow!("The service specified doesn't exist in the current environment")
-            })?;
+    let service_in_env = find_service_instance(&project, &environment_id, &service.node.id)
+        .ok_or_else(|| anyhow!("The service specified doesn't exist in the current environment"))?;
 
-    let Some(ref latest) = service_in_env.latest_deployment else {
-        bail!("No deployment found for service")
+    let latest_deployment_id = if args.from_source {
+        None
+    } else {
+        let latest = service_in_env
+            .latest_deployment
+            .as_ref()
+            .ok_or_else(|| anyhow!("No deployment found for service"))?;
+        if !latest.can_redeploy {
+            bail!(
+                "The latest deployment for service {service_name} cannot be redeployed. \
+                This may be because it's currently building, deploying, or was removed."
+            );
+        }
+        Some(latest.id.clone())
     };
 
-    if !latest.can_redeploy {
-        bail!(
-            "The latest deployment for service {} cannot be redeployed. \
-            This may be because it's currently building, deploying, or was removed.",
-            service.node.name
-        );
-    }
+    let (prompt_msg, spinner_msg, finish_msg) = if args.from_source {
+        (
+            format!(
+                "Pull the latest source (commit or image) and deploy service {service_name} in environment {environment_name}?"
+            ),
+            format!("Pulling the latest source and deploying service {service_name}..."),
+            format!(
+                "Triggered a deploy from the latest source for service {}",
+                service_name.green()
+            ),
+        )
+    } else {
+        (
+            format!(
+                "Redeploy the latest deployment from service {service_name} in environment {environment_name}?"
+            ),
+            format!("Redeploying the latest deployment from service {service_name}..."),
+            format!(
+                "The latest deployment from service {} has been redeployed",
+                service_name.green()
+            ),
+        )
+    };
 
     let confirmed = if args.bypass {
         true
-    } else if is_terminal {
-        prompt_confirm_with_default(
-            format!(
-                "Redeploy the latest deployment from service {} in environment {}?",
-                service.node.name,
-                linked_project
-                    .environment_name
-                    .clone()
-                    .unwrap_or("unknown".to_string())
-            )
-            .as_str(),
-            false,
-        )?
+    } else if std::io::stdout().is_terminal() {
+        prompt_confirm_with_default(&prompt_msg, false)?
     } else {
         bail!(
             "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip confirmation."
@@ -91,33 +121,36 @@ pub async fn command(args: Args) -> Result<()> {
         return Ok(());
     }
 
-    let spinner = create_spinner_if(
-        !args.json,
-        format!(
-            "Redeploying the latest deployment from service {}...",
-            service.node.name
-        ),
-    );
+    let spinner = create_spinner_if(!args.json, spinner_msg);
 
-    let response = post_graphql::<mutations::DeploymentRedeploy, _>(
-        &client,
-        configs.get_backboard(),
-        mutations::deployment_redeploy::Variables {
-            id: latest.id.clone(),
-        },
-    )
-    .await?;
+    let json_output = match latest_deployment_id {
+        None => {
+            post_graphql::<mutations::ServiceInstanceDeployLatestCommit, _>(
+                &client,
+                configs.get_backboard(),
+                mutations::service_instance_deploy_latest_commit::Variables {
+                    environment_id,
+                    service_id: service.node.id.clone(),
+                },
+            )
+            .await?;
+            serde_json::json!({ "success": true })
+        }
+        Some(id) => {
+            let response = post_graphql::<mutations::DeploymentRedeploy, _>(
+                &client,
+                configs.get_backboard(),
+                mutations::deployment_redeploy::Variables { id },
+            )
+            .await?;
+            serde_json::json!({ "id": response.deployment_redeploy.id })
+        }
+    };
 
     if args.json {
-        println!(
-            "{}",
-            serde_json::json!({"id": response.deployment_redeploy.id})
-        );
+        println!("{json_output}");
     } else if let Some(spinner) = spinner {
-        spinner.finish_with_message(format!(
-            "The latest deployment from service {} has been redeployed",
-            service.node.name.green()
-        ));
+        spinner.finish_with_message(finish_msg);
     }
 
     Ok(())

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -204,6 +204,14 @@ pub struct ServiceInstanceDeploy;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/ServiceInstanceDeployLatestCommit.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ServiceInstanceDeployLatestCommit;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/ServiceDelete.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/mutations/strings/ServiceInstanceDeployLatestCommit.graphql
+++ b/src/gql/mutations/strings/ServiceInstanceDeployLatestCommit.graphql
@@ -1,0 +1,3 @@
+mutation ServiceInstanceDeployLatestCommit($environmentId: String!, $serviceId: String!) {
+  serviceInstanceDeploy(environmentId: $environmentId, serviceId: $serviceId, latestCommit: true)
+}


### PR DESCRIPTION
## Summary

- `railway redeploy` calls `deploymentRedeploy`, which redeploys the existing build/image as-is. Many users actually want a fresh deploy that picks up the latest commit (for source-connected services) or the latest image (for image-based services).
- Adds `--from-source` to `railway redeploy`. When passed, the command calls `serviceInstanceDeploy` with `latestCommit: true` instead of `deploymentRedeploy`.
- Default behavior is unchanged — existing scripts won't break.
- Condensed the command body so both paths share confirm/spinner/output scaffolding (`environment_id`, `environment_name`, `service_name` hoisted; messages chosen up-front; single mutation/output match).

## Test plan

- [x] `cargo run -- redeploy --help` shows the new flag with accurate copy
- [x] `cargo run -- redeploy` (no flag) still triggers `deploymentRedeploy` on the latest deployment
- [x] `cargo run -- redeploy --from-source -y` on a source-connected service deploys the latest commit
- [x] `cargo run -- redeploy --from-source -y` on an image-based service deploys the latest image
- [x] `--from-source --json` prints `{"success": true}`; default `--json` still prints `{"id": "..."}`
- [x] Non-interactive without `--yes` bails with the existing message in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)