### PR TITLE
Add metrics command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,6 +2526,7 @@ dependencies = [
  "country-emoji",
  "croner",
  "crossterm 0.27.0",
+ "csv",
  "ctrlc",
  "derive-new",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ scopeguard = "1.2"
 schemars = "0.8"
 rmcp = { version = "0.16", features = ["transport-io"] }
 termimad = "0.28"
+csv = "1.3"
 
 [profile.release]
 lto = "fat"

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -25,7 +25,7 @@ use super::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-enum HttpMethod {
+pub enum HttpMethod {
     #[value(name = "GET")]
     Get,
     #[value(name = "POST")]
@@ -57,7 +57,7 @@ impl fmt::Display for HttpMethod {
 }
 
 #[derive(Debug, Clone)]
-enum StatusFilter {
+pub enum StatusFilter {
     Exact(u16),
     Comparison { op: &'static str, value: u16 },
     Range { low: u16, high: u16 },
@@ -112,27 +112,44 @@ impl FromStr for StatusFilter {
 }
 
 fn build_http_filter(args: &Args) -> Option<String> {
+    compose_http_filter(
+        args.method.as_ref(),
+        args.status.as_ref(),
+        args.path.as_deref(),
+        args.request_id.as_deref(),
+        args.filter.as_deref(),
+    )
+}
+
+/// Build a Railway query filter string from typed HTTP filter components.
+pub fn compose_http_filter(
+    method: Option<&HttpMethod>,
+    status: Option<&StatusFilter>,
+    path: Option<&str>,
+    request_id: Option<&str>,
+    raw_filter: Option<&str>,
+) -> Option<String> {
     let mut parts: Vec<String> = Vec::new();
 
-    if let Some(ref method) = args.method {
+    if let Some(method) = method {
         parts.push(format!("@method:{method}"));
     }
 
-    if let Some(ref status) = args.status {
+    if let Some(status) = status {
         parts.push(status.to_filter_expr());
     }
 
-    if let Some(ref path) = args.path {
+    if let Some(path) = path {
         parts.push(format!("@path:{path}"));
     }
 
-    if let Some(ref request_id) = args.request_id {
+    if let Some(request_id) = request_id {
         parts.push(format!("@requestId:{request_id}"));
     }
 
-    if let Some(ref raw_filter) = args.filter {
+    if let Some(raw_filter) = raw_filter {
         if !raw_filter.is_empty() {
-            parts.push(raw_filter.clone());
+            parts.push(raw_filter.to_string());
         }
     }
 

--- a/src/commands/mcp/tools/observability.rs
+++ b/src/commands/mcp/tools/observability.rs
@@ -1,10 +1,11 @@
 use rmcp::{ErrorData as McpError, model::*};
 
 use crate::{
-    client::post_graphql,
-    controllers::deployment::{FetchLogsParams, fetch_http_logs},
+    controllers::metrics::{
+        FetchResourceMetricsParams, compute_http_metrics, fetch_http_logs_for_deployment,
+        fetch_resource_metrics,
+    },
     gql::queries,
-    util::logs::HttpLogLike,
 };
 
 use super::super::handler::RailwayMcp;
@@ -31,25 +32,16 @@ impl RailwayMcp {
             }
         };
 
-        let mut logs: Vec<queries::http_logs::HttpLogFields> = Vec::new();
         let backboard = self.configs.get_backboard();
-        let fetch_params = FetchLogsParams {
-            client: &self.client,
-            backboard: &backboard,
+        fetch_http_logs_for_deployment(
+            &self.client,
+            &backboard,
             deployment_id,
-            limit: Some(lines.unwrap_or(200)),
-            filter: None,
-            start_date: None,
-            end_date: None,
-        };
-
-        fetch_http_logs(fetch_params, |log| {
-            logs.push(log);
-        })
+            lines.unwrap_or(200),
+            None,
+        )
         .await
-        .map_err(|e| McpError::internal_error(format!("Failed to fetch HTTP logs: {e}"), None))?;
-
-        Ok(logs)
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch HTTP logs: {e}"), None))
     }
 
     pub(crate) async fn do_service_metrics(
@@ -89,47 +81,36 @@ impl RailwayMcp {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let vars = queries::metrics::Variables {
-            service_id: Some(ctx.service_id),
-            environment_id: Some(ctx.environment_id),
+        let backboard = self.configs.get_backboard();
+        let result = fetch_resource_metrics(FetchResourceMetricsParams {
+            client: &self.client,
+            backboard: &backboard,
+            service_id: &ctx.service_id,
+            environment_id: &ctx.environment_id,
             start_date,
             end_date: None,
             measurements,
             sample_rate_seconds: params.sample_rate_seconds,
-        };
+            include_raw: false,
+        })
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch metrics: {e}"), None))?;
 
-        let resp =
-            post_graphql::<queries::Metrics, _>(&self.client, self.configs.get_backboard(), vars)
-                .await
-                .map_err(|e| {
-                    McpError::internal_error(format!("Failed to fetch metrics: {e}"), None)
-                })?;
-
-        if resp.metrics.is_empty() {
+        if result.metrics.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text(
                 "No metrics data available for this service.".to_string(),
             )]));
         }
 
         let mut output = String::new();
-        for metric in &resp.metrics {
-            output.push_str(&format!("\n### {:?}\n", metric.measurement));
-            if metric.values.is_empty() {
+        for metric in &result.metrics {
+            output.push_str(&format!("\n### {}\n", metric.measurement));
+            if metric.data_points == 0 {
                 output.push_str("No data points.\n");
             } else {
-                let last_n: Vec<_> = metric.values.iter().rev().take(5).collect();
-                for point in last_n.into_iter().rev() {
-                    let ts = chrono::DateTime::from_timestamp(point.ts, 0)
-                        .map(|dt| dt.format("%H:%M:%S UTC").to_string())
-                        .unwrap_or_else(|| point.ts.to_string());
-                    output.push_str(&format!("  {ts} -> {:.4}\n", point.value));
-                }
-                let avg =
-                    metric.values.iter().map(|p| p.value).sum::<f64>() / metric.values.len() as f64;
                 output.push_str(&format!(
-                    "  Average ({}pts): {:.4}\n",
-                    metric.values.len(),
-                    avg
+                    "  Current: {:.4}\n  Average ({}pts): {:.4}\n  Min: {:.4}\n  Max: {:.4}\n",
+                    metric.current, metric.data_points, metric.average, metric.min, metric.max
                 ));
             }
         }
@@ -151,27 +132,19 @@ impl RailwayMcp {
             )
             .await?;
 
-        let total = logs.len();
-        if total == 0 {
-            return Ok(CallToolResult::success(vec![Content::text(
+        match compute_http_metrics(&logs) {
+            Some(result) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "HTTP Requests:\n  Total: {}\n  2xx: {}\n  3xx: {}\n  4xx: {}\n  5xx: {}",
+                result.total,
+                result.status_counts[2],
+                result.status_counts[3],
+                result.status_counts[4],
+                result.status_counts[5]
+            ))])),
+            None => Ok(CallToolResult::success(vec![Content::text(
                 "No HTTP logs found.".to_string(),
-            )]));
+            )])),
         }
-
-        let mut counts = [0usize; 6]; // index by status/100: 0=other,1=1xx,2=2xx,3=3xx,4=4xx,5=5xx
-        for log in &logs {
-            let bucket = (log.http_status() / 100) as usize;
-            if bucket < counts.len() {
-                counts[bucket] += 1;
-            } else {
-                counts[0] += 1;
-            }
-        }
-
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "HTTP Requests (sampled {} logs):\n  Total: {}\n  2xx: {}\n  3xx: {}\n  4xx: {}\n  5xx: {}",
-            total, total, counts[2], counts[3], counts[4], counts[5]
-        ))]))
     }
 
     pub(crate) async fn do_http_error_rate(
@@ -188,25 +161,25 @@ impl RailwayMcp {
             )
             .await?;
 
-        let total = logs.len();
-        if total == 0 {
-            return Ok(CallToolResult::success(vec![Content::text(
+        match compute_http_metrics(&logs) {
+            Some(result) => {
+                let errors = result.status_counts[4] + result.status_counts[5];
+                let error_rate = if result.total > 0 {
+                    (errors as f64 / result.total as f64) * 100.0
+                } else {
+                    0.0
+                };
+                let success_rate = 100.0 - error_rate;
+                let success = result.total - errors;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "HTTP Error Rate (sampled {} requests):\n  Errors (4xx+5xx): {} ({:.1}%)\n  Success: {} ({:.1}%)",
+                    result.total, errors, error_rate, success, success_rate
+                ))]))
+            }
+            None => Ok(CallToolResult::success(vec![Content::text(
                 "No HTTP logs found.".to_string(),
-            )]));
+            )])),
         }
-
-        let errors = logs.iter().filter(|l| l.http_status() >= 400).count();
-
-        let rate = (errors as f64 / total as f64) * 100.0;
-
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "HTTP Error Rate (sampled {} requests):\n  Errors (4xx+5xx): {} ({:.1}%)\n  Success (1xx-3xx): {} ({:.1}%)",
-            total,
-            errors,
-            rate,
-            total - errors,
-            100.0 - rate
-        ))]))
     }
 
     pub(crate) async fn do_http_response_time(
@@ -223,29 +196,14 @@ impl RailwayMcp {
             )
             .await?;
 
-        let total = logs.len();
-        if total == 0 {
-            return Ok(CallToolResult::success(vec![Content::text(
+        match compute_http_metrics(&logs) {
+            Some(result) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "HTTP Response Times (sampled {} requests):\n  p50: {}ms\n  p90: {}ms\n  p95: {}ms\n  p99: {}ms",
+                result.total, result.p50_ms, result.p90_ms, result.p95_ms, result.p99_ms
+            ))])),
+            None => Ok(CallToolResult::success(vec![Content::text(
                 "No HTTP logs found.".to_string(),
-            )]));
+            )])),
         }
-
-        let mut durations: Vec<i64> = logs.iter().map(|l| l.total_duration()).collect();
-        durations.sort_unstable();
-
-        let percentile = |p: f64| -> i64 {
-            let idx = ((durations.len() as f64 * p / 100.0) as usize)
-                .min(durations.len().saturating_sub(1));
-            durations[idx]
-        };
-
-        Ok(CallToolResult::success(vec![Content::text(format!(
-            "HTTP Response Times (sampled {} requests):\n  p50: {}ms\n  p90: {}ms\n  p95: {}ms\n  p99: {}ms",
-            total,
-            percentile(50.0),
-            percentile(90.0),
-            percentile(95.0),
-            percentile(99.0),
-        ))]))
     }
 }

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -119,6 +119,7 @@ pub struct Args {
     path: Option<String>,
 }
 
+#[derive(Clone)]
 pub(crate) struct Sections {
     pub(crate) cpu: bool,
     pub(crate) memory: bool,

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -404,13 +404,10 @@ pub async fn command(args: Args) -> Result<()> {
         None
     };
 
-    // Resolve service instance ID for native SSH (needed for DB stats).
-    // Skip if preflight already failed -- the GraphQL call would succeed but
-    // the eventual SSH would fail with the same message.
-    let service_instance_id = if db_type.is_some()
-        && (args.watch || include_db_stats)
-        && db_stats_preflight_error.is_none()
-    {
+    // Resolve service instance ID for native SSH (needed for DB stats). Keep
+    // it even after a preflight failure so watch mode can retry after the user
+    // fixes local SSH setup and presses refresh.
+    let service_instance_id = if db_type.is_some() && (args.watch || include_db_stats) {
         service_instance.map(|service_instance| service_instance.id.clone())
     } else {
         None
@@ -693,28 +690,6 @@ fn format_window_label(since: &str, until: Option<&str>) -> String {
             format!("last {}", format_time_bound_label(since, None))
         }
         None => format!("since {since}"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::format_window_label;
-
-    #[test]
-    fn window_label_includes_until_when_present() {
-        assert_eq!(
-            format_window_label("1h", Some("30m")),
-            "from 1h ago until 30m ago"
-        );
-    }
-
-    #[test]
-    fn window_label_preserves_unbounded_relative_and_absolute_since() {
-        assert_eq!(format_window_label("6h", None), "last 6h");
-        assert_eq!(
-            format_window_label("2024-01-15T10:00:00Z", None),
-            "since 2024-01-15T10:00:00Z"
-        );
     }
 }
 
@@ -2091,5 +2066,27 @@ fn detect_database_type(source_image: Option<&str>) -> Option<DatabaseType> {
         Some(DatabaseType::MySQL)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_window_label;
+
+    #[test]
+    fn window_label_includes_until_when_present() {
+        assert_eq!(
+            format_window_label("1h", Some("30m")),
+            "from 1h ago until 30m ago"
+        );
+    }
+
+    #[test]
+    fn window_label_preserves_unbounded_relative_and_absolute_since() {
+        assert_eq!(format_window_label("6h", None), "last 6h");
+        assert_eq!(
+            format_window_label("2024-01-15T10:00:00Z", None),
+            "since 2024-01-15T10:00:00Z"
+        );
     }
 }

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -1,0 +1,2095 @@
+use crate::{
+    controllers::{
+        database::DatabaseType,
+        db_stats::{self, DatabaseStats},
+        environment::get_matched_environment,
+        metrics::{
+            FetchHttpMetricsParams, FetchProjectMetricsParams, FetchResourceMetricsParams,
+            HttpMetricsResult, ResourceMetricsResult, ServiceMetricsSummary, VolumeMetrics,
+            compute_sample_rate, fetch_http_metrics, fetch_project_metrics, fetch_resource_metrics,
+            find_metric, format_count, format_cpu, format_gb, format_mb, get_volume_metrics,
+            is_database_service, pct, utilization,
+        },
+        project::{ensure_project_and_environment_exist, find_service_instance, get_project},
+    },
+    util::{progress::create_spinner_if, time::parse_time},
+};
+
+use super::{
+    queries::{
+        self,
+        deployments::{DeploymentListInput, DeploymentStatus},
+        metrics::MetricMeasurement,
+    },
+    *,
+};
+
+/// View resource and HTTP metrics for a Railway service
+#[derive(Parser)]
+#[clap(
+    alias = "metric",
+    after_help = "Examples:
+
+  Quick overview:
+  railway metrics                                        # All metrics for linked service (last 1h)
+  railway metrics -s my-api -e production                # Specific service and environment
+  railway metrics --since 6h                             # Last 6 hours
+
+  Focus on specific metrics:
+  railway metrics --cpu --memory                         # Only CPU and memory
+  railway metrics --http                                 # Only HTTP metrics
+  railway metrics --network                              # Only public network traffic
+
+  HTTP filtering (requires --http):
+  railway metrics --http --method POST --path /api/users # POST requests to a specific path
+  railway metrics --http --method GET                    # GET requests only
+
+  Raw time-series data (for deeper analysis):
+  railway metrics --raw --cpu                            # CPU data points in terminal
+  railway metrics --raw --json --cpu                     # CPU time-series as JSON
+
+  All services in the project:
+  railway metrics --all                                  # Compact table across all services
+  railway metrics --all --json                           # All services as JSON
+  railway metrics --all --cpu --memory                   # Table with only CPU and memory
+
+  JSON output (for scripting and agents):
+  railway metrics --json                                 # Compact summary as JSON
+  railway metrics --json --http --method POST              # HTTP metrics for POST as JSON"
+)]
+pub struct Args {
+    /// Service to view metrics for (defaults to linked service)
+    #[clap(short, long, conflicts_with = "all")]
+    service: Option<String>,
+
+    /// Show metrics for all services in the project
+    #[clap(short = 'a', long, conflicts_with = "raw")]
+    all: bool,
+
+    /// Environment to view metrics for (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Time window start. Accepts relative (1h, 6h, 1d, 7d) or ISO 8601. Default: 1h
+    #[clap(long, short = 'S', default_value = "1h")]
+    since: String,
+
+    /// Time window end. Same formats as --since. Default: now
+    #[clap(long, short = 'U', conflicts_with = "watch")]
+    until: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
+
+    /// Show only CPU metrics
+    #[clap(long)]
+    cpu: bool,
+
+    /// Show only memory metrics
+    #[clap(long)]
+    memory: bool,
+
+    /// Show only public network traffic (egress/ingress)
+    #[clap(long)]
+    network: bool,
+
+    /// Show only volume/disk metrics
+    #[clap(long)]
+    volume: bool,
+
+    /// Show only HTTP metrics
+    #[clap(long)]
+    http: bool,
+
+    /// Output raw time-series data points instead of summaries
+    #[clap(long)]
+    raw: bool,
+
+    /// Live dashboard mode — continuously refresh metrics in a TUI
+    #[clap(short = 'w', long, conflicts_with_all = ["json", "raw"])]
+    watch: bool,
+
+    /// Filter HTTP metrics by request method (requires --http)
+    #[clap(long, requires = "http", value_enum, ignore_case = true)]
+    method: Option<crate::commands::logs::HttpMethod>,
+
+    /// Filter HTTP metrics by request path (requires --http)
+    #[clap(long, requires = "http", value_name = "PATH")]
+    path: Option<String>,
+}
+
+pub(crate) struct Sections {
+    pub(crate) cpu: bool,
+    pub(crate) memory: bool,
+    pub(crate) network: bool,
+    pub(crate) volume: bool,
+    pub(crate) http: bool,
+    /// True when user explicitly set filter flags (vs showing everything by default)
+    pub(crate) has_explicit_filter: bool,
+}
+
+impl Sections {
+    pub(crate) fn from_args(args: &Args) -> Self {
+        let any_filter = args.cpu || args.memory || args.network || args.volume || args.http;
+        if any_filter {
+            Self {
+                cpu: args.cpu,
+                memory: args.memory,
+                network: args.network,
+                volume: args.volume,
+                http: args.http,
+                has_explicit_filter: true,
+            }
+        } else {
+            // Show everything by default
+            Self {
+                cpu: true,
+                memory: true,
+                network: true,
+                volume: true,
+                http: true,
+                has_explicit_filter: false,
+            }
+        }
+    }
+
+    pub(crate) fn needs_resource_metrics(&self) -> bool {
+        self.cpu || self.memory || self.network || self.volume
+    }
+
+    pub(crate) fn measurements(&self, include_disk: bool) -> Vec<MetricMeasurement> {
+        let mut m = Vec::new();
+        if self.cpu {
+            m.push(MetricMeasurement::CPU_USAGE);
+            m.push(MetricMeasurement::CPU_LIMIT);
+        }
+        if self.memory {
+            m.push(MetricMeasurement::MEMORY_USAGE_GB);
+            m.push(MetricMeasurement::MEMORY_LIMIT_GB);
+        }
+        if self.network {
+            m.push(MetricMeasurement::NETWORK_TX_GB);
+            m.push(MetricMeasurement::NETWORK_RX_GB);
+        }
+        if self.volume && include_disk {
+            m.push(MetricMeasurement::DISK_USAGE_GB);
+        }
+        m
+    }
+}
+
+fn should_include_db_stats(args: &Args, sections: &Sections, is_db: bool) -> bool {
+    is_db && !args.raw && !sections.has_explicit_filter
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let start_date = parse_time(&args.since)?;
+    let end_date = args.until.as_ref().map(|s| parse_time(s)).transpose()?;
+
+    if let Some(ref e) = end_date {
+        if &start_date >= e {
+            bail!("--since time must be before --until time");
+        }
+    }
+
+    let watch_since_label = if args.watch {
+        match crate::controllers::metrics_tui::normalize_time_range_label(&args.since) {
+            Some(label) => Some(label),
+            None => bail!(
+                "--watch supports --since values: {}",
+                crate::controllers::metrics_tui::supported_time_ranges_label()
+            ),
+        }
+    } else {
+        None
+    };
+
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let backboard = configs.get_backboard();
+    let linked_project = configs.get_linked_project().await?;
+
+    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
+
+    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+
+    let environment = match args
+        .environment
+        .clone()
+        .or_else(|| linked_project.environment_name.clone())
+        .or_else(|| linked_project.environment.clone())
+    {
+        Some(environment) => environment,
+        None => linked_project.environment_id()?.to_string(),
+    };
+    let environment = get_matched_environment(&project, environment)?;
+    let environment_id = environment.id.clone();
+    let environment_name = environment.name.clone();
+
+    // Cross-service mode: --all
+    let show_spinner = !args.json && !args.raw && !args.watch;
+
+    if args.all {
+        if args.raw {
+            bail!("--raw requires a specific service (--service).");
+        }
+
+        // Live TUI for all services
+        if args.watch {
+            let sections = Sections::from_args(&args);
+            return crate::controllers::metrics_tui::run_project(
+                crate::controllers::metrics_tui::ProjectTuiParams {
+                    client: client.clone(),
+                    backboard: backboard.clone(),
+                    project_id: linked_project.project.clone(),
+                    project: project.clone(),
+                    environment_id: environment_id.clone(),
+                    environment_name: environment_name.clone(),
+                    method: args.method.as_ref().map(|m| m.to_string()),
+                    path: args.path.clone(),
+                    since_label: watch_since_label
+                        .clone()
+                        .expect("watch time range was validated"),
+                    sections,
+                },
+            )
+            .await;
+        }
+
+        let spinner = create_spinner_if(show_spinner, "Fetching metrics...".into());
+        let sections = Sections::from_args(&args);
+        let mut measurements = sections.measurements(false);
+        if measurements.is_empty() {
+            measurements.push(MetricMeasurement::CPU_USAGE);
+        }
+
+        let duration = end_date.unwrap_or_else(chrono::Utc::now) - start_date;
+        let sample_rate = compute_sample_rate(duration);
+        let window_label = format_window_label(&args.since, args.until.as_deref());
+
+        let mut services = fetch_project_metrics(
+            FetchProjectMetricsParams {
+                client: &client,
+                backboard: &backboard,
+                project_id: &linked_project.project,
+                environment_id: &environment_id,
+                start_date,
+                end_date,
+                measurements,
+                sample_rate_seconds: Some(sample_rate),
+            },
+            &project,
+        )
+        .await?;
+
+        // Populate volume data per service
+        if sections.volume {
+            for svc in &mut services {
+                svc.volumes = get_volume_metrics(&project, &environment_id, &svc.service_id);
+            }
+        }
+
+        // Fetch HTTP metrics per service (skip databases)
+        if sections.http {
+            let method_filter = args.method.as_ref().map(|m| m.to_string());
+            let path_filter = args.path.clone();
+            let end = end_date.unwrap_or_else(chrono::Utc::now);
+
+            // Determine which services are databases
+            for svc in &mut services {
+                let service_instance =
+                    find_service_instance(&project, &environment_id, &svc.service_id);
+                let source_image = service_instance
+                    .and_then(|si| si.source.as_ref())
+                    .and_then(|src| src.image.as_deref());
+                svc.is_database = is_database_service(source_image);
+            }
+
+            // Fetch HTTP metrics for non-database services in parallel
+            let http_futures: Vec<_> = services
+                .iter()
+                .enumerate()
+                .filter(|(_, svc)| !svc.is_database)
+                .map(|(i, svc)| {
+                    let params = FetchHttpMetricsParams {
+                        client: &client,
+                        backboard: &backboard,
+                        service_id: &svc.service_id,
+                        environment_id: &environment_id,
+                        start_date,
+                        end_date: end,
+                        step_seconds: Some(sample_rate),
+                        method: method_filter.clone(),
+                        path: path_filter.clone(),
+                        include_time_series: false,
+                    };
+                    async move { (i, fetch_http_metrics(params).await) }
+                })
+                .collect();
+
+            let results = futures::future::join_all(http_futures).await;
+            for (i, result) in results {
+                if let Ok(http) = result {
+                    services[i].http = http;
+                }
+            }
+        }
+
+        if let Some(sp) = spinner {
+            sp.finish_and_clear();
+        }
+
+        let project_name = project.name.clone();
+        if args.json {
+            print_project_json(
+                &project_name,
+                &environment_name,
+                start_date,
+                end_date,
+                &sections,
+                &services,
+            )?;
+        } else {
+            print_project_terminal(
+                &project_name,
+                &environment_name,
+                &window_label,
+                &sections,
+                &services,
+            );
+        }
+        return Ok(());
+    }
+
+    let services = project.services.edges.iter().collect::<Vec<_>>();
+    let (service_id, service_name) = match (args.service.as_deref(), linked_project.service) {
+        (Some(service_arg), _) => {
+            let s = services
+                .iter()
+                .find(|s| s.node.name == service_arg || s.node.id == service_arg)
+                .with_context(|| format!("Service '{service_arg}' not found"))?;
+            (s.node.id.clone(), s.node.name.clone())
+        }
+        (_, Some(linked_service)) => {
+            let name = services
+                .iter()
+                .find(|s| s.node.id == linked_service)
+                .map(|s| s.node.name.clone())
+                .unwrap_or_else(|| linked_service.clone());
+            (linked_service, name)
+        }
+        _ => bail!(
+            "No service could be found. Please either link one with `railway service` or specify one via the `--service` flag."
+        ),
+    };
+
+    let sections = Sections::from_args(&args);
+
+    // Detect if service is a database (and which type)
+    let service_instance = find_service_instance(&project, &environment_id, &service_id);
+    let source_image = service_instance
+        .and_then(|si| si.source.as_ref())
+        .and_then(|src| src.image.as_deref());
+    let is_db = is_database_service(source_image);
+    let db_type = detect_database_type(source_image);
+    let include_db_stats = should_include_db_stats(&args, &sections, is_db);
+
+    // DB stats go over native SSH. Do a local preflight before we try; a missing
+    // SSH key is by far the most common failure mode and we can tell the user
+    // exactly how to fix it without waiting on a connection.
+    let db_stats_preflight_error = if db_type.is_some() && (args.watch || include_db_stats) {
+        db_stats::preflight_db_stats_ssh().err()
+    } else {
+        None
+    };
+
+    // Resolve service instance ID for native SSH (needed for DB stats).
+    // Skip if preflight already failed -- the GraphQL call would succeed but
+    // the eventual SSH would fail with the same message.
+    let service_instance_id = if db_type.is_some()
+        && (args.watch || include_db_stats)
+        && db_stats_preflight_error.is_none()
+    {
+        service_instance.map(|service_instance| service_instance.id.clone())
+    } else {
+        None
+    };
+
+    // Live TUI for single service
+    if args.watch {
+        let volumes = if sections.volume {
+            get_volume_metrics(&project, &environment_id, &service_id)
+        } else {
+            vec![]
+        };
+
+        return crate::controllers::metrics_tui::run(
+            crate::controllers::metrics_tui::ServiceTuiParams {
+                client: client.clone(),
+                backboard: backboard.clone(),
+                service_id: service_id.clone(),
+                service_name: service_name.clone(),
+                environment_id: environment_id.clone(),
+                environment_name: environment_name.clone(),
+                since_label: watch_since_label.expect("watch time range was validated"),
+                sections,
+                is_db,
+                db_stats_supported: db_type.is_some(),
+                method: args.method.as_ref().map(|m| m.to_string()),
+                path: args.path.clone(),
+                volumes,
+                db_type: db_type.clone(),
+                service_instance_id: service_instance_id.clone(),
+                db_stats_preflight_error: db_stats_preflight_error.clone(),
+            },
+        )
+        .await;
+    }
+
+    // Compute sample rate from time window
+    let duration = end_date.unwrap_or_else(chrono::Utc::now) - start_date;
+    let sample_rate = compute_sample_rate(duration);
+
+    // Build a human-readable time window label
+    let window_label = format_window_label(&args.since, args.until.as_deref());
+
+    let spinner = create_spinner_if(show_spinner, "Fetching metrics...".into());
+
+    // Launch DB stats fetch in parallel with resource metrics (for database services)
+    let db_stats_future = if include_db_stats && db_stats_preflight_error.is_none() {
+        if let (Some(dt), Some(instance_id)) = (db_type.as_ref(), service_instance_id.as_ref()) {
+            let dt = dt.clone();
+            let instance_id = instance_id.clone();
+            Some(tokio::spawn(async move {
+                db_stats::fetch_db_stats(&instance_id, &dt).await
+            }))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let resource_result = if sections.needs_resource_metrics() {
+        let measurements = sections.measurements(true);
+        Some(
+            fetch_resource_metrics(FetchResourceMetricsParams {
+                client: &client,
+                backboard: &backboard,
+                service_id: &service_id,
+                environment_id: &environment_id,
+                start_date,
+                end_date,
+                measurements,
+                sample_rate_seconds: Some(sample_rate),
+                include_raw: args.raw,
+            })
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    let volume_metrics = if sections.volume {
+        get_volume_metrics(&project, &environment_id, &service_id)
+    } else {
+        vec![]
+    };
+
+    // Only fetch deployments when needed (HTTP section or default view)
+    let needs_deployments = sections.http || !sections.has_explicit_filter;
+    let deployments_data = if needs_deployments {
+        fetch_deployments(
+            &client,
+            &backboard,
+            &linked_project.project,
+            &environment_id,
+            &service_id,
+        )
+        .await?
+    } else {
+        DeploymentsData { recent: vec![] }
+    };
+
+    // Fetch HTTP metrics using dedicated queries (skip for databases)
+    let http_result = if sections.http && !is_db {
+        let end = end_date.unwrap_or_else(chrono::Utc::now);
+        fetch_http_metrics(FetchHttpMetricsParams {
+            client: &client,
+            backboard: &backboard,
+            service_id: &service_id,
+            environment_id: &environment_id,
+            start_date,
+            end_date: end,
+            step_seconds: Some(sample_rate),
+            method: args.method.as_ref().map(|m| m.to_string()),
+            path: args.path.clone(),
+            include_time_series: args.raw,
+        })
+        .await?
+    } else {
+        None
+    };
+
+    // Collect DB stats result (non-blocking -- failures don't stop resource metrics)
+    let db_stats_result = if let Some(handle) = db_stats_future {
+        match handle.await {
+            Ok(Ok(stats)) => Some(stats),
+            Ok(Err(e)) => {
+                if show_spinner {
+                    let dt = db_type
+                        .as_ref()
+                        .expect("db_type present when fetch spawned");
+                    let msg = db_stats::diagnose_db_stats_failure(&e, dt);
+                    eprintln!("{} database stats unavailable:", "warning:".yellow().bold());
+                    for line in msg.lines() {
+                        eprintln!("  {line}");
+                    }
+                }
+                None
+            }
+            Err(_) => None, // task panicked
+        }
+    } else if let Some(ref msg) = db_stats_preflight_error {
+        if show_spinner && include_db_stats {
+            eprintln!("{} database stats unavailable:", "warning:".yellow().bold());
+            for line in msg.lines() {
+                eprintln!("  {line}");
+            }
+        }
+        None
+    } else {
+        None
+    };
+
+    if let Some(sp) = spinner {
+        sp.finish_and_clear();
+    }
+
+    if args.raw {
+        if args.json {
+            print_raw_json(
+                &service_name,
+                &environment_name,
+                start_date,
+                end_date,
+                resource_result.as_ref(),
+                http_result.as_ref(),
+            )?;
+        } else {
+            print_raw_terminal(resource_result.as_ref(), http_result.as_ref());
+        }
+    } else if args.json {
+        print_json(
+            &service_name,
+            &environment_name,
+            start_date,
+            end_date,
+            &sections,
+            resource_result.as_ref(),
+            &volume_metrics,
+            http_result.as_ref(),
+            &deployments_data,
+            db_stats_result.as_ref(),
+        )?;
+    } else {
+        let has_http_filter = args.method.is_some() || args.path.is_some();
+        print_terminal(
+            &service_name,
+            &environment_name,
+            &window_label,
+            &sections,
+            resource_result.as_ref(),
+            &volume_metrics,
+            http_result.as_ref(),
+            &deployments_data,
+            is_db,
+            has_http_filter,
+        );
+        if let Some(ref db_stats) = db_stats_result {
+            print_db_stats_terminal(db_stats);
+        }
+    }
+
+    Ok(())
+}
+
+struct DeploymentInfo {
+    id: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+    status: DeploymentStatus,
+}
+
+struct DeploymentsData {
+    recent: Vec<DeploymentInfo>,
+}
+
+async fn fetch_deployments(
+    client: &reqwest::Client,
+    backboard: &str,
+    project_id: &str,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<DeploymentsData> {
+    let vars = queries::deployments::Variables {
+        input: DeploymentListInput {
+            project_id: Some(project_id.to_string()),
+            environment_id: Some(environment_id.to_string()),
+            service_id: Some(service_id.to_string()),
+            include_deleted: None,
+            status: None,
+        },
+        first: None,
+    };
+    let deployments = post_graphql::<queries::Deployments, _>(client, backboard, vars)
+        .await?
+        .deployments;
+    let mut all: Vec<_> = deployments.edges.into_iter().map(|d| d.node).collect();
+    all.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+
+    let recent = all
+        .iter()
+        .take(5)
+        .map(|d| DeploymentInfo {
+            id: d.id.clone(),
+            created_at: d.created_at,
+            status: d.status.clone(),
+        })
+        .collect();
+
+    Ok(DeploymentsData { recent })
+}
+
+fn is_relative_time_value(value: &str) -> bool {
+    let value_lower = value.trim().to_lowercase();
+    value_lower.ends_with('h')
+        || value_lower.ends_with('m')
+        || value_lower.ends_with('d')
+        || value_lower.ends_with('w')
+        || value_lower.ends_with('s')
+}
+
+fn format_time_bound_label(value: &str, suffix_for_relative: Option<&str>) -> String {
+    let value_lower = value.to_lowercase().trim().to_string();
+    if is_relative_time_value(value) {
+        match suffix_for_relative {
+            Some(suffix) => format!("{value_lower} {suffix}"),
+            None => value_lower,
+        }
+    } else {
+        value.to_string()
+    }
+}
+
+fn format_window_label(since: &str, until: Option<&str>) -> String {
+    match until {
+        Some(until) => format!(
+            "from {} until {}",
+            format_time_bound_label(since, Some("ago")),
+            format_time_bound_label(until, Some("ago"))
+        ),
+        None if is_relative_time_value(since) => {
+            format!("last {}", format_time_bound_label(since, None))
+        }
+        None => format!("since {since}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_window_label;
+
+    #[test]
+    fn window_label_includes_until_when_present() {
+        assert_eq!(
+            format_window_label("1h", Some("30m")),
+            "from 1h ago until 30m ago"
+        );
+    }
+
+    #[test]
+    fn window_label_preserves_unbounded_relative_and_absolute_since() {
+        assert_eq!(format_window_label("6h", None), "last 6h");
+        assert_eq!(
+            format_window_label("2024-01-15T10:00:00Z", None),
+            "since 2024-01-15T10:00:00Z"
+        );
+    }
+}
+
+/// Pad a string to `width` using its visible length (ignoring ANSI codes).
+fn pad_visible(visible: &str, display: &str, width: usize) -> String {
+    let pad = width.saturating_sub(visible.len());
+    format!("{}{}", display, " ".repeat(pad))
+}
+
+/// Print a resource metric line in columnar format with optional utilization coloring.
+fn print_resource_line(
+    label: &str,
+    usage: &crate::controllers::metrics::MetricSummary,
+    limit: Option<&crate::controllers::metrics::MetricSummary>,
+    format_fn: fn(f64) -> String,
+) {
+    let limit_val = limit.filter(|l| l.current > 0.0).map(|l| l.current);
+    let util_pct = utilization(usage.current, limit_val);
+
+    let current_plain = format_fn(usage.current);
+    let current_display = match util_pct {
+        Some(pct) => {
+            let plain = format!("{} ({:.0}%)", current_plain, pct);
+            let colored = format!("{} ({:.0}%)", color_by_health(&current_plain, pct), pct);
+            pad_visible(&plain, &colored, 18)
+        }
+        None => format!("{:<18}", current_plain),
+    };
+
+    let limit_str = limit_val.map(format_fn).unwrap_or_else(|| "–".to_string());
+
+    println!(
+        "  {:<9} {} {:<15} {:<15} {}",
+        label,
+        current_display,
+        format_fn(usage.average),
+        format_fn(usage.max),
+        limit_str,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_terminal(
+    service_name: &str,
+    environment_name: &str,
+    window_label: &str,
+    sections: &Sections,
+    resource: Option<&ResourceMetricsResult>,
+    volumes: &[VolumeMetrics],
+    http: Option<&HttpMetricsResult>,
+    deployments: &DeploymentsData,
+    is_db: bool,
+    has_http_filter: bool,
+) {
+    println!(
+        "\nMetrics for {} in {} ({})\n",
+        service_name.bold(),
+        environment_name.blue().bold(),
+        window_label
+    );
+
+    let mut printed_any = false;
+
+    if let Some(res) = resource {
+        // Resource Usage section (CPU + Memory)
+        let cpu_usage = sections
+            .cpu
+            .then(|| find_metric(&res.metrics, "CPU_USAGE"))
+            .flatten();
+        let cpu_limit = sections
+            .cpu
+            .then(|| find_metric(&res.metrics, "CPU_LIMIT"))
+            .flatten();
+        let mem_usage = sections
+            .memory
+            .then(|| find_metric(&res.metrics, "MEMORY_USAGE_GB"))
+            .flatten();
+        let mem_limit = sections
+            .memory
+            .then(|| find_metric(&res.metrics, "MEMORY_LIMIT_GB"))
+            .flatten();
+
+        let has_cpu = cpu_usage.is_some();
+        let has_mem = mem_usage.is_some();
+
+        if has_cpu || has_mem {
+            println!("  {}", "Resource Usage".bold());
+            println!("  ─────────────────────────────────────────────────────────────────────");
+            println!(
+                "  {}",
+                "           current            avg             max             limit".dimmed()
+            );
+            if let Some(cpu) = cpu_usage {
+                print_resource_line("CPU", cpu, cpu_limit, format_cpu);
+            }
+            if let Some(mem) = mem_usage {
+                print_resource_line("Memory", mem, mem_limit, format_gb);
+            }
+            println!();
+            printed_any = true;
+        }
+
+        // Network section
+        if sections.network {
+            let tx = find_metric(&res.metrics, "NETWORK_TX_GB");
+            let rx = find_metric(&res.metrics, "NETWORK_RX_GB");
+            let has_network = tx.is_some() || rx.is_some();
+            if has_network {
+                println!("  {}", "Public Network Traffic".bold());
+                println!("  ──────────────────────────────────────────────");
+                if let Some(tx) = tx {
+                    println!(
+                        "  {:<13}{:<24}avg: {:<17}max: {}",
+                        "Egress",
+                        format_gb(tx.current),
+                        format_gb(tx.average),
+                        format_gb(tx.max),
+                    );
+                }
+                if let Some(rx) = rx {
+                    println!(
+                        "  {:<13}{:<24}avg: {:<17}max: {}",
+                        "Ingress",
+                        format_gb(rx.current),
+                        format_gb(rx.average),
+                        format_gb(rx.max),
+                    );
+                }
+                println!();
+                printed_any = true;
+            }
+        }
+
+        // Volume section
+        if sections.volume {
+            let disk = find_metric(&res.metrics, "DISK_USAGE_GB");
+            let use_service_disk_per_volume = disk.is_some() && volumes.len() <= 1;
+            for vol in volumes {
+                println!("  {}", format!("Volume: {}", vol.mount_path).bold());
+                println!("  ──────────────────────────────────────────────");
+
+                if use_service_disk_per_volume {
+                    let disk = disk.expect("checked above");
+                    let limit_val = if vol.limit_size_mb > 0.0 {
+                        Some(vol.limit_size_mb / 1024.0)
+                    } else {
+                        None
+                    };
+                    let util_pct = utilization(disk.current, limit_val);
+                    let current_str = format_gb(disk.current);
+                    let current_display = match util_pct {
+                        Some(p) => {
+                            format!("{} ({:.0}%)", color_by_health(&current_str, p), p)
+                        }
+                        None => current_str,
+                    };
+                    let limit_str = if vol.limit_size_mb > 0.0 {
+                        format!("   (limit: {})", format_mb(vol.limit_size_mb))
+                    } else {
+                        String::new()
+                    };
+                    println!(
+                        "  {:<13}{:<24}avg: {:<17}max: {}{}",
+                        "Disk",
+                        current_display,
+                        format_gb(disk.average),
+                        format_gb(disk.max),
+                        limit_str,
+                    );
+                } else {
+                    let util = utilization(
+                        vol.current_size_mb,
+                        Some(vol.limit_size_mb).filter(|&l| l > 0.0),
+                    );
+                    let pct_str = util.map(|p| format!(" ({:.0}%)", p)).unwrap_or_default();
+                    println!(
+                        "  {:<13}{} / {}{}",
+                        "Usage",
+                        format_mb(vol.current_size_mb),
+                        format_mb(vol.limit_size_mb),
+                        pct_str,
+                    );
+                }
+                println!();
+                printed_any = true;
+            }
+
+            if volumes.len() > 1 {
+                if let Some(disk) = disk {
+                    println!("  {}", "Disk Usage (service total)".bold());
+                    println!("  ──────────────────────────────────────────────");
+                    println!(
+                        "  {:<13}{:<24}avg: {:<17}max: {}",
+                        "Current",
+                        format_gb(disk.current),
+                        format_gb(disk.average),
+                        format_gb(disk.max),
+                    );
+                    println!();
+                    printed_any = true;
+                }
+            }
+
+            if volumes.is_empty() {
+                if let Some(disk) = disk {
+                    println!("  {}", "Disk Usage".bold());
+                    println!("  ──────────────────────────────────────────────");
+                    println!(
+                        "  {:<13}{:<24}avg: {:<17}max: {}",
+                        "Current",
+                        format_gb(disk.current),
+                        format_gb(disk.average),
+                        format_gb(disk.max),
+                    );
+                    println!();
+                    printed_any = true;
+                } else if sections.has_explicit_filter {
+                    println!("  No volumes attached to this service.\n");
+                    printed_any = true;
+                }
+            }
+        }
+    } else if sections.volume && !volumes.is_empty() {
+        for vol in volumes {
+            println!("  {}", format!("Volume: {}", vol.mount_path).bold());
+            println!("  ──────────────────────────────────────────────");
+            let util = utilization(
+                vol.current_size_mb,
+                Some(vol.limit_size_mb).filter(|&l| l > 0.0),
+            );
+            let pct_str = util.map(|p| format!(" ({:.0}%)", p)).unwrap_or_default();
+            println!(
+                "  {:<13}{} / {}{}",
+                "Usage",
+                format_mb(vol.current_size_mb),
+                format_mb(vol.limit_size_mb),
+                pct_str,
+            );
+            println!();
+            printed_any = true;
+        }
+    } else if sections.volume && sections.has_explicit_filter {
+        println!("  No volumes attached to this service.\n");
+        printed_any = true;
+    }
+
+    // HTTP section
+    if sections.http {
+        if is_db {
+            if sections.has_explicit_filter {
+                println!("  HTTP metrics are not available for database services.\n");
+                printed_any = true;
+            }
+        } else if let Some(http) = http {
+            let header = format!("HTTP Requests ({} total)", format_count(http.total));
+            println!("  {}", header.bold());
+            println!("  ──────────────────────────────────────────────");
+            println!("  {:<13}{}", "Total", format_count(http.total));
+            println!(
+                "  {:<13}{} ({:.1}%)",
+                "2xx".green(),
+                format_count(http.status_counts[2]),
+                pct(http.status_counts[2], http.total),
+            );
+            println!(
+                "  {:<13}{} ({:.1}%)",
+                "3xx".cyan(),
+                format_count(http.status_counts[3]),
+                pct(http.status_counts[3], http.total),
+            );
+            println!(
+                "  {:<13}{} ({:.1}%)",
+                "4xx".yellow(),
+                format_count(http.status_counts[4]),
+                pct(http.status_counts[4], http.total),
+            );
+            println!(
+                "  {:<13}{} ({:.1}%)",
+                "5xx".red(),
+                format_count(http.status_counts[5]),
+                pct(http.status_counts[5], http.total),
+            );
+
+            let error_rate_str = format!("{:.1}%", http.error_rate);
+            let error_rate_display = color_by_health(&error_rate_str, http.error_rate * 10.0);
+            println!("  {:<13}{}", "Error Rate", error_rate_display);
+            println!();
+            println!(
+                "  {:<13}p50: {}ms   p90: {}ms   p95: {}ms   p99: {}ms",
+                "Latency", http.p50_ms, http.p90_ms, http.p95_ms, http.p99_ms,
+            );
+            println!();
+            printed_any = true;
+        } else if sections.has_explicit_filter {
+            if has_http_filter {
+                println!("  No HTTP logs matched the filter.\n");
+            } else {
+                println!("  No HTTP logs found.\n");
+            }
+            printed_any = true;
+        }
+    }
+
+    // Recent deployments: show when no explicit filters are set, or when HTTP data was displayed
+    let show_deploys = !sections.has_explicit_filter || http.is_some();
+    if show_deploys && !deployments.recent.is_empty() {
+        println!("  {}", "Recent Deployments".bold());
+        println!("  ──────────────────────────────────────────────");
+        for d in &deployments.recent {
+            let line = format!(
+                "  {}   {}   {:?}",
+                d.created_at.format("%Y-%m-%d %H:%M UTC"),
+                &d.id[..8.min(d.id.len())],
+                d.status,
+            );
+            if matches!(d.status, DeploymentStatus::SUCCESS) {
+                println!("{}", line.green().bold());
+            } else if matches!(d.status, DeploymentStatus::REMOVED) {
+                println!("{}", line.dimmed());
+            } else {
+                println!("{}", line);
+            }
+        }
+        println!();
+    }
+
+    // If nothing was printed at all, show a helpful message
+    if !printed_any {
+        println!(
+            "  No metrics data available yet. Metrics typically appear\n  within a few minutes of deployment.\n"
+        );
+    }
+}
+
+/// Color a string based on utilization percentage: green (<60%), yellow (60-85%), red (>85%)
+fn color_by_health(s: &str, utilization_pct: f64) -> colored::ColoredString {
+    if utilization_pct >= 85.0 {
+        s.red()
+    } else if utilization_pct >= 60.0 {
+        s.yellow()
+    } else {
+        s.green()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_json(
+    service_name: &str,
+    environment_name: &str,
+    start_date: chrono::DateTime<chrono::Utc>,
+    end_date: Option<chrono::DateTime<chrono::Utc>>,
+    sections: &Sections,
+    resource: Option<&ResourceMetricsResult>,
+    volumes: &[VolumeMetrics],
+    http: Option<&HttpMetricsResult>,
+    deployments: &DeploymentsData,
+    db_stats: Option<&DatabaseStats>,
+) -> Result<()> {
+    let mut json = serde_json::Map::new();
+    json.insert(
+        "service".to_string(),
+        serde_json::Value::String(service_name.to_string()),
+    );
+    json.insert(
+        "environment".to_string(),
+        serde_json::Value::String(environment_name.to_string()),
+    );
+
+    let mut window = serde_json::Map::new();
+    window.insert(
+        "since".to_string(),
+        serde_json::Value::String(start_date.to_rfc3339()),
+    );
+    window.insert(
+        "until".to_string(),
+        serde_json::Value::String(end_date.unwrap_or_else(chrono::Utc::now).to_rfc3339()),
+    );
+    json.insert("window".to_string(), serde_json::Value::Object(window));
+
+    if let Some(res) = resource {
+        if sections.cpu {
+            let cpu_usage = find_metric(&res.metrics, "CPU_USAGE");
+            let cpu_limit = find_metric(&res.metrics, "CPU_LIMIT");
+            if let Some(cpu) = cpu_usage {
+                let mut cpu_json = serde_json::Map::new();
+                cpu_json.insert("current".into(), serde_json::json!(cpu.current));
+                cpu_json.insert("average".into(), serde_json::json!(cpu.average));
+                cpu_json.insert("max".into(), serde_json::json!(cpu.max));
+                if let Some(limit) = cpu_limit.filter(|l| l.current > 0.0) {
+                    cpu_json.insert("limit".into(), serde_json::json!(limit.current));
+                    if let Some(pct) = utilization(cpu.current, Some(limit.current)) {
+                        cpu_json.insert(
+                            "utilization_pct".into(),
+                            serde_json::json!((pct * 10.0).round() / 10.0),
+                        );
+                    }
+                }
+                cpu_json.insert("unit".into(), serde_json::json!("vCPU"));
+                json.insert("cpu".into(), serde_json::Value::Object(cpu_json));
+            }
+        }
+
+        if sections.memory {
+            let mem_usage = find_metric(&res.metrics, "MEMORY_USAGE_GB");
+            let mem_limit = find_metric(&res.metrics, "MEMORY_LIMIT_GB");
+            if let Some(mem) = mem_usage {
+                let mut mem_json = serde_json::Map::new();
+                mem_json.insert("current_mb".into(), serde_json::json!(mem.current * 1024.0));
+                mem_json.insert("average_mb".into(), serde_json::json!(mem.average * 1024.0));
+                mem_json.insert("max_mb".into(), serde_json::json!(mem.max * 1024.0));
+                if let Some(limit) = mem_limit.filter(|l| l.current > 0.0) {
+                    mem_json.insert("limit_mb".into(), serde_json::json!(limit.current * 1024.0));
+                    if let Some(pct) = utilization(mem.current, Some(limit.current)) {
+                        mem_json.insert(
+                            "utilization_pct".into(),
+                            serde_json::json!((pct * 10.0).round() / 10.0),
+                        );
+                    }
+                }
+                json.insert("memory".into(), serde_json::Value::Object(mem_json));
+            }
+        }
+
+        if sections.network {
+            let tx = find_metric(&res.metrics, "NETWORK_TX_GB");
+            let rx = find_metric(&res.metrics, "NETWORK_RX_GB");
+            if tx.is_some() || rx.is_some() {
+                let mut net_json = serde_json::Map::new();
+                if let Some(tx) = tx {
+                    let mut egress = serde_json::Map::new();
+                    egress.insert("current_mb".into(), serde_json::json!(tx.current * 1024.0));
+                    egress.insert("average_mb".into(), serde_json::json!(tx.average * 1024.0));
+                    egress.insert("max_mb".into(), serde_json::json!(tx.max * 1024.0));
+                    net_json.insert("egress".into(), serde_json::Value::Object(egress));
+                }
+                if let Some(rx) = rx {
+                    let mut ingress = serde_json::Map::new();
+                    ingress.insert("current_mb".into(), serde_json::json!(rx.current * 1024.0));
+                    ingress.insert("average_mb".into(), serde_json::json!(rx.average * 1024.0));
+                    ingress.insert("max_mb".into(), serde_json::json!(rx.max * 1024.0));
+                    net_json.insert("ingress".into(), serde_json::Value::Object(ingress));
+                }
+                json.insert(
+                    "public_network_traffic".into(),
+                    serde_json::Value::Object(net_json),
+                );
+            }
+        }
+
+        if sections.volume {
+            let disk = find_metric(&res.metrics, "DISK_USAGE_GB");
+            let use_service_disk_per_volume = disk.is_some() && volumes.len() <= 1;
+            let vol_arr: Vec<serde_json::Value> = volumes
+                .iter()
+                .map(|v| {
+                    let mut vol_json = serde_json::json!({
+                        "name": v.volume_name,
+                        "mount_path": v.mount_path,
+                        "current_mb": v.current_size_mb,
+                        "limit_mb": v.limit_size_mb,
+                    });
+                    // Only merge service-level disk usage into a volume when there is a
+                    // single attached volume. Multi-volume services need to keep the
+                    // per-volume snapshots separate from the aggregated disk metric.
+                    if use_service_disk_per_volume {
+                        let disk = disk.expect("checked above");
+                        vol_json["current_mb"] = serde_json::json!(disk.current * 1024.0);
+                        vol_json["average_mb"] = serde_json::json!(disk.average * 1024.0);
+                        vol_json["max_mb"] = serde_json::json!(disk.max * 1024.0);
+                    }
+                    vol_json
+                })
+                .collect();
+            if !vol_arr.is_empty() {
+                json.insert("volumes".into(), serde_json::Value::Array(vol_arr));
+            }
+
+            if let Some(disk) = disk {
+                if volumes.is_empty() || volumes.len() > 1 {
+                    // No volumes or multiple volumes: expose the service-level disk metric
+                    // separately so it is not mistaken for a per-volume series.
+                    let mut disk_json = serde_json::Map::new();
+                    disk_json.insert(
+                        "current_mb".into(),
+                        serde_json::json!(disk.current * 1024.0),
+                    );
+                    disk_json.insert(
+                        "average_mb".into(),
+                        serde_json::json!(disk.average * 1024.0),
+                    );
+                    disk_json.insert("max_mb".into(), serde_json::json!(disk.max * 1024.0));
+                    json.insert("disk".into(), serde_json::Value::Object(disk_json));
+                }
+            }
+        }
+    }
+
+    if let Some(http) = http {
+        let mut http_json = serde_json::Map::new();
+        http_json.insert("total".into(), serde_json::json!(http.total));
+        http_json.insert("2xx".into(), serde_json::json!(http.status_counts[2]));
+        http_json.insert("3xx".into(), serde_json::json!(http.status_counts[3]));
+        http_json.insert("4xx".into(), serde_json::json!(http.status_counts[4]));
+        http_json.insert("5xx".into(), serde_json::json!(http.status_counts[5]));
+        http_json.insert("error_rate".into(), serde_json::json!(http.error_rate));
+        http_json.insert("p50_ms".into(), serde_json::json!(http.p50_ms));
+        http_json.insert("p90_ms".into(), serde_json::json!(http.p90_ms));
+        http_json.insert("p95_ms".into(), serde_json::json!(http.p95_ms));
+        http_json.insert("p99_ms".into(), serde_json::json!(http.p99_ms));
+        json.insert("http".into(), serde_json::Value::Object(http_json));
+    }
+
+    if !deployments.recent.is_empty() {
+        let deploys: Vec<serde_json::Value> = deployments
+            .recent
+            .iter()
+            .map(|d| {
+                serde_json::json!({
+                    "id": d.id,
+                    "created_at": d.created_at.to_rfc3339(),
+                    "status": format!("{:?}", d.status),
+                })
+            })
+            .collect();
+        json.insert("deployments".into(), serde_json::Value::Array(deploys));
+    }
+
+    if let Some(stats) = db_stats {
+        json.insert("db_stats".into(), serde_json::to_value(stats)?);
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::Value::Object(json))?
+    );
+
+    Ok(())
+}
+
+fn print_raw_json(
+    service_name: &str,
+    environment_name: &str,
+    start_date: chrono::DateTime<chrono::Utc>,
+    end_date: Option<chrono::DateTime<chrono::Utc>>,
+    resource: Option<&ResourceMetricsResult>,
+    http: Option<&HttpMetricsResult>,
+) -> Result<()> {
+    fn points_to_json(
+        points: &[crate::controllers::metrics::MetricDataPoint],
+    ) -> Vec<serde_json::Value> {
+        points
+            .iter()
+            .map(|p| {
+                let ts = chrono::DateTime::from_timestamp(p.ts, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_else(|| p.ts.to_string());
+                serde_json::json!({"ts": ts, "value": p.value})
+            })
+            .collect()
+    }
+
+    let mut json = serde_json::Map::new();
+    json.insert(
+        "service".into(),
+        serde_json::Value::String(service_name.to_string()),
+    );
+    json.insert(
+        "environment".into(),
+        serde_json::Value::String(environment_name.to_string()),
+    );
+
+    let mut window = serde_json::Map::new();
+    window.insert("since".into(), serde_json::json!(start_date.to_rfc3339()));
+    window.insert(
+        "until".into(),
+        serde_json::json!(end_date.unwrap_or_else(chrono::Utc::now).to_rfc3339()),
+    );
+    json.insert("window".into(), serde_json::Value::Object(window));
+
+    let mut measurements = serde_json::Map::new();
+    if let Some(res) = resource {
+        for metric in &res.metrics {
+            let points = points_to_json(&metric.raw_values);
+            measurements.insert(metric.measurement.clone(), serde_json::Value::Array(points));
+        }
+    }
+    json.insert(
+        "measurements".into(),
+        serde_json::Value::Object(measurements),
+    );
+
+    if let Some(http) = http.and_then(|result| result.time_series.as_ref()) {
+        let mut http_json = serde_json::Map::new();
+        let error_rate_pct: Vec<_> = http
+            .error_rate_ts
+            .iter()
+            .zip(http.request_rate_ts.iter())
+            .map(
+                |(errors, total)| crate::controllers::metrics::MetricDataPoint {
+                    ts: errors.ts,
+                    value: if total.value > 0.0 {
+                        (errors.value / total.value) * 100.0
+                    } else {
+                        0.0
+                    },
+                },
+            )
+            .collect();
+
+        http_json.insert(
+            "requests".into(),
+            serde_json::Value::Array(points_to_json(&http.request_rate_ts)),
+        );
+        http_json.insert(
+            "errors_5xx".into(),
+            serde_json::Value::Array(points_to_json(&http.error_rate_ts)),
+        );
+        http_json.insert(
+            "error_rate_pct".into(),
+            serde_json::Value::Array(points_to_json(&error_rate_pct)),
+        );
+        http_json.insert(
+            "status_2xx".into(),
+            serde_json::Value::Array(points_to_json(&http.status_2xx_ts)),
+        );
+        http_json.insert(
+            "status_3xx".into(),
+            serde_json::Value::Array(points_to_json(&http.status_3xx_ts)),
+        );
+        http_json.insert(
+            "status_4xx".into(),
+            serde_json::Value::Array(points_to_json(&http.status_4xx_ts)),
+        );
+        http_json.insert(
+            "status_5xx".into(),
+            serde_json::Value::Array(points_to_json(&http.status_5xx_ts)),
+        );
+        http_json.insert(
+            "p50_ms".into(),
+            serde_json::Value::Array(points_to_json(&http.p50_ts)),
+        );
+        http_json.insert(
+            "p90_ms".into(),
+            serde_json::Value::Array(points_to_json(&http.p90_ts)),
+        );
+        http_json.insert(
+            "p95_ms".into(),
+            serde_json::Value::Array(points_to_json(&http.p95_ts)),
+        );
+        http_json.insert(
+            "p99_ms".into(),
+            serde_json::Value::Array(points_to_json(&http.p99_ts)),
+        );
+
+        json.insert("http".into(), serde_json::Value::Object(http_json));
+    }
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::Value::Object(json))?
+    );
+    Ok(())
+}
+
+fn print_project_terminal(
+    project_name: &str,
+    environment_name: &str,
+    window_label: &str,
+    sections: &Sections,
+    services: &[ServiceMetricsSummary],
+) {
+    println!(
+        "\nMetrics for {} in {} ({})\n",
+        project_name.bold(),
+        environment_name.blue().bold(),
+        window_label
+    );
+
+    if services.is_empty() {
+        println!("  No metrics data available.");
+        return;
+    }
+
+    // Build header
+    let mut header = format!("  {:<25}", "Service");
+    if sections.cpu {
+        header.push_str(&format!("{:<28}", "CPU"));
+    }
+    if sections.memory {
+        header.push_str(&format!("{:<28}", "Memory"));
+    }
+    if sections.network {
+        header.push_str(&format!("{:<14}{:<14}", "Egress", "Ingress"));
+    }
+    if sections.volume {
+        header.push_str(&format!("{:<22}", "Volume"));
+    }
+    if sections.http {
+        header.push_str(&format!("{:<12}{:<12}", "Reqs", "Err Rate"));
+    }
+    println!("{}", header.bold());
+    println!("  {}", "─".repeat(header.len().saturating_sub(2)));
+
+    for svc in services {
+        let name = truncate(&svc.service_name, 23);
+        print!("  {:<25}", name);
+
+        if sections.cpu {
+            let (val, pct) = match (&svc.cpu, &svc.cpu_limit) {
+                (Some(cpu), Some(limit)) if limit.current > 0.0 => {
+                    let p = (cpu.current / limit.current) * 100.0;
+                    (
+                        format!(
+                            "{} / {}",
+                            format_cpu(cpu.current),
+                            format_cpu(limit.current)
+                        ),
+                        Some(p),
+                    )
+                }
+                (Some(cpu), _) => (format_cpu(cpu.current), None),
+                _ => ("—".to_string(), None),
+            };
+            // Print colored value then pad with spaces (avoids ANSI in padding)
+            let display = match pct {
+                Some(p) => format!("{}", color_by_health(&val, p)),
+                None => val.clone(),
+            };
+            let padding = 28usize.saturating_sub(val.len());
+            print!("{display}{:padding$}", "");
+        }
+
+        if sections.memory {
+            let (val, pct) = match (&svc.memory, &svc.memory_limit) {
+                (Some(mem), Some(limit)) if limit.current > 0.0 => {
+                    let p = (mem.current / limit.current) * 100.0;
+                    (
+                        format!("{} / {}", format_gb(mem.current), format_gb(limit.current)),
+                        Some(p),
+                    )
+                }
+                (Some(mem), _) => (format_gb(mem.current), None),
+                _ => ("—".to_string(), None),
+            };
+            let display = match pct {
+                Some(p) => format!("{}", color_by_health(&val, p)),
+                None => val.clone(),
+            };
+            let padding = 28usize.saturating_sub(val.len());
+            print!("{display}{:padding$}", "");
+        }
+
+        if sections.network {
+            let tx_str = svc
+                .network_tx
+                .as_ref()
+                .filter(|t| t.current > 0.0001)
+                .map(|t| format_gb(t.current))
+                .unwrap_or_else(|| "—".to_string());
+            let rx_str = svc
+                .network_rx
+                .as_ref()
+                .filter(|r| r.current > 0.0001)
+                .map(|r| format_gb(r.current))
+                .unwrap_or_else(|| "—".to_string());
+            print!("{:<14}{:<14}", tx_str, rx_str);
+        }
+
+        if sections.volume {
+            if svc.volumes.is_empty() {
+                print!("{:<22}", "—");
+            } else {
+                let vol = &svc.volumes[0];
+                if vol.limit_size_mb > 0.0 {
+                    let pct = (vol.current_size_mb / vol.limit_size_mb) * 100.0;
+                    let val = format!(
+                        "{} / {}",
+                        format_mb(vol.current_size_mb),
+                        format_mb(vol.limit_size_mb)
+                    );
+                    let display = format!("{}", color_by_health(&val, pct));
+                    let padding = 22usize.saturating_sub(val.len());
+                    print!("{display}{:padding$}", "");
+                } else {
+                    print!("{:<22}", format_mb(vol.current_size_mb));
+                }
+            }
+        }
+
+        if sections.http {
+            if svc.is_database {
+                print!("{:<12}{:<12}", "—", "—");
+            } else if let Some(ref http) = svc.http {
+                let reqs = format_count(http.total);
+                let err_val = format!("{:.1}%", http.error_rate);
+                let err_display = format!("{}", color_by_health(&err_val, http.error_rate * 10.0));
+                let err_padding = 12usize.saturating_sub(err_val.len());
+                print!("{:<12}{err_display}{:err_padding$}", reqs, "");
+            } else {
+                print!("{:<12}{:<12}", "—", "—");
+            }
+        }
+
+        println!();
+    }
+    println!();
+}
+
+fn print_project_json(
+    project_name: &str,
+    environment_name: &str,
+    start_date: chrono::DateTime<chrono::Utc>,
+    end_date: Option<chrono::DateTime<chrono::Utc>>,
+    sections: &Sections,
+    services: &[ServiceMetricsSummary],
+) -> Result<()> {
+    let svc_arr: Vec<serde_json::Value> = services
+        .iter()
+        .map(|svc| {
+            let mut obj = serde_json::json!({
+                "name": svc.service_name,
+                "id": svc.service_id,
+            });
+
+            if let Some(cpu) = sections.cpu.then_some(svc.cpu.as_ref()).flatten() {
+                let mut cpu_json = serde_json::json!({
+                    "current": cpu.current,
+                    "unit": "vCPU",
+                });
+                if let Some(ref limit) = svc.cpu_limit {
+                    if limit.current > 0.0 {
+                        cpu_json["limit"] = serde_json::json!(limit.current);
+                        if let Some(pct) = utilization(cpu.current, Some(limit.current)) {
+                            cpu_json["utilization_pct"] =
+                                serde_json::json!((pct * 10.0).round() / 10.0);
+                        }
+                    }
+                }
+                obj["cpu"] = cpu_json;
+            }
+
+            if let Some(mem) = sections.memory.then_some(svc.memory.as_ref()).flatten() {
+                let mut mem_json = serde_json::json!({
+                    "current_mb": mem.current * 1024.0,
+                });
+                if let Some(ref limit) = svc.memory_limit {
+                    if limit.current > 0.0 {
+                        mem_json["limit_mb"] = serde_json::json!(limit.current * 1024.0);
+                        if let Some(pct) = utilization(mem.current, Some(limit.current)) {
+                            mem_json["utilization_pct"] =
+                                serde_json::json!((pct * 10.0).round() / 10.0);
+                        }
+                    }
+                }
+                obj["memory"] = mem_json;
+            }
+
+            if sections.network && (svc.network_tx.is_some() || svc.network_rx.is_some()) {
+                let mut net = serde_json::Map::new();
+                if let Some(ref tx) = svc.network_tx {
+                    net.insert("egress_mb".into(), serde_json::json!(tx.current * 1024.0));
+                }
+                if let Some(ref rx) = svc.network_rx {
+                    net.insert("ingress_mb".into(), serde_json::json!(rx.current * 1024.0));
+                }
+                obj["network"] = serde_json::Value::Object(net);
+            }
+
+            if sections.volume && !svc.volumes.is_empty() {
+                let vol_arr: Vec<serde_json::Value> = svc
+                    .volumes
+                    .iter()
+                    .map(|v| {
+                        serde_json::json!({
+                            "name": v.volume_name,
+                            "mount_path": v.mount_path,
+                            "current_mb": v.current_size_mb,
+                            "limit_mb": v.limit_size_mb,
+                        })
+                    })
+                    .collect();
+                obj["volumes"] = serde_json::Value::Array(vol_arr);
+            }
+
+            if let Some(http) = sections.http.then_some(svc.http.as_ref()).flatten() {
+                obj["http"] = serde_json::json!({
+                    "total": http.total,
+                    "2xx": http.status_counts[2],
+                    "3xx": http.status_counts[3],
+                    "4xx": http.status_counts[4],
+                    "5xx": http.status_counts[5],
+                    "error_rate": http.error_rate,
+                    "p50_ms": http.p50_ms,
+                    "p90_ms": http.p90_ms,
+                    "p95_ms": http.p95_ms,
+                    "p99_ms": http.p99_ms,
+                });
+            }
+
+            obj
+        })
+        .collect();
+
+    let json = serde_json::json!({
+        "project": project_name,
+        "environment": environment_name,
+        "window": {
+            "since": start_date.to_rfc3339(),
+            "until": end_date.unwrap_or_else(chrono::Utc::now).to_rfc3339(),
+        },
+        "services": svc_arr,
+    });
+
+    println!("{}", serde_json::to_string_pretty(&json)?);
+    Ok(())
+}
+
+fn print_raw_terminal(resource: Option<&ResourceMetricsResult>, http: Option<&HttpMetricsResult>) {
+    fn print_raw_points(
+        name: &str,
+        points: &[crate::controllers::metrics::MetricDataPoint],
+        printed: &mut bool,
+    ) {
+        for point in points {
+            let ts = chrono::DateTime::from_timestamp(point.ts, 0)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_else(|| point.ts.to_string());
+            println!("{}  {:<20}  {:.6}", ts, name, point.value);
+            *printed = true;
+        }
+    }
+
+    let mut printed = false;
+    if let Some(res) = resource {
+        for metric in &res.metrics {
+            print_raw_points(&metric.measurement, &metric.raw_values, &mut printed);
+        }
+    }
+    if let Some(http) = http.and_then(|result| result.time_series.as_ref()) {
+        print_raw_points("HTTP_REQUESTS", &http.request_rate_ts, &mut printed);
+        print_raw_points("HTTP_5XX", &http.error_rate_ts, &mut printed);
+        print_raw_points("HTTP_2XX", &http.status_2xx_ts, &mut printed);
+        print_raw_points("HTTP_3XX", &http.status_3xx_ts, &mut printed);
+        print_raw_points("HTTP_4XX", &http.status_4xx_ts, &mut printed);
+        print_raw_points("HTTP_5XX_BUCKET", &http.status_5xx_ts, &mut printed);
+        print_raw_points("HTTP_P50_MS", &http.p50_ts, &mut printed);
+        print_raw_points("HTTP_P90_MS", &http.p90_ts, &mut printed);
+        print_raw_points("HTTP_P95_MS", &http.p95_ts, &mut printed);
+        print_raw_points("HTTP_P99_MS", &http.p99_ts, &mut printed);
+
+        for (errors, total) in http.error_rate_ts.iter().zip(http.request_rate_ts.iter()) {
+            let pct = if total.value > 0.0 {
+                (errors.value / total.value) * 100.0
+            } else {
+                0.0
+            };
+            print_raw_points(
+                "HTTP_ERROR_RATE_PCT",
+                &[crate::controllers::metrics::MetricDataPoint {
+                    ts: errors.ts,
+                    value: pct,
+                }],
+                &mut printed,
+            );
+        }
+    }
+    if !printed {
+        println!("No data points available.");
+    }
+}
+
+fn print_db_stats_terminal(stats: &DatabaseStats) {
+    use crate::controllers::db_stats::types::*;
+
+    fn health_color(value: f64, warn: f64, crit: f64, inverted: bool) -> colored::ColoredString {
+        let s = format!("{:.1}%", value);
+        if inverted {
+            // Lower is worse (cache hit ratio)
+            if value < crit {
+                s.red()
+            } else if value < warn {
+                s.yellow()
+            } else {
+                s.green()
+            }
+        } else {
+            // Higher is worse (utilization)
+            if value > crit {
+                s.red()
+            } else if value > warn {
+                s.yellow()
+            } else {
+                s.green()
+            }
+        }
+    }
+
+    fn fmt_bytes(bytes: i64) -> String {
+        if bytes >= 1_073_741_824 {
+            format!("{:.2} GB", bytes as f64 / 1_073_741_824.0)
+        } else if bytes >= 1_048_576 {
+            format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+        } else if bytes >= 1024 {
+            format!("{:.1} KB", bytes as f64 / 1024.0)
+        } else {
+            format!("{} B", bytes)
+        }
+    }
+
+    println!();
+    println!("  {}", "Database Stats".bold());
+    println!("  ─────────────────────────────────────────────────────────────────────");
+
+    match stats {
+        DatabaseStats::PostgreSQL(pg) => {
+            // Connections
+            let util = if pg.connections.max_connections > 0 {
+                pg.connections.total as f64 / pg.connections.max_connections as f64 * 100.0
+            } else {
+                0.0
+            };
+            println!(
+                "  {}  Active: {}  Idle: {}  Idle(txn): {}  Total: {} / {}  ({})",
+                "Connections".bold(),
+                format!("{}", pg.connections.active).cyan(),
+                pg.connections.idle,
+                pg.connections.idle_in_transaction,
+                pg.connections.total,
+                pg.connections.max_connections,
+                health_color(util, 60.0, 80.0, false),
+            );
+
+            // Cache
+            println!(
+                "  {}    Hit Ratio: {}",
+                "Cache      ".bold(),
+                health_color(pg.cache.hit_ratio * 100.0, 95.0, 90.0, true),
+            );
+
+            // Database size
+            println!(
+                "  {}    Total: {}  Tables: {}  Indexes: {}",
+                "Storage    ".bold(),
+                fmt_bytes(pg.database_size.total_bytes).cyan(),
+                fmt_bytes(pg.database_size.tables_bytes),
+                fmt_bytes(pg.database_size.indexes_bytes),
+            );
+
+            // Table stats
+            if !pg.table_stats.is_empty() {
+                println!();
+                println!(
+                    "  {}",
+                    "  Table                  Size         Seq Scan    Idx Scan    Dead Rows"
+                        .dimmed()
+                );
+                for t in &pg.table_stats {
+                    let dead_pct = if t.live_tuples + t.dead_tuples > 0 {
+                        t.dead_tuples as f64 / (t.live_tuples + t.dead_tuples) as f64 * 100.0
+                    } else {
+                        0.0
+                    };
+                    let dead_str = if dead_pct > 10.0 {
+                        format!("{:.1}%", dead_pct).red().to_string()
+                    } else if dead_pct > 5.0 {
+                        format!("{:.1}%", dead_pct).yellow().to_string()
+                    } else {
+                        format!("{:.1}%", dead_pct)
+                    };
+                    println!(
+                        "  {:24} {:12} {:11} {:11} {}",
+                        truncate(&t.table_name, 24),
+                        fmt_bytes(t.size_bytes),
+                        format_count(t.seq_scan as usize),
+                        format_count(t.idx_scan as usize),
+                        dead_str,
+                    );
+                }
+            }
+
+            // Query stats
+            if let Some(ref queries) = pg.query_stats {
+                if !queries.is_empty() {
+                    println!();
+                    println!(
+                        "  {}  {}",
+                        "Top Queries".bold(),
+                        "(pg_stat_statements)".dimmed()
+                    );
+                    println!("  {}", "  Calls     Total       Mean      Query".dimmed());
+                    for q in queries {
+                        println!(
+                            "  {:9} {:11} {:9} {}",
+                            format_count(q.calls as usize),
+                            format_duration_ms(q.total_time_ms),
+                            format_duration_ms(q.mean_time_ms),
+                            truncate(&q.query, 60),
+                        );
+                    }
+                }
+            }
+
+            // Index health
+            if !pg.index_health.unused_indexes.is_empty() {
+                println!();
+                println!(
+                    "  {}  {} unused out of {}",
+                    "Indexes    ".bold(),
+                    format!("{}", pg.index_health.unused_indexes.len()).yellow(),
+                    pg.index_health.total_index_count,
+                );
+            }
+        }
+
+        DatabaseStats::Redis(r) => {
+            // Overview
+            println!(
+                "  {}  Version: {}  Uptime: {}  Clients: {}  Blocked: {}",
+                "Server     ".bold(),
+                r.server.version.cyan(),
+                format_uptime(r.server.uptime_seconds),
+                r.server.connected_clients,
+                r.server.blocked_clients,
+            );
+
+            // Memory
+            println!(
+                "  {}  Used: {}  RSS: {}  Peak: {}  Frag: {:.2}x  Policy: {}",
+                "Memory     ".bold(),
+                fmt_bytes(r.memory.used_bytes).cyan(),
+                fmt_bytes(r.memory.rss_bytes),
+                fmt_bytes(r.memory.peak_bytes),
+                r.memory.fragmentation_ratio,
+                r.memory.eviction_policy,
+            );
+
+            // Throughput
+            println!(
+                "  {}  Ops/sec: {}  Total Cmds: {}  Total Conns: {}",
+                "Throughput ".bold(),
+                format!("{:.0}", r.throughput.ops_per_sec).cyan(),
+                format_count(r.throughput.total_commands as usize),
+                format_count(r.throughput.total_connections as usize),
+            );
+
+            // Cache
+            println!(
+                "  {}  Hit Rate: {}  Hits: {}  Misses: {}  Expired: {}  Evicted: {}",
+                "Cache      ".bold(),
+                health_color(r.cache.hit_rate * 100.0, 95.0, 90.0, true),
+                format_count(r.cache.hits as usize),
+                format_count(r.cache.misses as usize),
+                format_count(r.cache.expired_keys as usize),
+                format_count(r.cache.evicted_keys as usize),
+            );
+
+            // Persistence
+            println!(
+                "  {}  RDB: {}  AOF: {}",
+                "Persistence".bold(),
+                r.persistence.rdb_last_save_status,
+                if r.persistence.aof_enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+            );
+
+            // Keyspace
+            if !r.keyspace.is_empty() {
+                println!();
+                println!("  {}", "  DB     Keys       Expires    Avg TTL".dimmed());
+                for db in &r.keyspace {
+                    println!(
+                        "  db{:<4} {:10} {:10} {}",
+                        db.db_index,
+                        format_count(db.keys as usize),
+                        format_count(db.expires as usize),
+                        if db.avg_ttl > 0 {
+                            format_duration_ms(db.avg_ttl as f64)
+                        } else {
+                            "-".to_string()
+                        },
+                    );
+                }
+            }
+        }
+
+        DatabaseStats::MySQL(my) => {
+            // Connections
+            let util = if my.connections.max_connections > 0 {
+                my.connections.threads_connected as f64 / my.connections.max_connections as f64
+                    * 100.0
+            } else {
+                0.0
+            };
+            println!(
+                "  {}  Connected: {}  Running: {}  Max Used: {}  Max: {}  ({})",
+                "Connections".bold(),
+                format!("{}", my.connections.threads_connected).cyan(),
+                my.connections.threads_running,
+                my.connections.max_used_connections,
+                my.connections.max_connections,
+                health_color(util, 60.0, 80.0, false),
+            );
+
+            // Buffer pool
+            println!(
+                "  {}  Hit Ratio: {}  Usage: {:.1}%  Size: {}",
+                "Buffer Pool".bold(),
+                health_color(my.buffer_pool.hit_ratio * 100.0, 95.0, 90.0, true),
+                my.buffer_pool.usage_pct,
+                fmt_bytes(my.buffer_pool.total_bytes),
+            );
+
+            // Query stats
+            println!(
+                "  {}  SELECT: {}  INSERT: {}  UPDATE: {}  DELETE: {}  Slow: {}",
+                "Queries    ".bold(),
+                format_count(my.queries.selects as usize),
+                format_count(my.queries.inserts as usize),
+                format_count(my.queries.updates as usize),
+                format_count(my.queries.deletes as usize),
+                if my.queries.slow_queries > 0 {
+                    format!("{}", my.queries.slow_queries).yellow().to_string()
+                } else {
+                    "0".to_string()
+                },
+            );
+
+            // InnoDB
+            println!(
+                "  {}  Reads: {}  Inserts: {}  Updates: {}  Deletes: {}",
+                "InnoDB Rows".bold(),
+                format_count(my.innodb.row_reads as usize),
+                format_count(my.innodb.row_inserts as usize),
+                format_count(my.innodb.row_updates as usize),
+                format_count(my.innodb.row_deletes as usize),
+            );
+
+            // Table sizes
+            if !my.table_sizes.is_empty() {
+                println!();
+                println!(
+                    "  {}",
+                    "  Table                  Data         Index        Total".dimmed()
+                );
+                for t in &my.table_sizes {
+                    println!(
+                        "  {:24} {:12} {:12} {}",
+                        truncate(&t.table_name, 24),
+                        fmt_bytes(t.data_bytes),
+                        fmt_bytes(t.index_bytes),
+                        fmt_bytes(t.total_bytes),
+                    );
+                }
+            }
+        }
+
+        DatabaseStats::MongoDB(m) => {
+            // Connections
+            println!(
+                "  {}  Current: {}  Available: {}  Total Created: {}",
+                "Connections".bold(),
+                format!("{}", m.connections.current).cyan(),
+                m.connections.available,
+                format_count(m.connections.total_created as usize),
+            );
+
+            // Operations
+            println!(
+                "  {}  Insert: {}  Query: {}  Update: {}  Delete: {}  Command: {}",
+                "Operations ".bold(),
+                format_count(m.operations.insert as usize),
+                format_count(m.operations.query as usize),
+                format_count(m.operations.update as usize),
+                format_count(m.operations.delete as usize),
+                format_count(m.operations.command as usize),
+            );
+
+            // Memory
+            println!(
+                "  {}  Resident: {} MB  Virtual: {} MB",
+                "Memory     ".bold(),
+                format!("{}", m.memory.resident_mb).cyan(),
+                m.memory.virtual_mb,
+            );
+
+            // WiredTiger cache
+            if m.wired_tiger.cache_max_bytes > 0 {
+                let util = m.wired_tiger.cache_used_bytes as f64
+                    / m.wired_tiger.cache_max_bytes as f64
+                    * 100.0;
+                println!(
+                    "  {}  Used: {} / {}  ({})",
+                    "WT Cache   ".bold(),
+                    fmt_bytes(m.wired_tiger.cache_used_bytes),
+                    fmt_bytes(m.wired_tiger.cache_max_bytes),
+                    health_color(util, 80.0, 95.0, false),
+                );
+            }
+
+            // Collection stats
+            if !m.collection_stats.is_empty() {
+                println!();
+                println!(
+                    "  {}",
+                    "  Collection             Size         Count      Indexes".dimmed()
+                );
+                for c in &m.collection_stats {
+                    println!(
+                        "  {:24} {:12} {:10} {}",
+                        truncate(&c.name, 24),
+                        fmt_bytes(c.size_bytes),
+                        format_count(c.count as usize),
+                        c.index_count,
+                    );
+                }
+            }
+        }
+    }
+
+    println!();
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.chars().count() <= max_len {
+        s.to_string()
+    } else if max_len <= 3 {
+        ".".repeat(max_len)
+    } else {
+        format!(
+            "{}...",
+            s.chars()
+                .take(max_len.saturating_sub(3))
+                .collect::<String>()
+        )
+    }
+}
+
+fn format_duration_ms(ms: f64) -> String {
+    if ms >= 1000.0 {
+        format!("{:.1}s", ms / 1000.0)
+    } else if ms >= 1.0 {
+        format!("{:.1}ms", ms)
+    } else {
+        format!("{:.0}us", ms * 1000.0)
+    }
+}
+
+fn format_uptime(seconds: i64) -> String {
+    let days = seconds / 86400;
+    let hours = (seconds % 86400) / 3600;
+    let mins = (seconds % 3600) / 60;
+    if days > 0 {
+        format!("{}d {}h", days, hours)
+    } else if hours > 0 {
+        format!("{}h {}m", hours, mins)
+    } else {
+        format!("{}m", mins)
+    }
+}
+
+/// Detect the database type from the source image string.
+fn detect_database_type(source_image: Option<&str>) -> Option<DatabaseType> {
+    let img = source_image?.to_lowercase();
+    if img.contains("postgres") || img.contains("postgis") || img.contains("timescale") {
+        Some(DatabaseType::PostgreSQL)
+    } else if img.contains("redis") || img.contains("valkey") {
+        Some(DatabaseType::Redis)
+    } else if img.contains("mongo") {
+        Some(DatabaseType::MongoDB)
+    } else if img.contains("mysql") || img.contains("mariadb") {
+        Some(DatabaseType::MySQL)
+    } else {
+        None
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod login;
 pub mod logout;
 pub mod logs;
 pub mod mcp;
+pub mod metrics;
 pub mod open;
 pub mod project;
 pub mod redeploy;

--- a/src/controllers/db_stats/mod.rs
+++ b/src/controllers/db_stats/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 use std::process::Stdio;
 
 use anyhow::{Result, bail};
+use tokio::io::AsyncWriteExt;
 
 use crate::controllers::database::DatabaseType;
 use crate::controllers::ssh_keys::find_local_ssh_keys;
@@ -115,18 +116,25 @@ fn cli_tool_missing(db_type: &DatabaseType, lower_err: &str) -> bool {
 async fn exec_command_in_container(service_instance_id: &str, command: &str) -> Result<String> {
     let target = format!("{service_instance_id}@{SSH_HOST}");
 
-    let output = tokio::process::Command::new("ssh")
+    let mut child = tokio::process::Command::new("ssh")
         .arg("-o")
         .arg("StrictHostKeyChecking=accept-new")
         .arg(&target)
         .arg("sh")
-        .arg("-c")
-        .arg(command)
-        .stdin(Stdio::null())
+        .arg("-s")
+        .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
-        .await?;
+        .spawn()?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(command.as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+    } else {
+        bail!("Failed to open stdin for SSH command");
+    }
+
+    let output = child.wait_with_output().await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/controllers/db_stats/mod.rs
+++ b/src/controllers/db_stats/mod.rs
@@ -1,0 +1,219 @@
+mod mongodb;
+mod mysql;
+mod postgres;
+mod redis;
+pub mod types;
+
+use std::process::Stdio;
+
+use anyhow::{Result, bail};
+
+use crate::controllers::database::DatabaseType;
+use crate::controllers::ssh_keys::find_local_ssh_keys;
+
+pub use types::DatabaseStats;
+
+const SSH_HOST: &str = "ssh.railway.com";
+
+/// Preflight check for SSH-based DB stats collection. Runs locally only --
+/// it catches the common "no SSH key" case before we spawn the SSH process,
+/// so we can surface actionable guidance instead of a cryptic failure.
+pub fn preflight_db_stats_ssh() -> Result<(), String> {
+    match find_local_ssh_keys() {
+        Ok(keys) if keys.is_empty() => Err(
+            "no local SSH key found in ~/.ssh\n  \
+             generate one with `ssh-keygen -t ed25519`, then register it with `railway ssh keys add`"
+                .to_string(),
+        ),
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!(
+            "unable to read ~/.ssh: {e}\n  \
+             ensure the directory is readable and contains a registered SSH key"
+        )),
+    }
+}
+
+/// Translate a raw db-stats fetch error into a user-facing message with an
+/// actionable next step. SSH and per-database CLI failures surface very
+/// differently, so we try to classify the common modes and fall back to the
+/// raw error otherwise.
+pub fn diagnose_db_stats_failure(err: &anyhow::Error, db_type: &DatabaseType) -> String {
+    let raw = format!("{err:#}");
+    let lower = raw.to_ascii_lowercase();
+
+    let hint = if lower.contains("permission denied (publickey)")
+        || lower.contains("permission denied, please try again")
+        || (lower.contains("permission denied") && lower.contains("publickey"))
+    {
+        Some(
+            "your SSH key isn't registered with Railway -- run `railway ssh keys add` \
+             (or import from GitHub with `railway ssh keys github`)",
+        )
+    } else if lower.contains("no such file or directory") && lower.contains("ssh")
+        || lower.contains("program not found")
+        || lower.contains("command not found")
+    {
+        Some(
+            "the `ssh` binary was not found on PATH -- install OpenSSH and retry \
+             (macOS: preinstalled; Linux: `apt install openssh-client` / equivalent)",
+        )
+    } else if lower.contains("host key verification failed") {
+        Some(
+            "SSH host key verification failed -- remove the stale entry with \
+             `ssh-keygen -R ssh.railway.com` and retry",
+        )
+    } else if lower.contains("could not resolve hostname")
+        || lower.contains("temporary failure in name resolution")
+    {
+        Some("could not resolve ssh.railway.com -- check your network connection")
+    } else if lower.contains("connection refused")
+        || lower.contains("connection timed out")
+        || lower.contains("network is unreachable")
+    {
+        Some("could not connect to ssh.railway.com -- check your network and firewall rules")
+    } else if lower.contains("not found") && cli_tool_missing(db_type, &lower) {
+        Some(match db_type {
+            DatabaseType::PostgreSQL => {
+                "this image does not ship `psql`; database stats need the official Railway \
+                 Postgres image"
+            }
+            DatabaseType::Redis => {
+                "this image does not ship `redis-cli`; database stats need the official Railway \
+                 Redis image"
+            }
+            DatabaseType::MySQL => {
+                "this image does not ship `mysql`; database stats need the official Railway \
+                 MySQL image"
+            }
+            DatabaseType::MongoDB => {
+                "this image does not ship `mongosh`; database stats need the official Railway \
+                 MongoDB image"
+            }
+        })
+    } else {
+        None
+    };
+
+    match hint {
+        Some(h) => format!("{raw}\n  {h}"),
+        None => raw,
+    }
+}
+
+fn cli_tool_missing(db_type: &DatabaseType, lower_err: &str) -> bool {
+    let tool = match db_type {
+        DatabaseType::PostgreSQL => "psql",
+        DatabaseType::Redis => "redis-cli",
+        DatabaseType::MySQL => "mysql",
+        DatabaseType::MongoDB => "mongosh",
+    };
+    lower_err.contains(tool)
+}
+
+/// Execute a shell command inside a service container via native SSH
+/// (`ssh <instanceId>@ssh.railway.com`) and capture stdout.
+async fn exec_command_in_container(service_instance_id: &str, command: &str) -> Result<String> {
+    let target = format!("{service_instance_id}@{SSH_HOST}");
+
+    let output = tokio::process::Command::new("ssh")
+        .arg("-o")
+        .arg("StrictHostKeyChecking=accept-new")
+        .arg(&target)
+        .arg("sh")
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "SSH command failed (exit {}): {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+/// Fetch database-specific internal metrics by SSHing into the container
+/// and running database CLI commands.
+pub async fn fetch_db_stats(
+    service_instance_id: &str,
+    db_type: &DatabaseType,
+) -> Result<DatabaseStats> {
+    match db_type {
+        DatabaseType::PostgreSQL => {
+            let stats = postgres::fetch_postgres_stats(service_instance_id).await?;
+            Ok(DatabaseStats::PostgreSQL(stats))
+        }
+        DatabaseType::Redis => {
+            let stats = redis::fetch_redis_stats(service_instance_id).await?;
+            Ok(DatabaseStats::Redis(stats))
+        }
+        DatabaseType::MySQL => {
+            let stats = mysql::fetch_mysql_stats(service_instance_id).await?;
+            Ok(DatabaseStats::MySQL(stats))
+        }
+        DatabaseType::MongoDB => {
+            let stats = mongodb::fetch_mongo_stats(service_instance_id).await?;
+            Ok(DatabaseStats::MongoDB(stats))
+        }
+    }
+}
+
+/// Split raw command output into sections by delimiter markers.
+/// Returns a map of section_name -> section_content.
+fn split_sections(output: &str) -> std::collections::HashMap<&str, &str> {
+    let mut sections = std::collections::HashMap::new();
+    let mut current_name: Option<&str> = None;
+    let mut current_start = 0;
+
+    // Walk the string by finding each line's byte range directly
+    let mut pos = 0;
+    for line in output.lines() {
+        // Find where this line actually starts in the original string
+        // (lines() may skip \r\n or \n, so advance pos past any line ending)
+        let line_start = pos;
+        pos += line.len();
+        // Skip the line ending (\r\n or \n)
+        if output.as_bytes().get(pos) == Some(&b'\r') {
+            pos += 1;
+        }
+        if output.as_bytes().get(pos) == Some(&b'\n') {
+            pos += 1;
+        }
+
+        if let Some(name) = line.strip_prefix("===").and_then(|s| s.strip_suffix("===")) {
+            // Save previous section
+            if let Some(prev) = current_name {
+                let content = &output[current_start..line_start];
+                sections.insert(prev, content.trim());
+            }
+            current_name = Some(name);
+            current_start = pos;
+        }
+    }
+
+    // Save last section
+    if let Some(name) = current_name {
+        let content = &output[current_start..];
+        sections.insert(name, content.trim());
+    }
+
+    sections
+}
+
+/// Parse a simple integer from a string, returning 0 on failure.
+fn parse_i64(s: &str) -> i64 {
+    s.trim().parse().unwrap_or(0)
+}
+
+/// Parse a simple float from a string, returning 0.0 on failure.
+fn parse_f64(s: &str) -> f64 {
+    s.trim().parse().unwrap_or(0.0)
+}

--- a/src/controllers/db_stats/mongodb.rs
+++ b/src/controllers/db_stats/mongodb.rs
@@ -1,0 +1,111 @@
+use anyhow::Result;
+use serde_json::Value;
+
+use super::exec_command_in_container;
+use super::types::*;
+
+/// Connect to localhost:27017 (already inside container via SSH).
+/// Builds auth URL from MONGO* env vars. Matches dashboard's mongo-ssh.ts.
+const MONGO_STATS_COMMAND: &str = r#"mongosh "mongodb://$MONGOUSER:$MONGOPASSWORD@localhost:27017/admin?authSource=admin" --quiet --norc --json=relaxed --eval "
+function databaseNameFromUrl(url) {
+    if (!url) {
+        return '';
+    }
+    try {
+        var parsed = new URL(url);
+        return decodeURIComponent(parsed.pathname.replace(/^\/+/, '').split('/')[0] || '');
+    } catch (e) {
+        return '';
+    }
+}
+var env = (typeof process !== 'undefined' && process.env) ? process.env : {};
+var dbName = env.MONGODATABASE || env.MONGO_DATABASE || databaseNameFromUrl(env.MONGO_URL);
+var targetDb = dbName ? db.getSiblingDB(dbName) : db;
+var status = db.serverStatus();
+var dbStats = targetDb.stats();
+var colls = targetDb.getCollectionNames().slice(0, 20).map(function(c) {
+    var s = targetDb.getCollection(c).stats();
+    return {name: c, count: s.count || 0, size: s.size || 0, nindexes: s.nindexes || 0};
+});
+print(JSON.stringify({server: status, dbStats: dbStats, database: targetDb.getName(), collections: colls}));
+" 2>/dev/null"#;
+
+pub async fn fetch_mongo_stats(service_instance_id: &str) -> Result<MongoStats> {
+    let output = exec_command_in_container(service_instance_id, MONGO_STATS_COMMAND).await?;
+    parse_mongo_output(&output)
+}
+
+fn parse_mongo_output(output: &str) -> Result<MongoStats> {
+    // The output may contain non-JSON lines (mongosh warnings, etc.)
+    // Find the JSON line (starts with '{')
+    let json_str = output
+        .lines()
+        .find(|line| line.trim_start().starts_with('{'))
+        .ok_or_else(|| anyhow::anyhow!("No JSON output from mongosh"))?;
+
+    let root: Value = serde_json::from_str(json_str)?;
+    let server = &root["server"];
+    let _db_stats = &root["dbStats"];
+
+    let mut stats = MongoStats::default();
+
+    // Connections
+    if let Some(conn) = server.get("connections") {
+        stats.connections = MongoConnections {
+            current: val_i64(conn, "current"),
+            available: val_i64(conn, "available"),
+            total_created: val_i64(conn, "totalCreated"),
+        };
+    }
+
+    // Operations (opcounters)
+    if let Some(ops) = server.get("opcounters") {
+        stats.operations = MongoOperations {
+            insert: val_i64(ops, "insert"),
+            query: val_i64(ops, "query"),
+            update: val_i64(ops, "update"),
+            delete: val_i64(ops, "delete"),
+            command: val_i64(ops, "command"),
+        };
+    }
+
+    // Memory
+    if let Some(mem) = server.get("mem") {
+        stats.memory = MongoMemory {
+            resident_mb: val_i64(mem, "resident"),
+            virtual_mb: val_i64(mem, "virtual"),
+        };
+    }
+
+    // WiredTiger cache
+    if let Some(wt) = server.get("wiredTiger") {
+        if let Some(cache) = wt.get("cache") {
+            stats.wired_tiger = MongoWiredTiger {
+                cache_used_bytes: val_i64(cache, "bytes currently in the cache"),
+                cache_max_bytes: val_i64(cache, "maximum bytes configured"),
+                cache_dirty_bytes: val_i64(cache, "tracked dirty bytes in the cache"),
+            };
+        }
+    }
+
+    // Collection stats
+    if let Some(colls) = root.get("collections").and_then(|c| c.as_array()) {
+        stats.collection_stats = colls
+            .iter()
+            .map(|c| MongoCollectionStats {
+                name: c["name"].as_str().unwrap_or("").to_string(),
+                count: val_i64(c, "count"),
+                size_bytes: val_i64(c, "size"),
+                index_count: val_i64(c, "nindexes"),
+            })
+            .collect();
+    }
+
+    Ok(stats)
+}
+
+fn val_i64(obj: &Value, key: &str) -> i64 {
+    obj.get(key)
+        .and_then(|v| v.as_i64().or_else(|| v.as_f64().map(|f| f as i64)))
+        .unwrap_or(0)
+}

--- a/src/controllers/db_stats/mysql.rs
+++ b/src/controllers/db_stats/mysql.rs
@@ -1,0 +1,152 @@
+use anyhow::Result;
+
+use super::types::*;
+use super::{exec_command_in_container, parse_f64, parse_i64};
+
+/// Connect to localhost:3306 (already inside container via SSH).
+/// Uses MYSQL_PWD env for password. Matches dashboard's mysql-ssh.ts.
+fn build_mysql_command() -> String {
+    let my = "MYSQL_PWD=\"$MYSQLPASSWORD\" mysql -h localhost -P 3306 -u \"$MYSQLUSER\" -D \"$MYSQLDATABASE\" --batch --skip-column-names";
+    format!(
+        r#"echo '===STATUS===';
+{my} -e "SHOW GLOBAL STATUS" 2>/dev/null;
+echo '===VARIABLES===';
+{my} -e "SHOW VARIABLES WHERE Variable_name IN ('max_connections','innodb_buffer_pool_size','version','slow_query_log')" 2>/dev/null;
+echo '===TABLES===';
+{my} -e "SELECT TABLE_NAME, DATA_LENGTH, INDEX_LENGTH FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() ORDER BY (DATA_LENGTH + INDEX_LENGTH) DESC LIMIT 20" 2>/dev/null
+"#
+    )
+}
+
+pub async fn fetch_mysql_stats(service_instance_id: &str) -> Result<MySqlStats> {
+    let cmd = build_mysql_command();
+    let output = exec_command_in_container(service_instance_id, &cmd).await?;
+    parse_mysql_output(&output)
+}
+
+fn parse_mysql_output(output: &str) -> Result<MySqlStats> {
+    let sections = super::split_sections(output);
+    let mut stats = MySqlStats::default();
+
+    // Parse SHOW GLOBAL STATUS into a map
+    let status = if let Some(tsv) = sections.get("STATUS") {
+        parse_tsv_map(tsv)
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    // Parse SHOW VARIABLES into a map
+    let vars = if let Some(tsv) = sections.get("VARIABLES") {
+        parse_tsv_map(tsv)
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    // Connections
+    stats.connections = MySqlConnections {
+        threads_connected: get_status_i64(&status, "Threads_connected"),
+        threads_running: get_status_i64(&status, "Threads_running"),
+        max_used_connections: get_status_i64(&status, "Max_used_connections"),
+        max_connections: vars
+            .get("max_connections")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+        aborted_connects: get_status_i64(&status, "Aborted_connects"),
+    };
+
+    // Buffer pool
+    let read_requests = get_status_f64(&status, "Innodb_buffer_pool_read_requests");
+    let reads = get_status_f64(&status, "Innodb_buffer_pool_reads");
+    let pool_size = vars
+        .get("innodb_buffer_pool_size")
+        .map(|s| parse_i64(s))
+        .unwrap_or(0);
+    let pool_data = get_status_i64(&status, "Innodb_buffer_pool_bytes_data");
+
+    stats.buffer_pool = MySqlBufferPool {
+        hit_ratio: buffer_pool_hit_ratio(read_requests, reads),
+        usage_pct: if pool_size > 0 {
+            pool_data as f64 / pool_size as f64 * 100.0
+        } else {
+            0.0
+        },
+        total_bytes: pool_size,
+    };
+
+    // Query stats
+    stats.queries = MySqlQueryStats {
+        selects: get_status_i64(&status, "Com_select"),
+        inserts: get_status_i64(&status, "Com_insert"),
+        updates: get_status_i64(&status, "Com_update"),
+        deletes: get_status_i64(&status, "Com_delete"),
+        slow_queries: get_status_i64(&status, "Slow_queries"),
+        questions: get_status_i64(&status, "Questions"),
+    };
+
+    // InnoDB row operations
+    stats.innodb = MySqlInnodb {
+        row_reads: get_status_i64(&status, "Innodb_rows_read"),
+        row_inserts: get_status_i64(&status, "Innodb_rows_inserted"),
+        row_updates: get_status_i64(&status, "Innodb_rows_updated"),
+        row_deletes: get_status_i64(&status, "Innodb_rows_deleted"),
+    };
+
+    // Table sizes
+    if let Some(tsv) = sections.get("TABLES") {
+        stats.table_sizes = parse_table_sizes(tsv);
+    }
+
+    Ok(stats)
+}
+
+fn buffer_pool_hit_ratio(read_requests: f64, reads: f64) -> f64 {
+    if read_requests <= 0.0 {
+        return 0.0;
+    }
+
+    ((read_requests - reads) / read_requests).clamp(0.0, 1.0)
+}
+
+fn parse_tsv_map(tsv: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for line in tsv.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = line.splitn(2, '\t').collect();
+        if parts.len() == 2 {
+            map.insert(parts[0].to_string(), parts[1].to_string());
+        }
+    }
+    map
+}
+
+fn get_status_i64(map: &std::collections::HashMap<String, String>, key: &str) -> i64 {
+    map.get(key).map(|s| parse_i64(s)).unwrap_or(0)
+}
+
+fn get_status_f64(map: &std::collections::HashMap<String, String>, key: &str) -> f64 {
+    map.get(key).map(|s| parse_f64(s)).unwrap_or(0.0)
+}
+
+fn parse_table_sizes(tsv: &str) -> Vec<MySqlTableSize> {
+    tsv.lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() >= 3 {
+                let data = parse_i64(parts[1]);
+                let index = parse_i64(parts[2]);
+                Some(MySqlTableSize {
+                    table_name: parts[0].to_string(),
+                    data_bytes: data,
+                    index_bytes: index,
+                    total_bytes: data + index,
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}

--- a/src/controllers/db_stats/postgres.rs
+++ b/src/controllers/db_stats/postgres.rs
@@ -1,0 +1,239 @@
+use anyhow::Result;
+use csv::ReaderBuilder;
+
+use super::types::*;
+use super::{exec_command_in_container, parse_f64, parse_i64, split_sections};
+
+/// Build the psql stats command. Connects to localhost:5432 with SSL disabled
+/// (we're already inside the container via SSH). Uses PGUSER/PGPASSWORD/PGDATABASE
+/// from the container env. This matches the dashboard's approach in postgres-ssh.ts.
+fn build_postgres_command() -> String {
+    let pg =
+        "PGHOST=localhost PGPORT=5432 PGSSLMODE=disable psql --csv -q -P pager=off -P footer=off";
+    let pgt = "PGHOST=localhost PGPORT=5432 PGSSLMODE=disable psql -t -A -q";
+    format!(
+        r#"echo '===CONNECTIONS===';
+{pg} -c "SELECT COALESCE(state, 'total') as state, count(*) as count FROM pg_stat_activity WHERE datname = current_database() GROUP BY ROLLUP(state)";
+echo '===MAX_CONN===';
+{pgt} -c "SHOW max_connections";
+echo '===CACHE_AND_DEADLOCKS===';
+{pg} -c "SELECT COALESCE(sum(heap_blks_hit)::float / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0), 0) as cache_hit_ratio, (SELECT deadlocks FROM pg_stat_database WHERE datname = current_database()) as deadlocks FROM pg_statio_user_tables";
+echo '===SIZE===';
+{pg} -c "SELECT pg_database_size(current_database()) as total, COALESCE((SELECT sum(pg_table_size(c.oid)) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname = 'public'), 0) as tables, COALESCE((SELECT sum(pg_indexes_size(c.oid)) FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind = 'r' AND n.nspname = 'public'), 0) as indexes";
+echo '===TABLES===';
+{pg} -c "SELECT relname, pg_total_relation_size(relid) as size, seq_scan, idx_scan, n_live_tup, n_dead_tup FROM pg_stat_user_tables ORDER BY pg_total_relation_size(relid) DESC LIMIT 20";
+echo '===QUERIES===';
+{pg} -c "SELECT left(query, 120) as query, calls, total_exec_time, mean_exec_time, rows FROM pg_stat_statements WHERE dbid = (SELECT oid FROM pg_database WHERE datname = current_database()) ORDER BY total_exec_time DESC LIMIT 10" 2>/dev/null || echo 'NOT_AVAILABLE';
+echo '===VACUUM===';
+{pg} -c "SELECT relname, n_dead_tup, n_live_tup, last_vacuum::text, last_analyze::text, age(relfrozenxid) as xid_age FROM pg_stat_user_tables s JOIN pg_class c ON c.oid = s.relid ORDER BY n_dead_tup DESC LIMIT 15";
+echo '===INDEXES===';
+{pg} -c "SELECT indexrelname, pg_relation_size(indexrelid) as index_size, idx_scan, (SELECT count(*) FROM pg_stat_user_indexes) as total_count FROM pg_stat_user_indexes WHERE idx_scan = 0 AND schemaname = 'public' LIMIT 20";
+echo '===MISSING_INDEXES===';
+{pg} -c "SELECT relname, n_live_tup, seq_scan, idx_scan FROM pg_stat_user_tables WHERE seq_scan > 0 AND idx_scan = 0 AND n_live_tup > 1000 ORDER BY seq_scan DESC LIMIT 10"
+"#
+    )
+}
+
+pub async fn fetch_postgres_stats(service_instance_id: &str) -> Result<PostgresStats> {
+    let cmd = build_postgres_command();
+    let output = exec_command_in_container(service_instance_id, &cmd).await?;
+    parse_postgres_output(&output)
+}
+
+fn parse_postgres_output(output: &str) -> Result<PostgresStats> {
+    let sections = split_sections(output);
+    let mut stats = PostgresStats::default();
+
+    // Connections
+    if let Some(csv) = sections.get("CONNECTIONS") {
+        stats.connections = parse_connections(csv);
+    }
+
+    // Max connections
+    if let Some(val) = sections.get("MAX_CONN") {
+        stats.connections.max_connections = parse_i64(val);
+    }
+
+    // Cache hit ratio + deadlocks (combined query)
+    if let Some(csv) = sections.get("CACHE_AND_DEADLOCKS") {
+        let rows = parse_csv_rows(csv);
+        if let Some(row) = rows.first() {
+            stats.cache.hit_ratio = row.first().map(|s| parse_f64(s)).unwrap_or(0.0);
+            stats.deadlocks = row.get(1).map(|s| parse_i64(s)).unwrap_or(0);
+        }
+    }
+
+    // Database size
+    if let Some(csv) = sections.get("SIZE") {
+        stats.database_size = parse_db_size(csv);
+    }
+
+    // Table stats
+    if let Some(csv) = sections.get("TABLES") {
+        stats.table_stats = parse_table_stats(csv);
+    }
+
+    // Query stats (optional -- pg_stat_statements may not be loaded)
+    if let Some(csv) = sections.get("QUERIES") {
+        if *csv != "NOT_AVAILABLE" && !csv.is_empty() {
+            stats.query_stats = Some(parse_query_stats(csv));
+        }
+    }
+
+    // Vacuum health
+    if let Some(csv) = sections.get("VACUUM") {
+        stats.vacuum_health = parse_vacuum_health(csv);
+    }
+
+    // Index health
+    if let Some(csv) = sections.get("INDEXES") {
+        stats.index_health = parse_index_health(csv);
+    }
+
+    // Missing indexes (tables that may benefit from an index)
+    if let Some(csv) = sections.get("MISSING_INDEXES") {
+        stats.missing_indexes = parse_missing_indexes(csv);
+    }
+
+    Ok(stats)
+}
+
+fn parse_csv_rows(csv: &str) -> Vec<Vec<String>> {
+    ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(csv.as_bytes())
+        .records()
+        .filter_map(|record| record.ok())
+        .map(|record| record.iter().map(|field| field.to_string()).collect())
+        .collect()
+}
+
+fn parse_connections(csv: &str) -> PgConnections {
+    let mut conn = PgConnections::default();
+    for row in parse_csv_rows(csv) {
+        if row.len() < 2 {
+            continue;
+        }
+        let count = parse_i64(&row[1]);
+        match row[0].as_str() {
+            "active" => conn.active = count,
+            "idle" => conn.idle = count,
+            "idle in transaction" => conn.idle_in_transaction = count,
+            "total" => conn.total = count,
+            _ => {}
+        }
+    }
+    // If total wasn't from ROLLUP, compute it
+    if conn.total == 0 {
+        conn.total = conn.active + conn.idle + conn.idle_in_transaction;
+    }
+    conn
+}
+
+fn parse_db_size(csv: &str) -> PgDatabaseSize {
+    let rows = parse_csv_rows(csv);
+    if let Some(row) = rows.first() {
+        PgDatabaseSize {
+            total_bytes: row.first().map(|s| parse_i64(s)).unwrap_or(0),
+            tables_bytes: row.get(1).map(|s| parse_i64(s)).unwrap_or(0),
+            indexes_bytes: row.get(2).map(|s| parse_i64(s)).unwrap_or(0),
+        }
+    } else {
+        PgDatabaseSize::default()
+    }
+}
+
+fn parse_table_stats(csv: &str) -> Vec<PgTableStats> {
+    parse_csv_rows(csv)
+        .into_iter()
+        .filter(|row| row.len() >= 6)
+        .map(|row| PgTableStats {
+            table_name: row[0].clone(),
+            size_bytes: parse_i64(&row[1]),
+            seq_scan: parse_i64(&row[2]),
+            idx_scan: parse_i64(&row[3]),
+            live_tuples: parse_i64(&row[4]),
+            dead_tuples: parse_i64(&row[5]),
+        })
+        .collect()
+}
+
+fn parse_query_stats(csv: &str) -> Vec<PgQueryStats> {
+    parse_csv_rows(csv)
+        .into_iter()
+        .filter(|row| row.len() >= 5)
+        .map(|row| PgQueryStats {
+            query: row[0].clone(),
+            calls: parse_i64(&row[1]),
+            total_time_ms: parse_f64(&row[2]),
+            mean_time_ms: parse_f64(&row[3]),
+            rows: parse_i64(&row[4]),
+        })
+        .collect()
+}
+
+fn parse_vacuum_health(csv: &str) -> Vec<PgVacuumHealth> {
+    parse_csv_rows(csv)
+        .into_iter()
+        .filter(|row| row.len() >= 5)
+        .map(|row| {
+            let dead = parse_f64(&row[1]);
+            let live = parse_f64(&row[2]);
+            let total = dead + live;
+            PgVacuumHealth {
+                table_name: row[0].clone(),
+                dead_rows_pct: if total > 0.0 {
+                    dead / total * 100.0
+                } else {
+                    0.0
+                },
+                last_vacuum: if row[3].is_empty() {
+                    None
+                } else {
+                    Some(row[3].clone())
+                },
+                last_analyze: if row[4].is_empty() {
+                    None
+                } else {
+                    Some(row[4].clone())
+                },
+                xid_age: row.get(5).map(|s| parse_i64(s)).unwrap_or(0),
+            }
+        })
+        .collect()
+}
+
+fn parse_index_health(csv: &str) -> PgIndexHealth {
+    let rows = parse_csv_rows(csv);
+    let total = rows
+        .first()
+        .and_then(|r| r.get(3))
+        .map(|s| parse_i64(s))
+        .unwrap_or(0);
+    let mut unused_indexes = Vec::new();
+    let mut unused_bytes = 0i64;
+    for row in &rows {
+        if let Some(name) = row.first() {
+            unused_indexes.push(name.clone());
+            unused_bytes += row.get(1).map(|s| parse_i64(s)).unwrap_or(0);
+        }
+    }
+    PgIndexHealth {
+        unused_indexes,
+        total_index_count: total,
+        unused_bytes,
+    }
+}
+
+fn parse_missing_indexes(csv: &str) -> Vec<PgMissingIndex> {
+    parse_csv_rows(csv)
+        .into_iter()
+        .filter(|row| row.len() >= 4)
+        .map(|row| PgMissingIndex {
+            table_name: row[0].clone(),
+            live_rows: parse_i64(&row[1]),
+            seq_scan: parse_i64(&row[2]),
+            idx_scan: parse_i64(&row[3]),
+        })
+        .collect()
+}

--- a/src/controllers/db_stats/redis.rs
+++ b/src/controllers/db_stats/redis.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+
+use super::types::*;
+use super::{exec_command_in_container, parse_f64, parse_i64};
+
+/// Connect to localhost:6379 (already inside container via SSH).
+/// Uses REDISPASSWORD from container env if set. Matches dashboard's redis-ssh.ts.
+const REDIS_STATS_COMMAND: &str = "redis-cli -h localhost -p 6379 ${REDISPASSWORD:+-a \"$REDISPASSWORD\"} --no-auth-warning INFO all";
+
+pub async fn fetch_redis_stats(service_instance_id: &str) -> Result<RedisStats> {
+    let output = exec_command_in_container(service_instance_id, REDIS_STATS_COMMAND).await?;
+    parse_redis_output(&output)
+}
+
+fn parse_redis_output(output: &str) -> Result<RedisStats> {
+    let mut stats = RedisStats::default();
+    let info = parse_info_map(output);
+
+    // Server
+    stats.server = RedisServerInfo {
+        version: info.get("redis_version").cloned().unwrap_or_default(),
+        uptime_seconds: info
+            .get("uptime_in_seconds")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+        connected_clients: info
+            .get("connected_clients")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+        blocked_clients: info
+            .get("blocked_clients")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+    };
+
+    // Memory
+    stats.memory = RedisMemoryInfo {
+        used_bytes: info.get("used_memory").map(|s| parse_i64(s)).unwrap_or(0),
+        rss_bytes: info
+            .get("used_memory_rss")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+        peak_bytes: info
+            .get("used_memory_peak")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+        fragmentation_ratio: info
+            .get("mem_fragmentation_ratio")
+            .map(|s| parse_f64(s))
+            .unwrap_or(0.0),
+        max_memory_bytes: info.get("maxmemory").map(|s| parse_i64(s)).unwrap_or(0),
+        eviction_policy: info.get("maxmemory_policy").cloned().unwrap_or_default(),
+    };
+
+    // Throughput
+    stats.throughput = RedisThroughput {
+        ops_per_sec: info
+            .get("instantaneous_ops_per_sec")
+            .map(|s| parse_f64(s))
+            .unwrap_or(0.0),
+        total_commands: info
+            .get("total_commands_processed")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+        total_connections: info
+            .get("total_connections_received")
+            .map(|s| parse_i64(s))
+            .unwrap_or(0),
+    };
+
+    // Cache
+    let hits = info.get("keyspace_hits").map(|s| parse_i64(s)).unwrap_or(0);
+    let misses = info
+        .get("keyspace_misses")
+        .map(|s| parse_i64(s))
+        .unwrap_or(0);
+    let total = hits + misses;
+    stats.cache = RedisCacheStats {
+        hit_rate: if total > 0 {
+            hits as f64 / total as f64
+        } else {
+            0.0
+        },
+        hits,
+        misses,
+        expired_keys: info.get("expired_keys").map(|s| parse_i64(s)).unwrap_or(0),
+        evicted_keys: info.get("evicted_keys").map(|s| parse_i64(s)).unwrap_or(0),
+    };
+
+    // Persistence
+    stats.persistence = RedisPersistence {
+        rdb_last_save_status: info
+            .get("rdb_last_bgsave_status")
+            .cloned()
+            .unwrap_or_default(),
+        aof_enabled: info.get("aof_enabled").map(|s| s == "1").unwrap_or(false),
+    };
+
+    // Keyspace (db0:keys=100,expires=50,avg_ttl=3600)
+    stats.keyspace = parse_keyspace(&info);
+
+    Ok(stats)
+}
+
+fn parse_info_map(output: &str) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for line in output.lines() {
+        let line = line.trim();
+        // Skip comments and empty lines
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            map.insert(key.to_string(), value.to_string());
+        }
+    }
+    map
+}
+
+fn parse_keyspace(info: &std::collections::HashMap<String, String>) -> Vec<RedisKeyspaceDb> {
+    let mut dbs = Vec::new();
+    for (key, value) in info {
+        if let Some(idx_str) = key.strip_prefix("db") {
+            if let Ok(idx) = idx_str.parse::<i32>() {
+                let mut keys = 0i64;
+                let mut expires = 0i64;
+                let mut avg_ttl = 0i64;
+                for part in value.split(',') {
+                    if let Some((k, v)) = part.split_once('=') {
+                        match k {
+                            "keys" => keys = parse_i64(v),
+                            "expires" => expires = parse_i64(v),
+                            "avg_ttl" => avg_ttl = parse_i64(v),
+                            _ => {}
+                        }
+                    }
+                }
+                dbs.push(RedisKeyspaceDb {
+                    db_index: idx,
+                    keys,
+                    expires,
+                    avg_ttl,
+                });
+            }
+        }
+    }
+    dbs.sort_by_key(|d| d.db_index);
+    dbs
+}

--- a/src/controllers/db_stats/types.rs
+++ b/src/controllers/db_stats/types.rs
@@ -1,0 +1,254 @@
+use serde::Serialize;
+
+/// Wrapper enum for all database-specific metrics.
+/// Tagged by database_type in JSON output.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "database_type")]
+pub enum DatabaseStats {
+    PostgreSQL(PostgresStats),
+    Redis(RedisStats),
+    MySQL(MySqlStats),
+    MongoDB(MongoStats),
+}
+
+// ─── PostgreSQL ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PostgresStats {
+    pub connections: PgConnections,
+    pub cache: PgCache,
+    pub database_size: PgDatabaseSize,
+    pub deadlocks: i64,
+    pub table_stats: Vec<PgTableStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_stats: Option<Vec<PgQueryStats>>,
+    pub vacuum_health: Vec<PgVacuumHealth>,
+    pub index_health: PgIndexHealth,
+    /// Tables with high sequential scans but no index scans (candidates for new indexes)
+    pub missing_indexes: Vec<PgMissingIndex>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PgConnections {
+    pub total: i64,
+    pub active: i64,
+    pub idle: i64,
+    pub idle_in_transaction: i64,
+    pub max_connections: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PgCache {
+    pub hit_ratio: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PgDatabaseSize {
+    pub total_bytes: i64,
+    pub tables_bytes: i64,
+    pub indexes_bytes: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PgTableStats {
+    pub table_name: String,
+    pub size_bytes: i64,
+    pub seq_scan: i64,
+    pub idx_scan: i64,
+    pub live_tuples: i64,
+    pub dead_tuples: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PgQueryStats {
+    pub query: String,
+    pub calls: i64,
+    pub total_time_ms: f64,
+    pub mean_time_ms: f64,
+    pub rows: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PgVacuumHealth {
+    pub table_name: String,
+    pub dead_rows_pct: f64,
+    pub last_vacuum: Option<String>,
+    pub last_analyze: Option<String>,
+    pub xid_age: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PgMissingIndex {
+    pub table_name: String,
+    pub live_rows: i64,
+    pub seq_scan: i64,
+    pub idx_scan: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct PgIndexHealth {
+    pub unused_indexes: Vec<String>,
+    pub total_index_count: i64,
+    pub unused_bytes: i64,
+}
+
+// ─── Redis ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RedisStats {
+    pub server: RedisServerInfo,
+    pub memory: RedisMemoryInfo,
+    pub throughput: RedisThroughput,
+    pub cache: RedisCacheStats,
+    pub persistence: RedisPersistence,
+    pub keyspace: Vec<RedisKeyspaceDb>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RedisServerInfo {
+    pub version: String,
+    pub uptime_seconds: i64,
+    pub connected_clients: i64,
+    pub blocked_clients: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RedisMemoryInfo {
+    pub used_bytes: i64,
+    pub rss_bytes: i64,
+    pub peak_bytes: i64,
+    pub fragmentation_ratio: f64,
+    pub max_memory_bytes: i64,
+    pub eviction_policy: String,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RedisThroughput {
+    pub ops_per_sec: f64,
+    pub total_commands: i64,
+    pub total_connections: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RedisCacheStats {
+    pub hit_rate: f64,
+    pub hits: i64,
+    pub misses: i64,
+    pub expired_keys: i64,
+    pub evicted_keys: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RedisPersistence {
+    pub rdb_last_save_status: String,
+    pub aof_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RedisKeyspaceDb {
+    pub db_index: i32,
+    pub keys: i64,
+    pub expires: i64,
+    pub avg_ttl: i64,
+}
+
+// ─── MySQL ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MySqlStats {
+    pub connections: MySqlConnections,
+    pub buffer_pool: MySqlBufferPool,
+    pub queries: MySqlQueryStats,
+    pub innodb: MySqlInnodb,
+    pub table_sizes: Vec<MySqlTableSize>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MySqlConnections {
+    pub threads_connected: i64,
+    pub threads_running: i64,
+    pub max_used_connections: i64,
+    pub max_connections: i64,
+    pub aborted_connects: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MySqlBufferPool {
+    pub hit_ratio: f64,
+    pub usage_pct: f64,
+    pub total_bytes: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MySqlQueryStats {
+    pub selects: i64,
+    pub inserts: i64,
+    pub updates: i64,
+    pub deletes: i64,
+    pub slow_queries: i64,
+    pub questions: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MySqlInnodb {
+    pub row_reads: i64,
+    pub row_inserts: i64,
+    pub row_updates: i64,
+    pub row_deletes: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MySqlTableSize {
+    pub table_name: String,
+    pub data_bytes: i64,
+    pub index_bytes: i64,
+    pub total_bytes: i64,
+}
+
+// ─── MongoDB ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MongoStats {
+    pub connections: MongoConnections,
+    pub operations: MongoOperations,
+    pub memory: MongoMemory,
+    pub wired_tiger: MongoWiredTiger,
+    pub collection_stats: Vec<MongoCollectionStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MongoConnections {
+    pub current: i64,
+    pub available: i64,
+    pub total_created: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MongoOperations {
+    pub insert: i64,
+    pub query: i64,
+    pub update: i64,
+    pub delete: i64,
+    pub command: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MongoMemory {
+    pub resident_mb: i64,
+    pub virtual_mb: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MongoWiredTiger {
+    pub cache_used_bytes: i64,
+    pub cache_max_bytes: i64,
+    pub cache_dirty_bytes: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MongoCollectionStats {
+    pub name: String,
+    pub count: i64,
+    pub size_bytes: i64,
+    pub index_count: i64,
+}

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -19,6 +19,14 @@ pub struct MetricDataPoint {
     pub value: f64,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ChartData {
+    pub x_min: f64,
+    pub x_max: f64,
+    pub points: Vec<(f64, f64)>,
+    pub labels: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct MetricSummary {
     pub measurement: String,
@@ -29,6 +37,8 @@ pub struct MetricSummary {
     pub data_points: usize,
     #[serde(skip_serializing)]
     pub raw_values: Vec<MetricDataPoint>,
+    #[serde(skip_serializing)]
+    pub chart_data: ChartData,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -48,6 +58,11 @@ pub struct HttpTimeSeries {
     pub p90_ts: Vec<MetricDataPoint>,
     pub p95_ts: Vec<MetricDataPoint>,
     pub p99_ts: Vec<MetricDataPoint>,
+    pub error_rate_chart: ChartData,
+    pub p50_chart: ChartData,
+    pub p90_chart: ChartData,
+    pub p95_chart: ChartData,
+    pub p99_chart: ChartData,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -173,6 +188,52 @@ fn sort_project_services(services: &mut [ServiceMetricsSummary], sort_by_cpu: bo
     });
 }
 
+fn chart_data_from_points(points: &[MetricDataPoint]) -> ChartData {
+    let Some(first) = points.first() else {
+        return ChartData {
+            x_min: 0.0,
+            x_max: 1.0,
+            ..ChartData::default()
+        };
+    };
+
+    chart_data_from_points_with_origin(points, first.ts)
+}
+
+fn chart_data_from_points_with_origin(points: &[MetricDataPoint], origin_ts: i64) -> ChartData {
+    let end_ts = points.last().map(|point| point.ts).unwrap_or(origin_ts);
+    let range = (end_ts - origin_ts).max(1) as f64;
+    let labels = time_labels(origin_ts, end_ts);
+    let origin = origin_ts as f64;
+    let chart_points = points
+        .iter()
+        .map(|point| (point.ts as f64 - origin, point.value))
+        .collect();
+
+    ChartData {
+        x_min: 0.0,
+        x_max: range,
+        points: chart_points,
+        labels,
+    }
+}
+
+fn time_labels(start_ts: i64, end_ts: i64) -> Vec<String> {
+    let range = (end_ts - start_ts).max(1) as f64;
+    let step = range / 4.0;
+    (0..=4)
+        .map(|i| {
+            let ts = start_ts as f64 + step * i as f64;
+            chrono::DateTime::from_timestamp(ts as i64, 0)
+                .map(|dt| {
+                    let local: chrono::DateTime<chrono::Local> = dt.into();
+                    local.format("%-I:%M %p").to_string()
+                })
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
 pub async fn fetch_project_metrics(
     params: FetchProjectMetricsParams<'_>,
     project: &ProjectProject,
@@ -256,6 +317,11 @@ fn summarize_metric(m: &queries::metrics::MetricsMetrics, include_raw: bool) -> 
             max: 0.0,
             data_points: 0,
             raw_values: vec![],
+            chart_data: ChartData {
+                x_min: 0.0,
+                x_max: 1.0,
+                ..ChartData::default()
+            },
         }
     } else {
         let values: Vec<f64> = m.values.iter().map(|v| v.value).collect();
@@ -275,6 +341,7 @@ fn summarize_metric(m: &queries::metrics::MetricsMetrics, include_raw: bool) -> 
         } else {
             vec![]
         };
+        let chart_data = chart_data_from_points(&raw_values);
 
         MetricSummary {
             measurement: format!("{:?}", m.measurement),
@@ -284,6 +351,7 @@ fn summarize_metric(m: &queries::metrics::MetricsMetrics, include_raw: bool) -> 
             max,
             data_points: values.len(),
             raw_values,
+            chart_data,
         }
     }
 }
@@ -486,53 +554,67 @@ pub async fn fetch_http_metrics(
     };
 
     let time_series = if params.include_time_series {
-        let request_rate_ts = ts_totals
+        let request_rate_ts: Vec<MetricDataPoint> = ts_totals
             .iter()
             .map(|(&ts, &(total, _))| MetricDataPoint { ts, value: total })
             .collect();
-        let error_rate_ts = ts_totals
+        let error_rate_ts: Vec<MetricDataPoint> = ts_totals
             .iter()
             .map(|(&ts, &(_, errors))| MetricDataPoint { ts, value: errors })
             .collect();
-        let p50_ts = samples
+        let p50_ts: Vec<MetricDataPoint> = samples
             .iter()
             .map(|s| MetricDataPoint {
                 ts: s.ts,
                 value: s.p50,
             })
             .collect();
-        let p90_ts = samples
+        let p90_ts: Vec<MetricDataPoint> = samples
             .iter()
             .map(|s| MetricDataPoint {
                 ts: s.ts,
                 value: s.p90,
             })
             .collect();
-        let p95_ts = samples
+        let p95_ts: Vec<MetricDataPoint> = samples
             .iter()
             .map(|s| MetricDataPoint {
                 ts: s.ts,
                 value: s.p95,
             })
             .collect();
-        let p99_ts = samples
+        let p99_ts: Vec<MetricDataPoint> = samples
             .iter()
             .map(|s| MetricDataPoint {
                 ts: s.ts,
                 value: s.p99,
             })
             .collect();
+        let error_rate_chart = chart_data_from_points(&error_rate_ts);
+        let status_2xx_ts = btree_to_vec(&ts_2xx);
+        let status_3xx_ts = btree_to_vec(&ts_3xx);
+        let status_4xx_ts = btree_to_vec(&ts_4xx);
+        let status_5xx_ts = btree_to_vec(&ts_5xx);
+        let p50_chart = chart_data_from_points(&p50_ts);
+        let p90_chart = chart_data_from_points(&p90_ts);
+        let p95_chart = chart_data_from_points(&p95_ts);
+        let p99_chart = chart_data_from_points(&p99_ts);
         Some(HttpTimeSeries {
             request_rate_ts,
             error_rate_ts,
-            status_2xx_ts: btree_to_vec(&ts_2xx),
-            status_3xx_ts: btree_to_vec(&ts_3xx),
-            status_4xx_ts: btree_to_vec(&ts_4xx),
-            status_5xx_ts: btree_to_vec(&ts_5xx),
+            status_2xx_ts,
+            status_3xx_ts,
+            status_4xx_ts,
+            status_5xx_ts,
             p50_ts,
             p90_ts,
             p95_ts,
             p99_ts,
+            error_rate_chart,
+            p50_chart,
+            p90_chart,
+            p95_chart,
+            p99_chart,
         })
     } else {
         None

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,0 +1,694 @@
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use reqwest::Client;
+use serde::Serialize;
+
+use crate::{
+    client::post_graphql,
+    controllers::deployment::{FetchLogsParams, fetch_http_logs},
+    gql::queries,
+    queries::project::ProjectProject,
+    util::logs::HttpLogLike,
+};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MetricDataPoint {
+    pub ts: i64,
+    pub value: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MetricSummary {
+    pub measurement: String,
+    pub current: f64,
+    pub average: f64,
+    pub min: f64,
+    pub max: f64,
+    pub data_points: usize,
+    #[serde(skip_serializing)]
+    pub raw_values: Vec<MetricDataPoint>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResourceMetricsResult {
+    pub metrics: Vec<MetricSummary>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpTimeSeries {
+    pub request_rate_ts: Vec<MetricDataPoint>,
+    pub error_rate_ts: Vec<MetricDataPoint>,
+    pub status_2xx_ts: Vec<MetricDataPoint>,
+    pub status_3xx_ts: Vec<MetricDataPoint>,
+    pub status_4xx_ts: Vec<MetricDataPoint>,
+    pub status_5xx_ts: Vec<MetricDataPoint>,
+    pub p50_ts: Vec<MetricDataPoint>,
+    pub p90_ts: Vec<MetricDataPoint>,
+    pub p95_ts: Vec<MetricDataPoint>,
+    pub p99_ts: Vec<MetricDataPoint>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HttpMetricsResult {
+    pub total: usize,
+    pub status_counts: [usize; 6], // index 0=other,1=1xx,2=2xx,3=3xx,4=4xx,5=5xx
+    pub error_rate: f64,
+    pub p50_ms: i64,
+    pub p90_ms: i64,
+    pub p95_ms: i64,
+    pub p99_ms: i64,
+    #[serde(skip_serializing)]
+    pub time_series: Option<HttpTimeSeries>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct VolumeMetrics {
+    pub volume_name: String,
+    pub mount_path: String,
+    pub current_size_mb: f64,
+    pub limit_size_mb: f64,
+}
+
+pub struct FetchResourceMetricsParams<'a> {
+    pub client: &'a Client,
+    pub backboard: &'a str,
+    pub service_id: &'a str,
+    pub environment_id: &'a str,
+    pub start_date: DateTime<Utc>,
+    pub end_date: Option<DateTime<Utc>>,
+    pub measurements: Vec<queries::metrics::MetricMeasurement>,
+    pub sample_rate_seconds: Option<i64>,
+    pub include_raw: bool,
+}
+
+pub async fn fetch_resource_metrics(
+    params: FetchResourceMetricsParams<'_>,
+) -> Result<ResourceMetricsResult> {
+    let vars = queries::metrics::Variables {
+        project_id: None,
+        service_id: Some(params.service_id.to_string()),
+        environment_id: Some(params.environment_id.to_string()),
+        start_date: params.start_date,
+        end_date: params.end_date,
+        measurements: params.measurements,
+        sample_rate_seconds: params.sample_rate_seconds,
+        group_by: None,
+    };
+
+    let resp = post_graphql::<queries::Metrics, _>(params.client, params.backboard, vars).await?;
+
+    let include_raw = params.include_raw;
+    let metrics = resp
+        .metrics
+        .iter()
+        .map(|m| summarize_metric(m, include_raw))
+        .collect();
+
+    Ok(ResourceMetricsResult { metrics })
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceMetricsSummary {
+    pub service_id: String,
+    pub service_name: String,
+    pub cpu: Option<MetricSummary>,
+    pub cpu_limit: Option<MetricSummary>,
+    pub memory: Option<MetricSummary>,
+    pub memory_limit: Option<MetricSummary>,
+    pub network_tx: Option<MetricSummary>,
+    pub network_rx: Option<MetricSummary>,
+    pub http: Option<HttpMetricsResult>,
+    pub volumes: Vec<VolumeMetrics>,
+    pub is_database: bool,
+}
+
+pub struct FetchProjectMetricsParams<'a> {
+    pub client: &'a Client,
+    pub backboard: &'a str,
+    pub project_id: &'a str,
+    pub environment_id: &'a str,
+    pub start_date: DateTime<Utc>,
+    pub end_date: Option<DateTime<Utc>>,
+    pub measurements: Vec<queries::metrics::MetricMeasurement>,
+    pub sample_rate_seconds: Option<i64>,
+}
+
+fn empty_service_metrics_summary(
+    service_id: String,
+    service_name: String,
+) -> ServiceMetricsSummary {
+    ServiceMetricsSummary {
+        service_id,
+        service_name,
+        cpu: None,
+        cpu_limit: None,
+        memory: None,
+        memory_limit: None,
+        network_tx: None,
+        network_rx: None,
+        http: None,
+        volumes: vec![],
+        is_database: false,
+    }
+}
+
+fn sort_project_services(services: &mut [ServiceMetricsSummary], sort_by_cpu: bool) {
+    services.sort_by(|a, b| {
+        let name_cmp = a
+            .service_name
+            .to_ascii_lowercase()
+            .cmp(&b.service_name.to_ascii_lowercase());
+        if !sort_by_cpu {
+            return name_cmp;
+        }
+
+        let a_cpu = a.cpu.as_ref().map(|c| c.current).unwrap_or(0.0);
+        let b_cpu = b.cpu.as_ref().map(|c| c.current).unwrap_or(0.0);
+        b_cpu
+            .partial_cmp(&a_cpu)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(name_cmp)
+    });
+}
+
+pub async fn fetch_project_metrics(
+    params: FetchProjectMetricsParams<'_>,
+    project: &ProjectProject,
+) -> Result<Vec<ServiceMetricsSummary>> {
+    let sort_by_cpu = params
+        .measurements
+        .iter()
+        .any(|measurement| matches!(measurement, queries::metrics::MetricMeasurement::CPU_USAGE));
+    let vars = queries::metrics::Variables {
+        project_id: Some(params.project_id.to_string()),
+        service_id: None,
+        environment_id: Some(params.environment_id.to_string()),
+        start_date: params.start_date,
+        end_date: params.end_date,
+        measurements: params.measurements,
+        sample_rate_seconds: params.sample_rate_seconds,
+        group_by: Some(vec![queries::metrics::MetricTag::SERVICE_ID]),
+    };
+
+    let resp = post_graphql::<queries::Metrics, _>(params.client, params.backboard, vars).await?;
+
+    let mut by_service: HashMap<String, ServiceMetricsSummary> = project
+        .environments
+        .edges
+        .iter()
+        .find(|env| env.node.id == params.environment_id)
+        .map(|env| {
+            env.node
+                .service_instances
+                .edges
+                .iter()
+                .map(|service_instance| {
+                    (
+                        service_instance.node.service_id.clone(),
+                        empty_service_metrics_summary(
+                            service_instance.node.service_id.clone(),
+                            service_instance.node.service_name.clone(),
+                        ),
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for m in &resp.metrics {
+        let Some(service_id) = m.tags.service_id.clone() else {
+            continue;
+        };
+
+        let Some(entry) = by_service.get_mut(&service_id) else {
+            continue;
+        };
+
+        let summary = summarize_metric(m, false);
+        match m.measurement {
+            queries::metrics::MetricMeasurement::CPU_USAGE => entry.cpu = Some(summary),
+            queries::metrics::MetricMeasurement::CPU_LIMIT => entry.cpu_limit = Some(summary),
+            queries::metrics::MetricMeasurement::MEMORY_USAGE_GB => entry.memory = Some(summary),
+            queries::metrics::MetricMeasurement::MEMORY_LIMIT_GB => {
+                entry.memory_limit = Some(summary)
+            }
+            queries::metrics::MetricMeasurement::NETWORK_TX_GB => entry.network_tx = Some(summary),
+            queries::metrics::MetricMeasurement::NETWORK_RX_GB => entry.network_rx = Some(summary),
+            _ => {}
+        }
+    }
+
+    let mut services: Vec<ServiceMetricsSummary> = by_service.into_values().collect();
+    sort_project_services(&mut services, sort_by_cpu);
+
+    Ok(services)
+}
+
+fn summarize_metric(m: &queries::metrics::MetricsMetrics, include_raw: bool) -> MetricSummary {
+    if m.values.is_empty() {
+        MetricSummary {
+            measurement: format!("{:?}", m.measurement),
+            current: 0.0,
+            average: 0.0,
+            min: 0.0,
+            max: 0.0,
+            data_points: 0,
+            raw_values: vec![],
+        }
+    } else {
+        let values: Vec<f64> = m.values.iter().map(|v| v.value).collect();
+        let current = values.last().copied().unwrap_or(0.0);
+        let sum: f64 = values.iter().sum();
+        let avg = sum / values.len() as f64;
+        let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let raw_values = if include_raw {
+            m.values
+                .iter()
+                .map(|v| MetricDataPoint {
+                    ts: v.ts,
+                    value: v.value,
+                })
+                .collect()
+        } else {
+            vec![]
+        };
+
+        MetricSummary {
+            measurement: format!("{:?}", m.measurement),
+            current,
+            average: avg,
+            min,
+            max,
+            data_points: values.len(),
+            raw_values,
+        }
+    }
+}
+
+pub fn compute_http_metrics(logs: &[impl HttpLogLike]) -> Option<HttpMetricsResult> {
+    let total = logs.len();
+    if total == 0 {
+        return None;
+    }
+
+    let mut counts = [0usize; 6];
+    for log in logs {
+        let bucket = (log.http_status() / 100) as usize;
+        if bucket < counts.len() {
+            counts[bucket] += 1;
+        } else {
+            counts[0] += 1;
+        }
+    }
+
+    let errors = logs.iter().filter(|l| l.http_status() >= 500).count();
+    let error_rate = (errors as f64 / total as f64) * 100.0;
+
+    let mut durations: Vec<i64> = logs.iter().map(|l| l.total_duration()).collect();
+    durations.sort_unstable();
+
+    let percentile = |p: f64| -> i64 {
+        let idx =
+            ((durations.len() as f64 * p / 100.0) as usize).min(durations.len().saturating_sub(1));
+        durations[idx]
+    };
+
+    Some(HttpMetricsResult {
+        total,
+        status_counts: counts,
+        error_rate,
+        p50_ms: percentile(50.0),
+        p90_ms: percentile(90.0),
+        p95_ms: percentile(95.0),
+        p99_ms: percentile(99.0),
+        time_series: None,
+    })
+}
+
+pub async fn fetch_http_logs_for_deployment(
+    client: &Client,
+    backboard: &str,
+    deployment_id: String,
+    limit: i64,
+    filter: Option<String>,
+) -> Result<Vec<queries::http_logs::HttpLogFields>> {
+    let mut logs: Vec<queries::http_logs::HttpLogFields> = Vec::new();
+    let fetch_params = FetchLogsParams {
+        client,
+        backboard,
+        deployment_id,
+        limit: Some(limit),
+        filter,
+        start_date: None,
+        end_date: None,
+    };
+
+    fetch_http_logs(fetch_params, |log| {
+        logs.push(log);
+    })
+    .await?;
+
+    Ok(logs)
+}
+
+pub struct FetchHttpMetricsParams<'a> {
+    pub client: &'a Client,
+    pub backboard: &'a str,
+    pub service_id: &'a str,
+    pub environment_id: &'a str,
+    pub start_date: DateTime<Utc>,
+    pub end_date: DateTime<Utc>,
+    pub step_seconds: Option<i64>,
+    pub method: Option<String>,
+    pub path: Option<String>,
+    /// When true, populate time-series fields in HttpMetricsResult (for TUI sparklines)
+    pub include_time_series: bool,
+}
+
+/// Fetch HTTP metrics using the dedicated pre-aggregated queries.
+/// Returns None if there is no HTTP traffic in the time window.
+pub async fn fetch_http_metrics(
+    params: FetchHttpMetricsParams<'_>,
+) -> Result<Option<HttpMetricsResult>> {
+    // Fetch status code breakdown
+    let status_vars = queries::http_metrics_by_status::Variables {
+        service_id: params.service_id.to_string(),
+        environment_id: params.environment_id.to_string(),
+        start_date: params.start_date,
+        end_date: params.end_date,
+        step_seconds: params.step_seconds,
+        method: params.method.clone(),
+        path: params.path.clone(),
+    };
+
+    let status_resp = post_graphql::<queries::HttpMetricsByStatus, _>(
+        params.client,
+        params.backboard,
+        status_vars,
+    )
+    .await?;
+
+    let mut counts = [0usize; 6]; // 0=other, 1=1xx, 2=2xx, 3=3xx, 4=4xx, 5=5xx
+    let mut ts_totals: BTreeMap<i64, (f64, f64)> = BTreeMap::new();
+    let mut ts_2xx: BTreeMap<i64, f64> = BTreeMap::new();
+    let mut ts_3xx: BTreeMap<i64, f64> = BTreeMap::new();
+    let mut ts_4xx: BTreeMap<i64, f64> = BTreeMap::new();
+    let mut ts_5xx: BTreeMap<i64, f64> = BTreeMap::new();
+    for group in &status_resp.http_metrics_grouped_by_status {
+        let bucket = (group.status_code / 100) as usize;
+        let is_5xx = bucket == 5;
+        let total_for_status: f64 = group.samples.iter().map(|s| s.value).sum();
+        let count = total_for_status.round() as usize;
+        if bucket < counts.len() {
+            counts[bucket] += count;
+        } else {
+            counts[0] += count;
+        }
+        if params.include_time_series {
+            let mut bucket_map = match bucket {
+                2 => Some(&mut ts_2xx),
+                3 => Some(&mut ts_3xx),
+                4 => Some(&mut ts_4xx),
+                5 => Some(&mut ts_5xx),
+                _ => None,
+            };
+            for sample in &group.samples {
+                let entry = ts_totals.entry(sample.ts).or_insert((0.0, 0.0));
+                entry.0 += sample.value;
+                if is_5xx {
+                    entry.1 += sample.value;
+                }
+                if let Some(ref mut bmap) = bucket_map {
+                    *bmap.entry(sample.ts).or_insert(0.0) += sample.value;
+                }
+            }
+        }
+    }
+
+    let total: usize = counts.iter().sum();
+    if total == 0 {
+        return Ok(None);
+    }
+
+    let error_rate = if total > 0 {
+        (counts[5] as f64 / total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    // Summary output needs the percentile for the whole requested window.
+    // Time-series callers still pass a step so the TUI/raw output can chart buckets.
+    let duration_step_seconds = if params.include_time_series {
+        params.step_seconds
+    } else {
+        None
+    };
+
+    // Fetch duration percentiles
+    let duration_vars = queries::http_duration_metrics::Variables {
+        service_id: params.service_id.to_string(),
+        environment_id: params.environment_id.to_string(),
+        start_date: params.start_date,
+        end_date: params.end_date,
+        step_seconds: duration_step_seconds,
+        method: params.method,
+        path: params.path,
+        status_code: None,
+    };
+
+    let duration_resp = post_graphql::<queries::HttpDurationMetrics, _>(
+        params.client,
+        params.backboard,
+        duration_vars,
+    )
+    .await?;
+
+    let samples = &duration_resp.http_duration_metrics.samples;
+    let (p50, p90, p95, p99) = if let Some(sample) = samples.last() {
+        // Aggregate calls return one sample; bucketed calls use the latest sample as current.
+        (
+            sample.p50.round() as i64,
+            sample.p90.round() as i64,
+            sample.p95.round() as i64,
+            sample.p99.round() as i64,
+        )
+    } else {
+        (0, 0, 0, 0)
+    };
+
+    let btree_to_vec = |map: &BTreeMap<i64, f64>| -> Vec<MetricDataPoint> {
+        map.iter()
+            .map(|(&ts, &value)| MetricDataPoint { ts, value })
+            .collect()
+    };
+
+    let time_series = if params.include_time_series {
+        let request_rate_ts = ts_totals
+            .iter()
+            .map(|(&ts, &(total, _))| MetricDataPoint { ts, value: total })
+            .collect();
+        let error_rate_ts = ts_totals
+            .iter()
+            .map(|(&ts, &(_, errors))| MetricDataPoint { ts, value: errors })
+            .collect();
+        let p50_ts = samples
+            .iter()
+            .map(|s| MetricDataPoint {
+                ts: s.ts,
+                value: s.p50,
+            })
+            .collect();
+        let p90_ts = samples
+            .iter()
+            .map(|s| MetricDataPoint {
+                ts: s.ts,
+                value: s.p90,
+            })
+            .collect();
+        let p95_ts = samples
+            .iter()
+            .map(|s| MetricDataPoint {
+                ts: s.ts,
+                value: s.p95,
+            })
+            .collect();
+        let p99_ts = samples
+            .iter()
+            .map(|s| MetricDataPoint {
+                ts: s.ts,
+                value: s.p99,
+            })
+            .collect();
+        Some(HttpTimeSeries {
+            request_rate_ts,
+            error_rate_ts,
+            status_2xx_ts: btree_to_vec(&ts_2xx),
+            status_3xx_ts: btree_to_vec(&ts_3xx),
+            status_4xx_ts: btree_to_vec(&ts_4xx),
+            status_5xx_ts: btree_to_vec(&ts_5xx),
+            p50_ts,
+            p90_ts,
+            p95_ts,
+            p99_ts,
+        })
+    } else {
+        None
+    };
+
+    Ok(Some(HttpMetricsResult {
+        total,
+        status_counts: counts,
+        error_rate,
+        p50_ms: p50,
+        p90_ms: p90,
+        p95_ms: p95,
+        p99_ms: p99,
+        time_series,
+    }))
+}
+
+pub fn is_database_service(source_image: Option<&str>) -> bool {
+    source_image
+        .map(|img| img.to_lowercase())
+        .is_some_and(|img| {
+            img.contains("postgres")
+                || img.contains("postgis")
+                || img.contains("timescale")
+                || img.contains("redis")
+                || img.contains("mongo")
+                || img.contains("mysql")
+                || img.contains("mariadb")
+                || img.contains("memcached")
+                || img.contains("valkey")
+        })
+}
+
+pub fn get_volume_metrics(
+    project: &ProjectProject,
+    environment_id: &str,
+    service_id: &str,
+) -> Vec<VolumeMetrics> {
+    project
+        .environments
+        .edges
+        .iter()
+        .find(|e| e.node.id == environment_id)
+        .map(|env| {
+            env.node
+                .volume_instances
+                .edges
+                .iter()
+                .filter(|vi| {
+                    vi.node.service_id.as_deref() == Some(service_id)
+                        && vi.node.environment_id == environment_id
+                })
+                .map(|vi| VolumeMetrics {
+                    volume_name: vi.node.volume.name.clone(),
+                    mount_path: vi.node.mount_path.clone(),
+                    current_size_mb: vi.node.current_size_mb,
+                    limit_size_mb: vi.node.size_mb as f64,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Maps time window duration to an appropriate sample rate in seconds,
+/// matching the Railway dashboard behavior.
+pub fn compute_sample_rate(duration: Duration) -> i64 {
+    let hours = duration.num_hours();
+    match hours {
+        0..=1 => 30,
+        2..=6 => 60,
+        7..=24 => 240,
+        25..=168 => 3600, // up to 7 days
+        _ => 14400,       // 30 days+
+    }
+}
+
+/// Find a metric by measurement name, filtering out entries with no data points.
+pub fn find_metric<'a>(metrics: &'a [MetricSummary], name: &str) -> Option<&'a MetricSummary> {
+    metrics
+        .iter()
+        .find(|m| m.measurement == name)
+        .filter(|m| m.data_points > 0)
+}
+
+/// Format a CPU value with vCPU unit
+pub fn format_cpu(value: f64) -> String {
+    if value == 0.0 {
+        "0 vCPU".to_string()
+    } else if value < 0.01 {
+        "< 0.01 vCPU".to_string()
+    } else if value < 1.0 {
+        format!("{:.2} vCPU", value)
+    } else {
+        format!("{:.1} vCPU", value)
+    }
+}
+
+/// Format a value in GB to human-friendly units (MB or GB)
+pub fn format_gb(value_gb: f64) -> String {
+    if value_gb == 0.0 {
+        "0 MB".to_string()
+    } else if value_gb < 0.001 {
+        format!("{:.2} MB", value_gb * 1024.0)
+    } else if value_gb < 1.0 {
+        let mb = value_gb * 1024.0;
+        if mb < 10.0 {
+            format!("{:.1} MB", mb)
+        } else {
+            format!("{:.0} MB", mb)
+        }
+    } else if value_gb < 10.0 {
+        format!("{:.2} GB", value_gb)
+    } else {
+        format!("{:.1} GB", value_gb)
+    }
+}
+
+/// Compute utilization percentage, returns None if limit is zero or missing
+pub fn utilization(current: f64, limit: Option<f64>) -> Option<f64> {
+    limit.filter(|&l| l > 0.0).map(|l| (current / l) * 100.0)
+}
+
+/// Compute percentage of count / total, returning 0.0 when total is zero
+pub fn pct(count: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        (count as f64 / total as f64) * 100.0
+    }
+}
+
+/// Format a count with K/M suffixes for readability
+pub fn format_count(n: usize) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Format a value in MB to human-friendly units (MB or GB)
+pub fn format_mb(value_mb: f64) -> String {
+    if value_mb < 1024.0 {
+        if value_mb < 10.0 {
+            format!("{:.1} MB", value_mb)
+        } else {
+            format!("{:.0} MB", value_mb)
+        }
+    } else {
+        let gb = value_mb / 1024.0;
+        if gb < 10.0 {
+            format!("{:.2} GB", gb)
+        } else {
+            format!("{:.1} GB", gb)
+        }
+    }
+}

--- a/src/controllers/metrics_tui/app.rs
+++ b/src/controllers/metrics_tui/app.rs
@@ -777,8 +777,9 @@ impl ProjectApp {
                 self.services = services;
                 self.error_message = None;
 
-                self.detail_cache
-                    .retain(|id, _| self.services.iter().any(|s| s.service_id == *id));
+                // Detail panels contain time-series data, so refresh them whenever
+                // the project summary refreshes instead of reusing stale charts.
+                self.detail_cache.clear();
 
                 if let Some(id) = prev_selected_id {
                     if let Some(idx) = self.services.iter().position(|s| s.service_id == id) {
@@ -1157,5 +1158,97 @@ pub async fn fetch_project_detail(
         request_id: request.request_id,
         service_id: request.service_id,
         entry: entry_result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service_summary(service_id: &str) -> ServiceMetricsSummary {
+        ServiceMetricsSummary {
+            service_id: service_id.to_string(),
+            service_name: "api".to_string(),
+            cpu: None,
+            cpu_limit: None,
+            memory: None,
+            memory_limit: None,
+            network_tx: None,
+            network_rx: None,
+            http: None,
+            volumes: vec![],
+            is_database: false,
+        }
+    }
+
+    fn detail_entry(time_range_idx: usize) -> DetailCacheEntry {
+        DetailCacheEntry {
+            cpu: None,
+            cpu_limit: None,
+            memory: None,
+            memory_limit: None,
+            network_tx: None,
+            network_rx: None,
+            disk: None,
+            volumes: vec![],
+            http: None,
+            is_database: false,
+            fetched_at: Utc::now(),
+            time_range_idx,
+        }
+    }
+
+    fn project_app_with_cached_detail() -> ProjectApp {
+        let services = vec![service_summary("svc_1")];
+        let detail_cache = HashMap::from([("svc_1".to_string(), detail_entry(0))]);
+
+        ProjectApp {
+            project_name: "project".to_string(),
+            environment_name: "production".to_string(),
+            time_range_idx: 0,
+            time_range_changed: false,
+            services,
+            selected_idx: 0,
+            table_scroll_offset: 0,
+            detail_cache,
+            detail_loading: false,
+            detail_loading_service_id: None,
+            show_cpu: true,
+            show_memory: true,
+            show_network: true,
+            show_volume: true,
+            show_http: true,
+            show_egress: true,
+            show_ingress: true,
+            show_2xx: true,
+            show_3xx: true,
+            show_4xx: true,
+            show_5xx: true,
+            show_p50: true,
+            show_p90: true,
+            show_p95: true,
+            show_p99: true,
+            last_refresh: None,
+            error_message: None,
+            show_help: false,
+            force_refresh: false,
+            refreshing: true,
+        }
+    }
+
+    #[test]
+    fn project_refresh_invalidates_selected_detail_cache() {
+        let mut app = project_app_with_cached_detail();
+
+        let applied = app.apply_refresh_result(ProjectRefreshResult {
+            request_id: 1,
+            time_range_idx: 0,
+            services: Ok(vec![service_summary("svc_1")]),
+            fetched_at: Utc::now(),
+        });
+
+        assert!(applied);
+        assert!(app.detail_cache.is_empty());
+        assert!(app.needs_detail_fetch());
     }
 }

--- a/src/controllers/metrics_tui/app.rs
+++ b/src/controllers/metrics_tui/app.rs
@@ -1,0 +1,901 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use futures::FutureExt;
+
+use crate::controllers::db_stats::{self, DatabaseStats};
+use crate::controllers::metrics::{
+    FetchHttpMetricsParams, FetchProjectMetricsParams, FetchResourceMetricsParams,
+    HttpMetricsResult, MetricSummary, ServiceMetricsSummary, VolumeMetrics, compute_sample_rate,
+    fetch_http_metrics, fetch_project_metrics, fetch_resource_metrics, find_metric,
+    get_volume_metrics, is_database_service,
+};
+use crate::controllers::project::find_service_instance;
+use crate::util::time::parse_time;
+
+use tokio::task::JoinHandle;
+
+use super::{POLL_INTERVALS_SECS, ProjectTuiParams, ServiceTuiParams, TIME_RANGES};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ActiveTab {
+    Metrics,
+    Stats,
+}
+
+type MetricMeasurement = crate::gql::queries::metrics::MetricMeasurement;
+
+fn build_measurements(
+    cpu: bool,
+    memory: bool,
+    network: bool,
+    volume: bool,
+) -> Vec<MetricMeasurement> {
+    let mut m = Vec::new();
+    if cpu {
+        m.push(MetricMeasurement::CPU_USAGE);
+        m.push(MetricMeasurement::CPU_LIMIT);
+    }
+    if memory {
+        m.push(MetricMeasurement::MEMORY_USAGE_GB);
+        m.push(MetricMeasurement::MEMORY_LIMIT_GB);
+    }
+    if network {
+        m.push(MetricMeasurement::NETWORK_TX_GB);
+        m.push(MetricMeasurement::NETWORK_RX_GB);
+    }
+    if volume {
+        m.push(MetricMeasurement::DISK_USAGE_GB);
+    }
+    if m.is_empty() {
+        m.push(MetricMeasurement::CPU_USAGE);
+    }
+    m
+}
+
+/// Single-service metrics app state
+pub struct MetricsApp {
+    // Identity
+    pub service_name: String,
+    pub environment_name: String,
+    pub is_db: bool,
+    pub db_stats_supported: bool,
+    pub active_tab: ActiveTab,
+
+    // Section visibility (toggled at runtime via 1-5)
+    pub show_cpu: bool,
+    pub show_memory: bool,
+    pub show_network: bool,
+    pub show_volume: bool,
+    pub show_http: bool,
+
+    // Network series toggles (toggled via e/i keys)
+    pub show_egress: bool,
+    pub show_ingress: bool,
+
+    // HTTP status code toggles (toggled via 6-9 keys)
+    pub show_2xx: bool,
+    pub show_3xx: bool,
+    pub show_4xx: bool,
+    pub show_5xx: bool,
+
+    // Response time percentile toggles (toggled via F1-F4 keys)
+    pub show_p50: bool,
+    pub show_p90: bool,
+    pub show_p95: bool,
+    pub show_p99: bool,
+
+    // Time range
+    pub time_range_idx: usize,
+    pub time_range_changed: bool,
+
+    // Resource data (with raw_values for charts)
+    pub cpu: Option<MetricSummary>,
+    pub cpu_limit: Option<MetricSummary>,
+    pub memory: Option<MetricSummary>,
+    pub memory_limit: Option<MetricSummary>,
+    pub network_tx: Option<MetricSummary>,
+    pub network_rx: Option<MetricSummary>,
+    pub disk: Option<MetricSummary>,
+    pub volumes: Vec<VolumeMetrics>,
+
+    // HTTP data
+    pub http: Option<HttpMetricsResult>,
+
+    // Database stats (fetched via SSH for database services)
+    pub db_stats: Option<DatabaseStats>,
+    pub db_stats_error: Option<String>,
+    pub db_stats_handle: Option<JoinHandle<anyhow::Result<DatabaseStats>>>,
+    pub db_stats_scroll: u16,
+
+    // State
+    pub last_refresh: Option<DateTime<Utc>>,
+    pub error_message: Option<String>,
+    pub show_help: bool,
+    pub force_refresh: bool,
+}
+
+impl MetricsApp {
+    pub fn new(params: &ServiceTuiParams) -> Self {
+        let time_range_idx = TIME_RANGES
+            .iter()
+            .position(|&r| r == params.since_label)
+            .unwrap_or(0);
+
+        Self {
+            service_name: params.service_name.clone(),
+            environment_name: params.environment_name.clone(),
+            is_db: params.is_db,
+            db_stats_supported: params.db_stats_supported,
+            active_tab: ActiveTab::Metrics,
+            show_cpu: params.sections.cpu,
+            show_memory: params.sections.memory,
+            show_network: params.sections.network,
+            show_volume: params.sections.volume,
+            show_http: params.sections.http,
+            show_egress: true,
+            show_ingress: true,
+            show_2xx: true,
+            show_3xx: true,
+            show_4xx: true,
+            show_5xx: true,
+            show_p50: true,
+            show_p90: true,
+            show_p95: true,
+            show_p99: true,
+            time_range_idx,
+            time_range_changed: false,
+            cpu: None,
+            cpu_limit: None,
+            memory: None,
+            memory_limit: None,
+            network_tx: None,
+            network_rx: None,
+            disk: None,
+            volumes: params.volumes.clone(),
+            http: None,
+            db_stats: None,
+            db_stats_error: params.db_stats_preflight_error.clone(),
+            db_stats_handle: None,
+            db_stats_scroll: 0,
+            last_refresh: None,
+            error_message: None,
+            show_help: false,
+            force_refresh: false,
+        }
+    }
+
+    pub fn time_range_label(&self) -> &'static str {
+        TIME_RANGES[self.time_range_idx]
+    }
+
+    pub fn poll_interval_secs(&self) -> u64 {
+        POLL_INTERVALS_SECS[self.time_range_idx]
+    }
+
+    pub fn maybe_start_db_stats_fetch(&mut self, params: &ServiceTuiParams) {
+        if !self.db_stats_supported
+            || self.active_tab != ActiveTab::Stats
+            || self.db_stats.is_some()
+            || self.db_stats_handle.is_some()
+            || self.db_stats_error.is_some()
+        {
+            return;
+        }
+
+        if let (Some(instance_id), Some(db_type)) =
+            (params.service_instance_id.clone(), params.db_type.clone())
+        {
+            self.db_stats_handle = Some(tokio::spawn(async move {
+                db_stats::fetch_db_stats(&instance_id, &db_type).await
+            }));
+        }
+    }
+
+    pub async fn refresh(&mut self, params: &ServiceTuiParams) {
+        let now = Utc::now();
+        let since_str = TIME_RANGES[self.time_range_idx];
+        let start_date = match parse_time(since_str) {
+            Ok(t) => t,
+            Err(e) => {
+                self.error_message = Some(format!("Failed to parse time range: {e}"));
+                return;
+            }
+        };
+
+        let duration = now - start_date;
+        let sample_rate = compute_sample_rate(duration);
+
+        let needs_resource =
+            self.show_cpu || self.show_memory || self.show_network || self.show_volume;
+        let measurements = if needs_resource {
+            build_measurements(
+                self.show_cpu,
+                self.show_memory,
+                self.show_network,
+                self.show_volume,
+            )
+        } else {
+            vec![]
+        };
+
+        let wants_http = self.show_http && !self.is_db;
+
+        // Fetch resource and HTTP metrics in parallel
+        let resource_fut = async {
+            if needs_resource {
+                Some(
+                    fetch_resource_metrics(FetchResourceMetricsParams {
+                        client: &params.client,
+                        backboard: &params.backboard,
+                        service_id: &params.service_id,
+                        environment_id: &params.environment_id,
+                        start_date,
+                        end_date: None,
+                        measurements,
+                        sample_rate_seconds: Some(sample_rate),
+                        include_raw: true,
+                    })
+                    .await,
+                )
+            } else {
+                None
+            }
+        };
+
+        let http_fut = async {
+            if wants_http {
+                Some(
+                    fetch_http_metrics(FetchHttpMetricsParams {
+                        client: &params.client,
+                        backboard: &params.backboard,
+                        service_id: &params.service_id,
+                        environment_id: &params.environment_id,
+                        start_date,
+                        end_date: now,
+                        step_seconds: Some(sample_rate),
+                        method: params.method.clone(),
+                        path: params.path.clone(),
+                        include_time_series: true,
+                    })
+                    .await,
+                )
+            } else {
+                None
+            }
+        };
+
+        let (resource_result, http_result) = tokio::join!(resource_fut, http_fut);
+
+        if let Some(result) = resource_result {
+            match result {
+                Ok(result) => {
+                    self.cpu = find_metric(&result.metrics, "CPU_USAGE").cloned();
+                    self.cpu_limit = find_metric(&result.metrics, "CPU_LIMIT").cloned();
+                    self.memory = find_metric(&result.metrics, "MEMORY_USAGE_GB").cloned();
+                    self.memory_limit = find_metric(&result.metrics, "MEMORY_LIMIT_GB").cloned();
+                    self.network_tx = find_metric(&result.metrics, "NETWORK_TX_GB").cloned();
+                    self.network_rx = find_metric(&result.metrics, "NETWORK_RX_GB").cloned();
+                    self.disk = find_metric(&result.metrics, "DISK_USAGE_GB").cloned();
+                    self.error_message = None;
+                }
+                Err(e) => {
+                    self.error_message = Some(format!("Resource fetch failed: {e}"));
+                }
+            }
+        }
+
+        if let Some(result) = http_result {
+            match result {
+                Ok(result) => {
+                    self.http = result;
+                    self.error_message = None;
+                }
+                Err(e) => {
+                    self.error_message = Some(format!("HTTP fetch failed: {e}"));
+                }
+            }
+        }
+
+        self.last_refresh = Some(Utc::now());
+    }
+
+    /// Handle mouse click events (tab switching)
+    pub fn handle_mouse(&mut self, mouse: MouseEvent) {
+        if !self.db_stats_supported {
+            return;
+        }
+        if let MouseEventKind::Down(MouseButton::Left) = mouse.kind {
+            let col = mouse.column;
+            let row = mouse.row;
+            // Tab bar: header(1) + padding(1) + tab labels(1)
+            // Layout: "   Metrics   Stats "
+            //          ^2      ^11 ^12   ^19
+            if row == 2 {
+                if (2..11).contains(&col) {
+                    self.active_tab = ActiveTab::Metrics;
+                } else if (12..19).contains(&col) {
+                    self.active_tab = ActiveTab::Stats;
+                }
+            }
+        }
+    }
+
+    /// Check if the background db_stats fetch has completed.
+    /// Call this from the event loop before each draw.
+    pub fn poll_db_stats(&mut self, params: &ServiceTuiParams) {
+        if let Some(ref handle) = self.db_stats_handle {
+            if handle.is_finished() {
+                let handle = self.db_stats_handle.take().unwrap();
+                // Use try_join (non-blocking since we know it's finished)
+                match handle.now_or_never() {
+                    Some(Ok(Ok(stats))) => {
+                        self.db_stats = Some(stats);
+                        self.db_stats_error = None;
+                    }
+                    Some(Ok(Err(e))) => {
+                        let msg = match params.db_type.as_ref() {
+                            Some(dt) => db_stats::diagnose_db_stats_failure(&e, dt),
+                            None => format!("{e:#}"),
+                        };
+                        self.db_stats_error = Some(msg);
+                    }
+                    Some(Err(_)) => {
+                        self.db_stats_error = Some("task panicked".to_string());
+                    }
+                    None => {} // shouldn't happen since is_finished() was true
+                }
+            }
+        }
+    }
+
+    /// Returns true if the user wants to quit
+    pub fn handle_key(&mut self, key: KeyEvent) -> bool {
+        if self.show_help {
+            // Any key dismisses the help overlay
+            self.show_help = false;
+            return false;
+        }
+
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return true,
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return true,
+            KeyCode::Char('1') => {
+                self.show_cpu = !self.show_cpu;
+                self.force_refresh = true;
+            }
+            KeyCode::Char('2') => {
+                self.show_memory = !self.show_memory;
+                self.force_refresh = true;
+            }
+            KeyCode::Char('3') => {
+                self.show_network = !self.show_network;
+                self.force_refresh = true;
+            }
+            KeyCode::Char('4') => {
+                self.show_volume = !self.show_volume;
+                self.force_refresh = true;
+            }
+            KeyCode::Char('5') => {
+                if !self.is_db {
+                    self.show_http = !self.show_http;
+                    self.force_refresh = true;
+                }
+            }
+            // Tab switching for database services
+            KeyCode::Tab | KeyCode::BackTab => {
+                if self.db_stats_supported {
+                    self.active_tab = match self.active_tab {
+                        ActiveTab::Metrics => ActiveTab::Stats,
+                        ActiveTab::Stats => ActiveTab::Metrics,
+                    };
+                }
+            }
+            // Scroll db stats with arrow keys / j/k (only on Stats tab)
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.active_tab == ActiveTab::Stats {
+                    self.db_stats_scroll = self.db_stats_scroll.saturating_add(1);
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.active_tab == ActiveTab::Stats {
+                    self.db_stats_scroll = self.db_stats_scroll.saturating_sub(1);
+                }
+            }
+            // Network series toggles
+            KeyCode::Char('e') => self.show_egress = !self.show_egress,
+            KeyCode::Char('i') => self.show_ingress = !self.show_ingress,
+            // HTTP status code toggles
+            KeyCode::Char('6') => self.show_2xx = !self.show_2xx,
+            KeyCode::Char('7') => self.show_3xx = !self.show_3xx,
+            KeyCode::Char('8') => self.show_4xx = !self.show_4xx,
+            KeyCode::Char('9') => self.show_5xx = !self.show_5xx,
+            // Response time percentile toggles
+            KeyCode::F(1) => self.show_p50 = !self.show_p50,
+            KeyCode::F(2) => self.show_p90 = !self.show_p90,
+            KeyCode::F(3) => self.show_p95 = !self.show_p95,
+            KeyCode::F(4) => self.show_p99 = !self.show_p99,
+            KeyCode::Char('t') => {
+                self.time_range_idx = (self.time_range_idx + 1) % TIME_RANGES.len();
+                self.time_range_changed = true;
+            }
+            KeyCode::Char('r') => {
+                // Debounce: skip if last refresh was < 2s ago
+                let should_refresh = self
+                    .last_refresh
+                    .map(|t| (Utc::now() - t).num_seconds() >= 2)
+                    .unwrap_or(true);
+                if should_refresh {
+                    if self.db_stats_supported {
+                        self.db_stats = None;
+                        self.db_stats_error = None;
+                    }
+                    self.force_refresh = true;
+                }
+            }
+            KeyCode::Char('?') => self.show_help = true,
+            _ => {}
+        }
+        false
+    }
+}
+
+/// Cached time-series data for one service's detail view
+pub struct DetailCacheEntry {
+    pub cpu: Option<MetricSummary>,
+    pub cpu_limit: Option<MetricSummary>,
+    pub memory: Option<MetricSummary>,
+    pub memory_limit: Option<MetricSummary>,
+    pub network_tx: Option<MetricSummary>,
+    pub network_rx: Option<MetricSummary>,
+    pub disk: Option<MetricSummary>,
+    pub volumes: Vec<VolumeMetrics>,
+    pub http: Option<HttpMetricsResult>,
+    pub is_database: bool,
+    pub fetched_at: DateTime<Utc>,
+    pub time_range_idx: usize,
+}
+
+/// Project-wide metrics app state (--all mode)
+pub struct ProjectApp {
+    pub project_name: String,
+    pub environment_name: String,
+
+    // Time range
+    pub time_range_idx: usize,
+    pub time_range_changed: bool,
+
+    // Per-service data
+    pub services: Vec<ServiceMetricsSummary>,
+
+    // Selection / scroll
+    pub selected_idx: usize,
+    pub table_scroll_offset: usize,
+
+    // Detail panel cache (keyed by service_id)
+    pub detail_cache: HashMap<String, DetailCacheEntry>,
+    pub detail_loading: bool,
+
+    // Section toggles (shared across detail views)
+    pub show_cpu: bool,
+    pub show_memory: bool,
+    pub show_network: bool,
+    pub show_volume: bool,
+    pub show_http: bool,
+    pub show_egress: bool,
+    pub show_ingress: bool,
+    pub show_2xx: bool,
+    pub show_3xx: bool,
+    pub show_4xx: bool,
+    pub show_5xx: bool,
+    pub show_p50: bool,
+    pub show_p90: bool,
+    pub show_p95: bool,
+    pub show_p99: bool,
+
+    // State
+    pub last_refresh: Option<DateTime<Utc>>,
+    pub error_message: Option<String>,
+    pub show_help: bool,
+    pub force_refresh: bool,
+}
+
+impl ProjectApp {
+    pub fn new(params: &ProjectTuiParams) -> Self {
+        let time_range_idx = TIME_RANGES
+            .iter()
+            .position(|&r| r == params.since_label)
+            .unwrap_or(0);
+
+        Self {
+            project_name: params.project.name.clone(),
+            environment_name: params.environment_name.clone(),
+            time_range_idx,
+            time_range_changed: false,
+            services: vec![],
+            selected_idx: 0,
+            table_scroll_offset: 0,
+            detail_cache: HashMap::new(),
+            detail_loading: false,
+            show_cpu: params.sections.cpu,
+            show_memory: params.sections.memory,
+            show_network: params.sections.network,
+            show_volume: params.sections.volume,
+            show_http: params.sections.http,
+            show_egress: true,
+            show_ingress: true,
+            show_2xx: true,
+            show_3xx: true,
+            show_4xx: true,
+            show_5xx: true,
+            show_p50: true,
+            show_p90: true,
+            show_p95: true,
+            show_p99: true,
+            last_refresh: None,
+            error_message: None,
+            show_help: false,
+            force_refresh: false,
+        }
+    }
+
+    pub fn time_range_label(&self) -> &'static str {
+        TIME_RANGES[self.time_range_idx]
+    }
+
+    pub fn poll_interval_secs(&self) -> u64 {
+        POLL_INTERVALS_SECS[self.time_range_idx]
+    }
+
+    pub fn selected_service(&self) -> Option<&ServiceMetricsSummary> {
+        self.services.get(self.selected_idx)
+    }
+
+    pub fn selected_detail(&self) -> Option<&DetailCacheEntry> {
+        let svc = self.services.get(self.selected_idx)?;
+        let entry = self.detail_cache.get(&svc.service_id)?;
+        if entry.time_range_idx != self.time_range_idx {
+            return None;
+        }
+        Some(entry)
+    }
+
+    pub fn needs_detail_fetch(&self) -> bool {
+        !self.detail_loading && self.selected_detail().is_none()
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        if self.services.is_empty() {
+            return;
+        }
+        let max = self.services.len() - 1;
+        self.selected_idx = if delta < 0 {
+            self.selected_idx.saturating_sub(delta.unsigned_abs())
+        } else {
+            (self.selected_idx + delta as usize).min(max)
+        };
+    }
+
+    pub fn clamp_selection(&mut self) {
+        if self.services.is_empty() {
+            self.selected_idx = 0;
+        } else if self.selected_idx >= self.services.len() {
+            self.selected_idx = self.services.len() - 1;
+        }
+    }
+
+    /// Adjust scroll offset to keep the selected row visible.
+    pub fn ensure_selection_visible(&mut self, visible_rows: usize) {
+        if visible_rows == 0 || self.services.is_empty() {
+            return;
+        }
+        if self.selected_idx < self.table_scroll_offset {
+            self.table_scroll_offset = self.selected_idx;
+        }
+        if self.selected_idx >= self.table_scroll_offset + visible_rows {
+            self.table_scroll_offset = self.selected_idx + 1 - visible_rows;
+        }
+    }
+
+    pub fn invalidate_detail_cache(&mut self) {
+        self.detail_cache.clear();
+    }
+
+    fn request_refresh_for_section_change(&mut self) {
+        self.invalidate_detail_cache();
+        self.force_refresh = true;
+    }
+
+    pub async fn refresh_selected_detail(&mut self, params: &ProjectTuiParams) {
+        let svc = match self.services.get(self.selected_idx) {
+            Some(s) => s,
+            None => return,
+        };
+        let service_id = svc.service_id.clone();
+        let is_database = svc.is_database;
+        let volumes = svc.volumes.clone();
+
+        self.detail_loading = true;
+
+        let now = Utc::now();
+        let since_str = TIME_RANGES[self.time_range_idx];
+        let start_date = match parse_time(since_str) {
+            Ok(t) => t,
+            Err(_) => {
+                self.detail_loading = false;
+                return;
+            }
+        };
+        let duration = now - start_date;
+        let sample_rate = compute_sample_rate(duration);
+
+        let measurements = build_measurements(
+            self.show_cpu,
+            self.show_memory,
+            self.show_network,
+            self.show_volume,
+        );
+
+        let wants_http = self.show_http && !is_database;
+
+        let resource_fut = async {
+            Some(
+                fetch_resource_metrics(FetchResourceMetricsParams {
+                    client: &params.client,
+                    backboard: &params.backboard,
+                    service_id: &service_id,
+                    environment_id: &params.environment_id,
+                    start_date,
+                    end_date: None,
+                    measurements,
+                    sample_rate_seconds: Some(sample_rate),
+                    include_raw: true,
+                })
+                .await,
+            )
+        };
+
+        let http_fut = async {
+            if wants_http {
+                Some(
+                    fetch_http_metrics(FetchHttpMetricsParams {
+                        client: &params.client,
+                        backboard: &params.backboard,
+                        service_id: &service_id,
+                        environment_id: &params.environment_id,
+                        start_date,
+                        end_date: now,
+                        step_seconds: Some(sample_rate),
+                        method: params.method.clone(),
+                        path: params.path.clone(),
+                        include_time_series: true,
+                    })
+                    .await,
+                )
+            } else {
+                None
+            }
+        };
+
+        let (resource_result, http_result) = tokio::join!(resource_fut, http_fut);
+
+        let mut entry = DetailCacheEntry {
+            cpu: None,
+            cpu_limit: None,
+            memory: None,
+            memory_limit: None,
+            network_tx: None,
+            network_rx: None,
+            disk: None,
+            volumes,
+            http: None,
+            is_database,
+            fetched_at: Utc::now(),
+            time_range_idx: self.time_range_idx,
+        };
+
+        if let Some(Ok(result)) = resource_result {
+            entry.cpu = find_metric(&result.metrics, "CPU_USAGE").cloned();
+            entry.cpu_limit = find_metric(&result.metrics, "CPU_LIMIT").cloned();
+            entry.memory = find_metric(&result.metrics, "MEMORY_USAGE_GB").cloned();
+            entry.memory_limit = find_metric(&result.metrics, "MEMORY_LIMIT_GB").cloned();
+            entry.network_tx = find_metric(&result.metrics, "NETWORK_TX_GB").cloned();
+            entry.network_rx = find_metric(&result.metrics, "NETWORK_RX_GB").cloned();
+            entry.disk = find_metric(&result.metrics, "DISK_USAGE_GB").cloned();
+        }
+
+        if let Some(Ok(result)) = http_result {
+            entry.http = result;
+        }
+
+        self.detail_cache.insert(service_id, entry);
+        self.detail_loading = false;
+    }
+
+    pub async fn refresh(&mut self, params: &ProjectTuiParams) {
+        let now = Utc::now();
+        let since_str = TIME_RANGES[self.time_range_idx];
+        let start_date = match parse_time(since_str) {
+            Ok(t) => t,
+            Err(e) => {
+                self.error_message = Some(format!("Failed to parse time range: {e}"));
+                return;
+            }
+        };
+
+        let duration = now - start_date;
+        let sample_rate = compute_sample_rate(duration);
+
+        let measurements =
+            build_measurements(self.show_cpu, self.show_memory, self.show_network, false);
+
+        // Preserve selection by service_id across refreshes (list reorders by CPU)
+        let prev_selected_id = self.selected_service().map(|s| s.service_id.clone());
+
+        match fetch_project_metrics(
+            FetchProjectMetricsParams {
+                client: &params.client,
+                backboard: &params.backboard,
+                project_id: &params.project_id,
+                environment_id: &params.environment_id,
+                start_date,
+                end_date: None,
+                measurements,
+                sample_rate_seconds: Some(sample_rate),
+            },
+            &params.project,
+        )
+        .await
+        {
+            Ok(mut services) => {
+                if self.show_volume {
+                    for svc in &mut services {
+                        svc.volumes = get_volume_metrics(
+                            &params.project,
+                            &params.environment_id,
+                            &svc.service_id,
+                        );
+                    }
+                }
+
+                if self.show_http {
+                    let end = now;
+
+                    for svc in &mut services {
+                        let service_instance = find_service_instance(
+                            &params.project,
+                            &params.environment_id,
+                            &svc.service_id,
+                        );
+                        let source_image = service_instance
+                            .and_then(|si| si.source.as_ref())
+                            .and_then(|src| src.image.as_deref());
+                        svc.is_database = is_database_service(source_image);
+                    }
+
+                    let http_futures: Vec<_> = services
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, svc)| !svc.is_database)
+                        .map(|(i, svc)| {
+                            let params = FetchHttpMetricsParams {
+                                client: &params.client,
+                                backboard: &params.backboard,
+                                service_id: &svc.service_id,
+                                environment_id: &params.environment_id,
+                                start_date,
+                                end_date: end,
+                                step_seconds: Some(sample_rate),
+                                method: params.method.clone(),
+                                path: params.path.clone(),
+                                include_time_series: false,
+                            };
+                            async move { (i, fetch_http_metrics(params).await) }
+                        })
+                        .collect();
+
+                    let results = futures::future::join_all(http_futures).await;
+                    for (i, result) in results {
+                        if let Ok(http) = result {
+                            services[i].http = http;
+                        }
+                    }
+                }
+
+                self.services = services;
+                self.error_message = None;
+
+                // Evict cache entries for services no longer in the project
+                self.detail_cache
+                    .retain(|id, _| self.services.iter().any(|s| s.service_id == *id));
+
+                // Restore selection by service_id
+                if let Some(id) = prev_selected_id {
+                    if let Some(idx) = self.services.iter().position(|s| s.service_id == id) {
+                        self.selected_idx = idx;
+                    }
+                }
+                self.clamp_selection();
+            }
+            Err(e) => {
+                self.error_message = Some(format!("Fetch failed: {e}"));
+            }
+        }
+
+        self.last_refresh = Some(Utc::now());
+
+        self.refresh_selected_detail(params).await;
+    }
+
+    /// Returns true if the user wants to quit
+    pub fn handle_key(&mut self, key: KeyEvent) -> bool {
+        if self.show_help {
+            self.show_help = false;
+            return false;
+        }
+
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return true,
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => return true,
+
+            // Navigation
+            KeyCode::Up | KeyCode::Char('k') => self.move_selection(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.move_selection(1),
+            KeyCode::Home => self.move_selection(-(self.services.len() as isize)),
+            KeyCode::End => self.move_selection(self.services.len() as isize),
+
+            // Section toggles (detail panel)
+            KeyCode::Char('1') => {
+                self.show_cpu = !self.show_cpu;
+                self.request_refresh_for_section_change();
+            }
+            KeyCode::Char('2') => {
+                self.show_memory = !self.show_memory;
+                self.request_refresh_for_section_change();
+            }
+            KeyCode::Char('3') => {
+                self.show_network = !self.show_network;
+                self.request_refresh_for_section_change();
+            }
+            KeyCode::Char('4') => {
+                self.show_volume = !self.show_volume;
+                self.request_refresh_for_section_change();
+            }
+            KeyCode::Char('5') => {
+                if self.selected_service().is_none_or(|s| !s.is_database) {
+                    self.show_http = !self.show_http;
+                    self.request_refresh_for_section_change();
+                }
+            }
+            KeyCode::Char('e') => self.show_egress = !self.show_egress,
+            KeyCode::Char('i') => self.show_ingress = !self.show_ingress,
+            KeyCode::Char('6') => self.show_2xx = !self.show_2xx,
+            KeyCode::Char('7') => self.show_3xx = !self.show_3xx,
+            KeyCode::Char('8') => self.show_4xx = !self.show_4xx,
+            KeyCode::Char('9') => self.show_5xx = !self.show_5xx,
+            KeyCode::F(1) => self.show_p50 = !self.show_p50,
+            KeyCode::F(2) => self.show_p90 = !self.show_p90,
+            KeyCode::F(3) => self.show_p95 = !self.show_p95,
+            KeyCode::F(4) => self.show_p99 = !self.show_p99,
+
+            KeyCode::Char('t') => {
+                self.time_range_idx = (self.time_range_idx + 1) % TIME_RANGES.len();
+                self.time_range_changed = true;
+                self.invalidate_detail_cache();
+            }
+            KeyCode::Char('r') => {
+                let should_refresh = self
+                    .last_refresh
+                    .map(|t| (Utc::now() - t).num_seconds() >= 2)
+                    .unwrap_or(true);
+                if should_refresh {
+                    self.force_refresh = true;
+                }
+            }
+            KeyCode::Char('?') => self.show_help = true,
+            _ => {}
+        }
+        false
+    }
+}

--- a/src/controllers/metrics_tui/app.rs
+++ b/src/controllers/metrics_tui/app.rs
@@ -7,9 +7,9 @@ use futures::FutureExt;
 use crate::controllers::db_stats::{self, DatabaseStats};
 use crate::controllers::metrics::{
     FetchHttpMetricsParams, FetchProjectMetricsParams, FetchResourceMetricsParams,
-    HttpMetricsResult, MetricSummary, ServiceMetricsSummary, VolumeMetrics, compute_sample_rate,
-    fetch_http_metrics, fetch_project_metrics, fetch_resource_metrics, find_metric,
-    get_volume_metrics, is_database_service,
+    HttpMetricsResult, MetricSummary, ResourceMetricsResult, ServiceMetricsSummary, VolumeMetrics,
+    compute_sample_rate, fetch_http_metrics, fetch_project_metrics, fetch_resource_metrics,
+    find_metric, get_volume_metrics, is_database_service,
 };
 use crate::controllers::project::find_service_instance;
 use crate::util::time::parse_time;
@@ -25,6 +25,7 @@ pub enum ActiveTab {
 }
 
 type MetricMeasurement = crate::gql::queries::metrics::MetricMeasurement;
+type FetchResult<T> = Result<T, String>;
 
 fn build_measurements(
     cpu: bool,
@@ -52,6 +53,87 @@ fn build_measurements(
         m.push(MetricMeasurement::CPU_USAGE);
     }
     m
+}
+
+#[derive(Clone, Copy)]
+pub struct ServiceRefreshOptions {
+    show_cpu: bool,
+    show_memory: bool,
+    show_network: bool,
+    show_volume: bool,
+    show_http: bool,
+    is_db: bool,
+}
+
+impl ServiceRefreshOptions {
+    pub fn from_app(app: &MetricsApp) -> Self {
+        Self {
+            show_cpu: app.show_cpu,
+            show_memory: app.show_memory,
+            show_network: app.show_network,
+            show_volume: app.show_volume,
+            show_http: app.show_http,
+            is_db: app.is_db,
+        }
+    }
+}
+
+pub struct ServiceRefreshResult {
+    pub request_id: u64,
+    pub time_range_idx: usize,
+    pub resource: Option<FetchResult<ResourceMetricsResult>>,
+    pub http: Option<FetchResult<Option<HttpMetricsResult>>>,
+    pub fetched_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Copy)]
+pub struct ProjectRefreshOptions {
+    show_cpu: bool,
+    show_memory: bool,
+    show_network: bool,
+    show_volume: bool,
+    show_http: bool,
+}
+
+impl ProjectRefreshOptions {
+    pub fn from_app(app: &ProjectApp) -> Self {
+        Self {
+            show_cpu: app.show_cpu,
+            show_memory: app.show_memory,
+            show_network: app.show_network,
+            show_volume: app.show_volume,
+            show_http: app.show_http,
+        }
+    }
+}
+
+pub struct ProjectRefreshResult {
+    pub request_id: u64,
+    pub time_range_idx: usize,
+    pub services: FetchResult<Vec<ServiceMetricsSummary>>,
+    pub fetched_at: DateTime<Utc>,
+}
+
+pub struct ProjectDetailRequest {
+    pub request_id: u64,
+    pub time_range_idx: usize,
+    pub service_id: String,
+    pub is_database: bool,
+    pub volumes: Vec<VolumeMetrics>,
+    pub options: ProjectRefreshOptions,
+}
+
+pub struct ProjectDetailResult {
+    pub request_id: u64,
+    pub service_id: String,
+    pub entry: FetchResult<DetailCacheEntry>,
+}
+
+pub struct ProjectHttpResult {
+    pub request_id: u64,
+    pub time_range_idx: usize,
+    pub service_id: String,
+    pub http: FetchResult<Option<HttpMetricsResult>>,
 }
 
 /// Single-service metrics app state
@@ -114,6 +196,7 @@ pub struct MetricsApp {
     pub error_message: Option<String>,
     pub show_help: bool,
     pub force_refresh: bool,
+    pub refreshing: bool,
 }
 
 impl MetricsApp {
@@ -163,6 +246,7 @@ impl MetricsApp {
             error_message: None,
             show_help: false,
             force_refresh: false,
+            refreshing: false,
         }
     }
 
@@ -172,6 +256,50 @@ impl MetricsApp {
 
     pub fn poll_interval_secs(&self) -> u64 {
         POLL_INTERVALS_SECS[self.time_range_idx]
+    }
+
+    pub fn mark_refreshing(&mut self) {
+        self.refreshing = true;
+    }
+
+    pub fn apply_refresh_result(&mut self, result: ServiceRefreshResult) {
+        if result.time_range_idx != self.time_range_idx {
+            return;
+        }
+        let fetched_at = result.fetched_at;
+
+        if let Some(result) = result.resource {
+            match result {
+                Ok(result) => {
+                    self.cpu = find_metric(&result.metrics, "CPU_USAGE").cloned();
+                    self.cpu_limit = find_metric(&result.metrics, "CPU_LIMIT").cloned();
+                    self.memory = find_metric(&result.metrics, "MEMORY_USAGE_GB").cloned();
+                    self.memory_limit = find_metric(&result.metrics, "MEMORY_LIMIT_GB").cloned();
+                    self.network_tx = find_metric(&result.metrics, "NETWORK_TX_GB").cloned();
+                    self.network_rx = find_metric(&result.metrics, "NETWORK_RX_GB").cloned();
+                    self.disk = find_metric(&result.metrics, "DISK_USAGE_GB").cloned();
+                    self.error_message = None;
+                }
+                Err(e) => {
+                    self.error_message = Some(format!("Resource fetch failed: {e}"));
+                }
+            }
+        }
+
+        if let Some(result) = result.http {
+            match result {
+                Ok(result) => {
+                    self.http = result;
+                    self.error_message = None;
+                }
+                Err(e) => {
+                    self.error_message = Some(format!("HTTP fetch failed: {e}"));
+                }
+            }
+        }
+
+        self.last_refresh = Some(fetched_at);
+        self.refreshing = false;
     }
 
     pub fn maybe_start_db_stats_fetch(&mut self, params: &ServiceTuiParams) {
@@ -191,114 +319,6 @@ impl MetricsApp {
                 db_stats::fetch_db_stats(&instance_id, &db_type).await
             }));
         }
-    }
-
-    pub async fn refresh(&mut self, params: &ServiceTuiParams) {
-        let now = Utc::now();
-        let since_str = TIME_RANGES[self.time_range_idx];
-        let start_date = match parse_time(since_str) {
-            Ok(t) => t,
-            Err(e) => {
-                self.error_message = Some(format!("Failed to parse time range: {e}"));
-                return;
-            }
-        };
-
-        let duration = now - start_date;
-        let sample_rate = compute_sample_rate(duration);
-
-        let needs_resource =
-            self.show_cpu || self.show_memory || self.show_network || self.show_volume;
-        let measurements = if needs_resource {
-            build_measurements(
-                self.show_cpu,
-                self.show_memory,
-                self.show_network,
-                self.show_volume,
-            )
-        } else {
-            vec![]
-        };
-
-        let wants_http = self.show_http && !self.is_db;
-
-        // Fetch resource and HTTP metrics in parallel
-        let resource_fut = async {
-            if needs_resource {
-                Some(
-                    fetch_resource_metrics(FetchResourceMetricsParams {
-                        client: &params.client,
-                        backboard: &params.backboard,
-                        service_id: &params.service_id,
-                        environment_id: &params.environment_id,
-                        start_date,
-                        end_date: None,
-                        measurements,
-                        sample_rate_seconds: Some(sample_rate),
-                        include_raw: true,
-                    })
-                    .await,
-                )
-            } else {
-                None
-            }
-        };
-
-        let http_fut = async {
-            if wants_http {
-                Some(
-                    fetch_http_metrics(FetchHttpMetricsParams {
-                        client: &params.client,
-                        backboard: &params.backboard,
-                        service_id: &params.service_id,
-                        environment_id: &params.environment_id,
-                        start_date,
-                        end_date: now,
-                        step_seconds: Some(sample_rate),
-                        method: params.method.clone(),
-                        path: params.path.clone(),
-                        include_time_series: true,
-                    })
-                    .await,
-                )
-            } else {
-                None
-            }
-        };
-
-        let (resource_result, http_result) = tokio::join!(resource_fut, http_fut);
-
-        if let Some(result) = resource_result {
-            match result {
-                Ok(result) => {
-                    self.cpu = find_metric(&result.metrics, "CPU_USAGE").cloned();
-                    self.cpu_limit = find_metric(&result.metrics, "CPU_LIMIT").cloned();
-                    self.memory = find_metric(&result.metrics, "MEMORY_USAGE_GB").cloned();
-                    self.memory_limit = find_metric(&result.metrics, "MEMORY_LIMIT_GB").cloned();
-                    self.network_tx = find_metric(&result.metrics, "NETWORK_TX_GB").cloned();
-                    self.network_rx = find_metric(&result.metrics, "NETWORK_RX_GB").cloned();
-                    self.disk = find_metric(&result.metrics, "DISK_USAGE_GB").cloned();
-                    self.error_message = None;
-                }
-                Err(e) => {
-                    self.error_message = Some(format!("Resource fetch failed: {e}"));
-                }
-            }
-        }
-
-        if let Some(result) = http_result {
-            match result {
-                Ok(result) => {
-                    self.http = result;
-                    self.error_message = None;
-                }
-                Err(e) => {
-                    self.error_message = Some(format!("HTTP fetch failed: {e}"));
-                }
-            }
-        }
-
-        self.last_refresh = Some(Utc::now());
     }
 
     /// Handle mouse click events (tab switching)
@@ -324,7 +344,7 @@ impl MetricsApp {
 
     /// Check if the background db_stats fetch has completed.
     /// Call this from the event loop before each draw.
-    pub fn poll_db_stats(&mut self, params: &ServiceTuiParams) {
+    pub fn poll_db_stats(&mut self, params: &ServiceTuiParams) -> bool {
         if let Some(ref handle) = self.db_stats_handle {
             if handle.is_finished() {
                 let handle = self.db_stats_handle.take().unwrap();
@@ -346,8 +366,10 @@ impl MetricsApp {
                     }
                     None => {} // shouldn't happen since is_finished() was true
                 }
+                return true;
             }
         }
+        false
     }
 
     /// Returns true if the user wants to quit
@@ -441,6 +463,100 @@ impl MetricsApp {
     }
 }
 
+pub async fn fetch_service_refresh(
+    params: ServiceTuiParams,
+    request_id: u64,
+    time_range_idx: usize,
+    options: ServiceRefreshOptions,
+) -> ServiceRefreshResult {
+    let now = Utc::now();
+    let since_str = TIME_RANGES[time_range_idx];
+    let start_date = match parse_time(since_str) {
+        Ok(t) => t,
+        Err(e) => {
+            return ServiceRefreshResult {
+                request_id,
+                time_range_idx,
+                resource: Some(Err(format!("Failed to parse time range: {e}"))),
+                http: None,
+                fetched_at: Utc::now(),
+            };
+        }
+    };
+
+    let duration = now - start_date;
+    let sample_rate = compute_sample_rate(duration);
+
+    let needs_resource =
+        options.show_cpu || options.show_memory || options.show_network || options.show_volume;
+    let measurements = if needs_resource {
+        build_measurements(
+            options.show_cpu,
+            options.show_memory,
+            options.show_network,
+            options.show_volume,
+        )
+    } else {
+        vec![]
+    };
+    let wants_http = options.show_http && !options.is_db;
+
+    let resource_fut = async {
+        if needs_resource {
+            Some(
+                fetch_resource_metrics(FetchResourceMetricsParams {
+                    client: &params.client,
+                    backboard: &params.backboard,
+                    service_id: &params.service_id,
+                    environment_id: &params.environment_id,
+                    start_date,
+                    end_date: None,
+                    measurements,
+                    sample_rate_seconds: Some(sample_rate),
+                    include_raw: true,
+                })
+                .await
+                .map_err(|e| format!("{e:#}")),
+            )
+        } else {
+            None
+        }
+    };
+
+    let http_fut = async {
+        if wants_http {
+            Some(
+                fetch_http_metrics(FetchHttpMetricsParams {
+                    client: &params.client,
+                    backboard: &params.backboard,
+                    service_id: &params.service_id,
+                    environment_id: &params.environment_id,
+                    start_date,
+                    end_date: now,
+                    step_seconds: Some(sample_rate),
+                    method: params.method.clone(),
+                    path: params.path.clone(),
+                    include_time_series: true,
+                })
+                .await
+                .map_err(|e| format!("{e:#}")),
+            )
+        } else {
+            None
+        }
+    };
+
+    let (resource, http) = tokio::join!(resource_fut, http_fut);
+
+    ServiceRefreshResult {
+        request_id,
+        time_range_idx,
+        resource,
+        http,
+        fetched_at: Utc::now(),
+    }
+}
+
 /// Cached time-series data for one service's detail view
 pub struct DetailCacheEntry {
     pub cpu: Option<MetricSummary>,
@@ -476,6 +592,7 @@ pub struct ProjectApp {
     // Detail panel cache (keyed by service_id)
     pub detail_cache: HashMap<String, DetailCacheEntry>,
     pub detail_loading: bool,
+    pub detail_loading_service_id: Option<String>,
 
     // Section toggles (shared across detail views)
     pub show_cpu: bool,
@@ -499,6 +616,7 @@ pub struct ProjectApp {
     pub error_message: Option<String>,
     pub show_help: bool,
     pub force_refresh: bool,
+    pub refreshing: bool,
 }
 
 impl ProjectApp {
@@ -518,6 +636,7 @@ impl ProjectApp {
             table_scroll_offset: 0,
             detail_cache: HashMap::new(),
             detail_loading: false,
+            detail_loading_service_id: None,
             show_cpu: params.sections.cpu,
             show_memory: params.sections.memory,
             show_network: params.sections.network,
@@ -537,6 +656,7 @@ impl ProjectApp {
             error_message: None,
             show_help: false,
             force_refresh: false,
+            refreshing: false,
         }
     }
 
@@ -562,7 +682,23 @@ impl ProjectApp {
     }
 
     pub fn needs_detail_fetch(&self) -> bool {
-        !self.detail_loading && self.selected_detail().is_none()
+        let Some(svc) = self.services.get(self.selected_idx) else {
+            return false;
+        };
+        self.selected_detail().is_none()
+            && self.detail_loading_service_id.as_deref() != Some(svc.service_id.as_str())
+    }
+
+    pub fn selected_detail_request(&self, request_id: u64) -> Option<ProjectDetailRequest> {
+        let svc = self.services.get(self.selected_idx)?;
+        Some(ProjectDetailRequest {
+            request_id,
+            time_range_idx: self.time_range_idx,
+            service_id: svc.service_id.clone(),
+            is_database: svc.is_database,
+            volumes: svc.volumes.clone(),
+            options: ProjectRefreshOptions::from_app(self),
+        })
     }
 
     pub fn move_selection(&mut self, delta: isize) {
@@ -607,210 +743,43 @@ impl ProjectApp {
         self.force_refresh = true;
     }
 
-    pub async fn refresh_selected_detail(&mut self, params: &ProjectTuiParams) {
-        let svc = match self.services.get(self.selected_idx) {
-            Some(s) => s,
-            None => return,
-        };
-        let service_id = svc.service_id.clone();
-        let is_database = svc.is_database;
-        let volumes = svc.volumes.clone();
-
-        self.detail_loading = true;
-
-        let now = Utc::now();
-        let since_str = TIME_RANGES[self.time_range_idx];
-        let start_date = match parse_time(since_str) {
-            Ok(t) => t,
-            Err(_) => {
-                self.detail_loading = false;
-                return;
-            }
-        };
-        let duration = now - start_date;
-        let sample_rate = compute_sample_rate(duration);
-
-        let measurements = build_measurements(
-            self.show_cpu,
-            self.show_memory,
-            self.show_network,
-            self.show_volume,
-        );
-
-        let wants_http = self.show_http && !is_database;
-
-        let resource_fut = async {
-            Some(
-                fetch_resource_metrics(FetchResourceMetricsParams {
-                    client: &params.client,
-                    backboard: &params.backboard,
-                    service_id: &service_id,
-                    environment_id: &params.environment_id,
-                    start_date,
-                    end_date: None,
-                    measurements,
-                    sample_rate_seconds: Some(sample_rate),
-                    include_raw: true,
-                })
-                .await,
-            )
-        };
-
-        let http_fut = async {
-            if wants_http {
-                Some(
-                    fetch_http_metrics(FetchHttpMetricsParams {
-                        client: &params.client,
-                        backboard: &params.backboard,
-                        service_id: &service_id,
-                        environment_id: &params.environment_id,
-                        start_date,
-                        end_date: now,
-                        step_seconds: Some(sample_rate),
-                        method: params.method.clone(),
-                        path: params.path.clone(),
-                        include_time_series: true,
-                    })
-                    .await,
-                )
-            } else {
-                None
-            }
-        };
-
-        let (resource_result, http_result) = tokio::join!(resource_fut, http_fut);
-
-        let mut entry = DetailCacheEntry {
-            cpu: None,
-            cpu_limit: None,
-            memory: None,
-            memory_limit: None,
-            network_tx: None,
-            network_rx: None,
-            disk: None,
-            volumes,
-            http: None,
-            is_database,
-            fetched_at: Utc::now(),
-            time_range_idx: self.time_range_idx,
-        };
-
-        if let Some(Ok(result)) = resource_result {
-            entry.cpu = find_metric(&result.metrics, "CPU_USAGE").cloned();
-            entry.cpu_limit = find_metric(&result.metrics, "CPU_LIMIT").cloned();
-            entry.memory = find_metric(&result.metrics, "MEMORY_USAGE_GB").cloned();
-            entry.memory_limit = find_metric(&result.metrics, "MEMORY_LIMIT_GB").cloned();
-            entry.network_tx = find_metric(&result.metrics, "NETWORK_TX_GB").cloned();
-            entry.network_rx = find_metric(&result.metrics, "NETWORK_RX_GB").cloned();
-            entry.disk = find_metric(&result.metrics, "DISK_USAGE_GB").cloned();
-        }
-
-        if let Some(Ok(result)) = http_result {
-            entry.http = result;
-        }
-
-        self.detail_cache.insert(service_id, entry);
-        self.detail_loading = false;
+    pub fn mark_refreshing(&mut self) {
+        self.refreshing = true;
     }
 
-    pub async fn refresh(&mut self, params: &ProjectTuiParams) {
-        let now = Utc::now();
-        let since_str = TIME_RANGES[self.time_range_idx];
-        let start_date = match parse_time(since_str) {
-            Ok(t) => t,
-            Err(e) => {
-                self.error_message = Some(format!("Failed to parse time range: {e}"));
-                return;
-            }
-        };
+    pub fn mark_detail_loading(&mut self, service_id: String) {
+        self.detail_loading = true;
+        self.detail_loading_service_id = Some(service_id);
+    }
 
-        let duration = now - start_date;
-        let sample_rate = compute_sample_rate(duration);
+    pub fn apply_refresh_result(&mut self, result: ProjectRefreshResult) -> bool {
+        if result.time_range_idx != self.time_range_idx {
+            return false;
+        }
+        let fetched_at = result.fetched_at;
+        let mut applied_services = false;
 
-        let measurements =
-            build_measurements(self.show_cpu, self.show_memory, self.show_network, false);
-
-        // Preserve selection by service_id across refreshes (list reorders by CPU)
-        let prev_selected_id = self.selected_service().map(|s| s.service_id.clone());
-
-        match fetch_project_metrics(
-            FetchProjectMetricsParams {
-                client: &params.client,
-                backboard: &params.backboard,
-                project_id: &params.project_id,
-                environment_id: &params.environment_id,
-                start_date,
-                end_date: None,
-                measurements,
-                sample_rate_seconds: Some(sample_rate),
-            },
-            &params.project,
-        )
-        .await
-        {
+        match result.services {
             Ok(mut services) => {
-                if self.show_volume {
-                    for svc in &mut services {
-                        svc.volumes = get_volume_metrics(
-                            &params.project,
-                            &params.environment_id,
-                            &svc.service_id,
-                        );
-                    }
-                }
-
-                if self.show_http {
-                    let end = now;
-
-                    for svc in &mut services {
-                        let service_instance = find_service_instance(
-                            &params.project,
-                            &params.environment_id,
-                            &svc.service_id,
-                        );
-                        let source_image = service_instance
-                            .and_then(|si| si.source.as_ref())
-                            .and_then(|src| src.image.as_deref());
-                        svc.is_database = is_database_service(source_image);
-                    }
-
-                    let http_futures: Vec<_> = services
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, svc)| !svc.is_database)
-                        .map(|(i, svc)| {
-                            let params = FetchHttpMetricsParams {
-                                client: &params.client,
-                                backboard: &params.backboard,
-                                service_id: &svc.service_id,
-                                environment_id: &params.environment_id,
-                                start_date,
-                                end_date: end,
-                                step_seconds: Some(sample_rate),
-                                method: params.method.clone(),
-                                path: params.path.clone(),
-                                include_time_series: false,
-                            };
-                            async move { (i, fetch_http_metrics(params).await) }
-                        })
-                        .collect();
-
-                    let results = futures::future::join_all(http_futures).await;
-                    for (i, result) in results {
-                        if let Ok(http) = result {
-                            services[i].http = http;
-                        }
+                applied_services = true;
+                let prev_selected_id = self.selected_service().map(|s| s.service_id.clone());
+                let previous_http = self
+                    .services
+                    .iter()
+                    .filter_map(|svc| svc.http.clone().map(|http| (svc.service_id.clone(), http)))
+                    .collect::<HashMap<_, _>>();
+                for svc in &mut services {
+                    if svc.http.is_none() {
+                        svc.http = previous_http.get(&svc.service_id).cloned();
                     }
                 }
 
                 self.services = services;
                 self.error_message = None;
 
-                // Evict cache entries for services no longer in the project
                 self.detail_cache
                     .retain(|id, _| self.services.iter().any(|s| s.service_id == *id));
 
-                // Restore selection by service_id
                 if let Some(id) = prev_selected_id {
                     if let Some(idx) = self.services.iter().position(|s| s.service_id == id) {
                         self.selected_idx = idx;
@@ -823,9 +792,62 @@ impl ProjectApp {
             }
         }
 
-        self.last_refresh = Some(Utc::now());
+        self.last_refresh = Some(fetched_at);
+        self.refreshing = false;
+        applied_services
+    }
 
-        self.refresh_selected_detail(params).await;
+    pub fn apply_detail_result(&mut self, result: ProjectDetailResult) {
+        let selected_id = self.selected_service().map(|s| s.service_id.as_str());
+        if selected_id != Some(result.service_id.as_str()) {
+            if self.detail_loading_service_id.as_deref() == Some(result.service_id.as_str()) {
+                self.detail_loading = false;
+                self.detail_loading_service_id = None;
+            }
+            return;
+        }
+
+        match result.entry {
+            Ok(entry) if entry.time_range_idx == self.time_range_idx => {
+                self.detail_cache.insert(result.service_id, entry);
+                self.detail_loading = false;
+                self.detail_loading_service_id = None;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                self.error_message = Some(format!("Detail fetch failed: {e}"));
+                self.detail_loading = false;
+                self.detail_loading_service_id = None;
+            }
+        }
+    }
+
+    pub fn http_summary_jobs(&self) -> Vec<String> {
+        if !self.show_http {
+            return vec![];
+        }
+        self.services
+            .iter()
+            .filter(|svc| !svc.is_database)
+            .map(|svc| svc.service_id.clone())
+            .collect()
+    }
+
+    pub fn apply_http_result(&mut self, result: ProjectHttpResult) {
+        if result.time_range_idx != self.time_range_idx {
+            return;
+        }
+        let Some(service) = self
+            .services
+            .iter_mut()
+            .find(|svc| svc.service_id == result.service_id)
+        else {
+            return;
+        };
+
+        if let Ok(http) = result.http {
+            service.http = http;
+        }
     }
 
     /// Returns true if the user wants to quit
@@ -897,5 +919,243 @@ impl ProjectApp {
             _ => {}
         }
         false
+    }
+}
+
+pub async fn fetch_project_refresh(
+    params: ProjectTuiParams,
+    request_id: u64,
+    time_range_idx: usize,
+    options: ProjectRefreshOptions,
+) -> ProjectRefreshResult {
+    let now = Utc::now();
+    let since_str = TIME_RANGES[time_range_idx];
+    let start_date = match parse_time(since_str) {
+        Ok(t) => t,
+        Err(e) => {
+            return ProjectRefreshResult {
+                request_id,
+                time_range_idx,
+                services: Err(format!("Failed to parse time range: {e}")),
+                fetched_at: Utc::now(),
+            };
+        }
+    };
+
+    let duration = now - start_date;
+    let sample_rate = compute_sample_rate(duration);
+    let measurements = build_measurements(
+        options.show_cpu,
+        options.show_memory,
+        options.show_network,
+        false,
+    );
+
+    let services = match fetch_project_metrics(
+        FetchProjectMetricsParams {
+            client: &params.client,
+            backboard: &params.backboard,
+            project_id: &params.project_id,
+            environment_id: &params.environment_id,
+            start_date,
+            end_date: None,
+            measurements,
+            sample_rate_seconds: Some(sample_rate),
+        },
+        &params.project,
+    )
+    .await
+    {
+        Ok(mut services) => {
+            if options.show_volume {
+                for svc in &mut services {
+                    svc.volumes = get_volume_metrics(
+                        &params.project,
+                        &params.environment_id,
+                        &svc.service_id,
+                    );
+                }
+            }
+
+            for svc in &mut services {
+                let service_instance =
+                    find_service_instance(&params.project, &params.environment_id, &svc.service_id);
+                let source_image = service_instance
+                    .and_then(|si| si.source.as_ref())
+                    .and_then(|src| src.image.as_deref());
+                svc.is_database = is_database_service(source_image);
+            }
+
+            Ok(services)
+        }
+        Err(e) => Err(format!("{e:#}")),
+    };
+
+    ProjectRefreshResult {
+        request_id,
+        time_range_idx,
+        services,
+        fetched_at: Utc::now(),
+    }
+}
+
+pub async fn fetch_project_http_summary(
+    params: ProjectTuiParams,
+    request_id: u64,
+    time_range_idx: usize,
+    service_id: String,
+) -> ProjectHttpResult {
+    let now = Utc::now();
+    let since_str = TIME_RANGES[time_range_idx];
+    let start_date = match parse_time(since_str) {
+        Ok(t) => t,
+        Err(e) => {
+            return ProjectHttpResult {
+                request_id,
+                time_range_idx,
+                service_id,
+                http: Err(format!("Failed to parse time range: {e}")),
+            };
+        }
+    };
+
+    let duration = now - start_date;
+    let sample_rate = compute_sample_rate(duration);
+    let http = fetch_http_metrics(FetchHttpMetricsParams {
+        client: &params.client,
+        backboard: &params.backboard,
+        service_id: &service_id,
+        environment_id: &params.environment_id,
+        start_date,
+        end_date: now,
+        step_seconds: Some(sample_rate),
+        method: params.method.clone(),
+        path: params.path.clone(),
+        include_time_series: false,
+    })
+    .await
+    .map_err(|e| format!("{e:#}"));
+
+    ProjectHttpResult {
+        request_id,
+        time_range_idx,
+        service_id,
+        http,
+    }
+}
+
+pub async fn fetch_project_detail(
+    params: ProjectTuiParams,
+    request: ProjectDetailRequest,
+) -> ProjectDetailResult {
+    let now = Utc::now();
+    let since_str = TIME_RANGES[request.time_range_idx];
+    let start_date = match parse_time(since_str) {
+        Ok(t) => t,
+        Err(e) => {
+            return ProjectDetailResult {
+                request_id: request.request_id,
+                service_id: request.service_id,
+                entry: Err(format!("Failed to parse time range: {e}")),
+            };
+        }
+    };
+
+    let duration = now - start_date;
+    let sample_rate = compute_sample_rate(duration);
+    let measurements = build_measurements(
+        request.options.show_cpu,
+        request.options.show_memory,
+        request.options.show_network,
+        request.options.show_volume,
+    );
+    let wants_http = request.options.show_http && !request.is_database;
+
+    let resource_fut = async {
+        fetch_resource_metrics(FetchResourceMetricsParams {
+            client: &params.client,
+            backboard: &params.backboard,
+            service_id: &request.service_id,
+            environment_id: &params.environment_id,
+            start_date,
+            end_date: None,
+            measurements,
+            sample_rate_seconds: Some(sample_rate),
+            include_raw: true,
+        })
+        .await
+    };
+
+    let http_fut = async {
+        if wants_http {
+            Some(
+                fetch_http_metrics(FetchHttpMetricsParams {
+                    client: &params.client,
+                    backboard: &params.backboard,
+                    service_id: &request.service_id,
+                    environment_id: &params.environment_id,
+                    start_date,
+                    end_date: now,
+                    step_seconds: Some(sample_rate),
+                    method: params.method.clone(),
+                    path: params.path.clone(),
+                    include_time_series: true,
+                })
+                .await,
+            )
+        } else {
+            None
+        }
+    };
+
+    let (resource_result, http_result) = tokio::join!(resource_fut, http_fut);
+
+    let mut entry = DetailCacheEntry {
+        cpu: None,
+        cpu_limit: None,
+        memory: None,
+        memory_limit: None,
+        network_tx: None,
+        network_rx: None,
+        disk: None,
+        volumes: request.volumes,
+        http: None,
+        is_database: request.is_database,
+        fetched_at: Utc::now(),
+        time_range_idx: request.time_range_idx,
+    };
+
+    let entry_result = match resource_result {
+        Ok(result) => {
+            entry.cpu = find_metric(&result.metrics, "CPU_USAGE").cloned();
+            entry.cpu_limit = find_metric(&result.metrics, "CPU_LIMIT").cloned();
+            entry.memory = find_metric(&result.metrics, "MEMORY_USAGE_GB").cloned();
+            entry.memory_limit = find_metric(&result.metrics, "MEMORY_LIMIT_GB").cloned();
+            entry.network_tx = find_metric(&result.metrics, "NETWORK_TX_GB").cloned();
+            entry.network_rx = find_metric(&result.metrics, "NETWORK_RX_GB").cloned();
+            entry.disk = find_metric(&result.metrics, "DISK_USAGE_GB").cloned();
+
+            if let Some(http_result) = http_result {
+                match http_result {
+                    Ok(http) => entry.http = http,
+                    Err(e) => {
+                        return ProjectDetailResult {
+                            request_id: request.request_id,
+                            service_id: request.service_id,
+                            entry: Err(format!("{e:#}")),
+                        };
+                    }
+                }
+            }
+
+            Ok(entry)
+        }
+        Err(e) => Err(format!("{e:#}")),
+    };
+
+    ProjectDetailResult {
+        request_id: request.request_id,
+        service_id: request.service_id,
+        entry: entry_result,
     }
 }

--- a/src/controllers/metrics_tui/mod.rs
+++ b/src/controllers/metrics_tui/mod.rs
@@ -6,22 +6,28 @@ use std::panic;
 
 use anyhow::Result;
 use crossterm::cursor::{Hide, Show};
-use crossterm::event::{Event, EventStream};
+use crossterm::event::{Event, EventStream, KeyEventKind};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
-use futures_util::StreamExt;
+use futures_util::{StreamExt, stream};
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
+use tokio::sync::mpsc;
 
-use app::{MetricsApp, ProjectApp};
+use app::{
+    MetricsApp, ProjectApp, ProjectDetailResult, ProjectRefreshOptions, ProjectRefreshResult,
+    ServiceRefreshOptions, fetch_project_detail, fetch_project_http_summary, fetch_project_refresh,
+    fetch_service_refresh,
+};
 
 use crate::commands::metrics::Sections;
 use crate::controllers::database::DatabaseType;
 use crate::queries::project::ProjectProject;
 
 /// Parameters for single-service metrics TUI
+#[derive(Clone)]
 pub struct ServiceTuiParams {
     pub client: reqwest::Client,
     pub backboard: String,
@@ -45,6 +51,7 @@ pub struct ServiceTuiParams {
 }
 
 /// Parameters for project-wide metrics TUI (--all)
+#[derive(Clone)]
 pub struct ProjectTuiParams {
     pub client: reqwest::Client,
     pub backboard: String,
@@ -85,6 +92,8 @@ fn restore_terminal() {
 /// Time range presets matching the Railway dashboard
 const TIME_RANGES: [&str; 5] = ["1h", "6h", "1d", "7d", "30d"];
 const POLL_INTERVALS_SECS: [u64; 5] = [5, 10, 30, 60, 180];
+const FRAME_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
+const PROJECT_HTTP_CONCURRENCY: usize = 6;
 
 pub(crate) fn normalize_time_range_label(since: &str) -> Option<String> {
     let normalized = since.trim().to_ascii_lowercase();
@@ -95,6 +104,75 @@ pub(crate) fn normalize_time_range_label(since: &str) -> Option<String> {
 
 pub(crate) fn supported_time_ranges_label() -> String {
     TIME_RANGES.join(", ")
+}
+
+fn spawn_service_refresh(
+    tx: mpsc::UnboundedSender<app::ServiceRefreshResult>,
+    params: ServiceTuiParams,
+    request_id: u64,
+    time_range_idx: usize,
+    options: ServiceRefreshOptions,
+) {
+    tokio::spawn(async move {
+        let result = fetch_service_refresh(params, request_id, time_range_idx, options).await;
+        let _ = tx.send(result);
+    });
+}
+
+enum ProjectFetchMsg {
+    Refresh(ProjectRefreshResult),
+    Detail(ProjectDetailResult),
+    Http(app::ProjectHttpResult),
+}
+
+fn spawn_project_refresh(
+    tx: mpsc::UnboundedSender<ProjectFetchMsg>,
+    params: ProjectTuiParams,
+    request_id: u64,
+    time_range_idx: usize,
+    options: ProjectRefreshOptions,
+) {
+    tokio::spawn(async move {
+        let result = fetch_project_refresh(params, request_id, time_range_idx, options).await;
+        let _ = tx.send(ProjectFetchMsg::Refresh(result));
+    });
+}
+
+fn spawn_project_detail(
+    tx: mpsc::UnboundedSender<ProjectFetchMsg>,
+    params: ProjectTuiParams,
+    request: app::ProjectDetailRequest,
+) {
+    tokio::spawn(async move {
+        let result = fetch_project_detail(params, request).await;
+        let _ = tx.send(ProjectFetchMsg::Detail(result));
+    });
+}
+
+fn spawn_project_http_summaries(
+    tx: mpsc::UnboundedSender<ProjectFetchMsg>,
+    params: ProjectTuiParams,
+    request_id: u64,
+    time_range_idx: usize,
+    service_ids: Vec<String>,
+) {
+    tokio::spawn(async move {
+        stream::iter(service_ids)
+            .map(|service_id| {
+                let params = params.clone();
+                async move {
+                    fetch_project_http_summary(params, request_id, time_range_idx, service_id).await
+                }
+            })
+            .buffer_unordered(PROJECT_HTTP_CONCURRENCY)
+            .for_each(|result| {
+                let tx = tx.clone();
+                async move {
+                    let _ = tx.send(ProjectFetchMsg::Http(result));
+                }
+            })
+            .await;
+    });
 }
 
 /// Run single-service metrics TUI
@@ -112,32 +190,55 @@ pub async fn run(params: ServiceTuiParams) -> Result<()> {
 
     let mut app = MetricsApp::new(&params);
     let mut events = EventStream::new();
+    let (refresh_tx, mut refresh_rx) = mpsc::unbounded_channel();
+    let mut refresh_request_id = 0u64;
+    let mut active_refresh_request_id: u64;
 
-    // Initial fetch
-    app.refresh(&params).await;
+    refresh_request_id += 1;
+    active_refresh_request_id = refresh_request_id;
+    app.mark_refreshing();
+    spawn_service_refresh(
+        refresh_tx.clone(),
+        params.clone(),
+        refresh_request_id,
+        app.time_range_idx,
+        ServiceRefreshOptions::from_app(&app),
+    );
 
     let mut poll_interval =
         tokio::time::interval(std::time::Duration::from_secs(app.poll_interval_secs()));
     poll_interval.tick().await; // consume first instant tick
+    let mut render_interval = tokio::time::interval(FRAME_INTERVAL);
+    render_interval.tick().await;
+    let mut dirty = true;
 
     'main: loop {
         // Check if background db_stats fetch completed (non-blocking)
-        app.poll_db_stats(&params);
+        if app.poll_db_stats(&params) {
+            dirty = true;
+        }
         app.maybe_start_db_stats_fetch(&params);
-
-        terminal.draw(|f| ui::render_service(&app, f))?;
 
         tokio::select! {
             biased;
+            _ = render_interval.tick(), if dirty || app.refreshing => {
+                terminal.draw(|f| ui::render_service(&app, f))?;
+                dirty = false;
+            }
+            Some(result) = refresh_rx.recv() => {
+                if result.request_id == active_refresh_request_id {
+                    app.apply_refresh_result(result);
+                    dirty = true;
+                }
+            }
             Some(Ok(event)) = events.next() => {
                 match event {
                     Event::Key(key) => {
+                        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+                            continue;
+                        }
                         if app.handle_key(key) {
                             break 'main;
-                        }
-                        if app.force_refresh {
-                            app.force_refresh = false;
-                            app.refresh(&params).await;
                         }
                         if app.time_range_changed {
                             app.time_range_changed = false;
@@ -145,20 +246,46 @@ pub async fn run(params: ServiceTuiParams) -> Result<()> {
                                 std::time::Duration::from_secs(app.poll_interval_secs()),
                             );
                             poll_interval.tick().await;
-                            app.refresh(&params).await;
+                            app.force_refresh = true;
                         }
+                        if app.force_refresh {
+                            app.force_refresh = false;
+                            refresh_request_id += 1;
+                            active_refresh_request_id = refresh_request_id;
+                            app.mark_refreshing();
+                            spawn_service_refresh(
+                                refresh_tx.clone(),
+                                params.clone(),
+                                refresh_request_id,
+                                app.time_range_idx,
+                                ServiceRefreshOptions::from_app(&app),
+                            );
+                        }
+                        dirty = true;
                     }
                     Event::Mouse(mouse) => {
                         app.handle_mouse(mouse);
+                        dirty = true;
                     }
                     Event::Resize(_, _) => {
                         let _ = terminal.clear();
+                        dirty = true;
                     }
                     _ => {}
                 }
             }
             _ = poll_interval.tick() => {
-                app.refresh(&params).await;
+                refresh_request_id += 1;
+                active_refresh_request_id = refresh_request_id;
+                app.mark_refreshing();
+                spawn_service_refresh(
+                    refresh_tx.clone(),
+                    params.clone(),
+                    refresh_request_id,
+                    app.time_range_idx,
+                    ServiceRefreshOptions::from_app(&app),
+                );
+                dirty = true;
             }
             _ = tokio::signal::ctrl_c() => {
                 break 'main;
@@ -184,14 +311,31 @@ pub async fn run_project(params: ProjectTuiParams) -> Result<()> {
 
     let mut app = ProjectApp::new(&params);
     let mut events = EventStream::new();
+    let (fetch_tx, mut fetch_rx) = mpsc::unbounded_channel();
+    let mut refresh_request_id = 0u64;
+    let mut active_refresh_request_id: u64;
+    let mut detail_request_id = 0u64;
+    let mut active_detail_request_id = 0u64;
 
-    app.refresh(&params).await;
+    refresh_request_id += 1;
+    active_refresh_request_id = refresh_request_id;
+    app.mark_refreshing();
+    spawn_project_refresh(
+        fetch_tx.clone(),
+        params.clone(),
+        refresh_request_id,
+        app.time_range_idx,
+        ProjectRefreshOptions::from_app(&app),
+    );
 
     let mut poll_interval =
         tokio::time::interval(std::time::Duration::from_secs(app.poll_interval_secs()));
     poll_interval.tick().await;
+    let mut render_interval = tokio::time::interval(FRAME_INTERVAL);
+    render_interval.tick().await;
 
     let mut prev_selected_idx = app.selected_idx;
+    let mut dirty = true;
 
     'main: loop {
         // Adjust scroll before drawing
@@ -200,13 +344,61 @@ pub async fn run_project(params: ProjectTuiParams) -> Result<()> {
         let table_body_rows = (app.services.len() as u16).min(max_table_body).max(1);
         app.ensure_selection_visible(table_body_rows as usize);
 
-        terminal.draw(|f| ui::render_project(&app, f))?;
-
         tokio::select! {
             biased;
+            _ = render_interval.tick(), if dirty || app.refreshing || app.detail_loading => {
+                terminal.draw(|f| ui::render_project(&app, f))?;
+                dirty = false;
+            }
+            Some(msg) = fetch_rx.recv() => {
+                match msg {
+                    ProjectFetchMsg::Refresh(result) => {
+                        if result.request_id == active_refresh_request_id {
+                            let applied_services = app.apply_refresh_result(result);
+                            if applied_services {
+                                prev_selected_idx = app.selected_idx;
+                                let http_jobs = app.http_summary_jobs();
+                                if !http_jobs.is_empty() {
+                                    spawn_project_http_summaries(
+                                        fetch_tx.clone(),
+                                        params.clone(),
+                                        active_refresh_request_id,
+                                        app.time_range_idx,
+                                        http_jobs,
+                                    );
+                                }
+                                if app.needs_detail_fetch() {
+                                    detail_request_id += 1;
+                                    active_detail_request_id = detail_request_id;
+                                    if let Some(request) = app.selected_detail_request(detail_request_id) {
+                                        app.mark_detail_loading(request.service_id.clone());
+                                        spawn_project_detail(fetch_tx.clone(), params.clone(), request);
+                                    }
+                                }
+                            }
+                            dirty = true;
+                        }
+                    }
+                    ProjectFetchMsg::Detail(result) => {
+                        if result.request_id == active_detail_request_id {
+                            app.apply_detail_result(result);
+                            dirty = true;
+                        }
+                    }
+                    ProjectFetchMsg::Http(result) => {
+                        if result.request_id == active_refresh_request_id {
+                            app.apply_http_result(result);
+                            dirty = true;
+                        }
+                    }
+                }
+            }
             Some(Ok(event)) = events.next() => {
                 match event {
                     Event::Key(key) => {
+                        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+                            continue;
+                        }
                         if app.handle_key(key) {
                             break 'main;
                         }
@@ -215,31 +407,57 @@ pub async fn run_project(params: ProjectTuiParams) -> Result<()> {
                         if app.selected_idx != prev_selected_idx {
                             prev_selected_idx = app.selected_idx;
                             if app.needs_detail_fetch() {
-                                app.refresh_selected_detail(&params).await;
+                                detail_request_id += 1;
+                                active_detail_request_id = detail_request_id;
+                                if let Some(request) = app.selected_detail_request(detail_request_id) {
+                                    app.mark_detail_loading(request.service_id.clone());
+                                    spawn_project_detail(fetch_tx.clone(), params.clone(), request);
+                                }
                             }
                         }
 
-                        if app.force_refresh {
-                            app.force_refresh = false;
-                            app.refresh(&params).await;
-                        }
                         if app.time_range_changed {
                             app.time_range_changed = false;
                             poll_interval = tokio::time::interval(
                                 std::time::Duration::from_secs(app.poll_interval_secs()),
                             );
                             poll_interval.tick().await;
-                            app.refresh(&params).await;
+                            app.force_refresh = true;
                         }
+                        if app.force_refresh {
+                            app.force_refresh = false;
+                            refresh_request_id += 1;
+                            active_refresh_request_id = refresh_request_id;
+                            app.mark_refreshing();
+                            spawn_project_refresh(
+                                fetch_tx.clone(),
+                                params.clone(),
+                                refresh_request_id,
+                                app.time_range_idx,
+                                ProjectRefreshOptions::from_app(&app),
+                            );
+                        }
+                        dirty = true;
                     }
                     Event::Resize(_, _) => {
                         let _ = terminal.clear();
+                        dirty = true;
                     }
                     _ => {}
                 }
             }
             _ = poll_interval.tick() => {
-                app.refresh(&params).await;
+                refresh_request_id += 1;
+                active_refresh_request_id = refresh_request_id;
+                app.mark_refreshing();
+                spawn_project_refresh(
+                    fetch_tx.clone(),
+                    params.clone(),
+                    refresh_request_id,
+                    app.time_range_idx,
+                    ProjectRefreshOptions::from_app(&app),
+                );
+                dirty = true;
             }
             _ = tokio::signal::ctrl_c() => {
                 break 'main;

--- a/src/controllers/metrics_tui/mod.rs
+++ b/src/controllers/metrics_tui/mod.rs
@@ -1,0 +1,251 @@
+mod app;
+mod ui;
+
+use std::io::stdout;
+use std::panic;
+
+use anyhow::Result;
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{Event, EventStream};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use futures_util::StreamExt;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+
+use app::{MetricsApp, ProjectApp};
+
+use crate::commands::metrics::Sections;
+use crate::controllers::database::DatabaseType;
+use crate::queries::project::ProjectProject;
+
+/// Parameters for single-service metrics TUI
+pub struct ServiceTuiParams {
+    pub client: reqwest::Client,
+    pub backboard: String,
+    pub service_id: String,
+    pub service_name: String,
+    pub environment_id: String,
+    pub environment_name: String,
+    pub since_label: String,
+    pub sections: Sections,
+    pub is_db: bool,
+    pub db_stats_supported: bool,
+    pub method: Option<String>,
+    pub path: Option<String>,
+    pub volumes: Vec<crate::controllers::metrics::VolumeMetrics>,
+    // For native SSH db stats (only set when is_db)
+    pub db_type: Option<DatabaseType>,
+    pub service_instance_id: Option<String>,
+    /// Populated when a local preflight decided DB stats can't run (e.g. no SSH key).
+    /// The Stats tab shows this instead of hanging on "Loading...".
+    pub db_stats_preflight_error: Option<String>,
+}
+
+/// Parameters for project-wide metrics TUI (--all)
+pub struct ProjectTuiParams {
+    pub client: reqwest::Client,
+    pub backboard: String,
+    pub project_id: String,
+    pub project: ProjectProject,
+    pub environment_id: String,
+    pub environment_name: String,
+    pub method: Option<String>,
+    pub path: Option<String>,
+    pub since_label: String,
+    pub sections: Sections,
+}
+
+fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
+    enable_raw_mode()?;
+    execute!(
+        stdout(),
+        EnterAlternateScreen,
+        Hide,
+        crossterm::event::EnableMouseCapture
+    )?;
+    let backend = CrosstermBackend::new(stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+    Ok(terminal)
+}
+
+fn restore_terminal() {
+    let _ = execute!(
+        stdout(),
+        LeaveAlternateScreen,
+        Show,
+        crossterm::event::DisableMouseCapture
+    );
+    let _ = disable_raw_mode();
+}
+
+/// Time range presets matching the Railway dashboard
+const TIME_RANGES: [&str; 5] = ["1h", "6h", "1d", "7d", "30d"];
+const POLL_INTERVALS_SECS: [u64; 5] = [5, 10, 30, 60, 180];
+
+pub(crate) fn normalize_time_range_label(since: &str) -> Option<String> {
+    let normalized = since.trim().to_ascii_lowercase();
+    TIME_RANGES
+        .contains(&normalized.as_str())
+        .then_some(normalized)
+}
+
+pub(crate) fn supported_time_ranges_label() -> String {
+    TIME_RANGES.join(", ")
+}
+
+/// Run single-service metrics TUI
+pub async fn run(params: ServiceTuiParams) -> Result<()> {
+    let original_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        original_hook(info);
+    }));
+
+    let mut terminal = setup_terminal()?;
+    let _cleanup = scopeguard::guard((), |_| {
+        restore_terminal();
+    });
+
+    let mut app = MetricsApp::new(&params);
+    let mut events = EventStream::new();
+
+    // Initial fetch
+    app.refresh(&params).await;
+
+    let mut poll_interval =
+        tokio::time::interval(std::time::Duration::from_secs(app.poll_interval_secs()));
+    poll_interval.tick().await; // consume first instant tick
+
+    'main: loop {
+        // Check if background db_stats fetch completed (non-blocking)
+        app.poll_db_stats(&params);
+        app.maybe_start_db_stats_fetch(&params);
+
+        terminal.draw(|f| ui::render_service(&app, f))?;
+
+        tokio::select! {
+            biased;
+            Some(Ok(event)) = events.next() => {
+                match event {
+                    Event::Key(key) => {
+                        if app.handle_key(key) {
+                            break 'main;
+                        }
+                        if app.force_refresh {
+                            app.force_refresh = false;
+                            app.refresh(&params).await;
+                        }
+                        if app.time_range_changed {
+                            app.time_range_changed = false;
+                            poll_interval = tokio::time::interval(
+                                std::time::Duration::from_secs(app.poll_interval_secs()),
+                            );
+                            poll_interval.tick().await;
+                            app.refresh(&params).await;
+                        }
+                    }
+                    Event::Mouse(mouse) => {
+                        app.handle_mouse(mouse);
+                    }
+                    Event::Resize(_, _) => {
+                        let _ = terminal.clear();
+                    }
+                    _ => {}
+                }
+            }
+            _ = poll_interval.tick() => {
+                app.refresh(&params).await;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                break 'main;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Run project-wide metrics TUI (--all)
+pub async fn run_project(params: ProjectTuiParams) -> Result<()> {
+    let original_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        original_hook(info);
+    }));
+
+    let mut terminal = setup_terminal()?;
+    let _cleanup = scopeguard::guard((), |_| {
+        restore_terminal();
+    });
+
+    let mut app = ProjectApp::new(&params);
+    let mut events = EventStream::new();
+
+    app.refresh(&params).await;
+
+    let mut poll_interval =
+        tokio::time::interval(std::time::Duration::from_secs(app.poll_interval_secs()));
+    poll_interval.tick().await;
+
+    let mut prev_selected_idx = app.selected_idx;
+
+    'main: loop {
+        // Adjust scroll before drawing
+        let term_height = terminal.size()?.height;
+        let max_table_body = (term_height / 3).max(3);
+        let table_body_rows = (app.services.len() as u16).min(max_table_body).max(1);
+        app.ensure_selection_visible(table_body_rows as usize);
+
+        terminal.draw(|f| ui::render_project(&app, f))?;
+
+        tokio::select! {
+            biased;
+            Some(Ok(event)) = events.next() => {
+                match event {
+                    Event::Key(key) => {
+                        if app.handle_key(key) {
+                            break 'main;
+                        }
+
+                        // Fetch detail when selection changes
+                        if app.selected_idx != prev_selected_idx {
+                            prev_selected_idx = app.selected_idx;
+                            if app.needs_detail_fetch() {
+                                app.refresh_selected_detail(&params).await;
+                            }
+                        }
+
+                        if app.force_refresh {
+                            app.force_refresh = false;
+                            app.refresh(&params).await;
+                        }
+                        if app.time_range_changed {
+                            app.time_range_changed = false;
+                            poll_interval = tokio::time::interval(
+                                std::time::Duration::from_secs(app.poll_interval_secs()),
+                            );
+                            poll_interval.tick().await;
+                            app.refresh(&params).await;
+                        }
+                    }
+                    Event::Resize(_, _) => {
+                        let _ = terminal.clear();
+                    }
+                    _ => {}
+                }
+            }
+            _ = poll_interval.tick() => {
+                app.refresh(&params).await;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                break 'main;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/controllers/metrics_tui/ui.rs
+++ b/src/controllers/metrics_tui/ui.rs
@@ -1,0 +1,2173 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    symbols,
+    text::{Line, Span},
+    widgets::{Axis, Block, Borders, Chart, Dataset, Gauge, GraphType, Padding, Paragraph},
+};
+
+use crate::controllers::metrics::{
+    MetricDataPoint, MetricSummary, format_count, format_cpu, format_gb, format_mb, pct,
+    utilization,
+};
+
+use super::app::{ActiveTab, MetricsApp, ProjectApp};
+
+// ─── Colors (matching Railway dashboard) ─────────────────────────────────────
+
+/// CPU + Memory use a blue-purple in the dashboard; closest 256-color match
+const CPU_COLOR: Color = Color::Indexed(63); // blue-purple (#5f5fff)
+const MEMORY_COLOR: Color = Color::Indexed(63); // same blue-purple as dashboard
+const EGRESS_COLOR: Color = Color::Yellow;
+const INGRESS_COLOR: Color = Color::Blue;
+const DISK_COLOR: Color = Color::Magenta;
+// Response Time percentile colors (matching dashboard legend exactly)
+const P50_COLOR: Color = Color::Blue; // p50 (median) — blue
+const P90_COLOR: Color = Color::Yellow; // p90 — yellow/orange
+const P95_COLOR: Color = Color::Magenta; // p95 — purple
+const P99_COLOR: Color = Color::Red; // p99 — red
+// HTTP status codes (matching dashboard stacked bar legend)
+const STATUS_2XX: Color = Color::Blue; // blue in dashboard
+const STATUS_3XX: Color = Color::Magenta; // purple in dashboard
+const STATUS_4XX: Color = Color::Yellow; // yellow/gold in dashboard
+const STATUS_5XX: Color = Color::Red; // dark red in dashboard
+const ERROR_RATE_COLOR: Color = Color::Red; // error rate line — red/pink
+const BORDER_COLOR: Color = Color::DarkGray;
+const LABEL_COLOR: Color = Color::DarkGray;
+
+fn health_color(pct: f64) -> Color {
+    if pct >= 85.0 {
+        Color::Red
+    } else if pct >= 60.0 {
+        Color::Yellow
+    } else {
+        Color::Green
+    }
+}
+
+fn error_rate_color(rate: f64) -> Color {
+    if rate >= 10.0 {
+        Color::Red
+    } else if rate >= 5.0 {
+        Color::Yellow
+    } else {
+        Color::Green
+    }
+}
+
+// ─── Data helpers ────────────────────────────────────────────────────────────
+
+/// Convert raw metric data points to (f64, f64) for Chart datasets.
+/// X = seconds since first point, Y = value
+fn to_chart_data(points: &[MetricDataPoint]) -> Vec<(f64, f64)> {
+    if points.is_empty() {
+        return vec![];
+    }
+    let t0 = points[0].ts as f64;
+    points.iter().map(|p| (p.ts as f64 - t0, p.value)).collect()
+}
+
+/// Build X-axis time labels from data points
+fn time_bounds_and_labels(points: &[MetricDataPoint]) -> (f64, f64, Vec<String>) {
+    if points.is_empty() {
+        return (0.0, 1.0, vec![]);
+    }
+    let t0 = points[0].ts as f64;
+    let t_end = points.last().unwrap().ts as f64;
+    let range = (t_end - t0).max(1.0);
+
+    let num_labels = 4;
+    let step = range / num_labels as f64;
+    let labels: Vec<String> = (0..=num_labels)
+        .map(|i| {
+            let ts = t0 + step * i as f64;
+            chrono::DateTime::from_timestamp(ts as i64, 0)
+                .map(|dt| {
+                    // Use local time with AM/PM format like the Railway dashboard
+                    let local: chrono::DateTime<chrono::Local> = dt.into();
+                    local.format("%-I:%M %p").to_string()
+                })
+                .unwrap_or_default()
+        })
+        .collect();
+
+    (0.0, range, labels)
+}
+
+/// Create a consistent card block with inner padding
+fn card_block(title: &str) -> Block<'_> {
+    Block::default()
+        .title(format!(" {title} "))
+        .title_style(Style::default().add_modifier(Modifier::BOLD))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(BORDER_COLOR))
+        .padding(Padding::new(2, 2, 1, 1)) // left, right, top, bottom
+}
+
+/// Uniform gap between all cards
+const CARD_SPACING: u16 = 1;
+
+/// Compute the left offset for text below a Chart to align with the chart's plot area.
+/// Mirrors ratatui's `max_width_of_labels_left_of_y_axis` + 1 for the axis line.
+fn chart_left_pad(y_labels: &[String], x_labels: &[String]) -> String {
+    let max_y = y_labels.iter().map(|l| l.len()).max().unwrap_or(0);
+    // First X-axis label extends left of the Y-axis (Alignment::Left: width - 1)
+    let first_x = x_labels
+        .first()
+        .map(|l| l.len().saturating_sub(1))
+        .unwrap_or(0);
+    let max_w = max_y.max(first_x);
+    // +1 for the axis line itself
+    " ".repeat(max_w + 1)
+}
+
+/// Build a togglable legend entry: colored dot + label + key hint
+fn make_legend_item<'a>(active: bool, color: Color, label: &str, key: &str) -> Vec<Span<'a>> {
+    let dot_style = if active {
+        Style::default().fg(color)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let text_style = if active {
+        Style::default()
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    vec![
+        Span::styled("●", dot_style),
+        Span::styled(format!(" {label}"), text_style),
+        Span::styled(
+            format!(" [{key}]"),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+    ]
+}
+
+// ─── Single-service rendering ────────────────────────────────────────────────
+
+pub fn render_service(app: &MetricsApp, frame: &mut Frame) {
+    let area = frame.area();
+
+    if area.width < 60 || area.height < 10 {
+        let msg = Paragraph::new("Terminal too small. Please resize (min 60x10).")
+            .style(Style::default().fg(Color::Yellow));
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    // For database services with native stats: header + tab bar + content + help bar
+    // For non-database: header + content + help bar (no tab bar)
+    if app.db_stats_supported {
+        let outer = Layout::vertical([
+            Constraint::Length(1), // header
+            Constraint::Length(3), // tab bar (padding + tabs + padding)
+            Constraint::Min(0),    // content
+            Constraint::Length(1), // help bar
+        ])
+        .split(area);
+
+        render_header(app, frame, outer[0]);
+        render_tab_bar(app, frame, outer[1]);
+
+        match app.active_tab {
+            ActiveTab::Metrics => render_metrics_content(app, frame, outer[2]),
+            ActiveTab::Stats => render_stats_content(app, frame, outer[2]),
+        }
+
+        render_service_help_bar(app, frame, outer[3]);
+    } else {
+        // Non-database: no tabs, original layout
+        let outer = Layout::vertical([
+            Constraint::Length(2), // header
+            Constraint::Min(0),    // content
+            Constraint::Length(1), // help bar
+        ])
+        .split(area);
+
+        render_header(app, frame, outer[0]);
+        render_metrics_content(app, frame, outer[1]);
+        render_service_help_bar(app, frame, outer[2]);
+    }
+
+    if app.show_help {
+        render_help_overlay(frame, area);
+    }
+}
+
+fn render_tab_bar(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let active = Style::default()
+        .fg(Color::Black)
+        .bg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let inactive = Style::default().fg(Color::DarkGray);
+
+    let line = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            " Metrics ",
+            if app.active_tab == ActiveTab::Metrics {
+                active
+            } else {
+                inactive
+            },
+        ),
+        Span::raw(" "),
+        Span::styled(
+            " Stats ",
+            if app.active_tab == ActiveTab::Stats {
+                active
+            } else {
+                inactive
+            },
+        ),
+    ]);
+
+    // Center the tabs vertically in the 3-row area
+    let inner = Layout::vertical([
+        Constraint::Length(1), // top padding
+        Constraint::Length(1), // tab labels
+        Constraint::Length(1), // bottom padding
+    ])
+    .split(area);
+
+    frame.render_widget(Paragraph::new(line), inner[1]);
+}
+
+fn render_metrics_content(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let show_cpu_mem = app.show_cpu || app.show_memory;
+    let show_net_req = app.show_network || (app.show_http && !app.is_db);
+    let show_err_resp = app.show_http && !app.is_db;
+    let show_vol = app.show_volume && (!app.volumes.is_empty() || app.disk.is_some());
+    let net_vol_combined = show_net_req && show_vol;
+
+    let mut constraints: Vec<Constraint> = Vec::new();
+    let mut chart_rows = 0u32;
+    if show_cpu_mem {
+        chart_rows += 1;
+    }
+    if net_vol_combined {
+        chart_rows += 1;
+    } else {
+        if show_net_req {
+            chart_rows += 1;
+        }
+        if show_err_resp {
+            chart_rows += 1;
+        }
+    }
+    let chart_rows = chart_rows.max(1);
+
+    if show_cpu_mem {
+        constraints.push(Constraint::Ratio(1, chart_rows));
+    }
+    if net_vol_combined {
+        constraints.push(Constraint::Ratio(1, chart_rows));
+    } else {
+        if show_net_req {
+            constraints.push(Constraint::Ratio(1, chart_rows));
+        }
+        if show_err_resp {
+            constraints.push(Constraint::Ratio(1, chart_rows));
+        }
+        if show_vol {
+            constraints.push(Constraint::Length(6));
+        }
+    }
+    constraints.push(Constraint::Min(0)); // filler
+
+    let chunks = Layout::vertical(constraints)
+        .spacing(CARD_SPACING)
+        .split(area);
+
+    let mut idx = 0;
+    if show_cpu_mem {
+        render_cpu_memory(app, frame, chunks[idx]);
+        idx += 1;
+    }
+    if net_vol_combined {
+        let cols = Layout::horizontal([Constraint::Percentage(65), Constraint::Percentage(35)])
+            .spacing(CARD_SPACING)
+            .split(chunks[idx]);
+        render_network_http(app, frame, cols[0]);
+        render_volume(app, frame, cols[1]);
+        idx += 1;
+    } else {
+        if show_net_req {
+            render_network_http(app, frame, chunks[idx]);
+            idx += 1;
+        }
+        if show_err_resp {
+            let row3_cols =
+                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                    .spacing(CARD_SPACING)
+                    .split(chunks[idx]);
+            render_error_rate_chart(app, frame, row3_cols[0]);
+            render_http_latency(app, frame, row3_cols[1]);
+            idx += 1;
+        }
+        if show_vol {
+            render_volume(app, frame, chunks[idx]);
+            idx += 1;
+        }
+    }
+
+    if let Some(ref err) = app.error_message {
+        let filler_idx = chunks.len() - 1;
+        if idx <= filler_idx {
+            let err_line = Paragraph::new(format!(" {err}")).style(Style::default().fg(Color::Red));
+            frame.render_widget(err_line, chunks[filler_idx]);
+        }
+    }
+}
+
+fn render_stats_content(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    if app.db_stats.is_some() {
+        render_db_stats(app, frame, area);
+    } else {
+        let msg = if let Some(ref e) = app.db_stats_error {
+            let mut lines = String::from("  Database stats unavailable:\n");
+            for line in e.lines() {
+                lines.push_str("    ");
+                lines.push_str(line);
+                lines.push('\n');
+            }
+            lines
+        } else {
+            "  Loading database stats...".to_string()
+        };
+        let style = if app.db_stats_error.is_some() {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        frame.render_widget(Paragraph::new(msg).style(style), area);
+    }
+}
+
+fn render_header(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let refresh_str = app
+        .last_refresh
+        .map(|t| t.format("%H:%M:%S").to_string())
+        .unwrap_or_else(|| "loading...".to_string());
+
+    let header = Line::from(vec![
+        Span::styled(
+            format!("  {}", app.service_name),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::raw(format!("env {}", app.environment_name)),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::raw(format!("last {}", app.time_range_label())),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::styled(
+            format!("refreshed {refresh_str}"),
+            Style::default().fg(LABEL_COLOR),
+        ),
+    ]);
+
+    frame.render_widget(Paragraph::new(vec![header, Line::from("")]), area);
+}
+
+fn render_cpu_memory(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let cols = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .spacing(CARD_SPACING)
+        .split(area);
+
+    if app.show_cpu {
+        render_metric_chart(
+            frame,
+            cols[0],
+            "CPU",
+            CPU_COLOR,
+            app.cpu.as_ref(),
+            app.cpu_limit.as_ref(),
+            format_cpu,
+            "vCPU",
+        );
+    }
+
+    if app.show_memory {
+        let col = if app.show_cpu { cols[1] } else { cols[0] };
+        render_metric_chart(
+            frame,
+            col,
+            "Memory",
+            MEMORY_COLOR,
+            app.memory.as_ref(),
+            app.memory_limit.as_ref(),
+            format_gb,
+            "GB",
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_metric_chart(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    color: Color,
+    metric: Option<&MetricSummary>,
+    limit: Option<&MetricSummary>,
+    format_fn: fn(f64) -> String,
+    _unit: &str,
+) {
+    let block = card_block(title);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    match metric {
+        Some(m) if !m.raw_values.is_empty() => {
+            let parts = Layout::vertical([
+                Constraint::Min(3),
+                Constraint::Length(1), // gap
+                Constraint::Length(1), // stats
+            ])
+            .split(inner);
+
+            let chart_data = to_chart_data(&m.raw_values);
+            let (x_min, x_max, x_labels) = time_bounds_and_labels(&m.raw_values);
+
+            let y_max = m.max * 1.15;
+            let y_max = if y_max < 0.001 { 1.0 } else { y_max };
+
+            let dataset = Dataset::default()
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(color))
+                .data(&chart_data);
+
+            let mut datasets = vec![dataset];
+
+            let limit_data;
+            if let Some(lim) = limit.filter(|l| l.current > 0.0) {
+                limit_data = vec![(x_min, lim.current), (x_max, lim.current)];
+                datasets.push(
+                    Dataset::default()
+                        .marker(symbols::Marker::Braille)
+                        .graph_type(GraphType::Line)
+                        .style(Style::default().fg(LABEL_COLOR))
+                        .data(&limit_data),
+                );
+            }
+
+            let x_axis = Axis::default()
+                .style(Style::default().fg(LABEL_COLOR))
+                .bounds([x_min, x_max])
+                .labels(x_labels.clone());
+
+            let y_label_strs = vec!["0".to_string(), format_fn(y_max / 2.0), format_fn(y_max)];
+            let pad = chart_left_pad(&y_label_strs, &x_labels);
+
+            let y_axis = Axis::default()
+                .style(Style::default().fg(LABEL_COLOR))
+                .bounds([0.0, y_max])
+                .labels(
+                    y_label_strs
+                        .iter()
+                        .map(|s| Span::raw(s.clone()))
+                        .collect::<Vec<_>>(),
+                );
+
+            let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+            frame.render_widget(chart, parts[0]);
+
+            let limit_str = limit
+                .filter(|l| l.current > 0.0)
+                .map(|l| format!(" / {}", format_fn(l.current)))
+                .unwrap_or_default();
+            let util_str = utilization(
+                m.current,
+                limit.filter(|l| l.current > 0.0).map(|l| l.current),
+            )
+            .map(|p| {
+                Span::styled(
+                    format!(" ({:.0}%)", p),
+                    Style::default().fg(health_color(p)),
+                )
+            });
+
+            let mut spans = vec![
+                Span::raw(pad),
+                Span::styled("Now: ", Style::default().fg(LABEL_COLOR)),
+                Span::styled(format_fn(m.current), Style::default().fg(color)),
+                Span::raw(limit_str),
+            ];
+            if let Some(u) = util_str {
+                spans.push(u);
+            }
+            spans.extend([
+                Span::styled("  Avg: ", Style::default().fg(LABEL_COLOR)),
+                Span::raw(format_fn(m.average)),
+                Span::styled("  Max: ", Style::default().fg(LABEL_COLOR)),
+                Span::raw(format_fn(m.max)),
+            ]);
+
+            frame.render_widget(Paragraph::new(Line::from(spans)), parts[2]);
+        }
+        _ => {
+            let msg =
+                Paragraph::new(format!(" No {title} data")).style(Style::default().fg(LABEL_COLOR));
+            frame.render_widget(msg, inner);
+        }
+    }
+}
+
+fn render_network_http(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let show_net = app.show_network;
+    let show_http = app.show_http && !app.is_db;
+
+    let cols = if show_net && show_http {
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .spacing(CARD_SPACING)
+            .split(area)
+    } else {
+        Layout::horizontal([Constraint::Percentage(100)]).split(area)
+    };
+
+    if show_net {
+        render_network_chart(app, frame, cols[0]);
+    }
+
+    if show_http {
+        let col = if show_net { cols[1] } else { cols[0] };
+        render_http_requests(app, frame, col);
+    }
+}
+
+fn render_network_chart(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let block = card_block(if app.is_db {
+        "Public Network Traffic — use private networking for service→db"
+    } else {
+        "Public Network Traffic"
+    });
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let has_tx = app
+        .network_tx
+        .as_ref()
+        .is_some_and(|t| !t.raw_values.is_empty());
+    let has_rx = app
+        .network_rx
+        .as_ref()
+        .is_some_and(|r| !r.raw_values.is_empty());
+
+    if !has_tx && !has_rx {
+        let msg = Paragraph::new(" No network data").style(Style::default().fg(LABEL_COLOR));
+        frame.render_widget(msg, inner);
+        return;
+    }
+
+    let parts = Layout::vertical([
+        Constraint::Min(3),    // chart
+        Constraint::Length(1), // gap
+        Constraint::Length(1), // legend
+    ])
+    .split(inner);
+
+    let ref_points = app
+        .network_tx
+        .as_ref()
+        .filter(|t| !t.raw_values.is_empty())
+        .or(app.network_rx.as_ref())
+        .map(|m| &m.raw_values[..])
+        .unwrap_or(&[]);
+
+    let (x_min, x_max, x_labels) = time_bounds_and_labels(ref_points);
+
+    let tx_data = app
+        .network_tx
+        .as_ref()
+        .filter(|_| app.show_egress)
+        .map(|t| to_chart_data(&t.raw_values))
+        .unwrap_or_default();
+    let rx_data = app
+        .network_rx
+        .as_ref()
+        .filter(|_| app.show_ingress)
+        .map(|r| to_chart_data(&r.raw_values))
+        .unwrap_or_default();
+
+    let mut y_max = 0.0f64;
+    for (_, v) in tx_data.iter().chain(rx_data.iter()) {
+        if *v > y_max {
+            y_max = *v;
+        }
+    }
+    y_max = (y_max * 1.15).max(0.001);
+
+    let mut datasets = Vec::new();
+    if !tx_data.is_empty() {
+        datasets.push(
+            Dataset::default()
+                .name("Egress")
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(EGRESS_COLOR))
+                .data(&tx_data),
+        );
+    }
+    if !rx_data.is_empty() {
+        datasets.push(
+            Dataset::default()
+                .name("Ingress")
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(INGRESS_COLOR))
+                .data(&rx_data),
+        );
+    }
+
+    let x_axis = Axis::default()
+        .style(Style::default().fg(LABEL_COLOR))
+        .bounds([x_min, x_max])
+        .labels(x_labels.clone());
+
+    let y_label_strs = vec!["0".to_string(), format_gb(y_max / 2.0), format_gb(y_max)];
+    let pad = chart_left_pad(&y_label_strs, &x_labels);
+
+    let y_axis = Axis::default()
+        .style(Style::default().fg(LABEL_COLOR))
+        .bounds([0.0, y_max])
+        .labels(
+            y_label_strs
+                .iter()
+                .map(|s| Span::raw(s.clone()))
+                .collect::<Vec<_>>(),
+        );
+
+    let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+    frame.render_widget(chart, parts[0]);
+
+    let mut spans = vec![Span::raw(pad)];
+    spans.extend(make_legend_item(
+        app.show_egress,
+        EGRESS_COLOR,
+        "Egress",
+        "e",
+    ));
+    spans.extend(make_legend_item(
+        app.show_ingress,
+        INGRESS_COLOR,
+        "Ingress",
+        "i",
+    ));
+    frame.render_widget(Paragraph::new(Line::from(spans)), parts[2]);
+}
+
+fn render_http_requests(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let http = app.http.as_ref();
+
+    let title = match http {
+        Some(h) => format!("Requests ({} total)", format_count(h.total)),
+        None => "Requests".to_string(),
+    };
+
+    let block = card_block(&title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let http = match http {
+        Some(h) => h,
+        None => {
+            let msg = Paragraph::new(" No HTTP data").style(Style::default().fg(LABEL_COLOR));
+            frame.render_widget(msg, inner);
+            return;
+        }
+    };
+
+    let parts = Layout::vertical([
+        Constraint::Min(3),    // chart area
+        Constraint::Length(1), // gap
+        Constraint::Length(1), // status counts
+        Constraint::Length(1), // gap
+        Constraint::Length(1), // interactive legend
+    ])
+    .split(inner);
+
+    let mut pad = String::new();
+
+    let has_ts = http.time_series.is_some();
+
+    if has_ts {
+        let ts = http.time_series.as_ref().unwrap();
+        let data_2xx = if app.show_2xx {
+            to_chart_data(&ts.status_2xx_ts)
+        } else {
+            vec![]
+        };
+        let data_3xx = if app.show_3xx {
+            to_chart_data(&ts.status_3xx_ts)
+        } else {
+            vec![]
+        };
+        let data_4xx = if app.show_4xx {
+            to_chart_data(&ts.status_4xx_ts)
+        } else {
+            vec![]
+        };
+        let data_5xx = if app.show_5xx {
+            to_chart_data(&ts.status_5xx_ts)
+        } else {
+            vec![]
+        };
+
+        let ref_ts = if !ts.status_2xx_ts.is_empty() {
+            &ts.status_2xx_ts
+        } else if !ts.status_5xx_ts.is_empty() {
+            &ts.status_5xx_ts
+        } else if !ts.status_4xx_ts.is_empty() {
+            &ts.status_4xx_ts
+        } else {
+            &ts.status_3xx_ts
+        };
+        let (x_min, x_max, x_labels) = time_bounds_and_labels(ref_ts);
+
+        let mut y_max = 0.0f64;
+        for (_, v) in data_2xx
+            .iter()
+            .chain(data_3xx.iter())
+            .chain(data_4xx.iter())
+            .chain(data_5xx.iter())
+        {
+            if *v > y_max {
+                y_max = *v;
+            }
+        }
+        y_max = (y_max * 1.15).max(1.0);
+
+        let mut datasets = vec![];
+        if !data_2xx.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name("2xx")
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(STATUS_2XX))
+                    .data(&data_2xx),
+            );
+        }
+        if !data_3xx.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name("3xx")
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(STATUS_3XX))
+                    .data(&data_3xx),
+            );
+        }
+        if !data_4xx.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name("4xx")
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(STATUS_4XX))
+                    .data(&data_4xx),
+            );
+        }
+        if !data_5xx.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name("5xx")
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(STATUS_5XX))
+                    .data(&data_5xx),
+            );
+        }
+
+        let x_axis = Axis::default()
+            .style(Style::default().fg(LABEL_COLOR))
+            .bounds([x_min, x_max])
+            .labels(x_labels.clone());
+
+        let y_label_strs = vec![
+            "0".to_string(),
+            format_count(y_max as usize / 2),
+            format_count(y_max as usize),
+        ];
+        pad = chart_left_pad(&y_label_strs, &x_labels);
+
+        let y_axis = Axis::default()
+            .style(Style::default().fg(LABEL_COLOR))
+            .bounds([0.0, y_max])
+            .labels(
+                y_label_strs
+                    .iter()
+                    .map(|s| Span::raw(s.clone()))
+                    .collect::<Vec<_>>(),
+            );
+
+        let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+        frame.render_widget(chart, parts[0]);
+    } else {
+        let msg = Line::from(vec![
+            Span::raw(format!(" {} total", format_count(http.total))),
+            Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+            Span::raw("Err: "),
+            Span::styled(
+                format!("{:.1}%", http.error_rate),
+                Style::default().fg(error_rate_color(http.error_rate)),
+            ),
+        ]);
+        frame.render_widget(Paragraph::new(msg), parts[0]);
+    }
+
+    let total = http.total;
+    let status_line = Line::from(vec![
+        Span::raw(pad.clone()),
+        Span::styled(
+            format!(
+                "2xx: {} ({:.1}%)",
+                format_count(http.status_counts[2]),
+                pct(http.status_counts[2], total)
+            ),
+            Style::default().fg(STATUS_2XX),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!(
+                "3xx: {} ({:.1}%)",
+                format_count(http.status_counts[3]),
+                pct(http.status_counts[3], total)
+            ),
+            Style::default().fg(STATUS_3XX),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!(
+                "4xx: {} ({:.1}%)",
+                format_count(http.status_counts[4]),
+                pct(http.status_counts[4], total)
+            ),
+            Style::default().fg(STATUS_4XX),
+        ),
+        Span::raw("   "),
+        Span::styled(
+            format!(
+                "5xx: {} ({:.1}%)",
+                format_count(http.status_counts[5]),
+                pct(http.status_counts[5], total)
+            ),
+            Style::default().fg(STATUS_5XX),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(status_line), parts[2]);
+
+    let mut spans = vec![Span::raw(pad)];
+    spans.extend(make_legend_item(app.show_2xx, STATUS_2XX, "2xx", "6"));
+    spans.extend(make_legend_item(app.show_3xx, STATUS_3XX, "3xx", "7"));
+    spans.extend(make_legend_item(app.show_4xx, STATUS_4XX, "4xx", "8"));
+    spans.extend(make_legend_item(app.show_5xx, STATUS_5XX, "5xx", "9"));
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), parts[4]);
+}
+
+fn render_error_rate_chart(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let block = card_block("Request Error Rate");
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let http = match app.http.as_ref() {
+        Some(h) if h.time_series.is_some() => h,
+        Some(h) => {
+            // No time-series, show summary text
+            let msg = Line::from(vec![
+                Span::raw(" Error Rate: "),
+                Span::styled(
+                    format!("{:.1}%", h.error_rate),
+                    Style::default().fg(error_rate_color(h.error_rate)),
+                ),
+            ]);
+            frame.render_widget(Paragraph::new(msg), inner);
+            return;
+        }
+        None => {
+            let msg = Paragraph::new(" No error data").style(Style::default().fg(LABEL_COLOR));
+            frame.render_widget(msg, inner);
+            return;
+        }
+    };
+
+    let ts = http.time_series.as_ref().unwrap();
+    let err_data = to_chart_data(&ts.error_rate_ts);
+    let (x_min, x_max, x_labels) = time_bounds_and_labels(&ts.error_rate_ts);
+
+    let err_pct_data: Vec<(f64, f64)> = ts
+        .error_rate_ts
+        .iter()
+        .zip(ts.request_rate_ts.iter())
+        .map(|(err, total)| {
+            let pct = if total.value > 0.0 {
+                (err.value / total.value) * 100.0
+            } else {
+                0.0
+            };
+            (err.ts as f64 - ts.error_rate_ts[0].ts as f64, pct)
+        })
+        .collect();
+
+    let chart_data = if !err_pct_data.is_empty() {
+        &err_pct_data
+    } else {
+        &err_data
+    };
+
+    let mut y_max = 0.0f64;
+    for (_, v) in chart_data.iter() {
+        if *v > y_max {
+            y_max = *v;
+        }
+    }
+    y_max = (y_max * 1.15).max(1.0);
+
+    let datasets = vec![
+        Dataset::default()
+            .marker(symbols::Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(Style::default().fg(ERROR_RATE_COLOR))
+            .data(chart_data),
+    ];
+
+    let x_axis = Axis::default()
+        .style(Style::default().fg(LABEL_COLOR))
+        .bounds([x_min, x_max])
+        .labels(x_labels.clone());
+
+    let y_axis = Axis::default()
+        .style(Style::default().fg(LABEL_COLOR))
+        .bounds([0.0, y_max])
+        .labels(vec![
+            Span::raw("0.0%"),
+            Span::raw(format!("{:.1}%", y_max / 2.0)),
+            Span::raw(format!("{:.1}%", y_max)),
+        ]);
+
+    let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+    frame.render_widget(chart, inner);
+}
+
+fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let block = card_block("Response Time");
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let http = match app.http.as_ref() {
+        Some(h) if h.time_series.is_some() => h,
+        _ => {
+            let msg = Paragraph::new(" No latency data").style(Style::default().fg(LABEL_COLOR));
+            frame.render_widget(msg, inner);
+            return;
+        }
+    };
+
+    let ts = http.time_series.as_ref().unwrap();
+
+    let parts = Layout::vertical([
+        Constraint::Min(3),    // chart
+        Constraint::Length(1), // gap
+        Constraint::Length(1), // legend
+    ])
+    .split(inner);
+
+    let p50_data = if app.show_p50 {
+        to_chart_data(&ts.p50_ts)
+    } else {
+        vec![]
+    };
+    let p90_data = if app.show_p90 {
+        to_chart_data(&ts.p90_ts)
+    } else {
+        vec![]
+    };
+    let p95_data = if app.show_p95 {
+        to_chart_data(&ts.p95_ts)
+    } else {
+        vec![]
+    };
+    let p99_data = if app.show_p99 {
+        to_chart_data(&ts.p99_ts)
+    } else {
+        vec![]
+    };
+    let (x_min, x_max, x_labels) = time_bounds_and_labels(&ts.p50_ts);
+
+    let mut y_max = 0.0f64;
+    for (_, v) in p50_data
+        .iter()
+        .chain(p90_data.iter())
+        .chain(p95_data.iter())
+        .chain(p99_data.iter())
+    {
+        if *v > y_max {
+            y_max = *v;
+        }
+    }
+    y_max = (y_max * 1.15).max(1.0);
+
+    let format_duration = |ms: f64| -> String {
+        if ms >= 1000.0 {
+            format!("{:.0} sec", ms / 1000.0)
+        } else {
+            format!("{:.0} ms", ms)
+        }
+    };
+
+    let mut datasets = vec![];
+    if !p50_data.is_empty() {
+        datasets.push(
+            Dataset::default()
+                .name("p50")
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(P50_COLOR))
+                .data(&p50_data),
+        );
+    }
+    if !p90_data.is_empty() {
+        datasets.push(
+            Dataset::default()
+                .name("p90")
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(P90_COLOR))
+                .data(&p90_data),
+        );
+    }
+    if !p95_data.is_empty() {
+        datasets.push(
+            Dataset::default()
+                .name("p95")
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(P95_COLOR))
+                .data(&p95_data),
+        );
+    }
+    if !p99_data.is_empty() {
+        datasets.push(
+            Dataset::default()
+                .name("p99")
+                .marker(symbols::Marker::Braille)
+                .graph_type(GraphType::Line)
+                .style(Style::default().fg(P99_COLOR))
+                .data(&p99_data),
+        );
+    }
+
+    let x_axis = Axis::default()
+        .style(Style::default().fg(LABEL_COLOR))
+        .bounds([x_min, x_max])
+        .labels(x_labels.clone());
+
+    let y_label_strs = vec![
+        format_duration(0.0),
+        format_duration(y_max / 2.0),
+        format_duration(y_max),
+    ];
+    let pad = chart_left_pad(&y_label_strs, &x_labels);
+
+    let y_axis = Axis::default()
+        .style(Style::default().fg(LABEL_COLOR))
+        .bounds([0.0, y_max])
+        .labels(
+            y_label_strs
+                .iter()
+                .map(|s| Span::raw(s.clone()))
+                .collect::<Vec<_>>(),
+        );
+
+    let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+    frame.render_widget(chart, parts[0]);
+
+    let mut spans = vec![Span::raw(pad)];
+    spans.extend(make_legend_item(app.show_p50, P50_COLOR, "p50", "F1"));
+    spans.extend(make_legend_item(app.show_p90, P90_COLOR, "p90", "F2"));
+    spans.extend(make_legend_item(app.show_p95, P95_COLOR, "p95", "F3"));
+    spans.extend(make_legend_item(app.show_p99, P99_COLOR, "p99", "F4"));
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), parts[2]);
+}
+
+fn render_volume(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let vol_name = app
+        .volumes
+        .first()
+        .map(|v| format!("Volume: {}", v.mount_path))
+        .unwrap_or_else(|| "Disk".to_string());
+
+    let block = card_block(&vol_name);
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let (current, limit_mb) = if let Some(vol) = app.volumes.first() {
+        (vol.current_size_mb, vol.limit_size_mb)
+    } else if let Some(ref disk) = app.disk {
+        (disk.current * 1024.0, 0.0) // disk is in GB, convert to MB
+    } else {
+        let msg = Paragraph::new(" No volume data").style(Style::default().fg(LABEL_COLOR));
+        frame.render_widget(msg, inner);
+        return;
+    };
+
+    let ratio = if limit_mb > 0.0 {
+        (current / limit_mb).min(1.0)
+    } else {
+        0.0
+    };
+
+    let pct_val = ratio * 100.0;
+    let label = if limit_mb > 0.0 {
+        format!(
+            "{} / {} ({:.0}%)",
+            format_mb(current),
+            format_mb(limit_mb),
+            pct_val
+        )
+    } else {
+        format_mb(current)
+    };
+
+    let gauge_color = if limit_mb > 0.0 {
+        health_color(pct_val)
+    } else {
+        DISK_COLOR
+    };
+
+    let parts = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(inner);
+
+    if limit_mb > 0.0 {
+        let gauge = Gauge::default()
+            .gauge_style(Style::default().fg(gauge_color))
+            .ratio(ratio)
+            .label(label);
+        frame.render_widget(gauge, parts[0]);
+    } else {
+        let text = Paragraph::new(format!(" Usage: {label}"));
+        frame.render_widget(text, parts[0]);
+    }
+
+    if let Some(ref disk) = app.disk {
+        let stats = Line::from(vec![
+            Span::styled(" Avg: ", Style::default().fg(LABEL_COLOR)),
+            Span::raw(format_gb(disk.average)),
+            Span::styled("  Max: ", Style::default().fg(LABEL_COLOR)),
+            Span::raw(format_gb(disk.max)),
+        ]);
+        frame.render_widget(Paragraph::new(stats), parts[1]);
+    }
+}
+
+fn render_db_stats(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    use crate::controllers::db_stats::types::*;
+
+    let stats = match &app.db_stats {
+        Some(s) => s,
+        None => return,
+    };
+
+    let title = match stats {
+        DatabaseStats::PostgreSQL(_) => "Database Stats (PostgreSQL)",
+        DatabaseStats::Redis(_) => "Database Stats (Redis)",
+        DatabaseStats::MySQL(_) => "Database Stats (MySQL)",
+        DatabaseStats::MongoDB(_) => "Database Stats (MongoDB)",
+    };
+
+    let block = card_block(title);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let l = Style::default().fg(LABEL_COLOR);
+    let v = Style::default().fg(Color::White);
+    let a = Style::default().fg(Color::Cyan);
+    let hint_style = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::ITALIC);
+
+    fn hs(value: f64, warn: f64, crit: f64, inverted: bool) -> Style {
+        if inverted {
+            if value < crit {
+                Style::default().fg(Color::Red)
+            } else if value < warn {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default().fg(Color::Green)
+            }
+        } else if value > crit {
+            Style::default().fg(Color::Red)
+        } else if value > warn {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default().fg(Color::Green)
+        }
+    }
+
+    fn fb(bytes: i64) -> String {
+        if bytes >= 1_073_741_824 {
+            format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
+        } else if bytes >= 1_048_576 {
+            format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+        } else if bytes >= 1024 {
+            format!("{:.1} KB", bytes as f64 / 1024.0)
+        } else {
+            format!("{} B", bytes)
+        }
+    }
+
+    fn fk(n: i64) -> String {
+        if n >= 1_000_000 {
+            format!("{:.1}M", n as f64 / 1_000_000.0)
+        } else if n >= 1000 {
+            format!("{:.1}K", n as f64 / 1000.0)
+        } else {
+            format!("{n}")
+        }
+    }
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    match stats {
+        DatabaseStats::PostgreSQL(pg) => {
+            let util = if pg.connections.max_connections > 0 {
+                pg.connections.total as f64 / pg.connections.max_connections as f64 * 100.0
+            } else {
+                0.0
+            };
+            lines.push(Line::from(vec![
+                Span::styled("Connections  ", l),
+                Span::styled(format!("{}", pg.connections.active), a),
+                Span::styled(" active  ", l),
+                Span::styled(format!("{}", pg.connections.idle), v),
+                Span::styled(" idle  ", l),
+                Span::styled(format!("{}", pg.connections.idle_in_transaction), v),
+                Span::styled(" idle in txn  ", l),
+                Span::styled(
+                    format!(
+                        "{} / {}",
+                        pg.connections.total, pg.connections.max_connections
+                    ),
+                    v,
+                ),
+                Span::raw("  "),
+                Span::styled(format!("({:.0}%)", util), hs(util, 60.0, 80.0, false)),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Cache        ", l),
+                Span::styled(
+                    format!("{:.1}%", pg.cache.hit_ratio * 100.0),
+                    hs(pg.cache.hit_ratio * 100.0, 95.0, 90.0, true),
+                ),
+                Span::styled(" hit ratio  ", l),
+                Span::styled("Deadlocks: ", l),
+                Span::styled(
+                    format!("{}", pg.deadlocks),
+                    if pg.deadlocks > 0 {
+                        Style::default().fg(Color::Red)
+                    } else {
+                        v
+                    },
+                ),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Storage      ", l),
+                Span::styled(fb(pg.database_size.total_bytes), a),
+                Span::styled(" total  ", l),
+                Span::styled(fb(pg.database_size.tables_bytes), v),
+                Span::styled(" tables  ", l),
+                Span::styled(fb(pg.database_size.indexes_bytes), v),
+                Span::styled(" indexes", l),
+            ]));
+            if !pg.index_health.unused_indexes.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::styled("Indexes      ", l),
+                    Span::styled(
+                        format!("{} unused", pg.index_health.unused_indexes.len()),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::styled(
+                        format!(
+                            " ({}) / {} total",
+                            fb(pg.index_health.unused_bytes),
+                            pg.index_health.total_index_count
+                        ),
+                        l,
+                    ),
+                    Span::styled("  — consider removing to save space", hint_style),
+                ]));
+            }
+            if !pg.missing_indexes.is_empty() {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        format!("{} tables may need an index", pg.missing_indexes.len()),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::styled("  (high seq scans, no index scans, >1K rows)", hint_style),
+                ]));
+                for t in pg.missing_indexes.iter().take(3) {
+                    lines.push(Line::from(vec![
+                        Span::styled("             ", l),
+                        Span::styled(truncate_str(&t.table_name, 24), v),
+                        Span::styled(
+                            format!("  {} rows  {} seq scans", fk(t.live_rows), fk(t.seq_scan)),
+                            l,
+                        ),
+                    ]));
+                }
+            }
+            if !pg.table_stats.is_empty() {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    "Table                     Size       Seq Scan   Idx Scan   Dead Rows",
+                    l,
+                )));
+                for t in &pg.table_stats {
+                    let dead_pct = if t.live_tuples + t.dead_tuples > 0 {
+                        t.dead_tuples as f64 / (t.live_tuples + t.dead_tuples) as f64 * 100.0
+                    } else {
+                        0.0
+                    };
+                    let name = truncate_str(&t.table_name, 24);
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("{:<24}", name), v),
+                        Span::styled(format!("  {:>8}", fb(t.size_bytes)), v),
+                        Span::styled(format!("  {:>9}", fk(t.seq_scan)), v),
+                        Span::styled(format!("  {:>9}", fk(t.idx_scan)), v),
+                        Span::styled(
+                            format!("  {:>7.1}%", dead_pct),
+                            hs(dead_pct, 5.0, 10.0, false),
+                        ),
+                    ]));
+                }
+            }
+            if let Some(ref queries) = pg.query_stats {
+                if !queries.is_empty() {
+                    lines.push(Line::default());
+                    lines.push(Line::from(Span::styled(
+                        "Calls     Total       Mean      Query (pg_stat_statements)",
+                        l,
+                    )));
+                    for q in queries {
+                        lines.push(Line::from(vec![
+                            Span::styled(format!("{:>7}", fk(q.calls)), v),
+                            Span::styled(format!("  {:>9}", fmt_duration(q.total_time_ms)), v),
+                            Span::styled(format!("  {:>8}", fmt_duration(q.mean_time_ms)), v),
+                            Span::styled(
+                                format!("  {}", truncate_str(&q.query, 55)),
+                                Style::default().fg(Color::DarkGray),
+                            ),
+                        ]));
+                    }
+                }
+            } else {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled("Query stats unavailable — enable pg_stat_statements to track query performance", hint_style)));
+                lines.push(Line::from(Span::styled(
+                    "Add pg_stat_statements to shared_preload_libraries and restart the database",
+                    hint_style,
+                )));
+            }
+            let needs_vacuum: Vec<_> = pg
+                .vacuum_health
+                .iter()
+                .filter(|t| t.dead_rows_pct > 10.0)
+                .collect();
+            let needs_freeze: Vec<_> = pg
+                .vacuum_health
+                .iter()
+                .filter(|t| t.xid_age > 150_000_000)
+                .collect();
+            if !needs_vacuum.is_empty() || !needs_freeze.is_empty() {
+                lines.push(Line::default());
+                let mut spans = vec![Span::styled("Vacuum       ", l)];
+                if !needs_vacuum.is_empty() {
+                    spans.push(Span::styled(
+                        format!("{} tables need vacuum", needs_vacuum.len()),
+                        Style::default().fg(Color::Yellow),
+                    ));
+                    spans.push(Span::styled("  ", l));
+                }
+                if !needs_freeze.is_empty() {
+                    spans.push(Span::styled(
+                        format!("{} need freeze (XID wraparound risk)", needs_freeze.len()),
+                        Style::default().fg(Color::Red),
+                    ));
+                }
+                lines.push(Line::from(spans));
+            }
+        }
+        DatabaseStats::Redis(r) => {
+            lines.push(Line::from(vec![
+                Span::styled("Server       ", l),
+                Span::styled(format!("v{}", r.server.version), a),
+                Span::styled("  Clients: ", l),
+                Span::styled(format!("{}", r.server.connected_clients), v),
+                Span::styled("  Blocked: ", l),
+                Span::styled(format!("{}", r.server.blocked_clients), v),
+                Span::styled("  Ops/sec: ", l),
+                Span::styled(format!("{:.0}", r.throughput.ops_per_sec), a),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Memory       ", l),
+                Span::styled(fb(r.memory.used_bytes), a),
+                Span::styled(" used  ", l),
+                Span::styled(fb(r.memory.peak_bytes), v),
+                Span::styled(" peak  ", l),
+                Span::styled(format!("{:.2}x", r.memory.fragmentation_ratio), v),
+                Span::styled(" frag  ", l),
+                Span::styled(&r.memory.eviction_policy, v),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Cache        ", l),
+                Span::styled(
+                    format!("{:.1}%", r.cache.hit_rate * 100.0),
+                    hs(r.cache.hit_rate * 100.0, 95.0, 90.0, true),
+                ),
+                Span::styled(" hit rate  ", l),
+                Span::styled(fk(r.cache.hits), v),
+                Span::styled(" hits  ", l),
+                Span::styled(fk(r.cache.misses), v),
+                Span::styled(" misses  ", l),
+                Span::styled(fk(r.cache.expired_keys), v),
+                Span::styled(" expired", l),
+            ]));
+            if !r.keyspace.is_empty() {
+                lines.push(Line::default());
+                lines.push(Line::from(Span::styled(
+                    "DB       Keys       Expires    Avg TTL",
+                    l,
+                )));
+                for db in &r.keyspace {
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("db{:<5}", db.db_index), v),
+                        Span::styled(format!("  {:>9}", fk(db.keys)), v),
+                        Span::styled(format!("  {:>9}", fk(db.expires)), v),
+                        Span::styled(
+                            if db.avg_ttl > 0 {
+                                format!("  {:>9}", format!("{}ms", fk(db.avg_ttl)))
+                            } else {
+                                "          -".to_string()
+                            },
+                            l,
+                        ),
+                    ]));
+                }
+            }
+        }
+        DatabaseStats::MySQL(my) => {
+            let util = if my.connections.max_connections > 0 {
+                my.connections.threads_connected as f64 / my.connections.max_connections as f64
+                    * 100.0
+            } else {
+                0.0
+            };
+            lines.push(Line::from(vec![
+                Span::styled("Connections  ", l),
+                Span::styled(format!("{}", my.connections.threads_connected), a),
+                Span::styled(
+                    format!(" / {} connected  ", my.connections.max_connections),
+                    l,
+                ),
+                Span::styled(format!("{}", my.connections.threads_running), v),
+                Span::styled(" running  ", l),
+                Span::styled(format!("({:.0}%)", util), hs(util, 60.0, 80.0, false)),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Buffer Pool  ", l),
+                Span::styled(
+                    format!("{:.1}%", my.buffer_pool.hit_ratio * 100.0),
+                    hs(my.buffer_pool.hit_ratio * 100.0, 95.0, 90.0, true),
+                ),
+                Span::styled(" hit ratio  ", l),
+                Span::styled(fb(my.buffer_pool.total_bytes), v),
+                Span::styled(format!("  {:.0}% used", my.buffer_pool.usage_pct), l),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Queries      ", l),
+                Span::styled(fk(my.queries.selects), v),
+                Span::styled(" sel  ", l),
+                Span::styled(fk(my.queries.inserts), v),
+                Span::styled(" ins  ", l),
+                Span::styled(fk(my.queries.updates), v),
+                Span::styled(" upd  ", l),
+                Span::styled(fk(my.queries.deletes), v),
+                Span::styled(" del  ", l),
+                Span::styled(
+                    format!("{} slow", my.queries.slow_queries),
+                    if my.queries.slow_queries > 0 {
+                        Style::default().fg(Color::Yellow)
+                    } else {
+                        l
+                    },
+                ),
+            ]));
+        }
+        DatabaseStats::MongoDB(m) => {
+            lines.push(Line::from(vec![
+                Span::styled("Connections  ", l),
+                Span::styled(format!("{}", m.connections.current), a),
+                Span::styled(format!(" / {} available  ", m.connections.available), l),
+                Span::styled(fk(m.connections.total_created), v),
+                Span::styled(" total created", l),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Operations   ", l),
+                Span::styled(fk(m.operations.query), v),
+                Span::styled(" query  ", l),
+                Span::styled(fk(m.operations.insert), v),
+                Span::styled(" insert  ", l),
+                Span::styled(fk(m.operations.update), v),
+                Span::styled(" update  ", l),
+                Span::styled(fk(m.operations.delete), v),
+                Span::styled(" delete  ", l),
+                Span::styled(fk(m.operations.command), v),
+                Span::styled(" cmd", l),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled("Memory       ", l),
+                Span::styled(format!("{} MB", m.memory.resident_mb), a),
+                Span::styled(" resident  ", l),
+                Span::styled(format!("{} MB", m.memory.virtual_mb), v),
+                Span::styled(" virtual", l),
+            ]));
+            if m.wired_tiger.cache_max_bytes > 0 {
+                let util = m.wired_tiger.cache_used_bytes as f64
+                    / m.wired_tiger.cache_max_bytes as f64
+                    * 100.0;
+                lines.push(Line::from(vec![
+                    Span::styled("WT Cache     ", l),
+                    Span::styled(fb(m.wired_tiger.cache_used_bytes), v),
+                    Span::styled(format!(" / {}", fb(m.wired_tiger.cache_max_bytes)), l),
+                    Span::raw("  "),
+                    Span::styled(format!("({:.0}%)", util), hs(util, 80.0, 95.0, false)),
+                ]));
+            }
+        }
+    }
+
+    // Scrollable: use Paragraph::scroll
+    let total_lines = lines.len() as u16;
+    let visible = inner.height;
+    let max_scroll = total_lines.saturating_sub(visible);
+
+    // Clamp scroll offset
+    let scroll = app.db_stats_scroll.min(max_scroll);
+
+    if total_lines > visible {
+        // Add scroll hint at the bottom of the block title
+        let scroll_hint = format!(" ↑↓ {}/{} ", scroll + 1, max_scroll + 1);
+        let hint_span = Span::styled(scroll_hint, Style::default().fg(Color::DarkGray));
+        let hint_width = hint_span.width() as u16;
+        let hint_area = Rect {
+            x: area.x + area.width.saturating_sub(hint_width + 2),
+            y: area.y + area.height.saturating_sub(1),
+            width: hint_width,
+            height: 1,
+        };
+        frame.render_widget(Paragraph::new(Line::from(hint_span)), hint_area);
+    }
+
+    let paragraph = Paragraph::new(lines).scroll((scroll, 0));
+    frame.render_widget(paragraph, inner);
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else if max <= 1 {
+        "…".repeat(max)
+    } else {
+        format!(
+            "{}…",
+            s.chars().take(max.saturating_sub(1)).collect::<String>()
+        )
+    }
+}
+
+fn fmt_duration(ms: f64) -> String {
+    if ms >= 1000.0 {
+        format!("{:.1}s", ms / 1000.0)
+    } else if ms >= 1.0 {
+        format!("{:.1}ms", ms)
+    } else {
+        format!("{:.0}µs", ms * 1000.0)
+    }
+}
+
+fn render_service_help_bar(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let key_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let on_style = Style::default().fg(Color::White);
+    let off_style = Style::default().fg(Color::DarkGray);
+
+    let cpu_style = if app.show_cpu { on_style } else { off_style };
+    let mem_style = if app.show_memory { on_style } else { off_style };
+    let net_style = if app.show_network {
+        on_style
+    } else {
+        off_style
+    };
+    let vol_style = if app.show_volume { on_style } else { off_style };
+    let http_style = if app.show_http && !app.is_db {
+        on_style
+    } else {
+        off_style
+    };
+
+    let help = Line::from(vec![
+        Span::raw(" "),
+        Span::styled("1", key_style),
+        Span::styled(" cpu ", cpu_style),
+        Span::styled("2", key_style),
+        Span::styled(" mem ", mem_style),
+        Span::styled("3", key_style),
+        Span::styled(" net ", net_style),
+        Span::styled("4", key_style),
+        Span::styled(" vol ", vol_style),
+        Span::styled("5", key_style),
+        Span::styled(" http ", http_style),
+        Span::styled(" · ", Style::default().fg(LABEL_COLOR)),
+        Span::styled(if app.db_stats_supported { "Tab" } else { "" }, key_style),
+        Span::styled(
+            if app.db_stats_supported {
+                " switch view "
+            } else {
+                ""
+            },
+            Style::default().fg(LABEL_COLOR),
+        ),
+        Span::styled("t", key_style),
+        Span::styled(
+            format!(" {} ", app.time_range_label()),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled("r", key_style),
+        Span::styled(" refresh ", Style::default().fg(LABEL_COLOR)),
+        Span::styled("?", key_style),
+        Span::styled(" help ", Style::default().fg(LABEL_COLOR)),
+        Span::styled("q", key_style),
+        Span::styled(" quit", Style::default().fg(LABEL_COLOR)),
+    ]);
+
+    frame.render_widget(Paragraph::new(help), area);
+}
+
+// ─── Project-wide rendering ──────────────────────────────────────────────────
+
+pub fn render_project(app: &ProjectApp, frame: &mut Frame) {
+    let area = frame.area();
+
+    if area.width < 60 || area.height < 20 {
+        let msg = Paragraph::new("Terminal too small. Please resize (min 60x20).")
+            .style(Style::default().fg(Color::Yellow));
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let max_table_body = (area.height / 3).max(3);
+    let table_body_rows = (app.services.len() as u16).min(max_table_body).max(1);
+
+    let chunks = Layout::vertical([
+        Constraint::Length(2),               // header
+        Constraint::Length(2),               // table header
+        Constraint::Length(table_body_rows), // table body (scrollable)
+        Constraint::Min(10),                 // detail panel
+        Constraint::Length(1),               // help bar
+    ])
+    .spacing(CARD_SPACING)
+    .split(area);
+
+    render_project_header(app, frame, chunks[0]);
+    render_table_header(frame, chunks[1]);
+    render_scrollable_services_table(app, frame, chunks[2]);
+    render_detail_panel(app, frame, chunks[3]);
+    render_project_help_bar(app, frame, chunks[4]);
+
+    if let Some(ref err) = app.error_message {
+        let err_area = Rect {
+            y: chunks[3].y,
+            height: 1,
+            ..chunks[3]
+        };
+        let err_line = Paragraph::new(format!(" {err}")).style(Style::default().fg(Color::Red));
+        frame.render_widget(err_line, err_area);
+    }
+
+    if app.show_help {
+        render_help_overlay(frame, area);
+    }
+}
+
+fn render_project_header(app: &ProjectApp, frame: &mut Frame, area: Rect) {
+    let refresh_str = app
+        .last_refresh
+        .map(|t| t.format("%H:%M:%S").to_string())
+        .unwrap_or_else(|| "loading...".to_string());
+
+    let header = Line::from(vec![
+        Span::styled(
+            format!("  {}", app.project_name),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::raw(format!("env {}", app.environment_name)),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::raw(format!("last {}", app.time_range_label())),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::styled(
+            format!("refreshed {refresh_str}"),
+            Style::default().fg(LABEL_COLOR),
+        ),
+        Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
+        Span::raw(format!("{} services", app.services.len())),
+    ]);
+
+    frame.render_widget(Paragraph::new(vec![header, Line::from("")]), area);
+}
+
+fn render_table_header(frame: &mut Frame, area: Rect) {
+    let header_style = Style::default()
+        .fg(LABEL_COLOR)
+        .add_modifier(Modifier::BOLD);
+
+    let header = Line::from(vec![
+        Span::styled(format!("    {:<22}", "Service"), header_style),
+        Span::styled(format!("{:<16}", "CPU"), header_style),
+        Span::styled(format!("{:<16}", "Memory"), header_style),
+        Span::styled(format!("{:<10}", "Disk"), header_style),
+        Span::styled(format!("{:<10}", "Reqs"), header_style),
+        Span::styled(format!("{:<8}", "Err%"), header_style),
+        Span::styled("p50", header_style),
+    ]);
+    let separator = Line::from(format!(
+        "  {}",
+        "─".repeat(area.width.saturating_sub(3) as usize)
+    ));
+
+    frame.render_widget(Paragraph::new(vec![header, separator]), area);
+}
+
+fn render_scrollable_services_table(app: &ProjectApp, frame: &mut Frame, area: Rect) {
+    if app.services.is_empty() {
+        let msg = Paragraph::new("  No services found.").style(Style::default().fg(LABEL_COLOR));
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let visible_rows = area.height as usize;
+    let start = app.table_scroll_offset;
+    let end = (start + visible_rows).min(app.services.len());
+
+    let constraints: Vec<Constraint> = (start..end)
+        .map(|_| Constraint::Length(1))
+        .chain(std::iter::once(Constraint::Min(0)))
+        .collect();
+    let rows = Layout::vertical(constraints).split(area);
+
+    for (row_idx, svc_idx) in (start..end).enumerate() {
+        let svc = &app.services[svc_idx];
+        let is_selected = svc_idx == app.selected_idx;
+
+        // Service name with DB indicator
+        let db_tag = if svc.is_database { " ◆" } else { "" };
+        let col_width = 20usize;
+        let tag_len = db_tag.chars().count();
+        let avail = col_width.saturating_sub(tag_len);
+        let raw = format!("{}{}", truncate_str(&svc.service_name, avail), db_tag);
+        let name = format!("{:<col_width$}", raw);
+
+        let cpu_str = svc
+            .cpu
+            .as_ref()
+            .map(|c| {
+                let val = format_cpu(c.current);
+                let color = svc
+                    .cpu_limit
+                    .as_ref()
+                    .filter(|l| l.current > 0.0)
+                    .and_then(|l| utilization(c.current, Some(l.current)))
+                    .map(health_color)
+                    .unwrap_or(Color::White);
+                (val, color)
+            })
+            .unwrap_or(("—".to_string(), LABEL_COLOR));
+
+        let mem_str = svc
+            .memory
+            .as_ref()
+            .map(|m| {
+                let val = format_gb(m.current);
+                let color = svc
+                    .memory_limit
+                    .as_ref()
+                    .filter(|l| l.current > 0.0)
+                    .and_then(|l| utilization(m.current, Some(l.current)))
+                    .map(health_color)
+                    .unwrap_or(Color::White);
+                (val, color)
+            })
+            .unwrap_or(("—".to_string(), LABEL_COLOR));
+
+        let disk_str = if let Some(vol) = svc.volumes.first() {
+            format_mb(vol.current_size_mb)
+        } else {
+            "—".to_string()
+        };
+
+        let (reqs_str, err_str, err_color, p50_str) = if svc.is_database {
+            ("—".into(), "—".into(), LABEL_COLOR, "—".into())
+        } else if let Some(ref http) = svc.http {
+            (
+                format_count(http.total),
+                format!("{:.1}%", http.error_rate),
+                error_rate_color(http.error_rate),
+                format!("{}ms", http.p50_ms),
+            )
+        } else {
+            ("—".into(), "—".into(), LABEL_COLOR, "—".into())
+        };
+
+        let cursor = if is_selected { "▸" } else { " " };
+        let name_style = if is_selected {
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+
+        let line = Line::from(vec![
+            Span::styled(format!(" {cursor} "), Style::default().fg(Color::Yellow)),
+            Span::styled(format!("{:<22}", name), name_style),
+            Span::styled(format!("{:<16}", cpu_str.0), Style::default().fg(cpu_str.1)),
+            Span::styled(format!("{:<16}", mem_str.0), Style::default().fg(mem_str.1)),
+            Span::styled(
+                format!("{:<10}", disk_str),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(
+                format!("{:<10}", reqs_str),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(format!("{:<8}", err_str), Style::default().fg(err_color)),
+            Span::styled(p50_str, Style::default().fg(Color::White)),
+        ]);
+
+        frame.render_widget(Paragraph::new(line), rows[row_idx]);
+    }
+
+    // Scroll indicators
+    if start > 0 {
+        let indicator = Span::styled(" ▴", Style::default().fg(LABEL_COLOR));
+        let r = Rect {
+            x: area.x + area.width.saturating_sub(3),
+            y: area.y,
+            width: 2,
+            height: 1,
+        };
+        frame.render_widget(Paragraph::new(Line::from(indicator)), r);
+    }
+    if end < app.services.len() {
+        let indicator = Span::styled(" ▾", Style::default().fg(LABEL_COLOR));
+        let r = Rect {
+            x: area.x + area.width.saturating_sub(3),
+            y: area.y + area.height.saturating_sub(1),
+            width: 2,
+            height: 1,
+        };
+        frame.render_widget(Paragraph::new(Line::from(indicator)), r);
+    }
+}
+
+fn render_detail_panel(app: &ProjectApp, frame: &mut Frame, area: Rect) {
+    let svc = match app.selected_service() {
+        Some(s) => s,
+        None => {
+            let msg =
+                Paragraph::new("  No service selected").style(Style::default().fg(LABEL_COLOR));
+            frame.render_widget(msg, area);
+            return;
+        }
+    };
+
+    let detail = match app.detail_cache.get(&svc.service_id) {
+        Some(entry) if entry.time_range_idx == app.time_range_idx => entry,
+        _ => {
+            let msg = Paragraph::new(format!("  Loading {}...", svc.service_name))
+                .style(Style::default().fg(LABEL_COLOR));
+            frame.render_widget(msg, area);
+            return;
+        }
+    };
+
+    // Split: service name header + chart area
+    let parts = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
+
+    let db_label = if svc.is_database { " (database)" } else { "" };
+    let detail_header = Line::from(vec![Span::styled(
+        format!("  {}{db_label}", svc.service_name),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]);
+    frame.render_widget(Paragraph::new(detail_header), parts[0]);
+
+    let temp_app = MetricsApp {
+        service_name: svc.service_name.clone(),
+        environment_name: app.environment_name.clone(),
+        is_db: detail.is_database,
+        db_stats_supported: false,
+        active_tab: ActiveTab::Metrics,
+        show_cpu: app.show_cpu,
+        show_memory: app.show_memory,
+        show_network: app.show_network,
+        show_volume: app.show_volume,
+        show_http: app.show_http,
+        show_egress: app.show_egress,
+        show_ingress: app.show_ingress,
+        show_2xx: app.show_2xx,
+        show_3xx: app.show_3xx,
+        show_4xx: app.show_4xx,
+        show_5xx: app.show_5xx,
+        show_p50: app.show_p50,
+        show_p90: app.show_p90,
+        show_p95: app.show_p95,
+        show_p99: app.show_p99,
+        time_range_idx: app.time_range_idx,
+        time_range_changed: false,
+        cpu: detail.cpu.clone(),
+        cpu_limit: detail.cpu_limit.clone(),
+        memory: detail.memory.clone(),
+        memory_limit: detail.memory_limit.clone(),
+        network_tx: detail.network_tx.clone(),
+        network_rx: detail.network_rx.clone(),
+        disk: detail.disk.clone(),
+        volumes: detail.volumes.clone(),
+        http: detail.http.clone(),
+        db_stats: None,
+        db_stats_error: None,
+        db_stats_handle: None,
+        db_stats_scroll: 0,
+        last_refresh: Some(detail.fetched_at),
+        error_message: None,
+        show_help: false,
+        force_refresh: false,
+    };
+
+    render_detail_charts(&temp_app, frame, parts[1]);
+}
+
+/// Render the chart dashboard for a service into a sub-area.
+/// Extracted from render_service() — same layout minus header and help bar.
+fn render_detail_charts(app: &MetricsApp, frame: &mut Frame, area: Rect) {
+    let show_cpu_mem = app.show_cpu || app.show_memory;
+    let show_net_req = app.show_network || (app.show_http && !app.is_db);
+    let show_err_resp = app.show_http && !app.is_db;
+    let show_vol = app.show_volume && (!app.volumes.is_empty() || app.disk.is_some());
+
+    let mut constraints: Vec<Constraint> = vec![];
+    let mut chart_rows = 0u32;
+    if show_cpu_mem {
+        chart_rows += 1;
+    }
+    if show_net_req {
+        chart_rows += 1;
+    }
+    if show_err_resp {
+        chart_rows += 1;
+    }
+    let chart_rows = chart_rows.max(1);
+
+    if show_cpu_mem {
+        constraints.push(Constraint::Ratio(1, chart_rows));
+    }
+    if show_net_req {
+        constraints.push(Constraint::Ratio(1, chart_rows));
+    }
+    if show_err_resp {
+        constraints.push(Constraint::Ratio(1, chart_rows));
+    }
+    if show_vol {
+        constraints.push(Constraint::Length(6)); // border(2) + padding(2) + gauge(1) + stats(1)
+    }
+    constraints.push(Constraint::Min(0)); // filler
+
+    let chunks = Layout::vertical(constraints)
+        .spacing(CARD_SPACING)
+        .split(area);
+
+    let mut idx = 0;
+    if show_cpu_mem {
+        render_cpu_memory(app, frame, chunks[idx]);
+        idx += 1;
+    }
+    if show_net_req {
+        render_network_http(app, frame, chunks[idx]);
+        idx += 1;
+    }
+    if show_err_resp {
+        let row_cols = Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .spacing(CARD_SPACING)
+            .split(chunks[idx]);
+        render_error_rate_chart(app, frame, row_cols[0]);
+        render_http_latency(app, frame, row_cols[1]);
+        idx += 1;
+    }
+    if show_vol {
+        render_volume(app, frame, chunks[idx]);
+    }
+}
+
+fn render_project_help_bar(app: &ProjectApp, frame: &mut Frame, area: Rect) {
+    let key_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let on_style = Style::default().fg(Color::White);
+    let off_style = Style::default().fg(Color::DarkGray);
+
+    let cpu_style = if app.show_cpu { on_style } else { off_style };
+    let mem_style = if app.show_memory { on_style } else { off_style };
+    let net_style = if app.show_network {
+        on_style
+    } else {
+        off_style
+    };
+    let http_style = if app.show_http { on_style } else { off_style };
+
+    let help = Line::from(vec![
+        Span::raw(" "),
+        Span::styled("j/k", key_style),
+        Span::styled(" nav ", Style::default().fg(LABEL_COLOR)),
+        Span::styled("1", key_style),
+        Span::styled(" cpu ", cpu_style),
+        Span::styled("2", key_style),
+        Span::styled(" mem ", mem_style),
+        Span::styled("3", key_style),
+        Span::styled(" net ", net_style),
+        Span::styled("5", key_style),
+        Span::styled(" http ", http_style),
+        Span::styled(" · ", Style::default().fg(LABEL_COLOR)),
+        Span::styled("t", key_style),
+        Span::styled(
+            format!(" {} ", app.time_range_label()),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled("r", key_style),
+        Span::styled(" refresh ", Style::default().fg(LABEL_COLOR)),
+        Span::styled("?", key_style),
+        Span::styled(" help ", Style::default().fg(LABEL_COLOR)),
+        Span::styled("q", key_style),
+        Span::styled(" quit", Style::default().fg(LABEL_COLOR)),
+    ]);
+
+    frame.render_widget(Paragraph::new(help), area);
+}
+
+// ─── Shared widgets ──────────────────────────────────────────────────────────
+
+fn render_help_overlay(frame: &mut Frame, area: Rect) {
+    let width = 52u16.min(area.width.saturating_sub(4));
+    let height = 26u16.min(area.height.saturating_sub(4));
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let overlay = Rect::new(x, y, width, height);
+
+    let clear = Paragraph::new(vec![Line::from(""); height as usize])
+        .style(Style::default().bg(Color::Black));
+    frame.render_widget(clear, overlay);
+
+    let block = Block::default()
+        .title(" Help ")
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let inner = block.inner(overlay);
+    frame.render_widget(block, overlay);
+
+    let key_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let section = Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::BOLD);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled("  Navigation", section)]),
+        Line::from(vec![
+            Span::styled("  j/k ↑↓ ", key_style),
+            Span::raw("Select service"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  Sections", section)]),
+        Line::from(vec![
+            Span::styled("  1-5    ", key_style),
+            Span::raw("Toggle metric sections"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  Network filters", section)]),
+        Line::from(vec![
+            Span::styled("  e      ", key_style),
+            Span::raw("Toggle Egress"),
+        ]),
+        Line::from(vec![
+            Span::styled("  i      ", key_style),
+            Span::raw("Toggle Ingress"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  HTTP status filters", section)]),
+        Line::from(vec![
+            Span::styled("  6-9    ", key_style),
+            Span::raw("Toggle 2xx / 3xx / 4xx / 5xx"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  Response time filters", section)]),
+        Line::from(vec![
+            Span::styled("  F1-F4  ", key_style),
+            Span::raw("Toggle p50 / p90 / p95 / p99"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled("  General", section)]),
+        Line::from(vec![
+            Span::styled("  t      ", key_style),
+            Span::raw("Cycle time range (1h/6h/1d/7d/30d)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  r      ", key_style),
+            Span::raw("Force refresh now"),
+        ]),
+        Line::from(vec![
+            Span::styled("  q/Esc  ", key_style),
+            Span::raw("Quit"),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "  Press any key to close",
+            Style::default().fg(LABEL_COLOR),
+        )]),
+    ];
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}

--- a/src/controllers/metrics_tui/ui.rs
+++ b/src/controllers/metrics_tui/ui.rs
@@ -61,10 +61,15 @@ fn error_rate_color(rate: f64) -> Color {
 /// Convert raw metric data points to (f64, f64) for Chart datasets.
 /// X = seconds since first point, Y = value
 fn to_chart_data(points: &[MetricDataPoint]) -> Vec<(f64, f64)> {
-    if points.is_empty() {
+    let Some(first) = points.first() else {
         return vec![];
-    }
-    let t0 = points[0].ts as f64;
+    };
+    to_chart_data_from(points, first.ts)
+}
+
+/// Convert points to chart coordinates using a shared timestamp origin.
+fn to_chart_data_from(points: &[MetricDataPoint], origin_ts: i64) -> Vec<(f64, f64)> {
+    let t0 = origin_ts as f64;
     points.iter().map(|p| (p.ts as f64 - t0, p.value)).collect()
 }
 
@@ -73,8 +78,32 @@ fn time_bounds_and_labels(points: &[MetricDataPoint]) -> (f64, f64, Vec<String>)
     if points.is_empty() {
         return (0.0, 1.0, vec![]);
     }
-    let t0 = points[0].ts as f64;
-    let t_end = points.last().unwrap().ts as f64;
+    time_bounds_and_labels_from_range(points[0].ts, points.last().unwrap().ts)
+}
+
+/// Build shared X-axis bounds and labels for multiple series in one chart.
+fn time_bounds_and_labels_for_series(
+    series: &[&[MetricDataPoint]],
+) -> (i64, f64, f64, Vec<String>) {
+    let Some(start_ts) = series
+        .iter()
+        .filter_map(|points| points.first().map(|point| point.ts))
+        .min()
+    else {
+        return (0, 0.0, 1.0, vec![]);
+    };
+    let end_ts = series
+        .iter()
+        .filter_map(|points| points.last().map(|point| point.ts))
+        .max()
+        .unwrap_or(start_ts);
+    let (x_min, x_max, labels) = time_bounds_and_labels_from_range(start_ts, end_ts);
+    (start_ts, x_min, x_max, labels)
+}
+
+fn time_bounds_and_labels_from_range(start_ts: i64, end_ts: i64) -> (f64, f64, Vec<String>) {
+    let t0 = start_ts as f64;
+    let t_end = end_ts as f64;
     let range = (t_end - t0).max(1.0);
 
     let num_labels = 4;
@@ -251,13 +280,11 @@ fn render_metrics_content(app: &MetricsApp, frame: &mut Frame, area: Rect) {
     }
     if net_vol_combined {
         chart_rows += 1;
-    } else {
-        if show_net_req {
-            chart_rows += 1;
-        }
-        if show_err_resp {
-            chart_rows += 1;
-        }
+    } else if show_net_req {
+        chart_rows += 1;
+    }
+    if show_err_resp {
+        chart_rows += 1;
     }
     let chart_rows = chart_rows.max(1);
 
@@ -270,9 +297,11 @@ fn render_metrics_content(app: &MetricsApp, frame: &mut Frame, area: Rect) {
         if show_net_req {
             constraints.push(Constraint::Ratio(1, chart_rows));
         }
-        if show_err_resp {
-            constraints.push(Constraint::Ratio(1, chart_rows));
-        }
+    }
+    if show_err_resp {
+        constraints.push(Constraint::Ratio(1, chart_rows));
+    }
+    if !net_vol_combined {
         if show_vol {
             constraints.push(Constraint::Length(6));
         }
@@ -300,19 +329,19 @@ fn render_metrics_content(app: &MetricsApp, frame: &mut Frame, area: Rect) {
             render_network_http(app, frame, chunks[idx]);
             idx += 1;
         }
-        if show_err_resp {
-            let row3_cols =
-                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                    .spacing(CARD_SPACING)
-                    .split(chunks[idx]);
-            render_error_rate_chart(app, frame, row3_cols[0]);
-            render_http_latency(app, frame, row3_cols[1]);
-            idx += 1;
-        }
-        if show_vol {
-            render_volume(app, frame, chunks[idx]);
-            idx += 1;
-        }
+    }
+    if show_err_resp {
+        let row3_cols =
+            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .spacing(CARD_SPACING)
+                .split(chunks[idx]);
+        render_error_rate_chart(app, frame, row3_cols[0]);
+        render_http_latency(app, frame, row3_cols[1]);
+        idx += 1;
+    }
+    if !net_vol_combined && show_vol {
+        render_volume(app, frame, chunks[idx]);
+        idx += 1;
     }
 
     if let Some(ref err) = app.error_message {
@@ -575,27 +604,31 @@ fn render_network_chart(app: &MetricsApp, frame: &mut Frame, area: Rect) {
     ])
     .split(inner);
 
-    let ref_points = app
+    let tx_points = app
         .network_tx
         .as_ref()
-        .filter(|t| !t.raw_values.is_empty())
-        .or(app.network_rx.as_ref())
-        .map(|m| &m.raw_values[..])
+        .map(|m| m.raw_values.as_slice())
+        .unwrap_or(&[]);
+    let rx_points = app
+        .network_rx
+        .as_ref()
+        .map(|m| m.raw_values.as_slice())
         .unwrap_or(&[]);
 
-    let (x_min, x_max, x_labels) = time_bounds_and_labels(ref_points);
+    let (origin_ts, x_min, x_max, x_labels) =
+        time_bounds_and_labels_for_series(&[tx_points, rx_points]);
 
     let tx_data = app
         .network_tx
         .as_ref()
         .filter(|_| app.show_egress)
-        .map(|t| to_chart_data(&t.raw_values))
+        .map(|t| to_chart_data_from(&t.raw_values, origin_ts))
         .unwrap_or_default();
     let rx_data = app
         .network_rx
         .as_ref()
         .filter(|_| app.show_ingress)
-        .map(|r| to_chart_data(&r.raw_values))
+        .map(|r| to_chart_data_from(&r.raw_values, origin_ts))
         .unwrap_or_default();
 
     let mut y_max = 0.0f64;
@@ -701,37 +734,32 @@ fn render_http_requests(app: &MetricsApp, frame: &mut Frame, area: Rect) {
 
     if has_ts {
         let ts = http.time_series.as_ref().unwrap();
+        let (origin_ts, x_min, x_max, x_labels) = time_bounds_and_labels_for_series(&[
+            &ts.status_2xx_ts,
+            &ts.status_3xx_ts,
+            &ts.status_4xx_ts,
+            &ts.status_5xx_ts,
+        ]);
         let data_2xx = if app.show_2xx {
-            to_chart_data(&ts.status_2xx_ts)
+            to_chart_data_from(&ts.status_2xx_ts, origin_ts)
         } else {
             vec![]
         };
         let data_3xx = if app.show_3xx {
-            to_chart_data(&ts.status_3xx_ts)
+            to_chart_data_from(&ts.status_3xx_ts, origin_ts)
         } else {
             vec![]
         };
         let data_4xx = if app.show_4xx {
-            to_chart_data(&ts.status_4xx_ts)
+            to_chart_data_from(&ts.status_4xx_ts, origin_ts)
         } else {
             vec![]
         };
         let data_5xx = if app.show_5xx {
-            to_chart_data(&ts.status_5xx_ts)
+            to_chart_data_from(&ts.status_5xx_ts, origin_ts)
         } else {
             vec![]
         };
-
-        let ref_ts = if !ts.status_2xx_ts.is_empty() {
-            &ts.status_2xx_ts
-        } else if !ts.status_5xx_ts.is_empty() {
-            &ts.status_5xx_ts
-        } else if !ts.status_4xx_ts.is_empty() {
-            &ts.status_4xx_ts
-        } else {
-            &ts.status_3xx_ts
-        };
-        let (x_min, x_max, x_labels) = time_bounds_and_labels(ref_ts);
 
         let mut y_max = 0.0f64;
         for (_, v) in data_2xx
@@ -984,27 +1012,28 @@ fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
     ])
     .split(inner);
 
+    let (origin_ts, x_min, x_max, x_labels) =
+        time_bounds_and_labels_for_series(&[&ts.p50_ts, &ts.p90_ts, &ts.p95_ts, &ts.p99_ts]);
     let p50_data = if app.show_p50 {
-        to_chart_data(&ts.p50_ts)
+        to_chart_data_from(&ts.p50_ts, origin_ts)
     } else {
         vec![]
     };
     let p90_data = if app.show_p90 {
-        to_chart_data(&ts.p90_ts)
+        to_chart_data_from(&ts.p90_ts, origin_ts)
     } else {
         vec![]
     };
     let p95_data = if app.show_p95 {
-        to_chart_data(&ts.p95_ts)
+        to_chart_data_from(&ts.p95_ts, origin_ts)
     } else {
         vec![]
     };
     let p99_data = if app.show_p99 {
-        to_chart_data(&ts.p99_ts)
+        to_chart_data_from(&ts.p99_ts, origin_ts)
     } else {
         vec![]
     };
-    let (x_min, x_max, x_labels) = time_bounds_and_labels(&ts.p50_ts);
 
     let mut y_max = 0.0f64;
     for (_, v) in p50_data

--- a/src/controllers/metrics_tui/ui.rs
+++ b/src/controllers/metrics_tui/ui.rs
@@ -58,27 +58,10 @@ fn error_rate_color(rate: f64) -> Color {
 
 // ─── Data helpers ────────────────────────────────────────────────────────────
 
-/// Convert raw metric data points to (f64, f64) for Chart datasets.
-/// X = seconds since first point, Y = value
-fn to_chart_data(points: &[MetricDataPoint]) -> Vec<(f64, f64)> {
-    let Some(first) = points.first() else {
-        return vec![];
-    };
-    to_chart_data_from(points, first.ts)
-}
-
 /// Convert points to chart coordinates using a shared timestamp origin.
 fn to_chart_data_from(points: &[MetricDataPoint], origin_ts: i64) -> Vec<(f64, f64)> {
     let t0 = origin_ts as f64;
     points.iter().map(|p| (p.ts as f64 - t0, p.value)).collect()
-}
-
-/// Build X-axis time labels from data points
-fn time_bounds_and_labels(points: &[MetricDataPoint]) -> (f64, f64, Vec<String>) {
-    if points.is_empty() {
-        return (0.0, 1.0, vec![]);
-    }
-    time_bounds_and_labels_from_range(points[0].ts, points.last().unwrap().ts)
 }
 
 /// Build shared X-axis bounds and labels for multiple series in one chart.
@@ -399,6 +382,11 @@ fn render_header(app: &MetricsApp, frame: &mut Frame, area: Rect) {
             format!("refreshed {refresh_str}"),
             Style::default().fg(LABEL_COLOR),
         ),
+        if app.refreshing {
+            Span::styled("  ·  refreshing", Style::default().fg(Color::Yellow))
+        } else {
+            Span::raw("")
+        },
     ]);
 
     frame.render_widget(Paragraph::new(vec![header, Line::from("")]), area);
@@ -462,8 +450,10 @@ fn render_metric_chart(
             ])
             .split(inner);
 
-            let chart_data = to_chart_data(&m.raw_values);
-            let (x_min, x_max, x_labels) = time_bounds_and_labels(&m.raw_values);
+            let chart_data = &m.chart_data.points;
+            let x_min = m.chart_data.x_min;
+            let x_max = m.chart_data.x_max;
+            let x_labels = &m.chart_data.labels;
 
             let y_max = m.max * 1.15;
             let y_max = if y_max < 0.001 { 1.0 } else { y_max };
@@ -472,7 +462,7 @@ fn render_metric_chart(
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(color))
-                .data(&chart_data);
+                .data(chart_data);
 
             let mut datasets = vec![dataset];
 
@@ -491,10 +481,10 @@ fn render_metric_chart(
             let x_axis = Axis::default()
                 .style(Style::default().fg(LABEL_COLOR))
                 .bounds([x_min, x_max])
-                .labels(x_labels.clone());
+                .labels(x_labels.to_vec());
 
             let y_label_strs = vec!["0".to_string(), format_fn(y_max / 2.0), format_fn(y_max)];
-            let pad = chart_left_pad(&y_label_strs, &x_labels);
+            let pad = chart_left_pad(&y_label_strs, x_labels);
 
             let y_axis = Axis::default()
                 .style(Style::default().fg(LABEL_COLOR))
@@ -931,9 +921,6 @@ fn render_error_rate_chart(app: &MetricsApp, frame: &mut Frame, area: Rect) {
     };
 
     let ts = http.time_series.as_ref().unwrap();
-    let err_data = to_chart_data(&ts.error_rate_ts);
-    let (x_min, x_max, x_labels) = time_bounds_and_labels(&ts.error_rate_ts);
-
     let err_pct_data: Vec<(f64, f64)> = ts
         .error_rate_ts
         .iter()
@@ -948,11 +935,22 @@ fn render_error_rate_chart(app: &MetricsApp, frame: &mut Frame, area: Rect) {
         })
         .collect();
 
-    let chart_data = if !err_pct_data.is_empty() {
-        &err_pct_data
-    } else {
-        &err_data
-    };
+    let (chart_data, x_min, x_max, x_labels): (&[(f64, f64)], f64, f64, Vec<String>) =
+        if !err_pct_data.is_empty() {
+            (
+                &err_pct_data,
+                ts.error_rate_chart.x_min,
+                ts.error_rate_chart.x_max,
+                ts.error_rate_chart.labels.clone(),
+            )
+        } else {
+            (
+                &ts.error_rate_chart.points,
+                ts.error_rate_chart.x_min,
+                ts.error_rate_chart.x_max,
+                ts.error_rate_chart.labels.clone(),
+            )
+        };
 
     let mut y_max = 0.0f64;
     for (_, v) in chart_data.iter() {
@@ -1012,27 +1010,28 @@ fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
     ])
     .split(inner);
 
-    let (origin_ts, x_min, x_max, x_labels) =
-        time_bounds_and_labels_for_series(&[&ts.p50_ts, &ts.p90_ts, &ts.p95_ts, &ts.p99_ts]);
-    let p50_data = if app.show_p50 {
-        to_chart_data_from(&ts.p50_ts, origin_ts)
+    let x_min = ts.p50_chart.x_min;
+    let x_max = ts.p50_chart.x_max;
+    let x_labels = ts.p50_chart.labels.clone();
+    let p50_data: &[(f64, f64)] = if app.show_p50 {
+        &ts.p50_chart.points
     } else {
-        vec![]
+        &[]
     };
-    let p90_data = if app.show_p90 {
-        to_chart_data_from(&ts.p90_ts, origin_ts)
+    let p90_data: &[(f64, f64)] = if app.show_p90 {
+        &ts.p90_chart.points
     } else {
-        vec![]
+        &[]
     };
-    let p95_data = if app.show_p95 {
-        to_chart_data_from(&ts.p95_ts, origin_ts)
+    let p95_data: &[(f64, f64)] = if app.show_p95 {
+        &ts.p95_chart.points
     } else {
-        vec![]
+        &[]
     };
-    let p99_data = if app.show_p99 {
-        to_chart_data_from(&ts.p99_ts, origin_ts)
+    let p99_data: &[(f64, f64)] = if app.show_p99 {
+        &ts.p99_chart.points
     } else {
-        vec![]
+        &[]
     };
 
     let mut y_max = 0.0f64;
@@ -1064,7 +1063,7 @@ fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(P50_COLOR))
-                .data(&p50_data),
+                .data(p50_data),
         );
     }
     if !p90_data.is_empty() {
@@ -1074,7 +1073,7 @@ fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(P90_COLOR))
-                .data(&p90_data),
+                .data(p90_data),
         );
     }
     if !p95_data.is_empty() {
@@ -1084,7 +1083,7 @@ fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(P95_COLOR))
-                .data(&p95_data),
+                .data(p95_data),
         );
     }
     if !p99_data.is_empty() {
@@ -1094,7 +1093,7 @@ fn render_http_latency(app: &MetricsApp, frame: &mut Frame, area: Rect) {
                 .marker(symbols::Marker::Braille)
                 .graph_type(GraphType::Line)
                 .style(Style::default().fg(P99_COLOR))
-                .data(&p99_data),
+                .data(p99_data),
         );
     }
 
@@ -1764,6 +1763,11 @@ fn render_project_header(app: &ProjectApp, frame: &mut Frame, area: Rect) {
             format!("refreshed {refresh_str}"),
             Style::default().fg(LABEL_COLOR),
         ),
+        if app.refreshing {
+            Span::styled("  ·  refreshing", Style::default().fg(Color::Yellow))
+        } else {
+            Span::raw("")
+        },
         Span::styled("  ·  ", Style::default().fg(LABEL_COLOR)),
         Span::raw(format!("{} services", app.services.len())),
     ]);
@@ -1998,6 +2002,7 @@ fn render_detail_panel(app: &ProjectApp, frame: &mut Frame, area: Rect) {
         error_message: None,
         show_help: false,
         force_refresh: false,
+        refreshing: false,
     };
 
     render_detail_charts(&temp_app, frame, parts[1]);

--- a/src/controllers/metrics_tui/ui.rs
+++ b/src/controllers/metrics_tui/ui.rs
@@ -669,7 +669,10 @@ fn render_network_chart(app: &MetricsApp, frame: &mut Frame, area: Rect) {
                 .collect::<Vec<_>>(),
         );
 
-    let chart = Chart::new(datasets).x_axis(x_axis).y_axis(y_axis);
+    let chart = Chart::new(datasets)
+        .x_axis(x_axis)
+        .y_axis(y_axis)
+        .legend_position(None);
     frame.render_widget(chart, parts[0]);
 
     let mut spans = vec![Span::raw(pad)];

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,10 +1,13 @@
 pub mod chat;
 pub mod config;
 pub mod database;
+pub mod db_stats;
 pub mod deployment;
 pub mod develop;
 pub mod environment;
 pub mod local_override;
+pub mod metrics;
+pub mod metrics_tui;
 pub mod project;
 pub mod regions;
 pub mod service;

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -210,6 +210,24 @@ pub struct Metrics;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/HttpMetricsByStatus.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct HttpMetricsByStatus;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/HttpDurationMetrics.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct HttpDurationMetrics;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/SshPublicKeys.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/HttpDurationMetrics.graphql
+++ b/src/gql/queries/strings/HttpDurationMetrics.graphql
@@ -1,0 +1,29 @@
+query HttpDurationMetrics(
+  $serviceId: String!
+  $environmentId: String!
+  $startDate: DateTime!
+  $endDate: DateTime!
+  $stepSeconds: Int
+  $method: String
+  $path: String
+  $statusCode: Int
+) {
+  httpDurationMetrics(
+    serviceId: $serviceId
+    environmentId: $environmentId
+    startDate: $startDate
+    endDate: $endDate
+    stepSeconds: $stepSeconds
+    method: $method
+    path: $path
+    statusCode: $statusCode
+  ) {
+    samples {
+      ts
+      p50
+      p90
+      p95
+      p99
+    }
+  }
+}

--- a/src/gql/queries/strings/HttpMetricsByStatus.graphql
+++ b/src/gql/queries/strings/HttpMetricsByStatus.graphql
@@ -1,0 +1,25 @@
+query HttpMetricsByStatus(
+  $serviceId: String!
+  $environmentId: String!
+  $startDate: DateTime!
+  $endDate: DateTime!
+  $stepSeconds: Int
+  $method: String
+  $path: String
+) {
+  httpMetricsGroupedByStatus(
+    serviceId: $serviceId
+    environmentId: $environmentId
+    startDate: $startDate
+    endDate: $endDate
+    stepSeconds: $stepSeconds
+    method: $method
+    path: $path
+  ) {
+    statusCode
+    samples {
+      ts
+      value
+    }
+  }
+}

--- a/src/gql/queries/strings/Metrics.graphql
+++ b/src/gql/queries/strings/Metrics.graphql
@@ -1,20 +1,27 @@
 query Metrics(
+  $projectId: String
   $serviceId: String
   $environmentId: String
   $startDate: DateTime!
   $endDate: DateTime
   $measurements: [MetricMeasurement!]!
   $sampleRateSeconds: Int
+  $groupBy: [MetricTag!]
 ) {
   metrics(
+    projectId: $projectId
     serviceId: $serviceId
     environmentId: $environmentId
     startDate: $startDate
     endDate: $endDate
     measurements: $measurements
     sampleRateSeconds: $sampleRateSeconds
+    groupBy: $groupBy
   ) {
     measurement
+    tags {
+      serviceId
+    }
     values {
       ts
       value

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -158,6 +158,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "CDN_CACHING"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "DEBUG_SMART_DIAGNOSIS"
             },
             {
@@ -171,6 +177,12 @@
               "description": null,
               "isDeprecated": false,
               "name": "MAGIC_CONFIG"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "POSTGRES_HA"
             },
             {
               "deprecationReason": null,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ commands!(
     logout,
     logs,
     mcp,
+    metrics,
     open,
     project,
     run(local),


### PR DESCRIPTION
## Summary

Adds `railway metrics`, a new observability command for inspecting service and project metrics from the CLI.

The command works at three levels:

- the linked service by default
- a specific service with `--service`
- every service in the project with `--all`

It supports quick human-readable summaries, JSON output for scripts and agents, raw time-series output for deeper analysis, and live TUI dashboards for ongoing monitoring.

## Command Structure

```sh
railway metrics [--service <service>] [--environment <environment>]
railway metrics --all
railway metrics --watch
railway metrics --all --watch
```

By default, `railway metrics` shows the linked service over the last hour.

Time windows can be controlled with:

```sh
railway metrics --since 6h
railway metrics --since 1d --until 1h
```

Users can narrow the output to specific metric groups:

```sh
railway metrics --cpu
railway metrics --memory
railway metrics --network
railway metrics --volume
railway metrics --http
```

HTTP metrics can also be filtered:

```sh
railway metrics --http --method POST
railway metrics --http --method GET --path /api/users
```

Output modes:

```sh
railway metrics --json
railway metrics --raw --cpu
railway metrics --raw --json --http
railway metrics --watch
```
## Command in action

### Database output `railway metrics`
<img width="1804" height="1580" alt="CleanShot 2026-05-04 at 17 33 44@2x" src="https://github.com/user-attachments/assets/072803d7-7de4-45ed-8f07-385712db636d" />

### Service output `railway metrics`
<img width="1566" height="848" alt="CleanShot 2026-05-04 at 17 34 19@2x" src="https://github.com/user-attachments/assets/1c2fb12b-898e-42df-8431-942c4b1bd0ee" />

### `railway metrics --all`

<img width="3668" height="500" alt="CleanShot 2026-05-04 at 17 36 21@2x" src="https://github.com/user-attachments/assets/74727335-60d0-44c7-bfc1-3c8fd0aaad02" />

### Database output `railway metrics --watch`


https://github.com/user-attachments/assets/672dc9d2-1b22-4163-a496-40c3e22bc749



### Service output `railway metrics --watch`
<img width="3768" height="1998" alt="CleanShot 2026-05-04 at 17 37 07@2x" src="https://github.com/user-attachments/assets/dc3d18eb-3c4a-4f34-ba9a-8106ba2687f2" />

### All services output `railway metrics --watch --all`


https://github.com/user-attachments/assets/855e5e24-bb6f-4a59-b9fc-edd47eb6046c


## What This Enables

For a single service, the command can show:

- CPU usage and limits
- memory usage and limits
- public network ingress and egress
- disk and volume usage
- HTTP request totals, status-code buckets, error rate, and latency percentiles
- recent deployments when useful for context

For project-wide views, `--all` provides a compact overview across services, including resource usage, volume information, HTTP summaries, and database-service detection.

For live monitoring, `--watch` opens an interactive TUI with refreshes, time-range switching, metric toggles, HTTP status/latency series toggles, and per-service detail panels in project mode.

For database services, the command detects supported database images and can surface native database stats for Postgres, Redis, MySQL, and MongoDB through Railway SSH.