### PR TITLE
Improve CLI ergonomics for agent and automation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,77 @@
 # Railway CLI
 
-[![Crates.io](https://img.shields.io/crates/v/railwayapp)](https://crates.io/crates/railwayapp)
-[![CI](https://github.com/railwayapp/cli/actions/workflows/ci.yml/badge.svg)](https://github.com/railwayapp/cliv3/actions/workflows/ci.yml)
-[![cargo audit](https://github.com/railwayapp/cli/actions/workflows/cargo-audit.yml/badge.svg)](https://github.com/railwayapp/cli/actions/workflows/cargo-audit.yml)
-
-## Overview
-
-This is the command line interface for [Railway](https://railway.com). Use it to connect your code to Railway's infrastructure without needing to worry about environment variables or configuration.
-
-The Railway command line interface (CLI) connects your code to your Railway project from the command line.
-
-The Railway CLI allows you to:
-
-- Create new Railway projects from the terminal
-- Link to an existing Railway project
-- Pull down environment variables for your project locally to run
-- Create services and databases right from the comfort of your fingertips
-
-And more.
-
-## Agent Skills
-
-Install [Railway agent skills](https://agentskills.io) for AI coding tools (Claude Code, Cursor, Codex, OpenCode, and more):
-
-```bash
-railway skills
-```
-
-Use `--agent` to target a specific tool:
-
-```bash
-railway skills --agent claude-code
-```
-
-You can also install via [skills.sh](https://skills.sh/railwayapp/railway-skills/use-railway):
-
-```bash
-npx skills add https://github.com/railwayapp/railway-skills --skill use-railway
-```
-
-## Documentation
-
-[View the CLI guide](https://docs.railway.com/guides/cli)
-
-[View the CLI API reference](https://docs.railway.com/reference/cli-api)
-
-## Quick start
-
-Follow the [CLI guide](https://docs.railway.com/guides/cli) to install the CLI and run your first command.
-
-## Authentication
-
-For non-interactive authentication details, see the [CLI guide](https://docs.railway.com/guides/cli#tokens).
+The Railway CLI lets you interact with your Railway projects from the command line. Read the [CLI documentation](https://docs.railway.com/cli).
 
 ## Installation
 
-### Package managers
-
-#### Cargo
+Install the CLI with the Bash script on macOS, Linux, or Windows through WSL:
 
 ```bash
-cargo install railwayapp --locked
-```
-
-#### Homebrew
-
-```bash
-brew install railway
-```
-
-#### NPM
-
-```bash
-npm install -g @railway/cli
-```
-
-#### Bash
-
-```bash
-# Install
 bash <(curl -fsSL cli.new)
+```
 
-# Install and configure Railway agent support
+Install the CLI and configure Railway agent support:
+
+```bash
 bash <(curl -fsSL cli.new) --agents -y
+```
 
-# Uninstall
+Uninstall the CLI:
+
+```bash
 bash <(curl -fsSL cli.new) -r
 ```
 
-#### Scoop
+Other installation methods are available in the CLI documentation: [Homebrew](https://docs.railway.com/cli#homebrew-macos), [npm](https://docs.railway.com/cli#npm-macos-linux-windows), [Scoop](https://docs.railway.com/cli#scoop-windows), [pre-built binaries](https://docs.railway.com/cli#pre-built-binaries), and [source builds](https://docs.railway.com/cli#from-source).
 
-```ps1
-scoop install railway
-```
+## Authentication
 
-#### Arch Linux AUR
-
-Install with Paru
+Before using the CLI, authenticate with your Railway account:
 
 ```bash
-paru -S railwayapp-cli
+railway login
 ```
 
-Install with Yay
+For environments without a browser, such as SSH sessions, use browserless login:
 
 ```bash
-yay -S railwayapp-cli
+railway login --browserless
 ```
 
-### Docker
+### Tokens
 
-#### Install from the command line
+For CI/CD pipelines, set environment variables instead of using interactive login:
+
+- Project token: Set `RAILWAY_TOKEN` for project-level actions.
+- Account or workspace token: Set `RAILWAY_API_TOKEN` for account-level or workspace-level actions.
 
 ```bash
-docker pull ghcr.io/railwayapp/cli:latest
+RAILWAY_TOKEN=xxx railway up
 ```
 
-#### Use in GitHub Actions
+See [Tokens](https://docs.railway.com/integrations/api#creating-a-token) for more information.
 
-For GitHub Actions setup, see the blog post at [blog.railway.com/p/github-actions](https://blog.railway.com/p/github-actions).
+## Agent Setup
 
-#### Use in GitLab CI/CD
+Configure Railway agent support for AI coding tools:
 
-For GitLab CI/CD setup, see the blog post at [blog.railway.com/p/gitlab-ci-cd](https://blog.railway.com/p/gitlab-ci-cd).
+```bash
+railway setup agent -y
+```
 
-### Contributing
+This installs Railway skills and configures the Railway MCP server for detected tools such as Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, and Factory Droid.
+
+Use the focused commands when you only need one part of the setup:
+
+```bash
+railway mcp install --agent cursor
+railway skills --agent claude-code
+```
+
+## Contributing
 
 See [CONTRIBUTING.md](https://github.com/railwayapp/cli/blob/master/CONTRIBUTING.md) for information on setting up this repository locally.
 
 ## Feedback
 
-We would love to hear your feedback or suggestions. The best way to reach us is on [Central Station](https://station.railway.com/feedback).
-
-We also welcome pull requests into this repository. See [CONTRIBUTING.md](https://github.com/railwayapp/cli/blob/master/CONTRIBUTING.md) for information on setting up this repository locally.
+Share feedback and suggestions on [Central Station](https://station.railway.com/feedback).

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -20,6 +20,9 @@ use super::*;
 
 /// Add a service to your project
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway add --service api --json\n  railway add --database postgres --json\n  railway add --repo railwayapp/starters --service web --json\n  railway add --image nginx:latest --service web --json\n\nAutomation notes:\n  Non-interactive runs must pass one of --service, --database, --repo, or --image.\n  Use --json for machine-readable output and read stderr separately for progress or selection echoes."
+)]
 pub struct Args {
     /// The name of the database to add
     #[arg(short, long, value_enum)]
@@ -61,7 +64,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
     if verbose {
-        println!("project and environment exist in linked project exist")
+        eprintln!("project and environment exist in linked project exist")
     }
     let type_of_create = if !args.database.is_empty() {
         fake_select("What do you need?", "Database");
@@ -124,14 +127,14 @@ pub async fn command(args: Args) -> Result<()> {
         }
     };
     if verbose {
-        println!("{:?}", type_of_create);
+        eprintln!("{:?}", type_of_create);
     }
     match type_of_create {
         CreateKind::Database(databases) => {
             let is_single_db = databases.len() == 1;
             for db in databases {
                 if verbose {
-                    println!("iterating through databases to add: {:?}", db)
+                    eprintln!("iterating through databases to add: {:?}", db)
                 }
                 deploy::fetch_and_create(
                     &client,
@@ -147,7 +150,7 @@ pub async fn command(args: Args) -> Result<()> {
                 )
                 .await?;
                 if verbose {
-                    println!("successfully created {:?}", db)
+                    eprintln!("successfully created {:?}", db)
                 }
             }
         }
@@ -300,7 +303,7 @@ async fn create_service(
     let source = mutations::service_create::ServiceSourceInput { repo, image };
     let branch = if let Some(repo) = &source.repo {
         if verbose {
-            println!("fetching branch for github repo {repo}")
+            eprintln!("fetching branch for github repo {repo}")
         }
         let repos = post_graphql::<queries::GitHubRepos, _>(
             client,
@@ -326,7 +329,7 @@ async fn create_service(
         branch,
     };
     if verbose {
-        println!("creating service");
+        eprintln!("creating service");
     }
     let s =
         post_graphql::<mutations::ServiceCreate, _>(client, &configs.get_backboard(), vars).await?;

--- a/src/commands/autoupdate.rs
+++ b/src/commands/autoupdate.rs
@@ -14,8 +14,10 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// Enable automatic updates
+    #[clap(visible_alias = "on")]
     Enable,
     /// Disable automatic updates
+    #[clap(visible_alias = "off")]
     Disable,
     /// Show current auto-update status
     Status,

--- a/src/commands/bucket.rs
+++ b/src/commands/bucket.rs
@@ -20,6 +20,9 @@ use std::{collections::BTreeMap, fmt::Display};
 
 /// Manage project buckets
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway bucket list --json\n  railway bucket create uploads --region sjc --json\n  railway bucket info --bucket uploads --json\n  railway bucket credentials --bucket uploads --json\n  railway bucket rename --bucket uploads --name assets --json\n  railway bucket delete --bucket assets --yes --json\n\nAliases:\n  list: ls\n  create: add, new\n  delete: remove, rm\n  info: show, get\n  credentials: creds\n  rename: mv\n\nAutomation notes:\n  `railway bucket credentials` prints access keys and secret keys. Avoid sharing command output."
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -90,7 +93,7 @@ struct CredentialsArgs {
     #[clap(long = "2fa-code", requires = "reset")]
     two_factor_code: Option<String>,
 
-    /// Output in JSON format
+    /// Output in JSON format. This includes access keys and secret keys.
     #[clap(long)]
     json: bool,
 }
@@ -109,24 +112,27 @@ struct RenameArgs {
 #[derive(Parser)]
 enum Commands {
     /// List buckets
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List(ListArgs),
 
     /// Create a new bucket
-    #[clap(alias = "add", alias = "new")]
+    #[clap(visible_alias = "add", visible_alias = "new")]
     Create(CreateArgs),
 
     /// Delete a bucket
-    #[clap(alias = "remove", alias = "rm")]
+    #[clap(visible_alias = "remove", visible_alias = "rm")]
     Delete(DeleteArgs),
 
     /// Show bucket details
+    #[clap(visible_alias = "show", visible_alias = "get")]
     Info(InfoArgs),
 
     /// Show or reset S3-compatible credentials
+    #[clap(visible_alias = "creds")]
     Credentials(CredentialsArgs),
 
     /// Rename a bucket
+    #[clap(visible_alias = "mv")]
     Rename(RenameArgs),
 }
 

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -19,6 +19,9 @@ use super::*;
 
 /// Connect to a database's shell (psql for Postgres, mongosh for MongoDB, etc.)
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway connect postgres\n  railway connect redis --environment production\n\nAutomation notes:\n  Non-interactive runs must pass the database service name.\n  The local database client must be installed before connecting."
+)]
 pub struct Args {
     /// The name of the database to connect to
     service_name: Option<String>,

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -17,6 +17,9 @@ use super::*;
 
 /// Delete a project
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway delete --project project-id --yes --json\n  railway rm --project project-id --yes --json\n  railway project delete --project project-id --yes --json\n\nAutomation notes:\n  Project deletion is scheduled by Railway. Treat a successful response as the deletion request being accepted.\n  Non-interactive deletion requires --yes. Use --2fa-code when your account requires 2FA."
+)]
 pub struct Args {
     /// The project ID or name to delete
     #[clap(short, long)]

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -109,7 +109,7 @@ pub async fn fetch_and_create(
     options: FetchAndCreateOptions,
 ) -> Result<(), anyhow::Error> {
     if verbose {
-        println!("fetching details for template")
+        eprintln!("fetching details for template")
     }
     let public_client = GQLClient::new_public()?;
     let details = post_graphql::<queries::TemplateDetail, _>(
@@ -129,7 +129,7 @@ pub async fn fetch_and_create(
 
     ensure_project_and_environment_exist(client, configs, linked_project).await?;
     if verbose {
-        println!("Project and environment in config exist");
+        eprintln!("Project and environment in config exist");
     }
 
     // Get current services before the mutation
@@ -178,7 +178,7 @@ pub async fn fetch_and_create(
         serialized_config: serde_json::to_value(&config).context("Failed to serialize config")?,
     };
     if verbose {
-        println!("deploying template");
+        eprintln!("deploying template");
     }
     let response = post_graphql::<mutations::TemplateDeploy, _>(
         client,
@@ -190,7 +190,7 @@ pub async fn fetch_and_create(
     // Wait for workflow to complete
     if let Some(workflow_id) = response.template_deploy_v2.workflow_id {
         if verbose {
-            println!("waiting for workflow {workflow_id} to complete");
+            eprintln!("waiting for workflow {workflow_id} to complete");
         }
         wait_for_workflow(client, configs, workflow_id)
             .await
@@ -219,7 +219,7 @@ pub async fn fetch_and_create(
             configs.link_service(service.node.id.clone())?;
             configs.write()?;
             if verbose {
-                println!("linked to service {}", service.node.name);
+                eprintln!("linked to service {}", service.node.name);
             }
         }
     }
@@ -247,7 +247,7 @@ pub async fn fetch_and_create(
         spinner.finish_with_message(msg);
     }
     if verbose {
-        println!("template deployed");
+        eprintln!("template deployed");
     }
 
     Ok(())

--- a/src/commands/deployment.rs
+++ b/src/commands/deployment.rs
@@ -19,10 +19,11 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// List deployments for a service with IDs, statuses and other metadata
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List(ListArgs),
 
     /// Upload and deploy project from the current directory
+    #[clap(visible_alias = "deploy")]
     Up(crate::commands::up::Args),
 
     /// Redeploy the latest deployment of a service

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -32,6 +32,9 @@ use super::*;
 
 /// Run Railway services locally
 #[derive(Debug, Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway dev up --dry-run --no-tui\n  railway dev start --no-https\n  railway dev configure\n  railway dev stop\n\nAliases:\n  up: start\n  down: stop\n  configure: config\n  clean: reset"
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Option<DevelopCommand>,
@@ -44,12 +47,16 @@ pub struct Args {
 #[derive(Debug, Subcommand)]
 enum DevelopCommand {
     /// Start services (default when no subcommand provided)
+    #[clap(visible_alias = "start")]
     Up(UpArgs),
     /// Stop services
+    #[clap(visible_alias = "stop")]
     Down(DownArgs),
     /// Stop services and remove volumes/data
+    #[clap(visible_alias = "reset")]
     Clean(CleanArgs),
     /// Configure local code services
+    #[clap(visible_alias = "config")]
     Configure(ConfigureArgs),
 }
 

--- a/src/commands/environment/mod.rs
+++ b/src/commands/environment/mod.rs
@@ -23,6 +23,9 @@ mod new;
 
 /// Create, delete or link an environment
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway environment list --json\n  railway environment new staging --json\n  railway environment create staging --duplicate production --json\n  railway environment delete staging --yes --json\n  railway environment config --environment production --json\n\nAutomation notes:\n  After creating an environment, verify the linked target with `railway status --json`.\n  Destructive non-interactive runs must pass the environment and --yes."
+)]
 pub struct Args {
     /// The environment to link to
     pub environment: Option<String>,
@@ -50,6 +53,7 @@ structstruck::strike! {
         }),
 
         /// Create a new environment
+        #[clap(visible_alias = "create", visible_alias = "add")]
         New(pub struct {
             /// The name of the environment to create
             pub name: Option<String>,
@@ -67,6 +71,7 @@ structstruck::strike! {
         }),
 
         /// Delete an environment
+        #[clap(visible_alias = "rm", visible_alias = "remove")]
         Delete(pub struct {
             /// Skip confirmation dialog
             #[clap(short = 'y', long = "yes")]
@@ -85,6 +90,7 @@ structstruck::strike! {
         }),
 
         /// Edit an environment's configuration
+        #[clap(visible_alias = "update")]
         Edit(pub struct {
             /// The environment to edit (defaults to linked environment)
             #[clap(long, short)]
@@ -107,6 +113,7 @@ structstruck::strike! {
         }),
 
         /// Show environment configuration
+        #[clap(visible_alias = "show", visible_alias = "info")]
         Config(pub struct {
             /// Environment to show config for (defaults to linked)
             #[clap(long, short)]
@@ -118,6 +125,7 @@ structstruck::strike! {
         }),
 
         /// List all environments in the project
+        #[clap(visible_alias = "ls")]
         List(pub struct {
             /// Show only ephemeral (PR) environments
             #[clap(long, conflicts_with = "no_ephemeral")]

--- a/src/commands/environment/new.rs
+++ b/src/commands/environment/new.rs
@@ -98,6 +98,7 @@ pub async fn new_environment(args: Args) -> Result<()> {
         env_id,
         Some(env_name),
     )?;
+    configs.write()?;
 
     Ok(())
 }

--- a/src/commands/functions/mod.rs
+++ b/src/commands/functions/mod.rs
@@ -37,7 +37,7 @@ structstruck::strike! {
         List,
 
         /// Add a new function
-        #[clap(visible_alias = "create")]
+        #[clap(visible_alias = "create", visible_alias = "add")]
         New(struct {
             /// The path to the function locally
             #[clap(long, short)]
@@ -81,7 +81,7 @@ structstruck::strike! {
         }),
 
         /// Push a new change to the function
-        #[clap(visible_alias = "up")]
+        #[clap(visible_alias = "up", visible_alias = "deploy")]
         Push(struct {
             /// The path to the function
             #[clap(long, short)]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -8,7 +8,10 @@ use super::*;
 
 /// Create a new project
 #[derive(Parser)]
-#[clap(alias = "new")]
+#[clap(
+    visible_alias = "new",
+    after_help = "Examples:\n\n  railway init --name api --json\n  railway init --name api --workspace workspace-id --json\n\nAutomation notes:\n  This creates a project and links the current directory to the project's default environment.\n  Use an exact workspace ID or name when running outside a terminal."
+)]
 pub struct Args {
     /// Project name
     #[clap(short, long)]

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -8,7 +8,7 @@ use crate::{
     consts::{RAILWAY_API_TOKEN_ENV, RAILWAY_TOKEN_ENV},
     controllers::user::get_user,
     errors::RailwayError,
-    interact_or, oauth,
+    oauth,
     util::{progress::create_spinner, prompt::prompt_confirm_with_default_with_cancel},
 };
 
@@ -23,7 +23,16 @@ pub struct Args {
 }
 
 pub async fn command(args: Args) -> Result<()> {
-    interact_or!("Cannot login in non-interactive mode");
+    if !crate::macros::is_stdout_terminal() {
+        if args.browserless {
+            bail!(
+                "Browserless login requires an interactive terminal. For non-interactive environments, set RAILWAY_API_TOKEN or RAILWAY_TOKEN."
+            );
+        }
+        bail!(
+            "Cannot login in non-interactive mode. For non-interactive environments, set RAILWAY_API_TOKEN or RAILWAY_TOKEN."
+        );
+    }
 
     let mut configs = Configs::new()?;
 

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -10,14 +10,14 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// List all projects in your Railway account
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List(crate::commands::list::Args),
 
     /// Link a project to the current directory
     Link(crate::commands::link::Args),
 
     /// Delete a project
-    #[clap(alias = "rm", alias = "remove")]
+    #[clap(visible_alias = "rm", visible_alias = "remove")]
     Delete(crate::commands::delete::Args),
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -19,6 +19,9 @@ use super::{queries::project::ProjectProject, *};
 
 /// Run a local command using variables from the active environment
 #[derive(Debug, Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway run --service api --environment production -- npm run migrate\n  railway run --project project-id --environment production --service api -- node script.js\n  railway run --service api -- printenv PORT\n\nAutomation notes:\n  Put Railway flags before the child command. Flags after the child command are passed to the child process.\n  `railway run env` and `railway run printenv` can print secret variable values. Avoid sharing command output."
+)]
 pub struct Args {
     /// Service to pull variables from (defaults to linked service)
     #[clap(short, long)]

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -26,6 +26,9 @@ use super::*;
 
 /// Manage services
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway service list --json\n  railway service delete --service api --environment production --yes --json\n  railway service rm --service api --yes --json\n  railway service link api\n\nAutomation notes:\n  Destructive non-interactive runs must pass exact selectors and --yes.\n  Prefer service IDs from `railway service list --json` when names may collide."
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -37,11 +40,11 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// List services in the current environment
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List(ListArgs),
 
     /// Delete a service from an environment
-    #[clap(alias = "remove", alias = "rm")]
+    #[clap(visible_alias = "remove", visible_alias = "rm")]
     Delete(DeleteArgs),
 
     /// Link a service to the current project

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -28,9 +28,10 @@ enum Commands {
     /// Install Railway agent skills for AI coding tools (Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, Factory Droid, and all tools that support .agents/skills)
     ///
     /// Always installs to ~/.agents/skills. Additionally installs to any detected tool directories (e.g. ~/.claude/skills, ~/.cursor/skills). Use --agent to target specific tools instead of auto-detection.
-    #[clap(alias = "update")]
+    #[clap(visible_alias = "update", visible_alias = "add")]
     Install,
     /// Remove Railway skills from all tools
+    #[clap(visible_alias = "rm", visible_alias = "uninstall")]
     Remove,
 }
 

--- a/src/commands/ssh/keys.rs
+++ b/src/commands/ssh/keys.rs
@@ -74,10 +74,11 @@ pub struct Args {
 #[derive(Parser, Clone)]
 enum Commands {
     /// List all registered SSH keys
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List,
 
     /// Add/register a local SSH key with Railway
+    #[clap(visible_alias = "create", visible_alias = "register")]
     Add {
         /// Path to the public key file (defaults to auto-detect)
         #[clap(long, short)]
@@ -89,7 +90,7 @@ enum Commands {
     },
 
     /// Remove a registered SSH key
-    #[clap(alias = "rm", alias = "delete")]
+    #[clap(visible_alias = "rm", visible_alias = "delete")]
     Remove {
         /// Key ID or fingerprint to remove
         key: Option<String>,
@@ -100,7 +101,7 @@ enum Commands {
     },
 
     /// Import SSH keys from your GitHub account
-    #[clap(alias = "import")]
+    #[clap(visible_alias = "import")]
     Github,
 }
 

--- a/src/commands/telemetry_cmd.rs
+++ b/src/commands/telemetry_cmd.rs
@@ -11,8 +11,10 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// Enable telemetry data collection
+    #[clap(visible_alias = "on")]
     Enable,
     /// Disable telemetry data collection
+    #[clap(visible_alias = "off")]
     Disable,
     /// Show current telemetry status
     Status,

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -46,6 +46,9 @@ enum TerminalTheme {
 
 /// Discover Railway templates
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -54,6 +57,7 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// Search published templates
+    #[clap(visible_alias = "find", visible_alias = "list", visible_alias = "ls")]
     Search(SearchArgs),
 }
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -24,6 +24,9 @@ use super::*;
 
 /// Upload and deploy project from the current directory
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway up --service api --environment production\n  railway up ./apps/api --path-as-root --service api\n  railway up --detach --json --message \"deploy api\"\n\nAutomation notes:\n  `railway up --detach --json` starts an upload and deployment, but it does not wait for the deployment to become healthy.\n  Poll with `railway deployment list --json` and inspect logs with `railway logs --json --lines 100`."
+)]
 pub struct Args {
     path: Option<PathBuf>,
 

--- a/src/commands/variable.rs
+++ b/src/commands/variable.rs
@@ -12,6 +12,9 @@ use std::io::{IsTerminal, Read};
 
 /// Manage environment variables for a service
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway variable list --service api --json\n  railway variable list --service api --kv\n  railway variable set API_URL=https://example.com --skip-deploys --json\n  echo \"secret\" | railway variable set API_KEY --stdin --skip-deploys --json\n  railway variable delete API_KEY --service api --json\n\nAutomation notes:\n  JSON and KV output include raw variable values. Avoid sharing command output from secret-bearing variable commands.\n  For idempotent deletes, list variables first, check whether the key exists, then delete it."
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -25,7 +28,7 @@ pub struct Args {
     #[clap(short, long)]
     environment: Option<String>,
 
-    /// Show variables in KV format
+    /// Show variables in KV format. This prints raw values.
     #[clap(short, long)]
     kv: bool,
 
@@ -37,7 +40,7 @@ pub struct Args {
     #[clap(long, value_name = "KEY")]
     set_from_stdin: Option<String>,
 
-    /// Output in JSON format
+    /// Output in JSON format. Variable list JSON includes raw values.
     #[clap(long)]
     json: bool,
 
@@ -49,14 +52,14 @@ pub struct Args {
 #[derive(Parser)]
 enum Commands {
     /// List variables for a service
-    #[clap(alias = "ls")]
+    #[clap(visible_alias = "ls")]
     List(ListArgs),
 
     /// Set a variable
     Set(SetArgs),
 
     /// Delete a variable
-    #[clap(alias = "rm", alias = "remove")]
+    #[clap(visible_alias = "rm", visible_alias = "remove")]
     Delete(DeleteArgs),
 }
 
@@ -70,11 +73,11 @@ struct ListArgs {
     #[clap(short, long)]
     environment: Option<String>,
 
-    /// Show variables in KV format
+    /// Show variables in KV format. This prints raw values.
     #[clap(short, long)]
     kv: bool,
 
-    /// Output in JSON format
+    /// Output in JSON format. This includes raw values.
     #[clap(long)]
     json: bool,
 }
@@ -232,6 +235,18 @@ async fn set_variable(args: SetArgs) -> Result<()> {
 
 async fn delete_variable(args: DeleteArgs) -> Result<()> {
     let ctx = resolve_service_context(args.service, args.environment).await?;
+
+    let variables = get_service_variables(
+        &ctx.client,
+        &ctx.configs,
+        ctx.project_id.clone(),
+        ctx.environment_id.clone(),
+        ctx.service_id.clone(),
+    )
+    .await?;
+    if !variables.contains_key(&args.key) {
+        bail!("Variable '{}' not found", args.key);
+    }
 
     let spinner = create_spinner_if(!args.json, format!("Deleting {}...", args.key.bold()));
 

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -21,6 +21,9 @@ use std::fmt::Display;
 
 /// Manage project volumes
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway volume list --json\n  railway volume add --service api --mount-path /data --json\n  railway volume update --volume volume-id --name data --mount-path /data --json\n  railway volume delete --volume data --yes --json\n\nAliases:\n  list: ls\n  add: create, new\n  delete: remove, rm\n  update: edit, rename\n\nAutomation notes:\n  Mount paths must start with `/`. Use volume IDs from `railway volume list --json` when names may collide."
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -37,7 +40,7 @@ structstruck::strike! {
     #[strikethrough[derive(Parser)]]
     enum Commands {
         /// List volumes
-        #[clap(alias = "ls")]
+        #[clap(visible_alias = "ls")]
         List(struct {
             /// Output in JSON format
             #[clap(long)]
@@ -45,7 +48,7 @@ structstruck::strike! {
         }),
 
         /// Add a new volume
-        #[clap(alias = "create")]
+        #[clap(visible_alias = "create", visible_alias = "new")]
         Add(struct {
             /// The mount path of the volume
             #[clap(long, short)]
@@ -57,7 +60,7 @@ structstruck::strike! {
         }),
 
         /// Delete a volume
-        #[clap(alias = "remove", alias = "rm")]
+        #[clap(visible_alias = "remove", visible_alias = "rm")]
         Delete(struct {
             /// The ID/name of the volume you wish to delete
             #[clap(long, short)]
@@ -77,7 +80,7 @@ structstruck::strike! {
         }),
 
         /// Update a volume
-        #[clap(alias = "edit")]
+        #[clap(visible_alias = "edit", visible_alias = "rename")]
         Update(struct {
             /// The ID/name of the volume you wish to update
             #[clap(long, short)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! commands {
                     .propagate_version(true)
                     .about(concat!(
                         clap::crate_description!(),
-                        "\n\nTip: Using an AI coding agent? Run `railway skills install` to enhance it with Railway expertise — deploying, debugging, managing services."
+                        "\n\nTip: Using an AI coding agent? Run `railway setup agent -y` to install Railway skills and MCP configuration."
                     ))
                     .long_about(None)
                     .version(clap::crate_version!());
@@ -44,6 +44,17 @@ macro_rules! commands {
                         cmd = cmd.subcommand(sub);
                     }
                 )*
+                cmd = cmd
+                    .mut_subcommand("list", |cmd| cmd.visible_alias("ls"))
+                    .mut_subcommand("delete", |cmd| {
+                        cmd.visible_alias("rm").visible_alias("remove")
+                    })
+                    .mut_subcommand("project", |cmd| cmd.visible_alias("projects"))
+                    .mut_subcommand("bucket", |cmd| cmd.visible_alias("buckets"))
+                    .mut_subcommand("volume", |cmd| cmd.visible_alias("volumes"))
+                    .mut_subcommand("deployment", |cmd| cmd.visible_alias("deployments"))
+                    .mut_subcommand("templates", |cmd| cmd.visible_alias("template"))
+                    .mut_subcommand("check_updates", |cmd| cmd.visible_alias("check-updates"));
                 cmd
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,8 +354,13 @@ async fn main() -> Result<()> {
     }
 
     if let Err(e) = exec_result {
-        if e.root_cause().to_string() == inquire::InquireError::OperationInterrupted.to_string() {
-            return Ok(()); // Exit gracefully if interrupted
+        let root_cause = e.root_cause().to_string();
+        if root_cause == inquire::InquireError::OperationInterrupted.to_string()
+            || root_cause == inquire::InquireError::OperationCanceled.to_string()
+        {
+            eprintln!("Operation cancelled.");
+            handle_update_task(check_updates_handle).await;
+            std::process::exit(130);
         }
 
         eprintln!("{e:?}");

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -159,7 +159,7 @@ pub fn prompt_select_with_cancel<T: Display>(message: &str, options: Vec<T>) -> 
 }
 
 pub fn fake_select(message: &str, selected: &str) {
-    println!("{} {} {}", ">".green(), message, selected.cyan().bold());
+    eprintln!("{} {} {}", ">".green(), message, selected.cyan().bold());
 }
 
 pub fn prompt_variables(service_name: Option<&str>) -> Result<Vec<Variable>> {
@@ -179,7 +179,7 @@ pub fn prompt_variables(service_name: Option<&str>) -> Result<Vec<Variable>> {
             }
             match variable.parse::<Variable>() {
                 Ok(v) => variables.push(v),
-                Err(err) => println!("{} {:?}", "Warn".yellow(), err),
+                Err(err) => eprintln!("{} {:?}", "Warn".yellow(), err),
             }
         } else {
             break Ok(variables);


### PR DESCRIPTION
## Summary

Improve Railway CLI ergonomics for coding agents and non-interactive automation.

- Keep `--json` stdout parseable by moving fake selections, verbose logs, and prompt warnings to stderr
- Fix concrete automation footguns:
  - `environment new` now persists the newly linked environment
  - `variable delete KEY` now errors when the variable does not exist
  - cancelled interactive prompts now exit `130`
  - non-TTY login errors now point users toward token auth
- Add agent-friendly aliases for common guessed command shapes:
  - Root aliases: `ls`, `rm`, `remove`, `projects`, `buckets`, `volumes`, `deployments`, `template`, `check-updates`
  - Environment aliases: `list/ls`, `new/create/add`, `delete/rm/remove`, `edit/update`, `config/show/info`
  - Bucket aliases: `list/ls`, `create/add/new`, `delete/remove/rm`, `info/show/get`, `credentials/creds`, `rename/mv`
  - Volume aliases: `list/ls`, `add/create/new`, `delete/remove/rm`, `update/edit/rename`
  - Deployment aliases: `list/ls`, `up/deploy`
  - Dev aliases: `up/start`, `down/stop`, `configure/config`, `clean/reset`
  - Function aliases: `new/create/add`, `delete/remove/rm`, `push/up/deploy`
  - Skills aliases: `install/update/add`, `remove/rm/uninstall`
  - SSH key aliases: `list/ls`, `add/create/register`, `remove/rm/delete`, `github/import`
  - Template aliases: `search/find/list/ls`
  - Preference aliases: `autoupdate enable/on`, `autoupdate disable/off`, `telemetry enable/on`, `telemetry disable/off`
- Add automation-focused help examples and secret-output warnings for variable, bucket, deploy, run, and destructive commands
- Simplify the README around installation, authentication, agent setup, and CLI docs