### PR TITLE
Detect Cline and Roo Code via CLINE_ACTIVE / ROO_ACTIVE env vars

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -174,6 +174,16 @@ const STRONG_AGENT_ENV: &[(&str, &str)] = &[
     ("REPLIT_AGENT", "replit_agent"),
     ("PI_CODING_AGENT", "pi"),
     ("__COG_BASHRC_SOURCED", "devin"),
+    // Cline sets CLINE_ACTIVE=true on every terminal it creates via
+    // vscode.window.createTerminal. Verified in cline/cline source at
+    // src/hosts/vscode/terminal/VscodeTerminalRegistry.ts and
+    // src/hosts/vscode/hostbridge/workspace/executeCommandInTerminal.ts;
+    // shipped in v3.24.0.
+    ("CLINE_ACTIVE", "cline"),
+    // Roo Code sets ROO_ACTIVE=true on every terminal it creates via
+    // Terminal.getEnv() in src/integrations/terminal/Terminal.ts
+    // (RooCodeInc/Roo-Code PR #11862, merged 2026-03-05).
+    ("ROO_ACTIVE", "roo_code"),
 ];
 
 fn agent_from_strong_env() -> Option<&'static str> {


### PR DESCRIPTION
## Summary

Adds two entries to `STRONG_AGENT_ENV` in `src/telemetry.rs` so the CLI fingerprints **Cline** and **Roo Code** when they spawn it. Both extensions stamp a `*_ACTIVE=true` marker on every terminal they create — high-confidence signals that exactly fit Layer 1's contract.

Currently both fall through Layer 1 (strong env) and Layer 2 (process tree) and land in Layer 4 as `agent_unknown:vscode`, which is our single largest unattributed bucket: 96 unique users / 2.4K events in the last 12h alone, accounting for ~27% of all `agent_unknown` traffic.

## Verification

Each entry was verified by reading the upstream source on `main`, not by docs or marketplace listings:

**Cline** — `CLINE_ACTIVE: "true"` set on every `vscode.window.createTerminal` call. Shipped in v3.24.0 (Aug 2025). Two source locations:
- [`src/hosts/vscode/terminal/VscodeTerminalRegistry.ts`](https://github.com/cline/cline/blob/main/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts)
- [`src/hosts/vscode/hostbridge/workspace/executeCommandInTerminal.ts`](https://github.com/cline/cline/blob/main/src/hosts/vscode/hostbridge/workspace/executeCommandInTerminal.ts)

**Roo Code** — `ROO_ACTIVE: "true"` set in `Terminal.getEnv()`, applied to every spawned terminal. Added in [PR #11862](https://github.com/RooCodeInc/Roo-Code/pull/11862), merged 2026-03-05.
- [`src/integrations/terminal/Terminal.ts`](https://github.com/RooCodeInc/Roo-Code/blob/main/src/integrations/terminal/Terminal.ts)

I deliberately skipped several other candidates that came up in research (Continue, GitHub Copilot Chat, Augment, Sourcegraph Cody) because none of them set a verifiable "I'm spawning this process" marker today — Copilot Chat has [an open feature request](https://github.com/microsoft/vscode/issues/265446) for one but it hasn't shipped, and the others surface only auth tokens that users set themselves.

## Downstream

The slugs `cline` and `roo_code` are already documented in the [`fct_agentic_events` schema](https://github.com/railwayapp/dbt-analytics/blob/main/models/marts/schema.yml) as known `caller_agent` values, so the dbt mart will route the new events into existing buckets without any analytics-side change. Effect: the next time someone queries `agent_unknown:vscode` rates, those rows should drop and the corresponding `caller_agent='cline'` / `caller_agent='roo_code'` rows should rise.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test --bin railway telemetry::tests` — 14 passed, 0 failed
- [ ] After release, sanity-check the mart: `agent_unknown:vscode` users should drop and `cline` / `roo_code` should appear with non-trivial volume in the affected window
- [ ] Confirm with at least one Cline user and one Roo Code user that their telemetry now classifies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)