### PR TITLE
Support agent skills and MCP configurations

### DIFF
--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -15,7 +15,6 @@ pub struct Args {
     agent: Vec<String>,
 
     /// Configure the remote HTTP MCP server at mcp.railway.com instead of the local stdio server.
-    /// Codex is skipped because it only supports stdio MCP servers.
     #[clap(long)]
     remote: bool,
 }
@@ -30,19 +29,11 @@ pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool) -> Result
 
     println!("\n{}\n", "Railway MCP".bold());
 
-    let (configurable, skipped_remote): (Vec<_>, Vec<_>) = tools
+    let configurable: Vec<_> = tools
         .iter()
         .filter(|t| supports_mcp(t.slug))
         .cloned()
-        .partition(|t| !remote || supports_remote(t.slug));
-
-    for tool in &skipped_remote {
-        println!(
-            "{} {}: skipped \u{2192} only stdio MCP is supported (no remote HTTP transport)",
-            "-".dimmed(),
-            tool.name.bold()
-        );
-    }
+        .collect();
 
     if configurable.is_empty() {
         // The skills command auto-includes "universal", which has no MCP target.
@@ -106,12 +97,6 @@ fn supports_mcp(slug: &str) -> bool {
     matches!(slug, "claude-code" | "cursor" | "opencode" | "codex")
 }
 
-/// Whether the harness can talk to a remote HTTP MCP server. Codex only speaks
-/// stdio today, so it's excluded from `--remote` runs.
-fn supports_remote(slug: &str) -> bool {
-    matches!(slug, "claude-code" | "cursor" | "opencode")
-}
-
 fn config_path(slug: &str, home: &Path) -> PathBuf {
     match slug {
         "claude-code" => home.join(".claude.json"),
@@ -135,7 +120,7 @@ pub(crate) fn mcp_configured_for_slug(home: &Path, slug: &str, remote: bool) -> 
             .ok()
             .and_then(|root| root.pointer("/mcp/railway").cloned())
             .is_some_and(|entry| opencode_mcp_entry_matches(&entry, remote)),
-        "codex" if !remote => codex_mcp_configured(&path),
+        "codex" => codex_mcp_configured(&path, remote),
         _ => false,
     }
 }
@@ -168,7 +153,7 @@ fn opencode_mcp_entry_matches(entry: &JsonValue, remote: bool) -> bool {
     }
 }
 
-fn codex_mcp_configured(path: &Path) -> bool {
+fn codex_mcp_configured(path: &Path, remote: bool) -> bool {
     let Ok(existing) = std::fs::read_to_string(path) else {
         return false;
     };
@@ -179,11 +164,15 @@ fn codex_mcp_configured(path: &Path) -> bool {
     doc.get("mcp_servers")
         .and_then(|servers| servers.get("railway"))
         .is_some_and(|entry| {
-            entry.get("command").and_then(toml::Value::as_str) == Some("railway")
-                && entry
-                    .get("args")
-                    .and_then(toml::Value::as_array)
-                    .is_some_and(|args| args.iter().any(|arg| arg.as_str() == Some("mcp")))
+            if remote {
+                entry.get("url").and_then(toml::Value::as_str) == Some(REMOTE_MCP_URL)
+            } else {
+                entry.get("command").and_then(toml::Value::as_str) == Some("railway")
+                    && entry
+                        .get("args")
+                        .and_then(toml::Value::as_array)
+                        .is_some_and(|args| args.iter().any(|arg| arg.as_str() == Some("mcp")))
+            }
         })
 }
 
@@ -211,8 +200,7 @@ fn install_for(slug: &str, path: &Path, remote: bool) -> Result<()> {
             write_json_mcp_servers(path, entry)
         }
         "opencode" => write_opencode_mcp(path, remote),
-        // supports_remote() filters codex out of remote runs before reaching here.
-        "codex" => write_codex_toml(path),
+        "codex" => write_codex_toml(path, remote),
         _ => bail!("Unsupported MCP target: {}", slug),
     }
 }
