### PR TITLE
feat(telemetry): propagate caller/agent-session as HTTP headers on the up upload

### DIFF
--- a/src/controllers/upload.rs
+++ b/src/controllers/upload.rs
@@ -107,12 +107,18 @@ pub async fn upload_deploy_tarball(
     }
 
     let body_len = body.len();
-    let res = client
+    let mut request = client
         .post(url.to_string())
-        .header("Content-Type", "application/gzip")
-        .body(body)
-        .send()
-        .await?;
+        .header("Content-Type", "application/gzip");
+    // Propagate the cliEventTrack telemetry envelope as HTTP headers so
+    // backboard's POST .../up handler can attribute the `CLI - Create Up`
+    // event it emits to the correct caller / agent session / CLI session.
+    // Without these the resulting `cli_create_up` event lands in the
+    // warehouse with null caller, breaking per-cohort deploy attribution.
+    for (name, value) in crate::telemetry::http_telemetry_headers() {
+        request = request.header(name, value);
+    }
+    let res = request.body(body).send().await?;
 
     let status = res.status();
     if status != 200 {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1341,7 +1341,9 @@ async fn post_telemetry_body(client: &reqwest::Client, url: String, body: Value)
 ///
 /// Header names mirror the propagation contract used by railway-skills
 /// (X-Railway-Skill-Id / X-Railway-Skill-Version / X-Railway-Agent-Session)
-/// to keep one envelope across surfaces.
+/// to keep one envelope across surfaces. The version rides on backboard's
+/// existing `x-railway-version` header (read by getCliVersionFromRequest)
+/// rather than a parallel name, so the two surfaces stay reconciled.
 pub fn http_telemetry_headers() -> Vec<(&'static str, String)> {
     if is_telemetry_disabled() {
         return Vec::new();
@@ -1352,10 +1354,7 @@ pub fn http_telemetry_headers() -> Vec<(&'static str, String)> {
     };
     let context = TelemetryContext::current(&configs);
     let mut headers = Vec::with_capacity(4);
-    headers.push((
-        "X-Railway-CLI-Version",
-        env!("CARGO_PKG_VERSION").to_string(),
-    ));
+    headers.push(("X-Railway-Version", env!("CARGO_PKG_VERSION").to_string()));
     headers.push(("X-Railway-Session", context.session_id));
     if !context.caller.is_empty() {
         headers.push(("X-Railway-Caller", context.caller));

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1328,6 +1328,44 @@ async fn post_telemetry_body(client: &reqwest::Client, url: String, body: Value)
     matches!(result, Ok(Ok(true)))
 }
 
+/// HTTP headers that carry the same telemetry envelope as the `cliEventTrack`
+/// GraphQL mutation, for REST endpoints (e.g. the backboard `POST .../up`
+/// upload handler) that emit their own analytics events server-side.
+/// Today those server-side events lack caller / agent_session_id / cli
+/// session_id because the request lacks any way to pass them — these
+/// headers close the gap so backboard can attribute the resulting
+/// `CLI - Create Up` / etc. event to the correct caller cohort.
+///
+/// Returns an empty Vec when telemetry is disabled so disabled clients
+/// stay opted out across both telemetry surfaces.
+///
+/// Header names mirror the propagation contract used by railway-skills
+/// (X-Railway-Skill-Id / X-Railway-Skill-Version / X-Railway-Agent-Session)
+/// to keep one envelope across surfaces.
+pub fn http_telemetry_headers() -> Vec<(&'static str, String)> {
+    if is_telemetry_disabled() {
+        return Vec::new();
+    }
+    let configs = match Configs::new() {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    let context = TelemetryContext::current(&configs);
+    let mut headers = Vec::with_capacity(4);
+    headers.push((
+        "X-Railway-CLI-Version",
+        env!("CARGO_PKG_VERSION").to_string(),
+    ));
+    headers.push(("X-Railway-Session", context.session_id));
+    if !context.caller.is_empty() {
+        headers.push(("X-Railway-Caller", context.caller));
+    }
+    if let Some(asid) = context.agent_session_id {
+        headers.push(("X-Railway-Agent-Session", asid));
+    }
+    headers
+}
+
 pub async fn send(event: CliTrackEvent) {
     send_with_caller_override(event, None).await;
 }


### PR DESCRIPTION
## Summary

`railway up` uploads its build tarball to backboard's `POST /project/.../environment/.../up` REST handler, which emits the `CLI - Create Up` telemetry event (warehouse: `cli_create_up`) via `trackCLIEvent`. About **107k of these events fire in a typical 48h window**, but **100% of them land in the warehouse with `caller`, `agent_session_id`, and `session_id` all NULL** because the upload request carries no envelope for backboard to attribute against.

This PR adds those fields as HTTP headers on the upload request, mirroring the propagation contract railway-skills already uses (`X-Railway-Skill-*` / `X-Railway-Agent-Session`):

```
X-Railway-CLI-Version
X-Railway-Session         (CLI session_id from telemetry::session_id())
X-Railway-Caller          (resolved caller, when non-empty)
X-Railway-Agent-Session   (agent_session_id, when set)
```

Headers are gated by `is_telemetry_disabled()` so disabled clients stay opted out across both surfaces. Caller / agent-session header omission mirrors the cliEventTrack mutation's null-skipping.

## Companion PR

This is the **producer half** of a two-PR fix. The companion mono backboard PR (forthcoming) reads these headers in the `up` handler and passes them to `trackCLIEvent` properties + adds the missing `deploymentId`.

Both can ship independently — backboard reading absent headers will fall back to null (today's behavior); CLI sending headers to a backboard that doesn't read them is harmless.

## Test plan

- [x] `cargo build --bin railway` clean
- [x] 21/21 telemetry unit tests pass
- [ ] CI green
- [ ] Manual: once the companion mono backboard PR ships, run `railway up` from claude_code and verify warehouse `cli_create_up` events have `caller='claude_code'` and a non-null `agent_session_id`

## Context

This is gap #2 from the May 12 agentic-adoption telemetry audit. Once it lands, we unlock:
- Strict "what % of new deploys are agent-driven" attribution (currently blocked because `cli_create_up` — the largest deploy event — has no caller)
- Direct deploy↔session linkage when paired with the deploymentId backboard fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)