### PR TITLE
feat(agent): add --list flag and replay history on --thread-id

### DIFF
--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -176,11 +176,14 @@ fn render_history(messages: &[ChatMessage], thread_id: Option<&str>) {
     };
     println!("{}", banner.dimmed());
 
+    let skin = termimad::MadSkin::default();
+
     for message in messages {
+        let is_assistant = message.role == "assistant";
         let role_label = match message.role.as_str() {
-            "user" => "You:".dimmed().bold(),
-            "assistant" => "Railway Agent:".dimmed().bold(),
-            other => other.dimmed().bold(),
+            "user" => "You:".bold(),
+            "assistant" => "Railway Agent:".purple().bold(),
+            other => other.bold(),
         };
         println!("{}", role_label);
 
@@ -199,7 +202,11 @@ fn render_history(messages: &[ChatMessage], thread_id: Option<&str>) {
             text_parts.join("")
         };
         if !text.trim().is_empty() {
-            println!("{}", text.dimmed());
+            if is_assistant {
+                skin.print_text(&text);
+            } else {
+                println!("{}", text);
+            }
         }
 
         for part in &message.parts {

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -18,9 +18,15 @@ const THINKING_MESSAGES: &[&str] = &[
     "All aboard...",
 ];
 
+use chrono::{DateTime, Local};
+
 use crate::{
     controllers::{
-        chat::{ChatEvent, ChatRequest, build_chat_client, get_chat_url, stream_chat},
+        chat::{
+            ChatEvent, ChatMessage, ChatMessagePart, ChatRequest, ChatThread, build_chat_client,
+            get_chat_url, get_thread_messages, get_thread_messages_url, get_threads_url,
+            list_threads, stream_chat,
+        },
         environment::get_matched_environment,
         project::get_project,
         service::get_or_prompt_service,
@@ -38,7 +44,9 @@ use super::*;
     after_help = "Examples:\n\n\
       railway agent                                             # Interactive mode\n\
       railway agent -p \"what's the status of my deployment?\"    # Single prompt\n\
-      railway agent -p \"why is my service crashing?\" --json     # JSON output"
+      railway agent -p \"why is my service crashing?\" --json     # JSON output\n\
+      railway agent --list                                      # List existing threads\n\
+      railway agent --thread-id <ID>                            # Continue a thread"
 )]
 pub struct Args {
     /// Send a single prompt (omit for interactive mode)
@@ -60,6 +68,10 @@ pub struct Args {
     /// Environment to use (defaults to linked environment)
     #[clap(short, long)]
     environment: Option<String>,
+
+    /// List existing agent threads for the current environment
+    #[clap(long, conflicts_with_all = ["prompt", "thread_id", "service"])]
+    list: bool,
 }
 
 #[derive(Default, Serialize)]
@@ -94,9 +106,22 @@ pub async fn command(args: Args) -> Result<()> {
         None => linked_project.environment_id()?.to_string(),
     };
 
+    let chat_client = build_chat_client(&configs)?;
+
+    if args.list {
+        let threads = list_threads(
+            &chat_client,
+            &get_threads_url(&configs),
+            &environment_id,
+            None,
+        )
+        .await?;
+        render_threads(&threads, args.json)?;
+        return Ok(());
+    }
+
     let service_id = get_or_prompt_service(Some(linked_project), project, args.service).await?;
 
-    let chat_client = build_chat_client(&configs)?;
     let url = get_chat_url(&configs);
     let is_tty = std::io::stdout().is_terminal();
 
@@ -116,6 +141,19 @@ pub async fn command(args: Args) -> Result<()> {
         )
         .await
     } else {
+        let history = match args.thread_id.as_deref() {
+            Some(tid) => {
+                let messages_url = get_thread_messages_url(&configs, tid);
+                get_thread_messages(&chat_client, &messages_url, Some(10))
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("{}", format!("Could not load thread history: {e}").dimmed());
+                        Vec::new()
+                    })
+            }
+            None => Vec::new(),
+        };
+
         run_repl(
             &chat_client,
             &url,
@@ -123,11 +161,98 @@ pub async fn command(args: Args) -> Result<()> {
             &environment_id,
             service_id.as_deref(),
             args.thread_id,
+            history,
             args.json,
             is_tty,
         )
         .await
     }
+}
+
+fn render_history(messages: &[ChatMessage], thread_id: Option<&str>) {
+    let banner = match thread_id {
+        Some(id) => format!("── resuming thread {id} ──"),
+        None => "── resuming thread ──".to_string(),
+    };
+    println!("{}", banner.dimmed());
+
+    for message in messages {
+        let role_label = match message.role.as_str() {
+            "user" => "You:".dimmed().bold(),
+            "assistant" => "Railway Agent:".dimmed().bold(),
+            other => other.dimmed().bold(),
+        };
+        println!("{}", role_label);
+
+        let text_parts: Vec<&str> = message
+            .parts
+            .iter()
+            .filter_map(|part| match part {
+                ChatMessagePart::Text { content } => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        let text = if text_parts.is_empty() {
+            message.content.clone()
+        } else {
+            text_parts.join("")
+        };
+        if !text.trim().is_empty() {
+            println!("{}", text.dimmed());
+        }
+
+        for part in &message.parts {
+            match part {
+                ChatMessagePart::Tool {
+                    tool_name,
+                    is_error,
+                    ..
+                } => {
+                    let label = if *is_error {
+                        format!("[tool failed: {tool_name}]")
+                    } else {
+                        format!("[used tool: {tool_name}]")
+                    };
+                    println!("{}", label.dimmed().italic());
+                }
+                ChatMessagePart::Attachment { name, .. } => {
+                    println!("{}", format!("[attachment: {name}]").dimmed().italic());
+                }
+                ChatMessagePart::Text { .. } => {}
+            }
+        }
+
+        println!();
+    }
+
+    println!("{}", "── end of history ──".dimmed());
+}
+
+fn render_threads(threads: &[ChatThread], json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(threads)?);
+        return Ok(());
+    }
+
+    if threads.is_empty() {
+        println!("No agent threads found for this environment.");
+        return Ok(());
+    }
+
+    println!("{}", "Agent Threads".bold());
+    for thread in threads {
+        let title = thread.title.as_deref().unwrap_or("(untitled)");
+        let updated = DateTime::parse_from_rfc3339(&thread.updated_at)
+            .map(|t| {
+                t.with_timezone(&Local)
+                    .format("%Y-%m-%d %H:%M:%S %Z")
+                    .to_string()
+            })
+            .unwrap_or_else(|_| thread.updated_at.clone());
+        println!("  {} | {} | {}", thread.id, title, updated.dimmed(),);
+    }
+    Ok(())
 }
 
 async fn run_single_shot(
@@ -146,6 +271,7 @@ async fn run_single_shot(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_repl(
     client: &reqwest::Client,
     url: &str,
@@ -153,6 +279,7 @@ async fn run_repl(
     environment_id: &str,
     service_id: Option<&str>,
     initial_thread_id: Option<String>,
+    history: Vec<ChatMessage>,
     json: bool,
     is_tty: bool,
 ) -> Result<()> {
@@ -165,6 +292,11 @@ async fn run_repl(
         "Railway Agent (type 'exit' or Ctrl+C to quit)".dimmed()
     );
     println!();
+
+    if !history.is_empty() {
+        render_history(&history, initial_thread_id.as_deref());
+        println!();
+    }
 
     let mut thread_id = initial_thread_id;
 

--- a/src/controllers/chat.rs
+++ b/src/controllers/chat.rs
@@ -67,6 +67,135 @@ pub fn get_chat_url(configs: &Configs) -> String {
     format!("https://backboard.{}/api/v1/agent", configs.get_host())
 }
 
+pub fn get_threads_url(configs: &Configs) -> String {
+    format!(
+        "https://backboard.{}/api/v1/agent/threads",
+        configs.get_host()
+    )
+}
+
+pub fn get_thread_messages_url(configs: &Configs, thread_id: &str) -> String {
+    format!(
+        "https://backboard.{}/api/v1/agent/threads/{}/messages",
+        configs.get_host(),
+        thread_id
+    )
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ChatMessagePart {
+    Text {
+        content: String,
+    },
+    Tool {
+        id: String,
+        #[serde(rename = "toolName")]
+        tool_name: String,
+        #[serde(default)]
+        args: Option<serde_json::Value>,
+        #[serde(default)]
+        result: Option<serde_json::Value>,
+        #[serde(rename = "isError", default)]
+        is_error: bool,
+    },
+    Attachment {
+        name: String,
+        #[serde(rename = "mimeType")]
+        mime_type: String,
+        content: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChatMessage {
+    pub id: String,
+    pub role: String,
+    pub content: String,
+    #[serde(default)]
+    pub parts: Vec<ChatMessagePart>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadMessagesResponse {
+    messages: Vec<ChatMessage>,
+}
+
+pub async fn get_thread_messages(
+    client: &Client,
+    url: &str,
+    limit: Option<u32>,
+) -> Result<Vec<ChatMessage>> {
+    let mut request = client.get(url).header("Accept", "application/json");
+    if let Some(limit) = limit {
+        request = request.query(&[("limit", limit.to_string())]);
+    }
+
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        match status.as_u16() {
+            401 | 403 => return Err(auth_failure_error().into()),
+            429 => return Err(RailwayError::Ratelimited.into()),
+            _ => {
+                let body = response.text().await.unwrap_or_default();
+                bail!("Get thread messages failed ({}): {}", status, body);
+            }
+        }
+    }
+
+    let parsed: ThreadMessagesResponse = response.json().await?;
+    Ok(parsed.messages)
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatThread {
+    pub id: String,
+    pub title: Option<String>,
+    pub resource_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListThreadsResponse {
+    threads: Vec<ChatThread>,
+}
+
+pub async fn list_threads(
+    client: &Client,
+    url: &str,
+    environment_id: &str,
+    limit: Option<u32>,
+) -> Result<Vec<ChatThread>> {
+    let mut request = client
+        .get(url)
+        .header("Accept", "application/json")
+        .query(&[("environmentId", environment_id)]);
+    if let Some(limit) = limit {
+        request = request.query(&[("limit", limit.to_string())]);
+    }
+
+    let response = request.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        match status.as_u16() {
+            401 | 403 => return Err(auth_failure_error().into()),
+            429 => return Err(RailwayError::Ratelimited.into()),
+            _ => {
+                let body = response.text().await.unwrap_or_default();
+                bail!("List threads request failed ({}): {}", status, body);
+            }
+        }
+    }
+
+    let parsed: ListThreadsResponse = response.json().await?;
+    Ok(parsed.threads)
+}
+
 /// Build an HTTP client for the chat API.
 ///
 /// The chat endpoint requires user OAuth tokens — project access tokens


### PR DESCRIPTION
## Summary
- `railway agent --list` — lists existing agent threads for the linked (or `--environment`-overridden) environment as `id | title | updated`. Supports `--json`. Conflicts with `--prompt` / `--thread-id` / `--service`.
- `railway agent --thread-id <id>` (REPL mode) now fetches the last 10 messages of the thread and renders them dimmed before the live prompt, with a `── resuming thread <id> ──` banner. Tool calls and attachments collapse to one-line markers so the replay stays readable.
- History fetch failures degrade gracefully: dim warning, REPL still opens.

Depends on https://github.com/railwayapp/mono/pull/29030 which adds the two REST endpoints (`GET /api/v1/agent/threads`, `GET /api/v1/agent/threads/:id/messages`). The CLI flag will return an error from those endpoints until the mono PR is deployed.

## Test plan
- [ ] `railway agent --list` prints threads for the linked environment in a readable format
- [ ] `railway agent --list --json` emits the raw thread array
- [ ] `railway agent --list -e <env>` lists threads for a specific environment
- [ ] `railway agent --list --prompt x` fails at parse time (clap conflict)
- [ ] `railway agent --thread-id <id>` shows the banner + dimmed history and continues the thread when the user types
- [ ] `railway agent --thread-id <id> -p "next"` (single-shot) still works without printing history
- [ ] Pointing the CLI at a backboard without the new endpoints prints "Could not load thread history: …" and falls back to an empty REPL
- [ ] Tool calls in history render as `[used tool: <name>]`; attachments as `[attachment: <name>]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)