@@ -277,7 +265,7 @@ fn write_opencode_mcp(path: &Path, remote: bool) -> Result<()> {
     write_json_pretty(path, &root)
 }
 
-fn write_codex_toml(path: &Path) -> Result<()> {
+fn write_codex_toml(path: &Path, remote: bool) -> Result<()> {
     let existing = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -304,14 +292,21 @@ fn write_codex_toml(path: &Path) -> Result<()> {
         .context("`mcp_servers` is not a TOML table")?;
 
     let mut railway = toml::value::Table::new();
-    railway.insert(
-        "command".to_string(),
-        toml::Value::String("railway".to_string()),
-    );
-    railway.insert(
-        "args".to_string(),
-        toml::Value::Array(vec![toml::Value::String("mcp".to_string())]),
-    );
+    if remote {
+        railway.insert(
+            "url".to_string(),
+            toml::Value::String(REMOTE_MCP_URL.to_string()),
+        );
+    } else {
+        railway.insert(
+            "command".to_string(),
+            toml::Value::String("railway".to_string()),
+        );
+        railway.insert(
+            "args".to_string(),
+            toml::Value::Array(vec![toml::Value::String("mcp".to_string())]),
+        );
+    }
     servers.insert("railway".to_string(), toml::Value::Table(railway));
 
     let serialized = toml::to_string_pretty(&doc).context("Failed to serialize TOML")?;
@@ -473,5 +468,46 @@ mod tests {
 
         assert!(mcp_configured_for_slug(home.path(), "codex", false));
         assert!(!mcp_configured_for_slug(home.path(), "codex", true));
+    }
+
+    #[test]
+    fn detects_existing_codex_remote_mcp() {
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join(".codex").join("config.toml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            r#"
+                [mcp_servers.railway]
+                url = "https://mcp.railway.com"
+            "#,
+        )
+        .unwrap();
+
+        assert!(mcp_configured_for_slug(home.path(), "codex", true));
+        assert!(!mcp_configured_for_slug(home.path(), "codex", false));
+    }
+
+    #[test]
+    fn writes_codex_remote_mcp() {
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join(".codex").join("config.toml");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        write_codex_toml(&path, true).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        let doc = written.parse::<toml::Value>().unwrap();
+        let railway = doc
+            .get("mcp_servers")
+            .and_then(|servers| servers.get("railway"))
+            .unwrap();
+
+        assert_eq!(
+            railway.get("url").and_then(toml::Value::as_str),
+            Some("https://mcp.railway.com")
+        );
+        assert!(railway.get("command").is_none());
+        assert!(railway.get("args").is_none());
     }
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -35,7 +35,6 @@ pub struct AgentArgs {
     yes: bool,
 
     /// Configure the remote HTTP MCP server at mcp.railway.com instead of the local stdio server.
-    /// Codex is skipped because it only supports stdio MCP servers.
     #[clap(long)]
     remote: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,6 +609,7 @@ mod cli_tests {
             ]);
             assert_parses(&["mcp", "install", "--remote"]);
             assert_parses(&["mcp", "install", "--remote", "--agent", "cursor"]);
+            assert_parses(&["mcp", "install", "--remote", "--agent", "codex"]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Configure Codex with Railway's remote MCP URL when `railway mcp install --remote` is used
- Add GitHub Copilot as a detected agent target for Railway skills and MCP configuration
- Add Factory Droid as a detected agent target for Railway skills and MCP configuration
- Preserve each tool's documented MCP schema for local stdio/local and remote HTTP transports

## Validation
- `nix-shell --run "cargo test commands::mcp::install"`
- `nix-shell --run "cargo test commands::skills"`
- `nix-shell --run "cargo test setup_agent_subcommand"`

## Notes
- `cargo fmt` is unavailable in the current nix shell because `cargo-fmt`/`rustfmt` is not installed.