### PR TITLE
Send setup agent telemetry without auth

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -486,9 +486,11 @@ pub async fn send_setup_agent(event: SetupAgentTrackEvent) {
         Err(_) => return,
     };
 
-    let client = match GQLClient::new_authorized(&configs) {
-        Ok(c) => c,
-        Err(_) => return,
+    let client = GQLClient::new_authorized(&configs)
+        .or_else(|_| GQLClient::new_public())
+        .ok();
+    let Some(client) = client else {
+        return;
     };
 
     let context = TelemetryContext::current(&configs);


### PR DESCRIPTION
## Summary
- Lets `send_setup_agent` fall back to a public GraphQL client when no Railway token/login is available.
- Keeps normal CLI command telemetry authenticated; only setup-agent lifecycle telemetry uses the public fallback.

## Why
`railway setup agent -y` is commonly run in a fresh environment before login. Without a public fallback, setup lifecycle telemetry exits before sending and the onboarding funnel cannot observe setup starts/finishes.

Depends on the Backboard mutation accepting anonymous setup telemetry: railwayapp/mono#28775.

## Validation
- `nix shell nixpkgs#rustfmt -c rustfmt --edition 2024 src/telemetry.rs`
- `nix shell nixpkgs#cargo nixpkgs#rustc -c cargo check`
- `nix shell nixpkgs#cargo nixpkgs#rustc -c cargo test --no-run`
- `git diff --check`