### PR TITLE
feat(environment): edit config by project

### DIFF
--- a/src/commands/environment/edit.rs
+++ b/src/commands/environment/edit.rs
@@ -20,15 +20,24 @@ use super::new::{
 pub async fn edit_environment(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let linked_project = if args.project.is_some() {
+        None
+    } else {
+        Some(configs.get_linked_project().await?)
+    };
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|linked| linked.project.clone()))
+        .ok_or_else(|| RailwayError::NoLinkedProject)?;
+    let project = get_project(&client, &configs, project_id.clone()).await?;
     let stdin_is_terminal = std::io::stdin().is_terminal();
     let stdout_is_terminal = std::io::stdout().is_terminal();
     let is_interactive = stdin_is_terminal && stdout_is_terminal;
     let json = args.json;
 
     // Resolve environment: --environment flag, or linked environment
-    let environment_id = resolve_environment(&args, &project, &linked_project)?;
+    let environment_id = resolve_environment(&args, &project, linked_project.as_ref())?;
 
     // Get environment name for display
     let environment_name = project
@@ -39,8 +48,7 @@ pub async fn edit_environment(args: Args) -> Result<()> {
         .map(|e| e.node.name.clone())
         .unwrap_or_else(|| environment_id.clone());
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
 
     // Get config from stdin (if piped), CLI flags, or interactive prompts
     let env_config = get_edit_config(
@@ -165,7 +173,7 @@ pub async fn edit_environment(args: Args) -> Result<()> {
 fn resolve_environment(
     args: &Args,
     project: &queries::project::ProjectProject,
-    linked_project: &crate::config::LinkedProject,
+    linked_project: Option<&crate::config::LinkedProject>,
 ) -> Result<String> {
     if let Some(ref env_input) = args.environment {
         // Find environment by name or ID
@@ -183,6 +191,11 @@ fn resolve_environment(
         }
     } else {
         // Use linked environment
+        let linked_project = linked_project.ok_or_else(|| {
+            anyhow::anyhow!(
+                "No environment specified. Use --environment or run `railway link` to link one."
+            )
+        })?;
         let env_id = linked_project.environment_id()?.to_string();
         let environment = get_matched_environment(project, env_id)?;
         fake_select("Environment", &environment.name);

--- a/src/commands/environment/mod.rs
+++ b/src/commands/environment/mod.rs
@@ -92,6 +92,10 @@ structstruck::strike! {
         /// Edit an environment's configuration
         #[clap(visible_alias = "update")]
         Edit(pub struct {
+            /// Project ID/name to edit (defaults to linked project)
+            #[clap(long, short = 'p')]
+            pub project: Option<String>,
+
             /// The environment to edit (defaults to linked environment)
             #[clap(long, short)]
             pub environment: Option<String>,


### PR DESCRIPTION
## Summary

Adds support for editing environment configuration by passing a project directly to `railway environment edit`. This removes the requirement for a locally linked project when applying or staging service config changes, while preserving the existing linked-project behavior as the default.

## Changes

- Added a `--project` / `-p` option to `railway environment edit`.
- Resolves the project from `--project` when provided, otherwise falls back to the linked project.
- Uses the resolved project ID when fetching environment service instances.
- Preserves linked environment fallback when editing from a linked project.
- Requires `--environment` when using `--project` without linked context.

## Example

Current behaviour:

```sh
railway environment edit \
  --environment 00000000-0000-0000-0000-000000000000 \
  --service-config 00000000-0000-0000-0000-000000000000 deploy.startCommand "wrapper.sh postgres --port=5432" \
  --stage
# => "No linked project found. Run railway link to connect to a project"
# Requires linking a project to a directory.
```

New behaviour:

```sh
railway environment edit \
  --project 00000000-0000-0000-0000-000000000000 \  # <-- New
  --environment 00000000-0000-0000-0000-000000000000 \
  --service-config 00000000-0000-0000-0000-000000000000 deploy.startCommand "wrapper.sh postgres --port=5432" \
  --stage
> Environment production
> Configuring startCommand
> Apply changes now? No
Changes staged for production (use 'railway environment edit' to commit)
```

## Test plan

- [x] Ran `cargo check -q`
- [x] Verified the branch diff only touches environment edit command handling
- [x] Manually verify `railway environment edit --project <id> --environment <id> --service-config ... --stage`
- [x] Manually verify existing linked-project flow still works without `--project`