### PR TITLE
feat(cli): add project selector to service commands

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -29,6 +29,10 @@ pub struct Args {
     /// Environment to pull variables from (defaults to linked environment)
     #[clap(short, long)]
     environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
 }
 
 impl Display for ProjectProjectServicesEdgesNode {
@@ -40,13 +44,31 @@ impl Display for ProjectProjectServicesEdgesNode {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
     let environment = match args.environment.clone() {
         Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
+        None => linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string(),
     };
 
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let project = get_project(&client, &configs, project_id.clone()).await?;
 
     let service = if let Some(name) = args.service_name.clone() {
         get_service(&project, name)?
@@ -72,12 +94,11 @@ pub async fn command(args: Args) -> Result<()> {
     let environment_id = get_matched_environment(&project, environment)?.id;
     let service_id = service.id.clone();
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
     let variables = get_service_variables(
         &client,
         &configs,
-        linked_project.project,
+        project_id,
         environment_id.clone(),
         service_id.clone(),
     )

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -6,11 +6,7 @@ use is_terminal::IsTerminal;
 use queries::domains::DomainsDomains;
 use serde_json::json;
 
-use crate::{
-    consts::TICK_STRING,
-    controllers::project::{ensure_project_and_environment_exist, get_project},
-    errors::RailwayError,
-};
+use crate::{consts::TICK_STRING, controllers::project::resolve_service_context};
 
 use super::*;
 
@@ -27,6 +23,14 @@ pub struct Args {
     #[clap(short, long)]
     service: Option<String>,
 
+    /// Environment to use (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Optionally, specify a custom domain to use. If not specified, a domain will be generated.
     ///
     /// Specifying a custom domain will also return the required DNS records
@@ -40,29 +44,36 @@ pub struct Args {
 
 pub async fn command(args: Args) -> Result<()> {
     if let Some(domain) = args.domain {
-        create_custom_domain(domain, args.port, args.service, args.json).await?;
+        create_custom_domain(
+            domain,
+            args.port,
+            args.project,
+            args.service,
+            args.environment,
+            args.json,
+        )
+        .await?;
     } else {
-        create_service_domain(args.service, args.json).await?;
+        create_service_domain(args.project, args.service, args.environment, args.json).await?;
     }
     Ok(())
 }
 
-async fn create_service_domain(service_name: Option<String>, json: bool) -> Result<()> {
+async fn create_service_domain(
+    project: Option<String>,
+    service_name: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
     let configs = Configs::new()?;
 
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-
-    let service = get_service(&linked_project, &project, service_name)?;
+    let ctx = resolve_service_context(project, service_name, environment).await?;
 
     let vars = queries::domains::Variables {
-        project_id: linked_project.project.clone(),
-        environment_id: linked_project.environment_id()?.to_string(),
-        service_id: service.id.clone(),
+        project_id: ctx.project_id.clone(),
+        environment_id: ctx.environment_id.clone(),
+        service_id: ctx.service_id.clone(),
     };
 
     let domains = post_graphql::<queries::Domains, _>(&client, configs.get_backboard(), vars)
@@ -79,8 +90,8 @@ async fn create_service_domain(service_name: Option<String>, json: bool) -> Resu
         .and_then(|s| s.ok());
 
     let vars = mutations::service_domain_create::Variables {
-        service_id: service.id.clone(),
-        environment_id: linked_project.environment_id()?.to_string(),
+        service_id: ctx.service_id.clone(),
+        environment_id: ctx.environment_id.clone(),
     };
     let domain =
         post_graphql::<mutations::ServiceDomainCreate, _>(&client, configs.get_backboard(), vars)
@@ -162,50 +173,6 @@ fn print_existing_domains(domains: &DomainsDomains, json: bool) -> Result<()> {
     Ok(())
 }
 
-// Returns a reference to save on Heap allocations
-pub fn get_service<'a>(
-    linked_project: &'a LinkedProject,
-    project: &'a queries::project::ProjectProject,
-    service_name: Option<String>,
-) -> anyhow::Result<&'a queries::project::ProjectProjectServicesEdgesNode> {
-    let services = project.services.edges.iter().collect::<Vec<_>>();
-
-    if services.is_empty() {
-        bail!(RailwayError::NoServices);
-    }
-
-    if project.services.edges.len() == 1 {
-        return Ok(&project.services.edges[0].node);
-    }
-
-    if let Some(service_name) = service_name {
-        if let Some(service) = project
-            .services
-            .edges
-            .iter()
-            .find(|s| s.node.name == service_name)
-        {
-            return Ok(&service.node);
-        }
-
-        bail!(RailwayError::ServiceNotFound(service_name));
-    }
-
-    if let Some(service) = linked_project.service.clone() {
-        if project.services.edges.iter().any(|s| s.node.id == service) {
-            return Ok(&project
-                .services
-                .edges
-                .iter()
-                .find(|s| s.node.id == service)
-                .unwrap()
-                .node);
-        }
-    }
-
-    bail!(RailwayError::NoServices);
-}
-
 pub fn creating_domain_spiner(message: Option<String>) -> anyhow::Result<indicatif::ProgressBar> {
     let spinner = indicatif::ProgressBar::new_spinner()
         .with_style(
@@ -222,25 +189,21 @@ pub fn creating_domain_spiner(message: Option<String>) -> anyhow::Result<indicat
 async fn create_custom_domain(
     domain: String,
     port: Option<u16>,
+    project: Option<String>,
     service_name: Option<String>,
+    environment: Option<String>,
     json: bool,
 ) -> Result<()> {
     let configs = Configs::new()?;
 
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-
-    let service = get_service(&linked_project, &project, service_name)?;
+    let ctx = resolve_service_context(project, service_name, environment).await?;
 
     let spinner = (std::io::stdout().is_terminal() && !json)
         .then(|| {
             creating_domain_spiner(Some(format!(
                 "Creating custom domain for service {}{}...",
-                service.name,
+                ctx.service_name,
                 port.map(|p| format!(" on port {p}")).unwrap_or_default()
             )))
         })
@@ -264,9 +227,9 @@ async fn create_custom_domain(
     let vars = mutations::custom_domain_create::Variables {
         input: mutations::custom_domain_create::CustomDomainCreateInput {
             domain: domain.clone(),
-            environment_id: linked_project.environment_id()?.to_string(),
-            project_id: linked_project.project.clone(),
-            service_id: service.id.clone(),
+            environment_id: ctx.environment_id.clone(),
+            project_id: ctx.project_id.clone(),
+            service_id: ctx.service_id.clone(),
             target_port: port.map(|p| p as i64),
         },
     };

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -35,6 +35,7 @@ pub async fn command(args: Args) -> Result<()> {
     let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
     let project_id = ctx.project_id;
     let environment_id = ctx.environment_id;
+    let environment_name = ctx.environment_name;
     let service = ctx.service_id;
     let project_name = ctx.project.name.clone();
 
@@ -51,7 +52,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     let linked_project_environment = format!(
         "{} environment of project {}",
-        environment_id.bold(),
+        environment_name.bold(),
         project_name.bold()
     );
 

--- a/src/commands/down.rs
+++ b/src/commands/down.rs
@@ -1,15 +1,11 @@
 use std::time::Duration;
 
-use anyhow::bail;
-
 use super::{
     queries::{deployments::DeploymentListInput, deployments::DeploymentStatus},
     *,
 };
 use crate::{
-    consts::TICK_STRING,
-    controllers::{environment::get_matched_environment, project::get_project},
-    errors::RailwayError,
+    consts::TICK_STRING, controllers::project::resolve_service_context,
     util::prompt::prompt_confirm_with_default,
 };
 
@@ -24,6 +20,10 @@ pub struct Args {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Skip confirmation dialog
     #[clap(short = 'y', long = "yes")]
     bypass: bool,
@@ -32,37 +32,16 @@ pub struct Args {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-
-    let environment = match args.environment.clone() {
-        Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
-    };
-
-    let services = project.services.edges.iter().collect::<Vec<_>>();
-
-    let environment_id = get_matched_environment(&project, environment)?.id;
-    let service = match (args.service, linked_project.service) {
-        // If the user specified a service, use that
-        (Some(service_arg), _) => services
-            .iter()
-            .find(|service| service.node.name == service_arg || service.node.id == service_arg)
-            .with_context(|| format!("Service '{service_arg}' not found"))?
-            .node
-            .id
-            .to_owned(),
-        // Otherwise if we have a linked service, use that
-        (_, Some(linked_service)) => linked_service,
-        // Otherwise it's a user error
-        _ => bail!(RailwayError::NoServiceLinked),
-    };
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
+    let project_id = ctx.project_id;
+    let environment_id = ctx.environment_id;
+    let service = ctx.service_id;
+    let project_name = ctx.project.name.clone();
 
     let vars = queries::deployments::Variables {
         input: DeploymentListInput {
-            project_id: Some(linked_project.project.clone()),
-            environment_id: Some(environment_id),
+            project_id: Some(project_id.clone()),
+            environment_id: Some(environment_id.clone()),
             service_id: Some(service),
             include_deleted: None,
             status: None,
@@ -70,20 +49,10 @@ pub async fn command(args: Args) -> Result<()> {
         first: None,
     };
 
-    let linked_project_name = linked_project
-        .name
-        .as_deref()
-        .unwrap_or(linked_project.project.as_str());
-
-    let linked_environment_name = linked_project
-        .environment_name
-        .as_deref()
-        .unwrap_or(linked_project.environment.as_deref().unwrap_or("unknown"));
-
     let linked_project_environment = format!(
         "{} environment of project {}",
-        linked_environment_name.bold(),
-        linked_project_name.bold()
+        environment_id.bold(),
+        project_name.bold()
     );
 
     let deployments =

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -9,8 +9,7 @@ use crate::{
             FetchLogsParams, fetch_build_logs, fetch_deploy_logs, fetch_http_logs,
             stream_build_logs, stream_deploy_logs, stream_http_logs,
         },
-        environment::get_matched_environment,
-        project::{ensure_project_and_environment_exist, get_project},
+        project::resolve_service_context,
     },
     util::{
         logs::{LogFormat, print_http_log, print_log},
@@ -201,6 +200,10 @@ pub struct Args {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Show deployment logs
     #[clap(short, long, group = "log_type")]
     deployment: bool,
@@ -288,9 +291,6 @@ pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
 
     // Build filter before args is partially moved by service matching below
     let http_filter = build_http_filter(&args);
@@ -309,38 +309,16 @@ pub async fn command(args: Args) -> Result<()> {
     // Stream only if no line limit or time filter is specified and running in a terminal
     let should_stream = args.lines.is_none() && !has_time_filter && std::io::stdout().is_terminal();
 
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-
-    let environment = match args.environment.clone() {
-        Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
-    };
-
-    let services = project.services.edges.iter().collect::<Vec<_>>();
-
-    let environment_id = get_matched_environment(&project, environment)?.id;
-    let service = match (args.service, linked_project.service) {
-        // If the user specified a service, use that
-        (Some(service_arg), _) => services
-            .iter()
-            .find(|service| service.node.name == service_arg || service.node.id == service_arg)
-            .with_context(|| format!("Service '{service_arg}' not found"))?
-            .node
-            .id
-            .to_owned(),
-        // Otherwise if we have a linked service, use that
-        (_, Some(linked_service)) => linked_service,
-        // Otherwise it's a user error
-        _ => bail!(
-            "No service could be found. Please either link one with `railway service` or specify one via the `--service` flag."
-        ),
-    };
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
+    let project_id = ctx.project_id;
+    let environment_id = ctx.environment_id;
+    let service = ctx.service_id;
 
     // Fetch all deployments so we can find a sensible default deployment id if
     // none is provided
     let vars = queries::deployments::Variables {
         input: DeploymentListInput {
-            project_id: Some(linked_project.project.clone()),
+            project_id: Some(project_id.clone()),
             environment_id: Some(environment_id),
             service_id: Some(service),
             include_deleted: None,

--- a/src/commands/metrics.rs
+++ b/src/commands/metrics.rs
@@ -74,6 +74,10 @@ pub struct Args {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Time window start. Accepts relative (1h, 6h, 1d, 7d) or ISO 8601. Default: 1h
     #[clap(long, short = 'S', default_value = "1h")]
     since: String,
@@ -213,27 +217,48 @@ pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
-    let linked_project = configs.get_linked_project().await?;
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
 
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
 
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-
-    let environment = match args
-        .environment
+    let project_id = args
+        .project
         .clone()
-        .or_else(|| linked_project.environment_name.clone())
-        .or_else(|| linked_project.environment.clone())
-    {
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
+
+    let project = get_project(&client, &configs, project_id.clone()).await?;
+
+    let environment = match args.environment.clone().or_else(|| {
+        linked_project.as_ref().and_then(|lp| {
+            lp.environment_name
+                .clone()
+                .or_else(|| lp.environment.clone())
+        })
+    }) {
         Some(environment) => environment,
-        None => linked_project.environment_id()?.to_string(),
+        None => linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string(),
     };
     let environment = get_matched_environment(&project, environment)?;
     let environment_id = environment.id.clone();
     let environment_name = environment.name.clone();
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
 
     // Cross-service mode: --all
     let show_spinner = !args.json && !args.raw && !args.watch;
@@ -250,7 +275,7 @@ pub async fn command(args: Args) -> Result<()> {
                 crate::controllers::metrics_tui::ProjectTuiParams {
                     client: client.clone(),
                     backboard: backboard.clone(),
-                    project_id: linked_project.project.clone(),
+                    project_id: project_id.clone(),
                     project: project.clone(),
                     environment_instances: environment_instances.clone(),
                     environment_id: environment_id.clone(),
@@ -281,7 +306,7 @@ pub async fn command(args: Args) -> Result<()> {
             FetchProjectMetricsParams {
                 client: &client,
                 backboard: &backboard,
-                project_id: &linked_project.project,
+                project_id: &project_id,
                 environment_id: &environment_id,
                 start_date,
                 end_date,
@@ -372,7 +397,8 @@ pub async fn command(args: Args) -> Result<()> {
     }
 
     let services = project.services.edges.iter().collect::<Vec<_>>();
-    let (service_id, service_name) = match (args.service.as_deref(), linked_project.service) {
+    let linked_service = linked_project.as_ref().and_then(|lp| lp.service.as_ref());
+    let (service_id, service_name) = match (args.service.as_deref(), linked_service) {
         (Some(service_arg), _) => {
             let s = services
                 .iter()
@@ -383,10 +409,10 @@ pub async fn command(args: Args) -> Result<()> {
         (_, Some(linked_service)) => {
             let name = services
                 .iter()
-                .find(|s| s.node.id == linked_service)
+                .find(|s| s.node.id == *linked_service)
                 .map(|s| s.node.name.clone())
                 .unwrap_or_else(|| linked_service.clone());
-            (linked_service, name)
+            (linked_service.clone(), name)
         }
         _ => bail!(
             "No service could be found. Please either link one with `railway service` or specify one via the `--service` flag."
@@ -509,7 +535,7 @@ pub async fn command(args: Args) -> Result<()> {
         fetch_deployments(
             &client,
             &backboard,
-            &linked_project.project,
+            &project_id,
             &environment_id,
             &service_id,
         )

--- a/src/commands/redeploy.rs
+++ b/src/commands/redeploy.rs
@@ -3,10 +3,8 @@ use is_terminal::IsTerminal;
 
 use crate::{
     controllers::project::{
-        ensure_project_and_environment_exist, find_service_instance, get_environment_instances,
-        get_project,
+        find_service_instance, get_environment_instances, resolve_service_context,
     },
-    errors::RailwayError,
     util::{progress::create_spinner_if, prompt::prompt_confirm_with_default},
 };
 
@@ -19,6 +17,14 @@ pub struct Args {
     /// The service ID/name to redeploy from
     #[clap(long, short)]
     service: Option<String>,
+
+    /// Environment to redeploy in (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
 
     /// Skip confirmation dialog
     #[clap(short = 'y', long = "yes")]
@@ -36,39 +42,17 @@ pub struct Args {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-    let environment_id = linked_project.environment_id()?.to_string();
-    let environment_name = linked_project
-        .environment_name
-        .as_deref()
-        .unwrap_or("unknown");
-
-    let service_id = args
-        .service
-        .or_else(|| linked_project.service.clone())
-        .ok_or_else(|| {
-            anyhow!(
-                "No service found. Please link one via `railway link` or specify one via the `--service` flag."
-            )
-        })?;
-    let service = project
-        .services
-        .edges
-        .iter()
-        .find(|s| {
-            s.node.id == service_id || s.node.name.to_lowercase() == service_id.to_lowercase()
-        })
-        .ok_or_else(|| anyhow!(RailwayError::ServiceNotFound(service_id)))?;
-    let service_name = &service.node.name;
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
+    let project_id = ctx.project_id;
+    let environment_id = ctx.environment_id;
+    let environment_name = environment_id.as_str();
+    let service_id = ctx.service_id;
+    let service_name = &ctx.service_name;
+    let service_node_id = service_id.clone();
 
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
-    let service_in_env = find_service_instance(&environment_instances, &service.node.id)
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
+    let service_in_env = find_service_instance(&environment_instances, &service_node_id)
         .ok_or_else(|| anyhow!("The service specified doesn't exist in the current environment"))?;
 
     let latest_deployment_id = if args.from_source {
@@ -134,7 +118,7 @@ pub async fn command(args: Args) -> Result<()> {
                 configs.get_backboard(),
                 mutations::service_instance_deploy_latest_commit::Variables {
                     environment_id,
-                    service_id: service.node.id.clone(),
+                    service_id: service_id.clone(),
                 },
             )
             .await?;

--- a/src/commands/redeploy.rs
+++ b/src/commands/redeploy.rs
@@ -45,7 +45,7 @@ pub async fn command(args: Args) -> Result<()> {
     let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
     let project_id = ctx.project_id;
     let environment_id = ctx.environment_id;
-    let environment_name = environment_id.as_str();
+    let environment_name = ctx.environment_name;
     let service_id = ctx.service_id;
     let service_name = &ctx.service_name;
     let service_node_id = service_id.clone();

--- a/src/commands/restart.rs
+++ b/src/commands/restart.rs
@@ -4,10 +4,8 @@ use is_terminal::IsTerminal;
 
 use crate::{
     controllers::project::{
-        ensure_project_and_environment_exist, find_service_instance, get_environment_instances,
-        get_project,
+        find_service_instance, get_environment_instances, resolve_service_context,
     },
-    errors::RailwayError,
     subscription::subscribe_graphql,
     subscriptions::deployment::DeploymentStatus,
     util::{progress::create_spinner_if, prompt::prompt_confirm_with_default},
@@ -23,6 +21,14 @@ pub struct Args {
     #[clap(long, short)]
     service: Option<String>,
 
+    /// Environment to restart in (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Skip confirmation dialog
     #[clap(short = 'y', long = "yes")]
     yes: bool,
@@ -35,38 +41,14 @@ pub struct Args {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
     let is_terminal = std::io::stdout().is_terminal();
+    let service_id = ctx.service_id;
+    let service_name = ctx.service_name;
 
-    let service_id = args
-        .service
-        .or_else(|| linked_project.service.clone())
-        .ok_or_else(|| {
-            anyhow!(
-                "No service found. Please link one via `railway link` or specify one via the `--service` flag."
-            )
-        })?;
-    let service = project
-        .services
-        .edges
-        .iter()
-        .find(|s| {
-            s.node.id == service_id || s.node.name.to_lowercase() == service_id.to_lowercase()
-        })
-        .ok_or_else(|| anyhow!(RailwayError::ServiceNotFound(service_id)))?;
-
-    let environment_instances = get_environment_instances(
-        &client,
-        &configs,
-        &linked_project.project,
-        linked_project.environment_id()?,
-    )
-    .await?;
-    let service_in_env = find_service_instance(&environment_instances, &service.node.id)
+    let environment_instances =
+        get_environment_instances(&client, &configs, &ctx.project_id, &ctx.environment_id).await?;
+    let service_in_env = find_service_instance(&environment_instances, &service_id)
         .ok_or_else(|| anyhow!("The service specified doesn't exist in the current environment"))?;
 
     let Some(ref latest) = service_in_env.latest_deployment else {
@@ -79,11 +61,7 @@ pub async fn command(args: Args) -> Result<()> {
         prompt_confirm_with_default(
             format!(
                 "Restart the latest deployment from service {} in environment {}?",
-                service.node.name,
-                linked_project
-                    .environment_name
-                    .clone()
-                    .unwrap_or("unknown".to_string())
+                service_name, ctx.environment_id
             )
             .as_str(),
             false,
@@ -102,7 +80,7 @@ pub async fn command(args: Args) -> Result<()> {
         !args.json,
         format!(
             "Restarting the latest deployment from service {}...",
-            service.node.name
+            service_name
         ),
     );
 
@@ -123,7 +101,7 @@ pub async fn command(args: Args) -> Result<()> {
     let spinner = spinner.unwrap();
     spinner.set_message(format!(
         "Waiting for deployment from service {} to be healthy...",
-        service.node.name
+        service_name
     ));
 
     let mut stream =
@@ -149,21 +127,21 @@ pub async fn command(args: Args) -> Result<()> {
                 DeploymentStatus::SUCCESS => {
                     spinner.finish_with_message(format!(
                         "The latest deployment from service {} has been restarted and is healthy",
-                        service.node.name.green()
+                        service_name.green()
                     ));
                     return Ok(());
                 }
                 DeploymentStatus::FAILED => {
                     spinner.finish_with_message(format!(
                         "Deployment from service {} failed",
-                        service.node.name.red()
+                        service_name.red()
                     ));
                     bail!("Deployment failed");
                 }
                 DeploymentStatus::CRASHED => {
                     spinner.finish_with_message(format!(
                         "Deployment from service {} crashed",
-                        service.node.name.red()
+                        service_name.red()
                     ));
                     bail!("Deployment crashed");
                 }
@@ -174,7 +152,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     spinner.finish_with_message(format!(
         "The latest deployment from service {} has been restarted",
-        service.node.name.green()
+        service_name.green()
     ));
 
     Ok(())

--- a/src/commands/restart.rs
+++ b/src/commands/restart.rs
@@ -45,6 +45,7 @@ pub async fn command(args: Args) -> Result<()> {
     let is_terminal = std::io::stdout().is_terminal();
     let service_id = ctx.service_id;
     let service_name = ctx.service_name;
+    let environment_name = ctx.environment_name;
 
     let environment_instances =
         get_environment_instances(&client, &configs, &ctx.project_id, &ctx.environment_id).await?;
@@ -61,7 +62,7 @@ pub async fn command(args: Args) -> Result<()> {
         prompt_confirm_with_default(
             format!(
                 "Restart the latest deployment from service {} in environment {}?",
-                service_name, ctx.environment_id
+                service_name, environment_name
             )
             .as_str(),
             false,

--- a/src/commands/scale.rs
+++ b/src/commands/scale.rs
@@ -35,6 +35,10 @@ pub struct Args {
     #[clap(long, short)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Output in JSON format
     #[clap(long)]
     json: bool,
@@ -53,28 +57,46 @@ Maximum: 50 total replicas across regions."#;
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
     let project = post_graphql::<queries::Project, _>(
         &client,
         configs.get_backboard(),
         queries::project::Variables {
-            id: linked_project.project.clone(),
+            id: project_id.clone(),
         },
     )
     .await?
     .project;
     let environment = match args.environment.clone() {
         Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
+        None => linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string(),
     };
     let environment = get_matched_environment(&project, environment)?;
     let environment_id = environment.id;
     let environment_name = environment.name;
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
+    let linked_service = linked_project.as_ref().and_then(|lp| lp.service.as_ref());
     let (existing, service_id) =
-        get_existing_config(&args, &linked_project, &project, &environment_instances)?;
+        get_existing_config(&args, linked_service, &project, &environment_instances)?;
     let service_name = project
         .services
         .edges
@@ -87,7 +109,7 @@ pub async fn command(args: Args) -> Result<()> {
             &args,
             &configs,
             &client,
-            &linked_project.project,
+            &project_id,
             &service_name,
             &environment_name,
             &existing,
@@ -117,8 +139,7 @@ pub async fn command(args: Args) -> Result<()> {
         println!("{}", serde_json::json!({"regions": region_data}));
     } else {
         let region_locations =
-            fetch_region_locations_for_project(&client, &configs, Some(&linked_project.project))
-                .await;
+            fetch_region_locations_for_project(&client, &configs, Some(&project_id)).await;
         print_scale_result(
             &service_name,
             &service_id,
@@ -217,13 +238,13 @@ async fn commit_scale_patch(
 /// Returns (existing_config, service_id)
 fn get_existing_config(
     args: &Args,
-    linked_project: &LinkedProject,
+    linked_service: Option<&String>,
     project: &queries::project::ProjectProject,
     environment_instances: &ProjectEnvironmentInstances,
 ) -> Result<(Value, String)> {
     let service_input = match args.service.as_ref() {
         Some(s) => s,
-        None => linked_project.service.as_ref().ok_or_else(|| {
+        None => linked_service.ok_or_else(|| {
             anyhow::anyhow!("No service linked. Please either specify a service with the --service flag or link one with `railway service`")
         })?,
     };

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -84,6 +84,10 @@ struct ListArgs {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Output in JSON format
     #[clap(long)]
     json: bool,
@@ -98,6 +102,10 @@ struct DeleteArgs {
     /// Environment to delete the service from (defaults to linked environment)
     #[clap(short, long)]
     environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
 
     /// Skip confirmation dialog
     #[clap(short = 'y', long = "yes")]
@@ -129,6 +137,10 @@ struct StatusArgs {
     /// Service name or ID to show status for (defaults to linked service)
     #[clap(short, long)]
     service: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
 
     /// Deprecated: use `railway service list` instead. Kept for backwards compatibility.
     #[clap(short, long, hide = true)]
@@ -175,20 +187,43 @@ pub async fn command(args: Args) -> Result<()> {
 async fn list_command(args: ListArgs) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
+
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
+
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
+
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
 
     let (project, region_locations) = tokio::join!(
-        get_project(&client, &configs, linked_project.project.clone()),
+        get_project(&client, &configs, project_id.clone()),
         fetch_region_locations(&client, &configs),
     );
     let project = project?;
 
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
     let env_id = if let Some(env_name) = args.environment {
         get_matched_environment(&project, env_name)?.id
     } else {
-        linked_project.environment_id()?.to_string()
+        linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string()
     };
     let env_name = project
         .environments
@@ -199,9 +234,9 @@ async fn list_command(args: ListArgs) -> Result<()> {
         .expect("environment resolved above");
 
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &env_id).await?;
+        get_environment_instances(&client, &configs, &project_id, &env_id).await?;
     let service_ids_in_env = get_service_ids_in_env(&environment_instances);
-    let linked_service_id = linked_project.service.as_deref();
+    let linked_service_id = linked_project.as_ref().and_then(|lp| lp.service.as_deref());
 
     let mut services: Vec<_> = project
         .services
@@ -247,18 +282,48 @@ async fn list_command(args: ListArgs) -> Result<()> {
 async fn delete_command(args: DeleteArgs) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
+
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
     let local_linked_project = configs.get_local_linked_project().ok();
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
+
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
+
+    let project = get_project(&client, &configs, project_id.clone()).await?;
     let is_terminal = std::io::stdout().is_terminal();
-    let environment =
-        resolve_environment_to_delete(&project, &linked_project, args.environment.as_deref())?;
+    let environment = if let Some(environment_arg) = args.environment.as_deref() {
+        get_matched_environment(&project, environment_arg.to_string())?
+    } else {
+        resolve_environment_to_delete(
+            &project,
+            linked_project
+                .as_ref()
+                .context("No environment linked. Use --environment when using --project")?,
+            None,
+        )?
+    };
     let environment_id = environment.id.clone();
     let environment_name = environment.name.clone();
 
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
     let service_ids_in_env = get_service_ids_in_env(&environment_instances);
     let services_in_env: Vec<_> = project
         .services
@@ -271,7 +336,7 @@ async fn delete_command(args: DeleteArgs) -> Result<()> {
     let service = select_service_to_delete(
         services_in_env,
         args.service.as_deref(),
-        linked_project.service.as_deref(),
+        linked_project.as_ref().and_then(|lp| lp.service.as_deref()),
         &environment_name,
         !args.json,
         is_terminal,
@@ -318,7 +383,7 @@ async fn delete_command(args: DeleteArgs) -> Result<()> {
     .await?;
 
     let unlink_path = local_linked_project.as_ref().and_then(|project| {
-        (project.project == linked_project.project
+        (project.project == project_id
             && project.service.as_deref() == Some(service_id.as_str())
             && project.environment_id().ok() == Some(environment_id.as_str()))
         .then(|| project.project_path.clone())
@@ -499,17 +564,41 @@ async fn status_command(args: StatusArgs) -> Result<()> {
 
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
 
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
+
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
+
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
+
+    let project = get_project(&client, &configs, project_id.clone()).await?;
 
     // Determine which environment to use
     let environment_id = if let Some(env_name) = args.environment {
         let env = get_matched_environment(&project, env_name)?;
         env.id
     } else {
-        linked_project.environment_id()?.to_string()
+        linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string()
     };
 
     let environment_name = project
@@ -523,8 +612,7 @@ async fn status_command(args: StatusArgs) -> Result<()> {
     // Collect service instances for the environment
     let mut service_statuses: Vec<ServiceStatusOutput> = Vec::new();
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment_id)
-            .await?;
+        get_environment_instances(&client, &configs, &project_id, &environment_id).await?;
 
     for instance_edge in service_instances_in_env(&environment_instances) {
         let instance = &instance_edge.node;
@@ -575,8 +663,8 @@ async fn status_command(args: StatusArgs) -> Result<()> {
         } else {
             // Use linked service
             let linked_service_id = linked_project
-                .service
                 .as_ref()
+                .and_then(|lp| lp.service.as_ref())
                 .context("No service linked. Use --service flag or --all to see all services")?;
 
             service_statuses

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -1,10 +1,7 @@
-use anyhow::bail;
 use std::collections::BTreeMap;
 
 use crate::{
-    controllers::project::{ensure_project_and_environment_exist, get_project},
-    controllers::variables::get_service_variables,
-    errors::RailwayError,
+    controllers::project::resolve_service_context, controllers::variables::get_service_variables,
 };
 
 use super::*;
@@ -34,6 +31,14 @@ pub struct Args {
     #[clap(short, long)]
     service: Option<String>,
 
+    /// Environment to pull variables from (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Open shell without banner
     #[clap(long)]
     silent: bool,
@@ -42,47 +47,20 @@ pub struct Args {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
 
     let mut all_variables = BTreeMap::<String, String>::new();
     all_variables.insert("IN_RAILWAY_SHELL".to_owned(), "true".to_owned());
 
-    if let Some(service) = args.service {
-        let service_id = project
-            .services
-            .edges
-            .iter()
-            .find(|s| s.node.name == service || s.node.id == service)
-            .ok_or_else(|| RailwayError::ServiceNotFound(service))?;
-
-        let mut variables = get_service_variables(
-            &client,
-            &configs,
-            linked_project.project.clone(),
-            linked_project.environment_id()?.to_string(),
-            service_id.node.id.clone(),
-        )
-        .await?;
-
-        all_variables.append(&mut variables);
-    } else if let Some(ref service) = linked_project.service {
-        let mut variables = get_service_variables(
-            &client,
-            &configs,
-            linked_project.project.clone(),
-            linked_project.environment_id()?.to_string(),
-            service.clone(),
-        )
-        .await?;
-
-        all_variables.append(&mut variables);
-    } else {
-        bail!("No service linked. Please link one with `railway service`");
-    }
+    let mut variables = get_service_variables(
+        &client,
+        &configs,
+        ctx.project_id,
+        ctx.environment_id,
+        ctx.service_id,
+    )
+    .await?;
+    all_variables.append(&mut variables);
 
     let shell = std::env::var("SHELL").unwrap_or(match std::env::consts::OS {
         "windows" => match windows_shell_detection().await {

--- a/src/commands/variable.rs
+++ b/src/commands/variable.rs
@@ -28,6 +28,10 @@ pub struct Args {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Show variables in KV format. This prints raw values.
     #[clap(short, long)]
     kv: bool,
@@ -73,6 +77,10 @@ struct ListArgs {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Show variables in KV format. This prints raw values.
     #[clap(short, long)]
     kv: bool,
@@ -95,6 +103,10 @@ struct SetArgs {
     /// The environment to set the variable in
     #[clap(short, long)]
     environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
 
     /// Read the value from stdin instead of the command line (only with single KEY)
     #[clap(long)]
@@ -122,6 +134,10 @@ struct DeleteArgs {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
     /// Output in JSON format
     #[clap(long)]
     json: bool,
@@ -144,6 +160,7 @@ pub async fn command(args: Args) -> Result<()> {
             vec![variable],
             args.service,
             args.environment,
+            args.project,
             args.skip_deploys,
         )
         .await;
@@ -151,14 +168,21 @@ pub async fn command(args: Args) -> Result<()> {
 
     // Legacy behavior: handle --set flag
     if !args.set.is_empty() {
-        return set_variables_legacy(args.set, args.service, args.environment, args.skip_deploys)
-            .await;
+        return set_variables_legacy(
+            args.set,
+            args.service,
+            args.environment,
+            args.project,
+            args.skip_deploys,
+        )
+        .await;
     }
 
     // Legacy behavior: list variables (default)
     list_variables(ListArgs {
         service: args.service,
         environment: args.environment,
+        project: args.project,
         kv: args.kv,
         json: args.json,
     })
@@ -166,7 +190,7 @@ pub async fn command(args: Args) -> Result<()> {
 }
 
 async fn list_variables(args: ListArgs) -> Result<()> {
-    let ctx = resolve_service_context(args.service, args.environment).await?;
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
 
     let variables = get_service_variables(
         &ctx.client,
@@ -227,6 +251,7 @@ async fn set_variable(args: SetArgs) -> Result<()> {
         variables,
         args.service,
         args.environment,
+        args.project,
         args.skip_deploys,
         args.json,
     )
@@ -234,7 +259,7 @@ async fn set_variable(args: SetArgs) -> Result<()> {
 }
 
 async fn delete_variable(args: DeleteArgs) -> Result<()> {
-    let ctx = resolve_service_context(args.service, args.environment).await?;
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
 
     let variables = get_service_variables(
         &ctx.client,
@@ -274,19 +299,29 @@ async fn set_variables_legacy(
     variables: Vec<Variable>,
     service: Option<String>,
     environment: Option<String>,
+    project: Option<String>,
     skip_deploys: bool,
 ) -> Result<()> {
-    set_variables_internal(variables, service, environment, skip_deploys, false).await
+    set_variables_internal(
+        variables,
+        service,
+        environment,
+        project,
+        skip_deploys,
+        false,
+    )
+    .await
 }
 
 async fn set_variables_internal(
     variables: Vec<Variable>,
     service: Option<String>,
     environment: Option<String>,
+    project: Option<String>,
     skip_deploys: bool,
     json: bool,
 ) -> Result<()> {
-    let ctx = resolve_service_context(service, environment).await?;
+    let ctx = resolve_service_context(project, service, environment).await?;
 
     let keys: Vec<String> = variables.iter().map(|v| v.key.clone()).collect();
     let fmt_keys = keys

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -35,6 +35,10 @@ pub struct Args {
     /// Environment ID
     #[clap(long, short)]
     environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
 }
 structstruck::strike! {
     #[strikethrough[derive(Parser)]]
@@ -134,19 +138,41 @@ structstruck::strike! {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+    let linked_project = if args.project.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
 
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
 
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-    let service = args.service.or_else(|| linked_project.service.clone());
+    let project_id = args
+        .project
+        .clone()
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
+    let project = get_project(&client, &configs, project_id.clone()).await?;
+    let service = args
+        .service
+        .or_else(|| linked_project.as_ref().and_then(|lp| lp.service.clone()));
     let environment_input = match args.environment.clone() {
         Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
+        None => linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string(),
     };
     let environment = get_matched_environment(&project, environment_input)?.id;
     let environment_instances =
-        get_environment_instances(&client, &configs, &linked_project.project, &environment).await?;
+        get_environment_instances(&client, &configs, &project_id, &environment).await?;
 
     match args.command {
         Commands::Add(a) => {

--- a/src/controllers/project.rs
+++ b/src/controllers/project.rs
@@ -219,6 +219,7 @@ pub struct ServiceContext {
     pub project: ProjectProject,
     pub project_id: String,
     pub environment_id: String,
+    pub environment_name: String,
     pub service_id: String,
     pub service_name: String,
 }
@@ -263,10 +264,16 @@ pub async fn resolve_service_context(
             .environment_id()?
             .to_string(),
     };
-    let environment_id = get_matched_environment(&project, env)?.id;
+    let environment = get_matched_environment(&project, env)?;
+    let environment_id = environment.id;
+    let environment_name = environment.name;
 
     let linked_service = linked_project.and_then(|lp| lp.service);
     let services = &project.services.edges;
+    if services.is_empty() {
+        bail!(RailwayError::ProjectHasNoServices);
+    }
+
     let (service_id, service_name) = match (service_arg, linked_service) {
         (Some(service_arg), _) => {
             let service = services
@@ -296,6 +303,7 @@ pub async fn resolve_service_context(
         project,
         project_id,
         environment_id,
+        environment_name,
         service_id,
         service_name,
     })

--- a/src/controllers/project.rs
+++ b/src/controllers/project.rs
@@ -224,26 +224,50 @@ pub struct ServiceContext {
 }
 
 /// Resolves project, environment, and service from args and linked project.
-/// Returns a ServiceContext with all resolved IDs.
+/// When project_arg is provided, environment_arg must also be provided.
 pub async fn resolve_service_context(
+    project_arg: Option<String>,
     service_arg: Option<String>,
     environment_arg: Option<String>,
 ) -> Result<ServiceContext> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
 
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
+    if project_arg.is_some() && environment_arg.is_none() {
+        bail!("--environment is required when using --project");
+    }
+
+    let linked_project = if project_arg.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
+
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
+
+    let project_id = project_arg
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
+
+    let project = get_project(&client, &configs, project_id.clone()).await?;
 
     let env = match environment_arg {
         Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
+        None => linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string(),
     };
     let environment_id = get_matched_environment(&project, env)?.id;
 
+    let linked_service = linked_project.and_then(|lp| lp.service);
     let services = &project.services.edges;
-    let (service_id, service_name) = match (service_arg, linked_project.service) {
+    let (service_id, service_name) = match (service_arg, linked_service) {
         (Some(service_arg), _) => {
             let service = services
                 .iter()
@@ -259,6 +283,10 @@ pub async fn resolve_service_context(
                 .unwrap_or_else(|| linked_service.clone());
             (linked_service, name)
         }
+        _ if services.len() == 1 => {
+            let service = &services[0].node;
+            (service.id.clone(), service.name.clone())
+        }
         _ => bail!(RailwayError::NoServiceLinked),
     };
 
@@ -266,7 +294,7 @@ pub async fn resolve_service_context(
         client,
         configs,
         project,
-        project_id: linked_project.project,
+        project_id,
         environment_id,
         service_id,
         service_name,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,6 +56,7 @@ pub enum RailwayError {
     #[error("No projects found. Run `railway init` to create a new project")]
     NoProjects,
 
+    #[allow(dead_code)]
     #[error("Project does not have any services")]
     NoServices,
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,10 +56,6 @@ pub enum RailwayError {
     #[error("No projects found. Run `railway init` to create a new project")]
     NoProjects,
 
-    #[allow(dead_code)]
-    #[error("Project does not have any services")]
-    NoServices,
-
     #[error(
         "Environment \"{0}\" not found.\nRun `railway environment` to connect to an environment."
     )]


### PR DESCRIPTION
## Summary

Adds `--project` support across service-scoped CLI commands so automation can target a project without first linking the working directory. This centralizes project/environment/service resolution in a shared resolver and keeps existing linked-project behavior as the default. Commands that accept `--project` require `--environment` to avoid ambiguous cross-project environment resolution.

## Changes

- Add `--project` support to service-scoped commands including logs, metrics, variables, service list/status/delete, redeploy, restart, down, scale, shell, connect, volume, and domain.
- Introduce shared service context resolution for project, environment, and service IDs.
- Preserve linked project/environment/service fallbacks when `--project` is omitted.
- Preserve single-service fallback behavior for commands that can infer the target service.
- Use `--project` without a short flag for `domain` because `-p` is already used for `--port`.
- Adds `--project` to:

  - `railway logs`
  - `railway metrics`
  - `railway variable`
  - `railway variable list`
  - `railway variable set`
  - `railway variable delete`
  - `railway service list`
  - `railway service status`
  - `railway service delete`
  - `railway redeploy`
  - `railway restart`
  - `railway down`
  - `railway scale`
  - `railway service scale`
  - `railway shell`
  - `railway connect`
  - `railway volume`
  - `railway domain`
- Note: `railway domain` gets `--project` only, not `-p`, because `-p` is already `--port`.

## Test plan

- [x] `cargo fmt`
- [x] `cargo check`
- [x] `cargo test`
- [x] Manually verified `service status --project ... --environment ... --service ... --json`
- [x] Manually verified `logs --project ... --environment ... --service ... --lines 1 --json`
- [x] Manually verified `metrics --project ... --environment ... --service ... --json --cpu`