### PR TITLE
fix(agent): preserve part order in history and surface auth errors

### DIFF
--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -31,6 +31,7 @@ use crate::{
         project::get_project,
         service::get_or_prompt_service,
     },
+    errors::RailwayError,
     interact_or,
     util::progress::create_spinner,
 };
@@ -144,12 +145,24 @@ pub async fn command(args: Args) -> Result<()> {
         let history = match args.thread_id.as_deref() {
             Some(tid) => {
                 let messages_url = get_thread_messages_url(&configs, tid);
-                get_thread_messages(&chat_client, &messages_url, Some(10))
-                    .await
-                    .unwrap_or_else(|e| {
+                match get_thread_messages(&chat_client, &messages_url, Some(10)).await {
+                    Ok(messages) => messages,
+                    Err(e) => {
+                        if let Some(railway_err) = e.downcast_ref::<RailwayError>()
+                            && matches!(
+                                railway_err,
+                                RailwayError::Unauthorized
+                                    | RailwayError::UnauthorizedToken(_)
+                                    | RailwayError::UnauthorizedLogin
+                                    | RailwayError::InvalidRailwayToken(_)
+                            )
+                        {
+                            return Err(e);
+                        }
                         eprintln!("{}", format!("Could not load thread history: {e}").dimmed());
                         Vec::new()
-                    })
+                    }
+                }
             }
             None => Vec::new(),
         };
@@ -166,6 +179,17 @@ pub async fn command(args: Args) -> Result<()> {
             is_tty,
         )
         .await
+    }
+}
+
+fn render_text_block(text: &str, is_assistant: bool, skin: &termimad::MadSkin) {
+    if text.trim().is_empty() {
+        return;
+    }
+    if is_assistant {
+        skin.print_text(text);
+    } else {
+        println!("{}", text);
     }
 }
 
@@ -187,47 +211,37 @@ fn render_history(messages: &[ChatMessage], thread_id: Option<&str>) {
         };
         println!("{}", role_label);
 
-        let text_parts: Vec<&str> = message
-            .parts
-            .iter()
-            .filter_map(|part| match part {
-                ChatMessagePart::Text { content } => Some(content.as_str()),
-                _ => None,
-            })
-            .collect();
-
-        let text = if text_parts.is_empty() {
-            message.content.clone()
+        if message.parts.is_empty() {
+            render_text_block(&message.content, is_assistant, &skin);
         } else {
-            text_parts.join("")
-        };
-        if !text.trim().is_empty() {
-            if is_assistant {
-                skin.print_text(&text);
-            } else {
-                println!("{}", text);
-            }
-        }
-
-        for part in &message.parts {
-            match part {
-                ChatMessagePart::Tool {
-                    tool_name,
-                    is_error,
-                    ..
-                } => {
-                    let label = if *is_error {
-                        format!("[tool failed: {tool_name}]")
-                    } else {
-                        format!("[used tool: {tool_name}]")
-                    };
-                    println!("{}", label.dimmed().italic());
+            let mut text_buf = String::new();
+            for part in &message.parts {
+                match part {
+                    ChatMessagePart::Text { content } => {
+                        text_buf.push_str(content);
+                    }
+                    ChatMessagePart::Tool {
+                        tool_name,
+                        is_error,
+                        ..
+                    } => {
+                        render_text_block(&text_buf, is_assistant, &skin);
+                        text_buf.clear();
+                        let label = if *is_error {
+                            format!("[tool failed: {tool_name}]")
+                        } else {
+                            format!("[used tool: {tool_name}]")
+                        };
+                        println!("{}", label.dimmed().italic());
+                    }
+                    ChatMessagePart::Attachment { name, .. } => {
+                        render_text_block(&text_buf, is_assistant, &skin);
+                        text_buf.clear();
+                        println!("{}", format!("[attachment: {name}]").dimmed().italic());
+                    }
                 }
-                ChatMessagePart::Attachment { name, .. } => {
-                    println!("{}", format!("[attachment: {name}]").dimmed().italic());
-                }
-                ChatMessagePart::Text { .. } => {}
             }
+            render_text_block(&text_buf, is_assistant, &skin);
         }
 
         println!();


### PR DESCRIPTION
## Summary
Patch follow-up to #897 (the `--list` + history replay feature). Two small fixes in `render_history` / the history fetch path:

- **Parts order preserved.** Previously `render_history` iterated each message's `parts` array twice — once to collect text, once to emit tool/attachment markers — so all text appeared before any markers, losing the source ordering. Now we iterate once, flushing buffered text whenever a `Tool` or `Attachment` part appears. Visual: `"thinking… [used tool: get_logs] here's what I found"` instead of `"thinking… here's what I found\n[used tool: get_logs]"`.
- **Auth errors propagated.** Previously a failed history fetch was always swallowed into a dim warning + empty history. If the user's token was expired, they'd see the warning, the REPL would open, and then the first message would fail with another auth error. Now: auth-class `RailwayError` variants (`Unauthorized`, `UnauthorizedToken`, `UnauthorizedLogin`, `InvalidRailwayToken`) propagate out of the command. Non-auth errors (network, rate limit, JSON parse) still fall back to the dim warning so the REPL stays usable.

Note: my deeper review of #897 originally flagged a third item (a missing `#[serde(rename = "mimeType")]` on `ChatMessagePart::Attachment.mime_type`). On re-inspection that rename was already present in #897 — false alarm, no fix needed.

## Test plan
- [ ] `railway agent --thread-id <id-with-mixed-text-and-tool-calls>` renders text and `[used tool: ...]` markers in the order the assistant emitted them
- [ ] `railway agent --thread-id <id>` with an expired token exits with the auth error instead of opening the REPL
- [ ] `railway agent --thread-id <id>` with a working token but the messages endpoint returning 500 prints the dim warning and opens an empty REPL
- [ ] `railway agent --list` and the rest of the feature still behave as in #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)