### PR TITLE
Add volume file browser and transfer commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +152,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,10 +215,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2",
+]
 
 [[package]]
 name = "bitflags"
@@ -181,9 +251,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -192,6 +274,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -266,6 +367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,17 +398,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -308,6 +429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -442,6 +573,12 @@ dependencies = [
  "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -615,7 +752,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -632,7 +769,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "mio 1.0.3",
  "parking_lot",
@@ -648,7 +785,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -674,6 +811,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -707,6 +856,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +872,33 @@ checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
  "nix 0.29.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -821,10 +1006,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "derive-new"
@@ -909,7 +1130,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -939,7 +1162,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -970,16 +1193,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
 
 [[package]]
 name = "env_home"
@@ -1064,6 +1359,22 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -1279,6 +1590,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1288,7 +1600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.2",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1314,6 +1626,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1406,6 +1728,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gzp"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1763,12 @@ dependencies = [
  "crunchy",
  "zerocopy 0.8.27",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1465,6 +1804,45 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -1588,7 +1966,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1782,7 +2160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1810,7 +2188,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -1825,12 +2203,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "inquire"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "crossterm 0.29.0",
  "dyn-clone",
  "fuzzy-matcher",
@@ -1849,6 +2237,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.93",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.11+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a77eae781ed6a7709fb15b64862fcca13d886b07c7e2786f5ed34e5e2b9187"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1987,6 +2403,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -1995,12 +2414,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall",
 ]
@@ -2051,8 +2476,14 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2134,7 +2565,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2146,7 +2577,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2158,7 +2589,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2178,12 +2609,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2211,7 +2690,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -2223,7 +2702,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -2234,7 +2713,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2253,7 +2732,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2264,7 +2743,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2274,6 +2753,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -2297,6 +2782,61 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
+name = "pageant"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb28bd89a207e5cad59072ac4b364b08459d05f90ccfbcdaa920a95857d94430"
+dependencies = [
+ "byteorder",
+ "bytes 1.11.1",
+ "delegate",
+ "futures 0.3.31",
+ "log",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows",
+]
 
 [[package]]
 name = "parking"
@@ -2328,6 +2868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2901,25 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2390,16 +2960,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
+]
+
+[[package]]
 name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2415,6 +3046,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2454,7 +3094,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.8",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2473,7 +3113,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2556,6 +3196,8 @@ dependencies = [
  "reqwest",
  "reqwest-websocket",
  "rmcp",
+ "russh",
+ "russh-sftp",
  "schemars 0.8.22",
  "scopeguard",
  "serde",
@@ -2572,7 +3214,7 @@ dependencies = [
  "tempfile",
  "termimad",
  "textwrap",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "toml",
@@ -2647,7 +3289,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "cassowary",
  "compact_str",
  "crossterm 0.28.1",
@@ -2668,7 +3310,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2785,12 +3427,22 @@ dependencies = [
  "bytes 1.11.1",
  "futures-util",
  "reqwest",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
  "tungstenite",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -2823,7 +3475,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2840,6 +3492,132 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.93",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.54.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3ee9363fcf66d434d8015d9ae7d879681206981534c21bfdff8a7e34f52cca"
+dependencies = [
+ "aes",
+ "base64ct",
+ "bitflags 2.11.1",
+ "block-padding",
+ "byteorder",
+ "bytes 1.11.1",
+ "cbc",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der",
+ "digest",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "futures 0.3.31",
+ "generic-array",
+ "getrandom 0.2.15",
+ "hex-literal",
+ "hmac",
+ "home",
+ "inout",
+ "internal-russh-forked-ssh-key",
+ "log",
+ "md5",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "ring",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "ssh-encoding",
+ "winapi",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09daa0ebcf53fb18d7b16167586a68b5bf2cfa3eaad49e661a19302552a2b879"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes 1.11.1",
+ "chrono",
+ "dashmap",
+ "log",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2863,7 +3641,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -2876,7 +3654,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -2949,6 +3727,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -3025,12 +3812,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3061,6 +3873,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3223,6 +4045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +4114,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes 1.11.1",
+ "pem-rfc7468",
+ "sha2",
 ]
 
 [[package]]
@@ -3499,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3519,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3628,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes 1.11.1",
  "futures-core",
@@ -3758,7 +4629,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -3820,6 +4691,16 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4056,6 +4937,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4063,6 +4954,47 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.3.4",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -4076,8 +5008,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -4091,13 +5023,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -4142,7 +5092,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4182,7 +5132,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4519,7 +5469,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.9",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,8 @@ rmcp = { version = "0.16", features = ["transport-io"] }
 toml = "0.8"
 termimad = "0.28"
 csv = "1.3"
+russh = { version = "0.54.5", default-features = false, features = ["ring", "rsa"] }
+russh-sftp = "2.1.2"
 
 [profile.release]
 lto = "fat"

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -7,7 +7,7 @@ use crate::{client::GQLClient, config::Configs};
 
 mod common;
 mod keys;
-mod native;
+pub(super) mod native;
 mod tel;
 
 use common::*;

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -3,9 +3,10 @@ use crate::{
     controllers::environment::get_matched_environment,
     controllers::project::{
         ProjectEnvironmentInstances, ProjectVolumeInstanceNode,
-        ensure_project_and_environment_exist, get_environment_instances, get_project,
-        volume_instances_in_env,
+        ensure_project_and_environment_exist, find_service_instance, get_environment_instances,
+        get_project, volume_instances_in_env,
     },
+    controllers::volume_browser::{VolumeBrowserParams, run as run_volume_browser},
     errors::RailwayError,
     queries::project::ProjectProject,
     util::{
@@ -17,7 +18,7 @@ use crate::{
 use anyhow::{anyhow, bail};
 use clap::Parser;
 use is_terminal::IsTerminal;
-use std::fmt::Display;
+use std::{fmt::Display, path::PathBuf};
 
 /// Manage project volumes
 #[derive(Parser)]
@@ -131,6 +132,21 @@ structstruck::strike! {
             /// Output in JSON format
             #[clap(long)]
             json: bool,
+        }),
+
+        /// Browse volume files over SSH/SCP
+        Browse(struct {
+            /// The ID/name of the volume you wish to browse
+            #[clap(long, short)]
+            volume: Option<String>,
+
+            /// Path to identity (private key) file to use, like `ssh -i`
+            #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
+            identity_file: Option<PathBuf>,
+
+            /// Local directory used for downloads and relative uploads
+            #[clap(long, value_name = "PATH")]
+            local_dir: Option<PathBuf>,
         })
     }
 }
@@ -234,7 +250,79 @@ pub async fn command(args: Args) -> Result<()> {
             )
             .await?
         }
+        Commands::Browse(b) => {
+            browse(
+                environment,
+                &environment_instances,
+                b.volume,
+                project,
+                b.identity_file,
+                b.local_dir,
+                &client,
+                &configs,
+            )
+            .await?
+        }
     }
+
+    Ok(())
+}
+
+async fn browse(
+    environment: String,
+    environment_instances: &ProjectEnvironmentInstances,
+    volume: Option<String>,
+    project: ProjectProject,
+    identity_file: Option<PathBuf>,
+    local_dir: Option<PathBuf>,
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<()> {
+    let is_terminal = std::io::stdout().is_terminal();
+    if !is_terminal {
+        bail!("Volume browsing requires an interactive terminal");
+    }
+
+    let volume = select_volume(
+        project.clone(),
+        environment_instances,
+        environment.as_str(),
+        volume,
+        is_terminal,
+    )?
+    .0;
+
+    let service_id = volume.service_id.clone().ok_or_else(|| {
+        anyhow!(
+            "Volume {} is not attached to any service. Attach it before browsing.",
+            volume.volume.name
+        )
+    })?;
+
+    let service_name = project
+        .services
+        .edges
+        .iter()
+        .find(|service| service.node.id == service_id)
+        .map(|service| service.node.name.clone())
+        .ok_or_else(|| anyhow!("The service attached to this volume doesn't exist"))?;
+
+    let service_instance_id = find_service_instance(environment_instances, &service_id)
+        .map(|instance| instance.id.clone())
+        .ok_or_else(|| anyhow!("No active service instance found for service {service_name}"))?;
+
+    if identity_file.is_none() {
+        super::ssh::native::ensure_ssh_key(client, configs).await?;
+    }
+
+    run_volume_browser(VolumeBrowserParams {
+        service_instance_id,
+        service_name,
+        volume_name: volume.volume.name,
+        mount_path: PathBuf::from(volume.mount_path),
+        local_dir: local_dir.unwrap_or(std::env::current_dir()?),
+        identity_file,
+    })?;
 
     Ok(())
 }

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -400,7 +400,15 @@ async fn browse(
 ) -> Result<()> {
     let is_terminal = std::io::stdout().is_terminal();
     if !is_terminal {
-        bail!("Volume browsing requires an interactive terminal");
+        bail!(
+            "Volume browsing requires an interactive terminal. Use `railway volume files`, `railway volume download`, or `railway volume upload` for non-interactive access."
+        );
+    }
+
+    if is_agent_environment() {
+        bail!(
+            "Volume browsing is interactive and is not available from detected agent environments. Use `railway volume files`, `railway volume download`, or `railway volume upload` instead."
+        );
     }
 
     let target = resolve_volume_file_target(
@@ -425,6 +433,44 @@ async fn browse(
     })?;
 
     Ok(())
+}
+
+fn is_agent_environment() -> bool {
+    if std::env::var("AGENT")
+        .map(|value| value.eq_ignore_ascii_case("amp"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+
+    let agent_env_vars = [
+        "AIDER",
+        "AI_AGENT",
+        "AMP_CURRENT_THREAD_ID",
+        "CLAUDECODE",
+        "CLAUDE_CODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CLAUDE_CODE_SESSION_ID",
+        "CLINE_ACTIVE",
+        "CODEX_SANDBOX",
+        "COPILOT_AGENT_SESSION_ID",
+        "COPILOT_CLI",
+        "CURSOR_AGENT",
+        "CURSOR_TRACE_ID",
+        "FACTORY_DROID",
+        "GEMINI_CLI",
+        "OPENAI_CODEX",
+        "OPENCODE",
+        "OPENCODE_SESSION_ID",
+        "PI_CODING_AGENT",
+        "REPLIT_AGENT",
+        "ROO_ACTIVE",
+        "__COG_BASHRC_SOURCED",
+    ];
+
+    agent_env_vars
+        .iter()
+        .any(|name| std::env::var_os(name).is_some())
 }
 
 struct ResolvedVolumeFileTarget {

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -405,7 +405,7 @@ async fn browse(
         );
     }
 
-    if is_agent_environment() {
+    if crate::telemetry::is_agent_invocation() {
         bail!(
             "Volume browsing is interactive and is not available from detected agent environments. Use `railway volume files`, `railway volume download`, or `railway volume upload` instead."
         );
@@ -433,44 +433,6 @@ async fn browse(
     })?;
 
     Ok(())
-}
-
-fn is_agent_environment() -> bool {
-    if std::env::var("AGENT")
-        .map(|value| value.eq_ignore_ascii_case("amp"))
-        .unwrap_or(false)
-    {
-        return true;
-    }
-
-    let agent_env_vars = [
-        "AIDER",
-        "AI_AGENT",
-        "AMP_CURRENT_THREAD_ID",
-        "CLAUDECODE",
-        "CLAUDE_CODE",
-        "CLAUDE_CODE_ENTRYPOINT",
-        "CLAUDE_CODE_SESSION_ID",
-        "CLINE_ACTIVE",
-        "CODEX_SANDBOX",
-        "COPILOT_AGENT_SESSION_ID",
-        "COPILOT_CLI",
-        "CURSOR_AGENT",
-        "CURSOR_TRACE_ID",
-        "FACTORY_DROID",
-        "GEMINI_CLI",
-        "OPENAI_CODEX",
-        "OPENCODE",
-        "OPENCODE_SESSION_ID",
-        "PI_CODING_AGENT",
-        "REPLIT_AGENT",
-        "ROO_ACTIVE",
-        "__COG_BASHRC_SOURCED",
-    ];
-
-    agent_env_vars
-        .iter()
-        .any(|name| std::env::var_os(name).is_some())
 }
 
 struct ResolvedVolumeFileTarget {

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -27,7 +27,7 @@ use std::{
 /// Manage project volumes
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway volume list --json\n  railway volume add --service api --mount-path /data --json\n  railway volume update --volume volume-id --name data --mount-path /data --json\n  railway volume delete --volume data --yes --json\n  railway volume ls pgdata --volume postgres-volume --json\n  railway volume download pgdata/postgresql.conf ./postgresql.conf --volume postgres-volume\n  railway volume upload ./postgresql.conf pgdata/postgresql.conf --volume postgres-volume --yes --json\n  railway volume browse --volume data\n\nAliases:\n  add: create, new\n  delete: remove, rm\n  update: edit, rename\n  download: dl, get\n  upload: up, put\n  ls: files\n\nAutomation notes:\n  Mount paths must start with `/`. Use volume IDs from `railway volume list --json` when names may collide.\n  File command remote paths are relative to the volume mount path unless absolute. Use --yes for non-interactive overwrite and --json for structured success output."
+    after_help = "Examples:\n\n  railway volume list --json\n  railway volume add --service api --mount-path /data --json\n  railway volume update --volume volume-id --name data --mount-path /data --json\n  railway volume delete --volume data --yes --json\n  railway volume files pgdata --volume postgres-volume --json\n  railway volume download pgdata/postgresql.conf ./postgresql.conf --volume postgres-volume\n  railway volume upload ./postgresql.conf pgdata/postgresql.conf --volume postgres-volume --yes --json\n  railway volume browse --volume data\n\nAliases:\n  list: ls\n  add: create, new\n  delete: remove, rm\n  update: edit, rename\n  download: dl, get\n  upload: up, put\n\nAutomation notes:\n  Mount paths must start with `/`. Use volume IDs from `railway volume list --json` when names may collide.\n  File command remote paths are relative to the volume mount path unless absolute. Use --yes for non-interactive overwrite and --json for structured success output."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -49,7 +49,7 @@ structstruck::strike! {
     #[strikethrough[derive(Parser)]]
     enum Commands {
         /// List volumes
-        #[clap(visible_alias = "volumes")]
+        #[clap(visible_alias = "ls")]
         List(struct {
             /// Output in JSON format
             #[clap(long)]
@@ -154,8 +154,7 @@ structstruck::strike! {
         }),
 
         /// List files in a volume path
-        #[clap(name = "ls", visible_alias = "files")]
-        Ls(struct {
+        Files(struct {
             /// Remote path to list, relative to the volume mount path unless absolute
             path: PathBuf,
 
@@ -338,7 +337,7 @@ pub async fn command(args: Args) -> Result<()> {
             )
             .await?
         }
-        Commands::Ls(l) => {
+        Commands::Files(l) => {
             file_ls(
                 environment,
                 &environment_instances,

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -7,6 +7,7 @@ use crate::{
         get_project, volume_instances_in_env,
     },
     controllers::volume_browser::{VolumeBrowserParams, run as run_volume_browser},
+    controllers::volume_files::{VolumeFileClient, VolumeFileKind},
     errors::RailwayError,
     queries::project::ProjectProject,
     util::{
@@ -18,12 +19,15 @@ use crate::{
 use anyhow::{anyhow, bail};
 use clap::Parser;
 use is_terminal::IsTerminal;
-use std::{fmt::Display, path::PathBuf};
+use std::{
+    fmt::Display,
+    path::{Component, Path, PathBuf},
+};
 
 /// Manage project volumes
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway volume list --json\n  railway volume add --service api --mount-path /data --json\n  railway volume update --volume volume-id --name data --mount-path /data --json\n  railway volume delete --volume data --yes --json\n\nAliases:\n  list: ls\n  add: create, new\n  delete: remove, rm\n  update: edit, rename\n\nAutomation notes:\n  Mount paths must start with `/`. Use volume IDs from `railway volume list --json` when names may collide."
+    after_help = "Examples:\n\n  railway volume list --json\n  railway volume add --service api --mount-path /data --json\n  railway volume update --volume volume-id --name data --mount-path /data --json\n  railway volume delete --volume data --yes --json\n  railway volume ls pgdata --volume postgres-volume --json\n  railway volume download pgdata/postgresql.conf ./postgresql.conf --volume postgres-volume\n  railway volume upload ./postgresql.conf pgdata/postgresql.conf --volume postgres-volume --yes --json\n  railway volume browse --volume data\n\nAliases:\n  add: create, new\n  delete: remove, rm\n  update: edit, rename\n  download: dl, get\n  upload: up, put\n  ls: files\n\nAutomation notes:\n  Mount paths must start with `/`. Use volume IDs from `railway volume list --json` when names may collide.\n  File command remote paths are relative to the volume mount path unless absolute. Use --yes for non-interactive overwrite and --json for structured success output."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -45,7 +49,7 @@ structstruck::strike! {
     #[strikethrough[derive(Parser)]]
     enum Commands {
         /// List volumes
-        #[clap(visible_alias = "ls")]
+        #[clap(visible_alias = "volumes")]
         List(struct {
             /// Output in JSON format
             #[clap(long)]
@@ -147,6 +151,77 @@ structstruck::strike! {
             /// Local directory used for downloads and relative uploads
             #[clap(long, value_name = "PATH")]
             local_dir: Option<PathBuf>,
+        }),
+
+        /// List files in a volume path
+        #[clap(name = "ls", visible_alias = "files")]
+        Ls(struct {
+            /// Remote path to list, relative to the volume mount path unless absolute
+            path: PathBuf,
+
+            /// The ID/name of the volume
+            #[clap(long, short)]
+            volume: Option<String>,
+
+            /// Path to identity (private key) file to use, like `ssh -i`
+            #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
+            identity_file: Option<PathBuf>,
+
+            /// Output in JSON format
+            #[clap(long)]
+            json: bool,
+        }),
+
+        /// Download a file or directory from a volume
+        #[clap(visible_alias = "dl", visible_alias = "get")]
+        Download(struct {
+            /// Remote file or directory path, relative to the volume mount path unless absolute
+            remote_path: PathBuf,
+
+            /// Local destination path
+            local_path: PathBuf,
+
+            /// The ID/name of the volume
+            #[clap(long, short)]
+            volume: Option<String>,
+
+            /// Path to identity (private key) file to use, like `ssh -i`
+            #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
+            identity_file: Option<PathBuf>,
+
+            /// Overwrite the local destination if it exists
+            #[clap(short = 'y', long = "yes")]
+            yes: bool,
+
+            /// Output in JSON format
+            #[clap(long)]
+            json: bool,
+        }),
+
+        /// Upload a file or directory to a volume
+        #[clap(visible_alias = "up", visible_alias = "put")]
+        Upload(struct {
+            /// Local file or directory path
+            local_path: PathBuf,
+
+            /// Remote destination path, relative to the volume mount path unless absolute
+            remote_path: PathBuf,
+
+            /// The ID/name of the volume
+            #[clap(long, short)]
+            volume: Option<String>,
+
+            /// Path to identity (private key) file to use, like `ssh -i`
+            #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
+            identity_file: Option<PathBuf>,
+
+            /// Overwrite the remote destination if it exists
+            #[clap(short = 'y', long = "yes")]
+            yes: bool,
+
+            /// Output in JSON format
+            #[clap(long)]
+            json: bool,
         })
     }
 }
@@ -263,6 +338,52 @@ pub async fn command(args: Args) -> Result<()> {
             )
             .await?
         }
+        Commands::Ls(l) => {
+            file_ls(
+                environment,
+                &environment_instances,
+                l.volume,
+                project,
+                l.path,
+                l.identity_file,
+                l.json,
+                &client,
+                &configs,
+            )
+            .await?
+        }
+        Commands::Download(d) => {
+            file_download(
+                environment,
+                &environment_instances,
+                d.volume,
+                project,
+                d.remote_path,
+                d.local_path,
+                d.identity_file,
+                d.yes,
+                d.json,
+                &client,
+                &configs,
+            )
+            .await?
+        }
+        Commands::Upload(u) => {
+            file_upload(
+                environment,
+                &environment_instances,
+                u.volume,
+                project,
+                u.local_path,
+                u.remote_path,
+                u.identity_file,
+                u.yes,
+                u.json,
+                &client,
+                &configs,
+            )
+            .await?
+        }
     }
 
     Ok(())
@@ -283,6 +404,44 @@ async fn browse(
         bail!("Volume browsing requires an interactive terminal");
     }
 
+    let target = resolve_volume_file_target(
+        environment,
+        environment_instances,
+        volume,
+        project,
+        is_terminal,
+    )?;
+
+    if identity_file.is_none() {
+        super::ssh::native::ensure_ssh_key(client, configs).await?;
+    }
+
+    run_volume_browser(VolumeBrowserParams {
+        service_instance_id: target.service_instance_id,
+        service_name: target.service_name,
+        volume_name: target.volume_name,
+        mount_path: target.mount_path,
+        local_dir: local_dir.unwrap_or(std::env::current_dir()?),
+        identity_file,
+    })?;
+
+    Ok(())
+}
+
+struct ResolvedVolumeFileTarget {
+    service_instance_id: String,
+    service_name: String,
+    volume_name: String,
+    mount_path: PathBuf,
+}
+
+fn resolve_volume_file_target(
+    environment: String,
+    environment_instances: &ProjectEnvironmentInstances,
+    volume: Option<String>,
+    project: ProjectProject,
+    is_terminal: bool,
+) -> Result<ResolvedVolumeFileTarget> {
     let volume = select_volume(
         project.clone(),
         environment_instances,
@@ -311,20 +470,338 @@ async fn browse(
         .map(|instance| instance.id.clone())
         .ok_or_else(|| anyhow!("No active service instance found for service {service_name}"))?;
 
-    if identity_file.is_none() {
-        super::ssh::native::ensure_ssh_key(client, configs).await?;
-    }
-
-    run_volume_browser(VolumeBrowserParams {
+    Ok(ResolvedVolumeFileTarget {
         service_instance_id,
         service_name,
         volume_name: volume.volume.name,
         mount_path: PathBuf::from(volume.mount_path),
-        local_dir: local_dir.unwrap_or(std::env::current_dir()?),
-        identity_file,
-    })?;
+    })
+}
+
+async fn file_ls(
+    environment: String,
+    environment_instances: &ProjectEnvironmentInstances,
+    volume: Option<String>,
+    project: ProjectProject,
+    path: PathBuf,
+    identity_file: Option<PathBuf>,
+    json: bool,
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<()> {
+    let target = prepare_file_target(
+        environment,
+        environment_instances,
+        volume,
+        project,
+        identity_file.clone(),
+        client,
+        configs,
+    )
+    .await?;
+    let remote_path = resolve_remote_path(&target.mount_path, &path)?;
+    let file_client = VolumeFileClient::connect(target.service_instance_id.clone(), identity_file)?;
+    let entries = file_client.list_dir(&remote_path)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "volume": target.volume_name,
+                "service": target.service_name,
+                "path": remote_path,
+                "entries": entries,
+            }))?
+        );
+    } else {
+        println!("{}", remote_path.display());
+        println!();
+        for entry in entries {
+            println!("{} {}", entry.kind.marker(), entry.name);
+        }
+    }
 
     Ok(())
+}
+
+async fn file_download(
+    environment: String,
+    environment_instances: &ProjectEnvironmentInstances,
+    volume: Option<String>,
+    project: ProjectProject,
+    remote_path: PathBuf,
+    local_path: PathBuf,
+    identity_file: Option<PathBuf>,
+    yes: bool,
+    json: bool,
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<()> {
+    let target = prepare_file_target(
+        environment,
+        environment_instances,
+        volume,
+        project,
+        identity_file.clone(),
+        client,
+        configs,
+    )
+    .await?;
+    let remote_path = resolve_remote_path(&target.mount_path, &remote_path)?;
+    let file_client = VolumeFileClient::connect(target.service_instance_id.clone(), identity_file)?;
+    let kind = file_client.stat_kind(&remote_path)?;
+    let local_path = resolve_download_local_path(&remote_path, local_path, kind)?;
+
+    confirm_local_overwrite(&local_path, yes)?;
+    if local_path.exists() {
+        remove_local_path(&local_path)?;
+    }
+
+    file_client.download(&remote_path, &local_path, kind)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "success": true,
+                "volume": target.volume_name,
+                "service": target.service_name,
+                "remotePath": remote_path,
+                "localPath": std::fs::canonicalize(&local_path).unwrap_or(local_path.clone()),
+                "kind": kind,
+            }))?
+        );
+    } else {
+        println!(
+            "Downloaded \"{}\" to \"{}\"",
+            remote_path.display(),
+            local_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+async fn file_upload(
+    environment: String,
+    environment_instances: &ProjectEnvironmentInstances,
+    volume: Option<String>,
+    project: ProjectProject,
+    local_path: PathBuf,
+    remote_path: PathBuf,
+    identity_file: Option<PathBuf>,
+    yes: bool,
+    json: bool,
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<()> {
+    let local_path = if local_path.is_absolute() {
+        local_path
+    } else {
+        std::env::current_dir()?.join(local_path)
+    };
+    if !local_path.exists() {
+        bail!("Local path does not exist: {}", local_path.display());
+    }
+
+    let target = prepare_file_target(
+        environment,
+        environment_instances,
+        volume,
+        project,
+        identity_file.clone(),
+        client,
+        configs,
+    )
+    .await?;
+    let remote_path = resolve_remote_path(&target.mount_path, &remote_path)?;
+    let file_client = VolumeFileClient::connect(target.service_instance_id.clone(), identity_file)?;
+    let remote_path = resolve_upload_remote_path(&file_client, &local_path, remote_path)?;
+    let kind = if local_path.is_dir() {
+        VolumeFileKind::Directory
+    } else {
+        VolumeFileKind::File
+    };
+
+    confirm_remote_overwrite(&file_client, &remote_path, yes)?;
+    if file_client.exists(&remote_path)? {
+        file_client.remove_path(&remote_path)?;
+    }
+
+    file_client.upload(&local_path, &remote_path)?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "success": true,
+                "volume": target.volume_name,
+                "service": target.service_name,
+                "remotePath": remote_path,
+                "localPath": std::fs::canonicalize(&local_path).unwrap_or(local_path.clone()),
+                "kind": kind,
+            }))?
+        );
+    } else {
+        println!(
+            "Uploaded \"{}\" to \"{}\"",
+            local_path.display(),
+            remote_path.display()
+        );
+    }
+
+    Ok(())
+}
+
+async fn prepare_file_target(
+    environment: String,
+    environment_instances: &ProjectEnvironmentInstances,
+    volume: Option<String>,
+    project: ProjectProject,
+    identity_file: Option<PathBuf>,
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<ResolvedVolumeFileTarget> {
+    let is_terminal = std::io::stdout().is_terminal();
+    let target = resolve_volume_file_target(
+        environment,
+        environment_instances,
+        volume,
+        project,
+        is_terminal,
+    )?;
+
+    if identity_file.is_none() {
+        super::ssh::native::ensure_ssh_key(client, configs).await?;
+    }
+
+    Ok(target)
+}
+
+fn resolve_remote_path(mount_path: &Path, input: &Path) -> Result<PathBuf> {
+    let path = if input.is_absolute() {
+        normalize_path(input)
+    } else {
+        normalize_path(&mount_path.join(input))
+    };
+
+    if !input.is_absolute() && !path.starts_with(mount_path) {
+        bail!("Remote path escapes the volume mount path");
+    }
+
+    Ok(path)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+fn resolve_download_local_path(
+    remote_path: &Path,
+    local_path: PathBuf,
+    kind: VolumeFileKind,
+) -> Result<PathBuf> {
+    let local_path = if local_path.is_absolute() {
+        local_path
+    } else {
+        std::env::current_dir()?.join(local_path)
+    };
+
+    if kind == VolumeFileKind::File && local_path.is_dir() {
+        let filename = remote_path
+            .file_name()
+            .ok_or_else(|| anyhow!("Remote file path has no filename"))?;
+        Ok(local_path.join(filename))
+    } else {
+        Ok(local_path)
+    }
+}
+
+fn resolve_upload_remote_path(
+    file_client: &VolumeFileClient,
+    local_path: &Path,
+    remote_path: PathBuf,
+) -> Result<PathBuf> {
+    if local_path.is_file()
+        && file_client.exists(&remote_path)?
+        && file_client.stat_kind(&remote_path)?.is_dir()
+    {
+        let filename = local_path
+            .file_name()
+            .ok_or_else(|| anyhow!("Local file path has no filename"))?;
+        Ok(remote_path.join(filename))
+    } else {
+        Ok(remote_path)
+    }
+}
+
+fn confirm_local_overwrite(path: &Path, yes: bool) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    if yes {
+        return Ok(());
+    }
+
+    if std::io::stdout().is_terminal() {
+        if prompt_confirm_with_default(
+            format!("Local path {} already exists. Overwrite?", path.display()).as_str(),
+            false,
+        )? {
+            Ok(())
+        } else {
+            bail!("Download cancelled")
+        }
+    } else {
+        bail!("Local destination exists. Use --yes to overwrite in non-interactive mode.")
+    }
+}
+
+fn confirm_remote_overwrite(file_client: &VolumeFileClient, path: &Path, yes: bool) -> Result<()> {
+    if !file_client.exists(path)? {
+        return Ok(());
+    }
+
+    if yes {
+        return Ok(());
+    }
+
+    if std::io::stdout().is_terminal() {
+        if prompt_confirm_with_default(
+            format!("Remote path {} already exists. Overwrite?", path.display()).as_str(),
+            false,
+        )? {
+            Ok(())
+        } else {
+            bail!("Upload cancelled")
+        }
+    } else {
+        bail!("Remote destination exists. Use --yes to overwrite in non-interactive mode.")
+    }
+}
+
+fn remove_local_path(path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect local path {}", path.display()))?;
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        std::fs::remove_file(path)
+    }
+    .with_context(|| format!("Failed to remove existing local path {}", path.display()))
 }
 
 async fn attach(

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -2,13 +2,14 @@ use super::*;
 use crate::{
     controllers::environment::get_matched_environment,
     controllers::project::{
-        ProjectEnvironmentInstances, ProjectVolumeInstanceNode,
+        ProjectEnvironmentInstances, ProjectServiceInstanceNode, ProjectVolumeInstanceNode,
         ensure_project_and_environment_exist, find_service_instance, get_environment_instances,
         get_project, volume_instances_in_env,
     },
     controllers::volume_browser::{VolumeBrowserParams, run as run_volume_browser},
     controllers::volume_files::{VolumeFileClient, VolumeFileKind},
     errors::RailwayError,
+    gql::queries::environment_instances::{DeploymentInstanceStatus, DeploymentStatus},
     queries::project::ProjectProject,
     util::{
         progress::create_spinner,
@@ -473,16 +474,67 @@ fn resolve_volume_file_target(
         .map(|service| service.node.name.clone())
         .ok_or_else(|| anyhow!("The service attached to this volume doesn't exist"))?;
 
-    let service_instance_id = find_service_instance(environment_instances, &service_id)
-        .map(|instance| instance.id.clone())
+    let service_instance = find_service_instance(environment_instances, &service_id)
         .ok_or_else(|| anyhow!("No active service instance found for service {service_name}"))?;
 
+    ensure_service_running(service_instance, &service_name)?;
+
     Ok(ResolvedVolumeFileTarget {
-        service_instance_id,
+        service_instance_id: service_instance.id.clone(),
         service_name,
         volume_name: volume.volume.name,
         mount_path: PathBuf::from(volume.mount_path),
     })
+}
+
+fn ensure_service_running(
+    service_instance: &ProjectServiceInstanceNode,
+    service_name: &str,
+) -> Result<()> {
+    let active_running = service_instance
+        .active_deployments
+        .iter()
+        .any(deployment_can_accept_ssh);
+    let latest_running = service_instance
+        .latest_deployment
+        .as_ref()
+        .is_some_and(latest_deployment_can_accept_ssh);
+
+    if active_running || latest_running {
+        Ok(())
+    } else {
+        bail!(
+            "Service {service_name} is not running. Start it before accessing volume files over SSH."
+        )
+    }
+}
+
+fn deployment_can_accept_ssh(
+    deployment: &crate::gql::queries::environment_instances::EnvironmentInstancesEnvironmentServiceInstancesEdgesNodeActiveDeployments,
+) -> bool {
+    if deployment.deployment_stopped {
+        return false;
+    }
+
+    matches!(deployment.status, DeploymentStatus::SUCCESS)
+        || deployment
+            .instances
+            .iter()
+            .any(|instance| matches!(instance.status, DeploymentInstanceStatus::RUNNING))
+}
+
+fn latest_deployment_can_accept_ssh(
+    deployment: &crate::gql::queries::environment_instances::EnvironmentInstancesEnvironmentServiceInstancesEdgesNodeLatestDeployment,
+) -> bool {
+    if deployment.deployment_stopped {
+        return false;
+    }
+
+    matches!(deployment.status, DeploymentStatus::SUCCESS)
+        || deployment
+            .instances
+            .iter()
+            .any(|instance| matches!(instance.status, DeploymentInstanceStatus::RUNNING))
 }
 
 async fn file_ls(

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -17,4 +17,5 @@ pub mod upload;
 pub mod user;
 pub mod variables;
 pub mod volume_browser;
+pub mod volume_files;
 pub mod workflow;

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -16,4 +16,5 @@ pub mod ssh_keys;
 pub mod upload;
 pub mod user;
 pub mod variables;
+pub mod volume_browser;
 pub mod workflow;

--- a/src/controllers/volume_browser/app.rs
+++ b/src/controllers/volume_browser/app.rs
@@ -17,6 +17,7 @@ pub enum BrowserAction {
     OpenSelected,
     Parent,
     DownloadSelected,
+    EditSelected,
     StartUpload,
     SubmitUpload(PathBuf),
     ConfirmOverwrite,
@@ -140,6 +141,7 @@ impl VolumeBrowserApp {
             KeyCode::Left | KeyCode::Backspace => BrowserAction::Parent,
             KeyCode::Char('r') => BrowserAction::Refresh,
             KeyCode::Char('d') => BrowserAction::DownloadSelected,
+            KeyCode::Char('e') => BrowserAction::EditSelected,
             KeyCode::Char('u') => {
                 self.mode = BrowserMode::UploadInput;
                 self.upload_input.clear();

--- a/src/controllers/volume_browser/app.rs
+++ b/src/controllers/volume_browser/app.rs
@@ -1,13 +1,7 @@
 use std::path::PathBuf;
 
+use crate::controllers::volume_files::VolumeFileEntry;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-
-#[derive(Debug, Clone)]
-pub struct RemoteEntry {
-    pub path: PathBuf,
-    pub name: String,
-    pub is_dir: bool,
-}
 
 #[derive(Debug, Clone)]
 pub enum BrowserAction {
@@ -26,8 +20,14 @@ pub enum BrowserAction {
 
 #[derive(Debug, Clone)]
 pub enum PendingTransfer {
-    Download { remote: RemoteEntry, local: PathBuf },
-    Upload { local: PathBuf, remote: PathBuf },
+    Download {
+        remote: VolumeFileEntry,
+        local: PathBuf,
+    },
+    Upload {
+        local: PathBuf,
+        remote: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -45,7 +45,7 @@ pub struct VolumeBrowserApp {
     pub mount_path: PathBuf,
     pub current_path: PathBuf,
     pub local_dir: PathBuf,
-    pub entries: Vec<RemoteEntry>,
+    pub entries: Vec<VolumeFileEntry>,
     pub selected: usize,
     pub status: Option<String>,
     pub error: Option<String>,
@@ -77,14 +77,15 @@ impl VolumeBrowserApp {
         }
     }
 
-    pub fn selected_entry(&self) -> Option<&RemoteEntry> {
+    pub fn selected_entry(&self) -> Option<&VolumeFileEntry> {
         self.entries.get(self.selected)
     }
 
-    pub fn set_entries(&mut self, mut entries: Vec<RemoteEntry>) {
+    pub fn set_entries(&mut self, mut entries: Vec<VolumeFileEntry>) {
         entries.sort_by(|a, b| {
-            b.is_dir
-                .cmp(&a.is_dir)
+            b.kind
+                .is_dir()
+                .cmp(&a.kind.is_dir())
                 .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
                 .then_with(|| a.name.cmp(&b.name))
         });

--- a/src/controllers/volume_browser/app.rs
+++ b/src/controllers/volume_browser/app.rs
@@ -1,0 +1,197 @@
+use std::path::PathBuf;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+#[derive(Debug, Clone)]
+pub struct RemoteEntry {
+    pub path: PathBuf,
+    pub name: String,
+    pub is_dir: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum BrowserAction {
+    Continue,
+    Quit,
+    Refresh,
+    OpenSelected,
+    Parent,
+    DownloadSelected,
+    StartUpload,
+    SubmitUpload(PathBuf),
+    ConfirmOverwrite,
+    CancelPrompt,
+}
+
+#[derive(Debug, Clone)]
+pub enum PendingTransfer {
+    Download { remote: RemoteEntry, local: PathBuf },
+    Upload { local: PathBuf, remote: PathBuf },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserMode {
+    Browse,
+    UploadInput,
+    ConfirmOverwrite,
+    Help,
+}
+
+#[derive(Debug)]
+pub struct VolumeBrowserApp {
+    pub service_name: String,
+    pub volume_name: String,
+    pub mount_path: PathBuf,
+    pub current_path: PathBuf,
+    pub local_dir: PathBuf,
+    pub entries: Vec<RemoteEntry>,
+    pub selected: usize,
+    pub status: Option<String>,
+    pub error: Option<String>,
+    pub mode: BrowserMode,
+    pub upload_input: String,
+    pub pending_transfer: Option<PendingTransfer>,
+}
+
+impl VolumeBrowserApp {
+    pub fn new(
+        service_name: String,
+        volume_name: String,
+        mount_path: PathBuf,
+        local_dir: PathBuf,
+    ) -> Self {
+        Self {
+            service_name,
+            volume_name,
+            current_path: mount_path.clone(),
+            mount_path,
+            local_dir,
+            entries: Vec::new(),
+            selected: 0,
+            status: None,
+            error: None,
+            mode: BrowserMode::Browse,
+            upload_input: String::new(),
+            pending_transfer: None,
+        }
+    }
+
+    pub fn selected_entry(&self) -> Option<&RemoteEntry> {
+        self.entries.get(self.selected)
+    }
+
+    pub fn set_entries(&mut self, mut entries: Vec<RemoteEntry>) {
+        entries.sort_by(|a, b| {
+            b.is_dir
+                .cmp(&a.is_dir)
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        self.entries = entries;
+        if self.entries.is_empty() {
+            self.selected = 0;
+        } else {
+            self.selected = self.selected.min(self.entries.len() - 1);
+        }
+    }
+
+    pub fn set_status<S: Into<String>>(&mut self, status: S) {
+        self.status = Some(status.into());
+        self.error = None;
+    }
+
+    pub fn set_error<S: Into<String>>(&mut self, error: S) {
+        self.error = Some(error.into());
+        self.status = None;
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> BrowserAction {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return BrowserAction::Quit;
+        }
+
+        match self.mode {
+            BrowserMode::Browse => self.handle_browse_key(key),
+            BrowserMode::UploadInput => self.handle_upload_key(key),
+            BrowserMode::ConfirmOverwrite => self.handle_confirm_key(key),
+            BrowserMode::Help => self.handle_help_key(key),
+        }
+    }
+
+    fn handle_browse_key(&mut self, key: KeyEvent) -> BrowserAction {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => BrowserAction::Quit,
+            KeyCode::Char('?') => {
+                self.mode = BrowserMode::Help;
+                BrowserAction::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+                BrowserAction::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.entries.is_empty() {
+                    self.selected = (self.selected + 1).min(self.entries.len() - 1);
+                }
+                BrowserAction::Continue
+            }
+            KeyCode::Enter | KeyCode::Right => BrowserAction::OpenSelected,
+            KeyCode::Left | KeyCode::Backspace => BrowserAction::Parent,
+            KeyCode::Char('r') => BrowserAction::Refresh,
+            KeyCode::Char('d') => BrowserAction::DownloadSelected,
+            KeyCode::Char('u') => {
+                self.mode = BrowserMode::UploadInput;
+                self.upload_input.clear();
+                BrowserAction::StartUpload
+            }
+            _ => BrowserAction::Continue,
+        }
+    }
+
+    fn handle_upload_key(&mut self, key: KeyEvent) -> BrowserAction {
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = BrowserMode::Browse;
+                BrowserAction::CancelPrompt
+            }
+            KeyCode::Enter => {
+                self.mode = BrowserMode::Browse;
+                BrowserAction::SubmitUpload(PathBuf::from(self.upload_input.trim()))
+            }
+            KeyCode::Backspace => {
+                self.upload_input.pop();
+                BrowserAction::Continue
+            }
+            KeyCode::Char(ch) => {
+                self.upload_input.push(ch);
+                BrowserAction::Continue
+            }
+            _ => BrowserAction::Continue,
+        }
+    }
+
+    fn handle_confirm_key(&mut self, key: KeyEvent) -> BrowserAction {
+        match key.code {
+            KeyCode::Enter | KeyCode::Char('y') => {
+                self.mode = BrowserMode::Browse;
+                BrowserAction::ConfirmOverwrite
+            }
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q') => {
+                self.mode = BrowserMode::Browse;
+                BrowserAction::CancelPrompt
+            }
+            _ => BrowserAction::Continue,
+        }
+    }
+
+    fn handle_help_key(&mut self, key: KeyEvent) -> BrowserAction {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => {
+                self.mode = BrowserMode::Browse;
+                BrowserAction::Continue
+            }
+            _ => BrowserAction::Continue,
+        }
+    }
+}

--- a/src/controllers/volume_browser/app.rs
+++ b/src/controllers/volume_browser/app.rs
@@ -172,8 +172,8 @@ impl VolumeBrowserApp {
                 }
                 BrowserAction::Continue
             }
-            KeyCode::Enter | KeyCode::Right => BrowserAction::OpenSelected,
-            KeyCode::Left | KeyCode::Backspace => BrowserAction::Parent,
+            KeyCode::Enter | KeyCode::Right | KeyCode::Char('l') => BrowserAction::OpenSelected,
+            KeyCode::Left | KeyCode::Backspace | KeyCode::Char('h') => BrowserAction::Parent,
             KeyCode::Char('r') => BrowserAction::Refresh,
             KeyCode::Char('d') => BrowserAction::DownloadSelected,
             KeyCode::Char('e') => BrowserAction::EditSelected,
@@ -202,12 +202,12 @@ impl VolumeBrowserApp {
                 }
                 BrowserAction::Continue
             }
-            KeyCode::Right => BrowserAction::OpenLocalSelected,
+            KeyCode::Right | KeyCode::Char('l') => BrowserAction::OpenLocalSelected,
             KeyCode::Enter => {
                 self.mode = BrowserMode::Browse;
                 BrowserAction::SubmitSelectedUpload
             }
-            KeyCode::Left | KeyCode::Backspace => BrowserAction::LocalParent,
+            KeyCode::Left | KeyCode::Backspace | KeyCode::Char('h') => BrowserAction::LocalParent,
             KeyCode::Char('r') => BrowserAction::RefreshLocal,
             _ => BrowserAction::Continue,
         }

--- a/src/controllers/volume_browser/app.rs
+++ b/src/controllers/volume_browser/app.rs
@@ -13,7 +13,10 @@ pub enum BrowserAction {
     DownloadSelected,
     EditSelected,
     StartUpload,
-    SubmitUpload(PathBuf),
+    OpenLocalSelected,
+    LocalParent,
+    SubmitSelectedUpload,
+    RefreshLocal,
     ConfirmOverwrite,
     CancelPrompt,
 }
@@ -33,9 +36,16 @@ pub enum PendingTransfer {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BrowserMode {
     Browse,
-    UploadInput,
+    UploadPicker,
     ConfirmOverwrite,
     Help,
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalFileEntry {
+    pub path: PathBuf,
+    pub name: String,
+    pub is_dir: bool,
 }
 
 #[derive(Debug)]
@@ -47,10 +57,12 @@ pub struct VolumeBrowserApp {
     pub local_dir: PathBuf,
     pub entries: Vec<VolumeFileEntry>,
     pub selected: usize,
+    pub local_current_path: PathBuf,
+    pub local_entries: Vec<LocalFileEntry>,
+    pub local_selected: usize,
     pub status: Option<String>,
     pub error: Option<String>,
     pub mode: BrowserMode,
-    pub upload_input: String,
     pub pending_transfer: Option<PendingTransfer>,
 }
 
@@ -66,19 +78,25 @@ impl VolumeBrowserApp {
             volume_name,
             current_path: mount_path.clone(),
             mount_path,
+            local_current_path: local_dir.clone(),
             local_dir,
             entries: Vec::new(),
             selected: 0,
+            local_entries: Vec::new(),
+            local_selected: 0,
             status: None,
             error: None,
             mode: BrowserMode::Browse,
-            upload_input: String::new(),
             pending_transfer: None,
         }
     }
 
     pub fn selected_entry(&self) -> Option<&VolumeFileEntry> {
         self.entries.get(self.selected)
+    }
+
+    pub fn selected_local_entry(&self) -> Option<&LocalFileEntry> {
+        self.local_entries.get(self.local_selected)
     }
 
     pub fn set_entries(&mut self, mut entries: Vec<VolumeFileEntry>) {
@@ -95,6 +113,22 @@ impl VolumeBrowserApp {
             self.selected = 0;
         } else {
             self.selected = self.selected.min(self.entries.len() - 1);
+        }
+    }
+
+    pub fn set_local_entries(&mut self, mut entries: Vec<LocalFileEntry>) {
+        entries.sort_by(|a, b| {
+            b.is_dir
+                .cmp(&a.is_dir)
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+                .then_with(|| a.name.cmp(&b.name))
+        });
+
+        self.local_entries = entries;
+        if self.local_entries.is_empty() {
+            self.local_selected = 0;
+        } else {
+            self.local_selected = self.local_selected.min(self.local_entries.len() - 1);
         }
     }
 
@@ -115,7 +149,7 @@ impl VolumeBrowserApp {
 
         match self.mode {
             BrowserMode::Browse => self.handle_browse_key(key),
-            BrowserMode::UploadInput => self.handle_upload_key(key),
+            BrowserMode::UploadPicker => self.handle_upload_key(key),
             BrowserMode::ConfirmOverwrite => self.handle_confirm_key(key),
             BrowserMode::Help => self.handle_help_key(key),
         }
@@ -144,8 +178,7 @@ impl VolumeBrowserApp {
             KeyCode::Char('d') => BrowserAction::DownloadSelected,
             KeyCode::Char('e') => BrowserAction::EditSelected,
             KeyCode::Char('u') => {
-                self.mode = BrowserMode::UploadInput;
-                self.upload_input.clear();
+                self.mode = BrowserMode::UploadPicker;
                 BrowserAction::StartUpload
             }
             _ => BrowserAction::Continue,
@@ -158,18 +191,24 @@ impl VolumeBrowserApp {
                 self.mode = BrowserMode::Browse;
                 BrowserAction::CancelPrompt
             }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.local_selected = self.local_selected.saturating_sub(1);
+                BrowserAction::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.local_entries.is_empty() {
+                    self.local_selected =
+                        (self.local_selected + 1).min(self.local_entries.len() - 1);
+                }
+                BrowserAction::Continue
+            }
+            KeyCode::Right => BrowserAction::OpenLocalSelected,
             KeyCode::Enter => {
                 self.mode = BrowserMode::Browse;
-                BrowserAction::SubmitUpload(PathBuf::from(self.upload_input.trim()))
+                BrowserAction::SubmitSelectedUpload
             }
-            KeyCode::Backspace => {
-                self.upload_input.pop();
-                BrowserAction::Continue
-            }
-            KeyCode::Char(ch) => {
-                self.upload_input.push(ch);
-                BrowserAction::Continue
-            }
+            KeyCode::Left | KeyCode::Backspace => BrowserAction::LocalParent,
+            KeyCode::Char('r') => BrowserAction::RefreshLocal,
             _ => BrowserAction::Continue,
         }
     }

--- a/src/controllers/volume_browser/mod.rs
+++ b/src/controllers/volume_browser/mod.rs
@@ -79,6 +79,7 @@ pub fn run(params: VolumeBrowserParams) -> Result<VolumeBrowserOutput> {
                         run_pending_transfer(&remote, &mut app, &mut terminal)
                     }
                 }
+                BrowserAction::EditSelected => edit_selected(&remote, &mut app, &mut terminal),
                 BrowserAction::StartUpload => app.set_status("Enter a local path to upload"),
                 BrowserAction::SubmitUpload(path) => {
                     if queue_upload(&remote, &mut app, path) {
@@ -96,6 +97,39 @@ pub fn run(params: VolumeBrowserParams) -> Result<VolumeBrowserOutput> {
             Event::Resize(_, _) => terminal.clear()?,
             _ => {}
         }
+    }
+}
+
+fn edit_selected(
+    remote: &NativeRemote,
+    app: &mut VolumeBrowserApp,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+) {
+    let Some(entry) = app.selected_entry().cloned() else {
+        app.set_status("Nothing selected");
+        return;
+    };
+
+    if entry.is_dir {
+        app.set_status("Selected entry is a directory");
+        return;
+    }
+
+    let result = run_with_restored_terminal(terminal, || {
+        let temp_path = edit_temp_path(&entry.name);
+        remote.download(&entry.path, &temp_path, false)?;
+        run_editor(&temp_path)?;
+        remote.upload(&temp_path, &entry.path)?;
+        let _ = fs::remove_file(&temp_path);
+        Ok(format!("Edited and synced {}", entry.name))
+    });
+
+    match result {
+        Ok(message) => {
+            app.set_status(message);
+            refresh_entries(remote, app);
+        }
+        Err(error) => app.set_error(error.to_string()),
     }
 }
 
@@ -589,6 +623,36 @@ fn shell_quote(path: &Path) -> String {
 fn shell_quote_path_fragment(value: &std::ffi::OsStr) -> String {
     let value = value.to_string_lossy();
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn edit_temp_path(name: &str) -> PathBuf {
+    let safe_name = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    env::temp_dir().join(format!("railway-volume-edit-{}-{safe_name}", process::id()))
+}
+
+fn run_editor(path: &Path) -> Result<()> {
+    let editor = env::var("VISUAL")
+        .or_else(|_| env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let status = Command::new(editor)
+        .arg(path)
+        .status()
+        .context("Failed to launch editor")?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        bail!("Editor exited without saving changes")
+    }
 }
 
 fn remove_local_path(path: &Path) -> Result<()> {

--- a/src/controllers/volume_browser/mod.rs
+++ b/src/controllers/volume_browser/mod.rs
@@ -1,0 +1,617 @@
+mod app;
+mod ui;
+
+use std::{
+    env, fs,
+    io::{self, stdout},
+    panic,
+    path::{Path, PathBuf},
+    process::{self, Command, Stdio},
+};
+
+pub use app::{BrowserAction, PendingTransfer, RemoteEntry, VolumeBrowserApp};
+
+use anyhow::{Context, Result, bail};
+use crossterm::{
+    cursor::{Hide, Show},
+    event::{self, Event, KeyEventKind},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+
+const SSH_HOST: &str = "ssh.railway.com";
+
+pub enum VolumeBrowserOutput {
+    Closed,
+}
+
+pub struct VolumeBrowserParams {
+    pub service_instance_id: String,
+    pub service_name: String,
+    pub volume_name: String,
+    pub mount_path: PathBuf,
+    pub local_dir: PathBuf,
+    pub identity_file: Option<PathBuf>,
+}
+
+pub fn run(params: VolumeBrowserParams) -> Result<VolumeBrowserOutput> {
+    fs::create_dir_all(&params.local_dir).with_context(|| {
+        format!(
+            "Failed to create local transfer directory {}",
+            params.local_dir.display()
+        )
+    })?;
+
+    let original_hook = panic::take_hook();
+    panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        original_hook(info);
+    }));
+
+    let remote = NativeRemote::connect(params.service_instance_id, params.identity_file)?;
+    let mut app = VolumeBrowserApp::new(
+        params.service_name,
+        params.volume_name,
+        params.mount_path,
+        params.local_dir,
+    );
+
+    refresh_entries(&remote, &mut app);
+
+    let mut terminal = setup_terminal()?;
+    let _terminal_cleanup = scopeguard::guard((), |_| {
+        restore_terminal();
+    });
+
+    loop {
+        terminal.draw(|frame| ui::render(&app, frame))?;
+
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press => match app.handle_key(key) {
+                BrowserAction::Continue => {}
+                BrowserAction::Quit => return Ok(VolumeBrowserOutput::Closed),
+                BrowserAction::Refresh => refresh_entries(&remote, &mut app),
+                BrowserAction::OpenSelected => open_selected(&remote, &mut app),
+                BrowserAction::Parent => open_parent(&remote, &mut app),
+                BrowserAction::DownloadSelected => {
+                    if queue_download(&mut app) {
+                        run_pending_transfer(&remote, &mut app, &mut terminal)
+                    }
+                }
+                BrowserAction::StartUpload => app.set_status("Enter a local path to upload"),
+                BrowserAction::SubmitUpload(path) => {
+                    if queue_upload(&remote, &mut app, path) {
+                        run_pending_transfer(&remote, &mut app, &mut terminal)
+                    }
+                }
+                BrowserAction::ConfirmOverwrite => {
+                    run_pending_transfer(&remote, &mut app, &mut terminal)
+                }
+                BrowserAction::CancelPrompt => {
+                    app.pending_transfer = None;
+                    app.set_status("Cancelled");
+                }
+            },
+            Event::Resize(_, _) => terminal.clear()?,
+            _ => {}
+        }
+    }
+}
+
+struct NativeRemote {
+    service_instance_id: String,
+    identity_file: Option<PathBuf>,
+    control_path: PathBuf,
+}
+
+impl NativeRemote {
+    fn connect(service_instance_id: String, identity_file: Option<PathBuf>) -> Result<Self> {
+        let remote = Self {
+            control_path: control_path(&service_instance_id),
+            service_instance_id,
+            identity_file,
+        };
+        remote.open_master_connection()?;
+        Ok(remote)
+    }
+
+    fn target(&self) -> String {
+        format!("{}@{}", self.service_instance_id, SSH_HOST)
+    }
+
+    fn base_ssh_command(&self) -> Command {
+        let mut command = Command::new("ssh");
+        if let Some(identity_file) = &self.identity_file {
+            command.arg("-i").arg(identity_file);
+        }
+        command
+    }
+
+    fn open_master_connection(&self) -> Result<()> {
+        let _ = fs::remove_file(&self.control_path);
+        let status = self
+            .base_ssh_command()
+            .args([
+                "-M",
+                "-N",
+                "-f",
+                "-o",
+                "ControlMaster=yes",
+                "-o",
+                &format!("ControlPath={}", self.control_path.display()),
+                "-o",
+                "ControlPersist=10m",
+            ])
+            .arg(self.target())
+            .status()
+            .context("Failed to start SSH control connection")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Failed to start SSH control connection")
+        }
+    }
+
+    fn ssh_command(&self) -> Command {
+        let mut command = self.base_ssh_command();
+        command
+            .args([
+                "-o",
+                &format!("ControlPath={}", self.control_path.display()),
+                "-o",
+                "ControlMaster=no",
+                "-o",
+                "BatchMode=yes",
+            ])
+            .arg("-T");
+        command.arg(self.target());
+        command
+    }
+
+    fn list_dir(&self, path: &Path) -> Result<Vec<RemoteEntry>> {
+        let output = self
+            .ssh_command()
+            .arg(format!("unset LANG; ls -la {}/", shell_quote(path)))
+            .output()
+            .context("Failed to run ssh for remote directory listing")?;
+
+        if !output.status.success() {
+            bail!(
+                "Remote directory listing failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        parse_ls_output(path, &String::from_utf8_lossy(&output.stdout))
+    }
+
+    fn exists(&self, path: &Path) -> Result<bool> {
+        let status = self
+            .ssh_command()
+            .arg(format!("test -e {}", shell_quote(path)))
+            .status()
+            .context("Failed to run ssh for remote path check")?;
+        Ok(status.success())
+    }
+
+    fn remove_path(&self, path: &Path) -> Result<()> {
+        let status = self
+            .ssh_command()
+            .arg(format!("rm -rf -- {}", shell_quote(path)))
+            .status()
+            .context("Failed to run ssh for remote path removal")?;
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Failed to remove remote path {}", path.display())
+        }
+    }
+
+    fn download(&self, remote: &Path, local: &Path, is_dir: bool) -> Result<()> {
+        if is_dir {
+            self.download_dir(remote, local)
+        } else {
+            self.download_file(remote, local)
+        }
+    }
+
+    fn upload(&self, local: &Path, remote: &Path) -> Result<()> {
+        if local.is_dir() {
+            self.upload_dir(local, remote)
+        } else {
+            self.upload_file(local, remote)
+        }
+    }
+
+    fn download_file(&self, remote: &Path, local: &Path) -> Result<()> {
+        let output = fs::File::create(local)
+            .with_context(|| format!("Failed to create local file {}", local.display()))?;
+        let status = self
+            .ssh_command()
+            .arg(format!("cat -- {}", shell_quote(remote)))
+            .stdout(Stdio::from(output))
+            .status()
+            .context("Failed to run ssh for file download")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Download failed for {}", remote.display())
+        }
+    }
+
+    fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
+        let parent = remote
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
+        let name = remote
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?;
+        let local_parent = local
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
+
+        fs::create_dir_all(local_parent).with_context(|| {
+            format!(
+                "Failed to create local directory {}",
+                local_parent.display()
+            )
+        })?;
+
+        let mut ssh = self
+            .ssh_command()
+            .arg(format!(
+                "tar -C {} -cf - {}",
+                shell_quote(parent),
+                shell_quote_path_fragment(name)
+            ))
+            .stdout(Stdio::piped())
+            .spawn()
+            .context("Failed to run ssh for directory download")?;
+
+        let stdout = ssh
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to read remote tar stream"))?;
+
+        let tar_status = Command::new("tar")
+            .args(["-xf", "-", "-C"])
+            .arg(local_parent)
+            .stdin(Stdio::from(stdout))
+            .status()
+            .context("Failed to extract downloaded directory")?;
+
+        let ssh_status = ssh
+            .wait()
+            .context("Failed to wait for remote directory download")?;
+
+        if tar_status.success() && ssh_status.success() {
+            Ok(())
+        } else {
+            bail!("Download failed for {}", remote.display())
+        }
+    }
+
+    fn upload_file(&self, local: &Path, remote: &Path) -> Result<()> {
+        let input = fs::File::open(local)
+            .with_context(|| format!("Failed to open local file {}", local.display()))?;
+        let status = self
+            .ssh_command()
+            .arg(format!("cat > {}", shell_quote(remote)))
+            .stdin(Stdio::from(input))
+            .status()
+            .context("Failed to run ssh for file upload")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Upload failed for {}", local.display())
+        }
+    }
+
+    fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
+        let local_parent = local
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
+        let name = local
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no name"))?;
+        let remote_parent = remote
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
+
+        let mut tar = Command::new("tar")
+            .args(["-C"])
+            .arg(local_parent)
+            .args(["-cf", "-"])
+            .arg(name)
+            .stdout(Stdio::piped())
+            .spawn()
+            .context("Failed to archive local directory for upload")?;
+
+        let stdout = tar
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to read local tar stream"))?;
+
+        let ssh_status = self
+            .ssh_command()
+            .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
+            .stdin(Stdio::from(stdout))
+            .status()
+            .context("Failed to run ssh for directory upload")?;
+
+        let tar_status = tar
+            .wait()
+            .context("Failed to wait for local directory archive")?;
+
+        if tar_status.success() && ssh_status.success() {
+            Ok(())
+        } else {
+            bail!("Upload failed for {}", local.display())
+        }
+    }
+}
+
+impl Drop for NativeRemote {
+    fn drop(&mut self) {
+        let _ = self
+            .base_ssh_command()
+            .args([
+                "-O",
+                "exit",
+                "-o",
+                &format!("ControlPath={}", self.control_path.display()),
+            ])
+            .arg(self.target())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let _ = fs::remove_file(&self.control_path);
+    }
+}
+
+fn control_path(service_instance_id: &str) -> PathBuf {
+    let service_fragment = service_instance_id
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .take(16)
+        .collect::<String>();
+    env::temp_dir().join(format!(
+        "railway-volume-{}-{}.sock",
+        process::id(),
+        service_fragment
+    ))
+}
+
+fn refresh_entries(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
+    match remote.list_dir(&app.current_path) {
+        Ok(entries) => {
+            app.set_entries(entries);
+            app.set_status("Ready");
+        }
+        Err(error) => app.set_error(format!("Failed to list directory: {error}")),
+    }
+}
+
+fn open_selected(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
+    let Some(entry) = app.selected_entry().cloned() else {
+        return;
+    };
+
+    if !entry.is_dir {
+        app.set_status("Selected entry is not a directory");
+        return;
+    }
+
+    app.current_path = entry.path;
+    app.selected = 0;
+    refresh_entries(remote, app);
+}
+
+fn open_parent(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
+    if app.current_path == app.mount_path {
+        app.set_status("Already at volume mount path");
+        return;
+    }
+
+    let Some(parent) = app.current_path.parent() else {
+        return;
+    };
+    let parent = parent.to_path_buf();
+    if !parent.starts_with(&app.mount_path) {
+        app.set_status("Cannot navigate above volume mount path");
+        return;
+    }
+
+    app.current_path = parent;
+    app.selected = 0;
+    refresh_entries(remote, app);
+}
+
+fn queue_download(app: &mut VolumeBrowserApp) -> bool {
+    let Some(entry) = app.selected_entry().cloned() else {
+        app.set_status("Nothing selected");
+        return false;
+    };
+
+    let local = app.local_dir.join(&entry.name);
+    app.pending_transfer = Some(PendingTransfer::Download {
+        remote: entry,
+        local: local.clone(),
+    });
+
+    if local.exists() {
+        app.mode = app::BrowserMode::ConfirmOverwrite;
+        false
+    } else {
+        true
+    }
+}
+
+fn queue_upload(remote: &NativeRemote, app: &mut VolumeBrowserApp, input: PathBuf) -> bool {
+    if input.as_os_str().is_empty() {
+        app.set_status("Upload cancelled");
+        return false;
+    }
+
+    let local = if input.is_absolute() {
+        input
+    } else {
+        app.local_dir.join(input)
+    };
+
+    if !local.exists() {
+        app.set_error(format!("Local path does not exist: {}", local.display()));
+        return false;
+    }
+
+    let Some(name) = local.file_name() else {
+        app.set_error("Local path must include a file or directory name");
+        return false;
+    };
+
+    let remote_path = app.current_path.join(name);
+    app.pending_transfer = Some(PendingTransfer::Upload {
+        local,
+        remote: remote_path.clone(),
+    });
+
+    match remote.exists(&remote_path) {
+        Ok(true) => {
+            app.mode = app::BrowserMode::ConfirmOverwrite;
+            false
+        }
+        Ok(false) => true,
+        Err(error) => {
+            app.set_error(format!("Failed to check remote destination: {error}"));
+            false
+        }
+    }
+}
+
+fn run_pending_transfer(
+    remote: &NativeRemote,
+    app: &mut VolumeBrowserApp,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+) {
+    let Some(transfer) = app.pending_transfer.take() else {
+        return;
+    };
+
+    let result = run_with_restored_terminal(terminal, || match transfer {
+        PendingTransfer::Download {
+            remote: entry,
+            local,
+        } => {
+            if local.exists() {
+                remove_local_path(&local)?;
+            }
+            remote.download(&entry.path, &local, entry.is_dir)?;
+            Ok(format!("Downloaded to {}", local.display()))
+        }
+        PendingTransfer::Upload {
+            local,
+            remote: dest,
+        } => {
+            if remote.exists(&dest)? {
+                remote.remove_path(&dest)?;
+            }
+            remote.upload(&local, &dest)?;
+            Ok(format!("Uploaded to {}", dest.display()))
+        }
+    });
+
+    match result {
+        Ok(message) => {
+            app.set_status(message);
+            refresh_entries(remote, app);
+        }
+        Err(error) => app.set_error(error.to_string()),
+    }
+}
+
+fn run_with_restored_terminal<F>(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    operation: F,
+) -> Result<String>
+where
+    F: FnOnce() -> Result<String>,
+{
+    restore_terminal();
+    let result = operation();
+    let _ = execute!(stdout(), EnterAlternateScreen, Hide);
+    let _ = crossterm::terminal::enable_raw_mode();
+    let _ = terminal.clear();
+    result
+}
+
+fn parse_ls_output(parent: &Path, output: &str) -> Result<Vec<RemoteEntry>> {
+    let mut entries = Vec::new();
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with("total ") {
+            continue;
+        }
+
+        let mut parts = line.split_whitespace();
+        let Some(mode) = parts.next() else {
+            continue;
+        };
+
+        for _ in 0..7 {
+            parts.next();
+        }
+
+        let name = parts.collect::<Vec<_>>().join(" ");
+        let name = name.split(" -> ").next().unwrap_or(name.as_str());
+        if name.is_empty() || name == "." || name == ".." {
+            continue;
+        }
+
+        entries.push(RemoteEntry {
+            path: parent.join(name),
+            name: name.to_string(),
+            is_dir: mode.starts_with('d'),
+        });
+    }
+
+    Ok(entries)
+}
+
+fn shell_quote(path: &Path) -> String {
+    let value = path.display().to_string();
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn shell_quote_path_fragment(value: &std::ffi::OsStr) -> String {
+    let value = value.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn remove_local_path(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect local path {}", path.display()))?;
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+    .with_context(|| format!("Failed to remove existing local path {}", path.display()))
+}
+
+fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen, Hide)?;
+    let backend = CrosstermBackend::new(stdout());
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+    Ok(terminal)
+}
+
+fn restore_terminal() {
+    let _ = execute!(stdout(), LeaveAlternateScreen, Show);
+    let _ = disable_raw_mode();
+}

--- a/src/controllers/volume_browser/mod.rs
+++ b/src/controllers/volume_browser/mod.rs
@@ -9,7 +9,7 @@ use std::{
     process::{self, Command},
 };
 
-pub use app::{BrowserAction, PendingTransfer, VolumeBrowserApp};
+pub use app::{BrowserAction, LocalFileEntry, PendingTransfer, VolumeBrowserApp};
 
 use anyhow::{Context, Result, bail};
 use crossterm::{
@@ -80,9 +80,15 @@ pub fn run(params: VolumeBrowserParams) -> Result<VolumeBrowserOutput> {
                     }
                 }
                 BrowserAction::EditSelected => edit_selected(&remote, &mut app, &mut terminal),
-                BrowserAction::StartUpload => app.set_status("Enter a local path to upload"),
-                BrowserAction::SubmitUpload(path) => {
-                    if queue_upload(&remote, &mut app, path) {
+                BrowserAction::StartUpload => {
+                    refresh_local_entries(&mut app);
+                    app.set_status("Select a local file or directory to upload");
+                }
+                BrowserAction::OpenLocalSelected => open_local_selected(&mut app),
+                BrowserAction::LocalParent => open_local_parent(&mut app),
+                BrowserAction::RefreshLocal => refresh_local_entries(&mut app),
+                BrowserAction::SubmitSelectedUpload => {
+                    if queue_selected_upload(&remote, &mut app) {
                         run_pending_transfer(&remote, &mut app, &mut terminal)
                     }
                 }
@@ -198,18 +204,59 @@ fn queue_download(app: &mut VolumeBrowserApp) -> bool {
     }
 }
 
-fn queue_upload(remote: &VolumeFileClient, app: &mut VolumeBrowserApp, input: PathBuf) -> bool {
-    if input.as_os_str().is_empty() {
-        app.set_status("Upload cancelled");
-        return false;
+fn refresh_local_entries(app: &mut VolumeBrowserApp) {
+    match fs::read_dir(&app.local_current_path) {
+        Ok(read_dir) => {
+            let entries = read_dir
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let path = entry.path();
+                    let metadata = entry.metadata().ok()?;
+                    Some(LocalFileEntry {
+                        name: entry.file_name().to_string_lossy().to_string(),
+                        path,
+                        is_dir: metadata.is_dir(),
+                    })
+                })
+                .collect();
+            app.set_local_entries(entries);
+        }
+        Err(error) => app.set_error(format!("Failed to list local directory: {error}")),
     }
+}
 
-    let local = if input.is_absolute() {
-        input
-    } else {
-        app.local_dir.join(input)
+fn open_local_selected(app: &mut VolumeBrowserApp) {
+    let Some(entry) = app.selected_local_entry().cloned() else {
+        app.set_status("Nothing selected");
+        return;
     };
 
+    if !entry.is_dir {
+        app.set_status("Press Enter to upload selected file");
+        return;
+    }
+
+    app.local_current_path = entry.path;
+    app.local_selected = 0;
+    refresh_local_entries(app);
+}
+
+fn open_local_parent(app: &mut VolumeBrowserApp) {
+    let Some(parent) = app.local_current_path.parent() else {
+        return;
+    };
+    app.local_current_path = parent.to_path_buf();
+    app.local_selected = 0;
+    refresh_local_entries(app);
+}
+
+fn queue_selected_upload(remote: &VolumeFileClient, app: &mut VolumeBrowserApp) -> bool {
+    let Some(local_entry) = app.selected_local_entry().cloned() else {
+        app.set_status("Nothing selected");
+        return false;
+    };
+
+    let local = local_entry.path;
     if !local.exists() {
         app.set_error(format!("Local path does not exist: {}", local.display()));
         return false;

--- a/src/controllers/volume_browser/mod.rs
+++ b/src/controllers/volume_browser/mod.rs
@@ -6,10 +6,10 @@ use std::{
     io::{self, stdout},
     panic,
     path::{Path, PathBuf},
-    process::{self, Command, Stdio},
+    process::{self, Command},
 };
 
-pub use app::{BrowserAction, PendingTransfer, RemoteEntry, VolumeBrowserApp};
+pub use app::{BrowserAction, PendingTransfer, VolumeBrowserApp};
 
 use anyhow::{Context, Result, bail};
 use crossterm::{
@@ -20,7 +20,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-const SSH_HOST: &str = "ssh.railway.com";
+use crate::controllers::volume_files::{VolumeFileClient, VolumeFileKind};
 
 pub enum VolumeBrowserOutput {
     Closed,
@@ -49,7 +49,7 @@ pub fn run(params: VolumeBrowserParams) -> Result<VolumeBrowserOutput> {
         original_hook(info);
     }));
 
-    let remote = NativeRemote::connect(params.service_instance_id, params.identity_file)?;
+    let remote = VolumeFileClient::connect(params.service_instance_id, params.identity_file)?;
     let mut app = VolumeBrowserApp::new(
         params.service_name,
         params.volume_name,
@@ -101,7 +101,7 @@ pub fn run(params: VolumeBrowserParams) -> Result<VolumeBrowserOutput> {
 }
 
 fn edit_selected(
-    remote: &NativeRemote,
+    remote: &VolumeFileClient,
     app: &mut VolumeBrowserApp,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) {
@@ -110,14 +110,14 @@ fn edit_selected(
         return;
     };
 
-    if entry.is_dir {
+    if entry.kind.is_dir() {
         app.set_status("Selected entry is a directory");
         return;
     }
 
     let result = run_with_restored_terminal(terminal, || {
         let temp_path = edit_temp_path(&entry.name);
-        remote.download(&entry.path, &temp_path, false)?;
+        remote.download(&entry.path, &temp_path, VolumeFileKind::File)?;
         run_editor(&temp_path)?;
         remote.upload(&temp_path, &entry.path)?;
         let _ = fs::remove_file(&temp_path);
@@ -133,294 +133,7 @@ fn edit_selected(
     }
 }
 
-struct NativeRemote {
-    service_instance_id: String,
-    identity_file: Option<PathBuf>,
-    control_path: PathBuf,
-}
-
-impl NativeRemote {
-    fn connect(service_instance_id: String, identity_file: Option<PathBuf>) -> Result<Self> {
-        let remote = Self {
-            control_path: control_path(&service_instance_id),
-            service_instance_id,
-            identity_file,
-        };
-        remote.open_master_connection()?;
-        Ok(remote)
-    }
-
-    fn target(&self) -> String {
-        format!("{}@{}", self.service_instance_id, SSH_HOST)
-    }
-
-    fn base_ssh_command(&self) -> Command {
-        let mut command = Command::new("ssh");
-        if let Some(identity_file) = &self.identity_file {
-            command.arg("-i").arg(identity_file);
-        }
-        command
-    }
-
-    fn open_master_connection(&self) -> Result<()> {
-        let _ = fs::remove_file(&self.control_path);
-        let status = self
-            .base_ssh_command()
-            .args([
-                "-M",
-                "-N",
-                "-f",
-                "-o",
-                "ControlMaster=yes",
-                "-o",
-                &format!("ControlPath={}", self.control_path.display()),
-                "-o",
-                "ControlPersist=10m",
-            ])
-            .arg(self.target())
-            .status()
-            .context("Failed to start SSH control connection")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Failed to start SSH control connection")
-        }
-    }
-
-    fn ssh_command(&self) -> Command {
-        let mut command = self.base_ssh_command();
-        command
-            .args([
-                "-o",
-                &format!("ControlPath={}", self.control_path.display()),
-                "-o",
-                "ControlMaster=no",
-                "-o",
-                "BatchMode=yes",
-            ])
-            .arg("-T");
-        command.arg(self.target());
-        command
-    }
-
-    fn list_dir(&self, path: &Path) -> Result<Vec<RemoteEntry>> {
-        let output = self
-            .ssh_command()
-            .arg(format!("unset LANG; ls -la {}/", shell_quote(path)))
-            .output()
-            .context("Failed to run ssh for remote directory listing")?;
-
-        if !output.status.success() {
-            bail!(
-                "Remote directory listing failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-
-        parse_ls_output(path, &String::from_utf8_lossy(&output.stdout))
-    }
-
-    fn exists(&self, path: &Path) -> Result<bool> {
-        let status = self
-            .ssh_command()
-            .arg(format!("test -e {}", shell_quote(path)))
-            .status()
-            .context("Failed to run ssh for remote path check")?;
-        Ok(status.success())
-    }
-
-    fn remove_path(&self, path: &Path) -> Result<()> {
-        let status = self
-            .ssh_command()
-            .arg(format!("rm -rf -- {}", shell_quote(path)))
-            .status()
-            .context("Failed to run ssh for remote path removal")?;
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Failed to remove remote path {}", path.display())
-        }
-    }
-
-    fn download(&self, remote: &Path, local: &Path, is_dir: bool) -> Result<()> {
-        if is_dir {
-            self.download_dir(remote, local)
-        } else {
-            self.download_file(remote, local)
-        }
-    }
-
-    fn upload(&self, local: &Path, remote: &Path) -> Result<()> {
-        if local.is_dir() {
-            self.upload_dir(local, remote)
-        } else {
-            self.upload_file(local, remote)
-        }
-    }
-
-    fn download_file(&self, remote: &Path, local: &Path) -> Result<()> {
-        let output = fs::File::create(local)
-            .with_context(|| format!("Failed to create local file {}", local.display()))?;
-        let status = self
-            .ssh_command()
-            .arg(format!("cat -- {}", shell_quote(remote)))
-            .stdout(Stdio::from(output))
-            .status()
-            .context("Failed to run ssh for file download")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Download failed for {}", remote.display())
-        }
-    }
-
-    fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
-        let parent = remote
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
-        let name = remote
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?;
-        let local_parent = local
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
-
-        fs::create_dir_all(local_parent).with_context(|| {
-            format!(
-                "Failed to create local directory {}",
-                local_parent.display()
-            )
-        })?;
-
-        let mut ssh = self
-            .ssh_command()
-            .arg(format!(
-                "tar -C {} -cf - {}",
-                shell_quote(parent),
-                shell_quote_path_fragment(name)
-            ))
-            .stdout(Stdio::piped())
-            .spawn()
-            .context("Failed to run ssh for directory download")?;
-
-        let stdout = ssh
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to read remote tar stream"))?;
-
-        let tar_status = Command::new("tar")
-            .args(["-xf", "-", "-C"])
-            .arg(local_parent)
-            .stdin(Stdio::from(stdout))
-            .status()
-            .context("Failed to extract downloaded directory")?;
-
-        let ssh_status = ssh
-            .wait()
-            .context("Failed to wait for remote directory download")?;
-
-        if tar_status.success() && ssh_status.success() {
-            Ok(())
-        } else {
-            bail!("Download failed for {}", remote.display())
-        }
-    }
-
-    fn upload_file(&self, local: &Path, remote: &Path) -> Result<()> {
-        let input = fs::File::open(local)
-            .with_context(|| format!("Failed to open local file {}", local.display()))?;
-        let status = self
-            .ssh_command()
-            .arg(format!("cat > {}", shell_quote(remote)))
-            .stdin(Stdio::from(input))
-            .status()
-            .context("Failed to run ssh for file upload")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Upload failed for {}", local.display())
-        }
-    }
-
-    fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
-        let local_parent = local
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
-        let name = local
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no name"))?;
-        let remote_parent = remote
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
-
-        let mut tar = Command::new("tar")
-            .args(["-C"])
-            .arg(local_parent)
-            .args(["-cf", "-"])
-            .arg(name)
-            .stdout(Stdio::piped())
-            .spawn()
-            .context("Failed to archive local directory for upload")?;
-
-        let stdout = tar
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to read local tar stream"))?;
-
-        let ssh_status = self
-            .ssh_command()
-            .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
-            .stdin(Stdio::from(stdout))
-            .status()
-            .context("Failed to run ssh for directory upload")?;
-
-        let tar_status = tar
-            .wait()
-            .context("Failed to wait for local directory archive")?;
-
-        if tar_status.success() && ssh_status.success() {
-            Ok(())
-        } else {
-            bail!("Upload failed for {}", local.display())
-        }
-    }
-}
-
-impl Drop for NativeRemote {
-    fn drop(&mut self) {
-        let _ = self
-            .base_ssh_command()
-            .args([
-                "-O",
-                "exit",
-                "-o",
-                &format!("ControlPath={}", self.control_path.display()),
-            ])
-            .arg(self.target())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        let _ = fs::remove_file(&self.control_path);
-    }
-}
-
-fn control_path(service_instance_id: &str) -> PathBuf {
-    let service_fragment = service_instance_id
-        .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .take(16)
-        .collect::<String>();
-    env::temp_dir().join(format!(
-        "railway-volume-{}-{}.sock",
-        process::id(),
-        service_fragment
-    ))
-}
-
-fn refresh_entries(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
+fn refresh_entries(remote: &VolumeFileClient, app: &mut VolumeBrowserApp) {
     match remote.list_dir(&app.current_path) {
         Ok(entries) => {
             app.set_entries(entries);
@@ -430,12 +143,12 @@ fn refresh_entries(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
     }
 }
 
-fn open_selected(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
+fn open_selected(remote: &VolumeFileClient, app: &mut VolumeBrowserApp) {
     let Some(entry) = app.selected_entry().cloned() else {
         return;
     };
 
-    if !entry.is_dir {
+    if !entry.kind.is_dir() {
         app.set_status("Selected entry is not a directory");
         return;
     }
@@ -445,7 +158,7 @@ fn open_selected(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
     refresh_entries(remote, app);
 }
 
-fn open_parent(remote: &NativeRemote, app: &mut VolumeBrowserApp) {
+fn open_parent(remote: &VolumeFileClient, app: &mut VolumeBrowserApp) {
     if app.current_path == app.mount_path {
         app.set_status("Already at volume mount path");
         return;
@@ -485,7 +198,7 @@ fn queue_download(app: &mut VolumeBrowserApp) -> bool {
     }
 }
 
-fn queue_upload(remote: &NativeRemote, app: &mut VolumeBrowserApp, input: PathBuf) -> bool {
+fn queue_upload(remote: &VolumeFileClient, app: &mut VolumeBrowserApp, input: PathBuf) -> bool {
     if input.as_os_str().is_empty() {
         app.set_status("Upload cancelled");
         return false;
@@ -527,7 +240,7 @@ fn queue_upload(remote: &NativeRemote, app: &mut VolumeBrowserApp, input: PathBu
 }
 
 fn run_pending_transfer(
-    remote: &NativeRemote,
+    remote: &VolumeFileClient,
     app: &mut VolumeBrowserApp,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
 ) {
@@ -543,7 +256,7 @@ fn run_pending_transfer(
             if local.exists() {
                 remove_local_path(&local)?;
             }
-            remote.download(&entry.path, &local, entry.is_dir)?;
+            remote.download(&entry.path, &local, entry.kind)?;
             Ok(format!("Downloaded to {}", local.display()))
         }
         PendingTransfer::Upload {
@@ -580,49 +293,6 @@ where
     let _ = crossterm::terminal::enable_raw_mode();
     let _ = terminal.clear();
     result
-}
-
-fn parse_ls_output(parent: &Path, output: &str) -> Result<Vec<RemoteEntry>> {
-    let mut entries = Vec::new();
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with("total ") {
-            continue;
-        }
-
-        let mut parts = line.split_whitespace();
-        let Some(mode) = parts.next() else {
-            continue;
-        };
-
-        for _ in 0..7 {
-            parts.next();
-        }
-
-        let name = parts.collect::<Vec<_>>().join(" ");
-        let name = name.split(" -> ").next().unwrap_or(name.as_str());
-        if name.is_empty() || name == "." || name == ".." {
-            continue;
-        }
-
-        entries.push(RemoteEntry {
-            path: parent.join(name),
-            name: name.to_string(),
-            is_dir: mode.starts_with('d'),
-        });
-    }
-
-    Ok(entries)
-}
-
-fn shell_quote(path: &Path) -> String {
-    let value = path.display().to_string();
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
-fn shell_quote_path_fragment(value: &std::ffi::OsStr) -> String {
-    let value = value.to_string_lossy();
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 fn edit_temp_path(name: &str) -> PathBuf {

--- a/src/controllers/volume_browser/ui.rs
+++ b/src/controllers/volume_browser/ui.rs
@@ -214,9 +214,9 @@ fn render_footer(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
 fn help_line(mode: BrowserMode) -> Line<'static> {
     let items: &[(&str, &str)] = match mode {
         BrowserMode::Browse => &[
-            ("j/k", "move"),
-            ("l/Enter", "open"),
-            ("h/Left", "parent"),
+            ("Up/Down", "move"),
+            ("Enter", "open"),
+            ("Left", "parent"),
             ("d", "download"),
             ("e", "edit"),
             ("u", "upload"),
@@ -225,9 +225,9 @@ fn help_line(mode: BrowserMode) -> Line<'static> {
             ("q", "quit"),
         ],
         BrowserMode::UploadPicker => &[
-            ("j/k", "move"),
-            ("l/Right", "open dir"),
-            ("h/Left", "parent"),
+            ("Up/Down", "move"),
+            ("Right", "open dir"),
+            ("Left", "parent"),
             ("Enter", "upload"),
             ("r", "refresh"),
             ("Esc", "cancel"),
@@ -277,8 +277,8 @@ fn render_help_popup(frame: &mut Frame, area: Rect) {
         Line::from("Browse Railway volume files over SSH/SCP."),
         Line::from(""),
         Line::from("Up/Down or k/j    Move selection"),
-        Line::from("Enter, Right, l   Open directory"),
-        Line::from("Left, Backspace, h Parent directory"),
+        Line::from("Enter or Right    Open directory"),
+        Line::from("Left or Backspace Parent directory"),
         Line::from("d                 Download selected file or directory"),
         Line::from("e                 Edit selected file and sync it back"),
         Line::from("u                 Open local upload picker"),

--- a/src/controllers/volume_browser/ui.rs
+++ b/src/controllers/volume_browser/ui.rs
@@ -214,9 +214,9 @@ fn render_footer(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
 fn help_line(mode: BrowserMode) -> Line<'static> {
     let items: &[(&str, &str)] = match mode {
         BrowserMode::Browse => &[
-            ("Up/Down", "move"),
-            ("Enter", "open"),
-            ("Left", "parent"),
+            ("j/k", "move"),
+            ("l/Enter", "open"),
+            ("h/Left", "parent"),
             ("d", "download"),
             ("e", "edit"),
             ("u", "upload"),
@@ -225,9 +225,9 @@ fn help_line(mode: BrowserMode) -> Line<'static> {
             ("q", "quit"),
         ],
         BrowserMode::UploadPicker => &[
-            ("Up/Down", "move"),
-            ("Right", "open dir"),
-            ("Left", "parent"),
+            ("j/k", "move"),
+            ("l/Right", "open dir"),
+            ("h/Left", "parent"),
             ("Enter", "upload"),
             ("r", "refresh"),
             ("Esc", "cancel"),
@@ -277,8 +277,8 @@ fn render_help_popup(frame: &mut Frame, area: Rect) {
         Line::from("Browse Railway volume files over SSH/SCP."),
         Line::from(""),
         Line::from("Up/Down or k/j    Move selection"),
-        Line::from("Enter or Right    Open directory"),
-        Line::from("Left or Backspace Parent directory"),
+        Line::from("Enter, Right, l   Open directory"),
+        Line::from("Left, Backspace, h Parent directory"),
         Line::from("d                 Download selected file or directory"),
         Line::from("e                 Edit selected file and sync it back"),
         Line::from("u                 Open local upload picker"),

--- a/src/controllers/volume_browser/ui.rs
+++ b/src/controllers/volume_browser/ui.rs
@@ -1,0 +1,208 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use super::app::{BrowserMode, PendingTransfer, VolumeBrowserApp};
+
+const LABEL_COLOR: Color = Color::DarkGray;
+const BORDER_COLOR: Color = Color::DarkGray;
+const SELECTED_STYLE: Style = Style::new()
+    .fg(Color::White)
+    .bg(Color::Indexed(238))
+    .add_modifier(Modifier::BOLD);
+
+pub fn render(app: &VolumeBrowserApp, frame: &mut Frame) {
+    let area = frame.area();
+    frame.render_widget(Clear, area);
+
+    if area.width < 72 || area.height < 18 {
+        let warning = Paragraph::new("Terminal too small. Please resize (min 72x18).")
+            .style(Style::default().fg(Color::Yellow));
+        frame.render_widget(warning, area);
+        return;
+    }
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Min(6),
+        Constraint::Length(1),
+        Constraint::Length(3),
+    ])
+    .split(area);
+
+    render_header(app, frame, chunks[0]);
+    render_entries(app, frame, chunks[1]);
+    render_help_bar(app, frame, chunks[2]);
+    render_status(app, frame, chunks[3]);
+
+    match app.mode {
+        BrowserMode::UploadInput => render_upload_popup(app, frame, area),
+        BrowserMode::ConfirmOverwrite => render_confirm_popup(app, frame, area),
+        BrowserMode::Help => render_help_popup(frame, area),
+        BrowserMode::Browse => {}
+    }
+}
+
+fn render_header(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("  Volume ", Style::default().fg(LABEL_COLOR)),
+            Span::styled(
+                app.volume_name.clone(),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" on ", Style::default().fg(LABEL_COLOR)),
+            Span::styled(
+                app.service_name.clone(),
+                Style::default()
+                    .fg(Color::Blue)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  Remote ", Style::default().fg(LABEL_COLOR)),
+            Span::raw(app.current_path.display().to_string()),
+            Span::styled("  Local ", Style::default().fg(LABEL_COLOR)),
+            Span::raw(app.local_dir.display().to_string()),
+        ]),
+    ];
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+}
+
+fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let items = if app.entries.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "  Directory is empty.",
+            Style::default().fg(LABEL_COLOR),
+        )))]
+    } else {
+        app.entries
+            .iter()
+            .map(|entry| {
+                let marker = if entry.is_dir { "[-]" } else { "---" };
+                let name = if entry.is_dir {
+                    format!("{marker} {}/", entry.name)
+                } else {
+                    format!("{marker} {}", entry.name)
+                };
+                ListItem::new(Line::from(name))
+            })
+            .collect()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::TOP | Borders::BOTTOM)
+                .border_style(Style::default().fg(BORDER_COLOR)),
+        )
+        .highlight_style(SELECTED_STYLE);
+
+    let mut state = ListState::default();
+    if !app.entries.is_empty() {
+        state.select(Some(app.selected));
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_help_bar(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let help = match app.mode {
+        BrowserMode::Browse => {
+            "Up/Down move  Enter open  Left parent  d download  u upload  r refresh  ? help  q quit"
+        }
+        BrowserMode::UploadInput => "Type local path  Enter upload  Esc cancel",
+        BrowserMode::ConfirmOverwrite => "Enter/y overwrite  n/Esc cancel",
+        BrowserMode::Help => "Esc close help",
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            help,
+            Style::default().fg(LABEL_COLOR),
+        ))),
+        area,
+    );
+}
+
+fn render_status(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let mut lines = Vec::new();
+    if let Some(error) = &app.error {
+        lines.push(Line::from(Span::styled(
+            error.clone(),
+            Style::default().fg(Color::Red),
+        )));
+    } else if let Some(status) = &app.status {
+        lines.push(Line::from(Span::styled(
+            status.clone(),
+            Style::default().fg(Color::Green),
+        )));
+    }
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+}
+
+fn render_upload_popup(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(72, 5, area);
+    frame.render_widget(Clear, popup);
+    let input = Paragraph::new(vec![
+        Line::from("Local path to upload"),
+        Line::from(Span::styled(
+            app.upload_input.clone(),
+            Style::default().fg(Color::White),
+        )),
+    ])
+    .block(Block::default().borders(Borders::ALL).title(" Upload "));
+    frame.render_widget(input, popup);
+}
+
+fn render_confirm_popup(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(72, 6, area);
+    frame.render_widget(Clear, popup);
+    let target = match &app.pending_transfer {
+        Some(PendingTransfer::Download { local, .. }) => local.display().to_string(),
+        Some(PendingTransfer::Upload { remote, .. }) => remote.display().to_string(),
+        None => "target".to_string(),
+    };
+    let content = Paragraph::new(vec![
+        Line::from("Destination already exists."),
+        Line::from(target),
+        Line::from("Overwrite?"),
+    ])
+    .wrap(Wrap { trim: true })
+    .block(Block::default().borders(Borders::ALL).title(" Confirm "));
+    frame.render_widget(content, popup);
+}
+
+fn render_help_popup(frame: &mut Frame, area: Rect) {
+    let popup = centered_rect(76, 11, area);
+    frame.render_widget(Clear, popup);
+    let help = Paragraph::new(vec![
+        Line::from("Browse Railway volume files over SSH/SCP."),
+        Line::from(""),
+        Line::from("Up/Down or k/j    Move selection"),
+        Line::from("Enter or Right    Open directory"),
+        Line::from("Left or Backspace Parent directory"),
+        Line::from("d                 Download selected file or directory"),
+        Line::from("u                 Upload local file or directory"),
+        Line::from("r                 Refresh"),
+        Line::from("q or Esc          Quit"),
+    ])
+    .block(Block::default().borders(Borders::ALL).title(" Help "));
+    frame.render_widget(help, popup);
+}
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let width = width.min(area.width.saturating_sub(4));
+    let height = height.min(area.height.saturating_sub(4));
+    Rect {
+        x: area.x + (area.width.saturating_sub(width)) / 2,
+        y: area.y + (area.height.saturating_sub(height)) / 2,
+        width,
+        height,
+    }
+}

--- a/src/controllers/volume_browser/ui.rs
+++ b/src/controllers/volume_browser/ui.rs
@@ -102,13 +102,13 @@ fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
         app.entries
             .iter()
             .map(|entry| {
-                let marker = if entry.is_dir { "[d]" } else { "[f]" };
-                let style = if entry.is_dir {
+                let marker = entry.kind.marker();
+                let style = if entry.kind.is_dir() {
                     Style::default().fg(Color::Blue)
                 } else {
                     Style::default().fg(Color::White)
                 };
-                let suffix = if entry.is_dir { "/" } else { "" };
+                let suffix = if entry.kind.is_dir() { "/" } else { "" };
                 ListItem::new(Line::from(vec![
                     Span::styled(marker, Style::default().fg(LABEL_COLOR)),
                     Span::raw(" "),

--- a/src/controllers/volume_browser/ui.rs
+++ b/src/controllers/volume_browser/ui.rs
@@ -10,6 +10,7 @@ use super::app::{BrowserMode, PendingTransfer, VolumeBrowserApp};
 
 const LABEL_COLOR: Color = Color::DarkGray;
 const BORDER_COLOR: Color = Color::DarkGray;
+const ACCENT_COLOR: Color = Color::Cyan;
 const SELECTED_STYLE: Style = Style::new()
     .fg(Color::White)
     .bg(Color::Indexed(238))
@@ -27,17 +28,15 @@ pub fn render(app: &VolumeBrowserApp, frame: &mut Frame) {
     }
 
     let chunks = Layout::vertical([
-        Constraint::Length(3),
+        Constraint::Length(4),
         Constraint::Min(6),
-        Constraint::Length(1),
         Constraint::Length(3),
     ])
     .split(area);
 
     render_header(app, frame, chunks[0]);
     render_entries(app, frame, chunks[1]);
-    render_help_bar(app, frame, chunks[2]);
-    render_status(app, frame, chunks[3]);
+    render_footer(app, frame, chunks[2]);
 
     match app.mode {
         BrowserMode::UploadInput => render_upload_popup(app, frame, area),
@@ -48,9 +47,13 @@ pub fn render(app: &VolumeBrowserApp, frame: &mut Frame) {
 }
 
 fn render_header(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::BOTTOM)
+        .border_style(Style::default().fg(BORDER_COLOR));
     let lines = vec![
         Line::from(vec![
-            Span::styled("  Volume ", Style::default().fg(LABEL_COLOR)),
+            Span::raw(" "),
+            Span::styled("Volume ", Style::default().fg(LABEL_COLOR)),
             Span::styled(
                 app.volume_name.clone(),
                 Style::default()
@@ -66,14 +69,27 @@ fn render_header(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
             ),
         ]),
         Line::from(vec![
-            Span::styled("  Remote ", Style::default().fg(LABEL_COLOR)),
-            Span::raw(app.current_path.display().to_string()),
-            Span::styled("  Local ", Style::default().fg(LABEL_COLOR)),
-            Span::raw(app.local_dir.display().to_string()),
+            Span::raw(" "),
+            Span::styled("Remote ", Style::default().fg(LABEL_COLOR)),
+            Span::styled(
+                app.current_path.display().to_string(),
+                Style::default().fg(Color::White),
+            ),
+        ]),
+        Line::from(vec![
+            Span::raw(" "),
+            Span::styled("Local  ", Style::default().fg(LABEL_COLOR)),
+            Span::styled(
+                app.local_dir.display().to_string(),
+                Style::default().fg(Color::White),
+            ),
         ]),
     ];
 
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+    frame.render_widget(
+        Paragraph::new(lines).block(block).wrap(Wrap { trim: true }),
+        area,
+    );
 }
 
 fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
@@ -86,13 +102,18 @@ fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
         app.entries
             .iter()
             .map(|entry| {
-                let marker = if entry.is_dir { "[-]" } else { "---" };
-                let name = if entry.is_dir {
-                    format!("{marker} {}/", entry.name)
+                let marker = if entry.is_dir { "[d]" } else { "[f]" };
+                let style = if entry.is_dir {
+                    Style::default().fg(Color::Blue)
                 } else {
-                    format!("{marker} {}", entry.name)
+                    Style::default().fg(Color::White)
                 };
-                ListItem::new(Line::from(name))
+                let suffix = if entry.is_dir { "/" } else { "" };
+                ListItem::new(Line::from(vec![
+                    Span::styled(marker, Style::default().fg(LABEL_COLOR)),
+                    Span::raw(" "),
+                    Span::styled(format!("{}{suffix}", entry.name), style),
+                ]))
             })
             .collect()
     };
@@ -100,7 +121,8 @@ fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
     let list = List::new(items)
         .block(
             Block::default()
-                .borders(Borders::TOP | Borders::BOTTOM)
+                .title(" Files ")
+                .borders(Borders::ALL)
                 .border_style(Style::default().fg(BORDER_COLOR)),
         )
         .highlight_style(SELECTED_STYLE);
@@ -112,26 +134,9 @@ fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
     frame.render_stateful_widget(list, area, &mut state);
 }
 
-fn render_help_bar(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
-    let help = match app.mode {
-        BrowserMode::Browse => {
-            "Up/Down move  Enter open  Left parent  d download  u upload  r refresh  ? help  q quit"
-        }
-        BrowserMode::UploadInput => "Type local path  Enter upload  Esc cancel",
-        BrowserMode::ConfirmOverwrite => "Enter/y overwrite  n/Esc cancel",
-        BrowserMode::Help => "Esc close help",
-    };
-    frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            help,
-            Style::default().fg(LABEL_COLOR),
-        ))),
-        area,
-    );
-}
-
-fn render_status(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+fn render_footer(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
     let mut lines = Vec::new();
+    lines.push(help_line(app.mode));
     if let Some(error) = &app.error {
         lines.push(Line::from(Span::styled(
             error.clone(),
@@ -143,7 +148,54 @@ fn render_status(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
             Style::default().fg(Color::Green),
         )));
     }
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_style(Style::default().fg(BORDER_COLOR)),
+            )
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn help_line(mode: BrowserMode) -> Line<'static> {
+    let items: &[(&str, &str)] = match mode {
+        BrowserMode::Browse => &[
+            ("Up/Down", "move"),
+            ("Enter", "open"),
+            ("Left", "parent"),
+            ("d", "download"),
+            ("e", "edit"),
+            ("u", "upload"),
+            ("r", "refresh"),
+            ("?", "help"),
+            ("q", "quit"),
+        ],
+        BrowserMode::UploadInput => &[
+            ("type", "local path"),
+            ("Enter", "upload"),
+            ("Esc", "cancel"),
+        ],
+        BrowserMode::ConfirmOverwrite => &[("Enter/y", "overwrite"), ("n/Esc", "cancel")],
+        BrowserMode::Help => &[("Esc", "close help")],
+    };
+
+    let mut spans = vec![Span::raw(" ")];
+    for (idx, (key, label)) in items.iter().enumerate() {
+        if idx > 0 {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(
+            *key,
+            Style::default()
+                .fg(ACCENT_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(format!(" {label}")));
+    }
+    Line::from(spans)
 }
 
 fn render_upload_popup(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
@@ -188,6 +240,7 @@ fn render_help_popup(frame: &mut Frame, area: Rect) {
         Line::from("Enter or Right    Open directory"),
         Line::from("Left or Backspace Parent directory"),
         Line::from("d                 Download selected file or directory"),
+        Line::from("e                 Edit selected file and sync it back"),
         Line::from("u                 Upload local file or directory"),
         Line::from("r                 Refresh"),
         Line::from("q or Esc          Quit"),

--- a/src/controllers/volume_browser/ui.rs
+++ b/src/controllers/volume_browser/ui.rs
@@ -35,11 +35,19 @@ pub fn render(app: &VolumeBrowserApp, frame: &mut Frame) {
     .split(area);
 
     render_header(app, frame, chunks[0]);
-    render_entries(app, frame, chunks[1]);
+    if app.mode == BrowserMode::UploadPicker {
+        let panes = Layout::horizontal([Constraint::Min(42), Constraint::Length(42)])
+            .spacing(1)
+            .split(chunks[1]);
+        render_entries(app, frame, panes[0]);
+        render_local_entries(app, frame, panes[1]);
+    } else {
+        render_entries(app, frame, chunks[1]);
+    }
     render_footer(app, frame, chunks[2]);
 
     match app.mode {
-        BrowserMode::UploadInput => render_upload_popup(app, frame, area),
+        BrowserMode::UploadPicker => {}
         BrowserMode::ConfirmOverwrite => render_confirm_popup(app, frame, area),
         BrowserMode::Help => render_help_popup(frame, area),
         BrowserMode::Browse => {}
@@ -134,6 +142,49 @@ fn render_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
     frame.render_stateful_widget(list, area, &mut state);
 }
 
+fn render_local_entries(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
+    let title = format!(" Upload from {} ", app.local_current_path.display());
+    let items = if app.local_entries.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "  Directory is empty.",
+            Style::default().fg(LABEL_COLOR),
+        )))]
+    } else {
+        app.local_entries
+            .iter()
+            .map(|entry| {
+                let marker = if entry.is_dir { "[d]" } else { "[f]" };
+                let suffix = if entry.is_dir { "/" } else { "" };
+                let style = if entry.is_dir {
+                    Style::default().fg(Color::Blue)
+                } else {
+                    Style::default().fg(Color::White)
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(marker, Style::default().fg(LABEL_COLOR)),
+                    Span::raw(" "),
+                    Span::styled(format!("{}{suffix}", entry.name), style),
+                ]))
+            })
+            .collect()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(ACCENT_COLOR)),
+        )
+        .highlight_style(SELECTED_STYLE);
+
+    let mut state = ListState::default();
+    if !app.local_entries.is_empty() {
+        state.select(Some(app.local_selected));
+    }
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
 fn render_footer(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
     let mut lines = Vec::new();
     lines.push(help_line(app.mode));
@@ -173,9 +224,12 @@ fn help_line(mode: BrowserMode) -> Line<'static> {
             ("?", "help"),
             ("q", "quit"),
         ],
-        BrowserMode::UploadInput => &[
-            ("type", "local path"),
+        BrowserMode::UploadPicker => &[
+            ("Up/Down", "move"),
+            ("Right", "open dir"),
+            ("Left", "parent"),
             ("Enter", "upload"),
+            ("r", "refresh"),
             ("Esc", "cancel"),
         ],
         BrowserMode::ConfirmOverwrite => &[("Enter/y", "overwrite"), ("n/Esc", "cancel")],
@@ -196,20 +250,6 @@ fn help_line(mode: BrowserMode) -> Line<'static> {
         spans.push(Span::raw(format!(" {label}")));
     }
     Line::from(spans)
-}
-
-fn render_upload_popup(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
-    let popup = centered_rect(72, 5, area);
-    frame.render_widget(Clear, popup);
-    let input = Paragraph::new(vec![
-        Line::from("Local path to upload"),
-        Line::from(Span::styled(
-            app.upload_input.clone(),
-            Style::default().fg(Color::White),
-        )),
-    ])
-    .block(Block::default().borders(Borders::ALL).title(" Upload "));
-    frame.render_widget(input, popup);
 }
 
 fn render_confirm_popup(app: &VolumeBrowserApp, frame: &mut Frame, area: Rect) {
@@ -241,7 +281,8 @@ fn render_help_popup(frame: &mut Frame, area: Rect) {
         Line::from("Left or Backspace Parent directory"),
         Line::from("d                 Download selected file or directory"),
         Line::from("e                 Edit selected file and sync it back"),
-        Line::from("u                 Upload local file or directory"),
+        Line::from("u                 Open local upload picker"),
+        Line::from("Enter             Upload selected local entry from picker"),
         Line::from("r                 Refresh"),
         Line::from("q or Esc          Quit"),
     ])

--- a/src/controllers/volume_files.rs
+++ b/src/controllers/volume_files.rs
@@ -7,13 +7,17 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
+use futures_util::{StreamExt, TryStreamExt, stream};
 use inquire::Password;
 use is_terminal::IsTerminal;
 use russh::{
     Preferred, client,
     keys::{PrivateKeyWithHashAlg, load_secret_key},
 };
-use russh_sftp::client::SftpSession;
+use russh_sftp::{
+    client::{SftpSession, error::Error as SftpError},
+    protocol::StatusCode,
+};
 use serde::Serialize;
 use tokio::{fs::File, io::AsyncWriteExt};
 
@@ -21,6 +25,8 @@ use crate::controllers::ssh_keys::find_local_ssh_keys;
 
 const SSH_HOST: &str = "ssh.railway.com";
 const SSH_PORT: u16 = 22;
+const DIRECTORY_FILE_CONCURRENCY: usize = 16;
+const DIRECTORY_SUBDIR_CONCURRENCY: usize = 4;
 
 pub struct VolumeFileClient {
     sftp: SftpSession,
@@ -98,12 +104,7 @@ impl VolumeFileClient {
     }
 
     pub fn exists(&self, path: &Path) -> Result<bool> {
-        block_on(async {
-            self.sftp
-                .try_exists(remote_path(path))
-                .await
-                .with_context(|| format!("Failed to check remote path {}", path.display()))
-        })
+        block_on(self.exists_async(path))
     }
 
     pub fn stat_kind(&self, path: &Path) -> Result<VolumeFileKind> {
@@ -163,14 +164,7 @@ impl VolumeFileClient {
             if current.as_os_str().is_empty() || current == Path::new("/") {
                 continue;
             }
-            if !self
-                .sftp
-                .try_exists(remote_path(&current))
-                .await
-                .with_context(|| {
-                    format!("Failed to check remote directory {}", current.display())
-                })?
-            {
+            if !self.exists_async(&current).await? {
                 self.sftp
                     .create_dir(remote_path(&current))
                     .await
@@ -181,6 +175,15 @@ impl VolumeFileClient {
         }
 
         Ok(())
+    }
+
+    async fn exists_async(&self, path: &Path) -> Result<bool> {
+        match self.sftp.symlink_metadata(remote_path(path)).await {
+            Ok(_) => Ok(true),
+            Err(error) if is_missing_remote_error(&error) => Ok(false),
+            Err(error) => Err(error)
+                .with_context(|| format!("Failed to check remote path {}", path.display())),
+        }
     }
 
     async fn list_dir_async(&self, path: &Path) -> Result<Vec<VolumeFileEntry>> {
@@ -252,17 +255,45 @@ impl VolumeFileClient {
     }
 
     async fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
+        let created_root = !tokio::fs::try_exists(local)
+            .await
+            .with_context(|| format!("Failed to inspect local directory {}", local.display()))?;
         tokio::fs::create_dir_all(local)
             .await
             .with_context(|| format!("Failed to create local directory {}", local.display()))?;
 
-        for entry in self.list_dir_async(remote).await? {
-            let child_local = local.join(&entry.name);
-            if entry.kind.is_dir() {
-                Box::pin(self.download_dir(&entry.path, &child_local)).await?;
-            } else {
-                self.download_file(&entry.path, &child_local).await?;
+        let result = async {
+            let entries = self.list_dir_async(remote).await?;
+            let (dirs, files): (Vec<_>, Vec<_>) =
+                entries.into_iter().partition(|entry| entry.kind.is_dir());
+
+            stream::iter(files)
+                .map(|entry| async move {
+                    let child_local = local.join(&entry.name);
+                    self.download_file(&entry.path, &child_local).await
+                })
+                .buffer_unordered(DIRECTORY_FILE_CONCURRENCY)
+                .try_collect::<Vec<_>>()
+                .await?;
+
+            stream::iter(dirs)
+                .map(|entry| async move {
+                    let child_local = local.join(&entry.name);
+                    self.download_dir(&entry.path, &child_local).await
+                })
+                .buffer_unordered(DIRECTORY_SUBDIR_CONCURRENCY)
+                .try_collect::<Vec<_>>()
+                .await?;
+
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            if created_root {
+                let _ = tokio::fs::remove_dir_all(local).await;
             }
+            return Err(error);
         }
 
         Ok(())
@@ -304,25 +335,58 @@ impl VolumeFileClient {
     }
 
     async fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
+        let created_root = !self
+            .exists_async(remote)
+            .await
+            .with_context(|| format!("Failed to inspect remote directory {}", remote.display()))?;
         self.create_dir_all_async(remote).await?;
 
-        let mut entries = tokio::fs::read_dir(local)
-            .await
-            .with_context(|| format!("Failed to read local directory {}", local.display()))?;
-        while let Some(entry) = entries
-            .next_entry()
-            .await
-            .with_context(|| format!("Failed to read local directory {}", local.display()))?
-        {
-            let file_type = entry.file_type().await.with_context(|| {
-                format!("Failed to inspect local path {}", entry.path().display())
-            })?;
-            let child_remote = remote.join(entry.file_name());
-            if file_type.is_dir() {
-                Box::pin(self.upload_dir(&entry.path(), &child_remote)).await?;
-            } else if file_type.is_file() {
-                self.upload_file(&entry.path(), &child_remote).await?;
+        let result =
+            async {
+                let mut read_dir = tokio::fs::read_dir(local).await.with_context(|| {
+                    format!("Failed to read local directory {}", local.display())
+                })?;
+                let mut dirs = Vec::new();
+                let mut files = Vec::new();
+
+                while let Some(entry) = read_dir.next_entry().await.with_context(|| {
+                    format!("Failed to read local directory {}", local.display())
+                })? {
+                    let file_type = entry.file_type().await.with_context(|| {
+                        format!("Failed to inspect local path {}", entry.path().display())
+                    })?;
+                    if file_type.is_dir() {
+                        dirs.push((entry.path(), remote.join(entry.file_name())));
+                    } else if file_type.is_file() {
+                        files.push((entry.path(), remote.join(entry.file_name())));
+                    }
+                }
+
+                stream::iter(files)
+                    .map(|(local_path, remote_path)| async move {
+                        self.upload_file(&local_path, &remote_path).await
+                    })
+                    .buffer_unordered(DIRECTORY_FILE_CONCURRENCY)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+
+                stream::iter(dirs)
+                    .map(|(local_path, remote_path)| async move {
+                        self.upload_dir(&local_path, &remote_path).await
+                    })
+                    .buffer_unordered(DIRECTORY_SUBDIR_CONCURRENCY)
+                    .try_collect::<Vec<_>>()
+                    .await?;
+
+                Ok(())
             }
+            .await;
+
+        if let Err(error) = result {
+            if created_root {
+                let _ = self.remove_path_async(remote).await;
+            }
+            return Err(error);
         }
 
         Ok(())
@@ -476,6 +540,17 @@ fn kind_from_file_type(file_type: russh_sftp::protocol::FileType) -> VolumeFileK
         VolumeFileKind::Symlink
     } else {
         VolumeFileKind::Other
+    }
+}
+
+fn is_missing_remote_error(error: &SftpError) -> bool {
+    match error {
+        SftpError::Status(status) if status.status_code == StatusCode::NoSuchFile => true,
+        SftpError::Status(status) if status.status_code == StatusCode::Failure => status
+            .error_message
+            .to_ascii_lowercase()
+            .contains("no such file or directory"),
+        _ => false,
     }
 }
 

--- a/src/controllers/volume_files.rs
+++ b/src/controllers/volume_files.rs
@@ -1,5 +1,6 @@
 use std::{
     env, fs,
+    fs::File,
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
 };
@@ -205,12 +206,9 @@ impl VolumeFileClient {
         command
     }
 
-    fn scp_command(&self) -> Command {
-        let mut command = Command::new("scp");
-        if let Some(identity_file) = &self.identity_file {
-            command.arg("-i").arg(identity_file);
-        }
-        command.args(["-r", "-o", "BatchMode=yes"]);
+    fn transfer_ssh_command(&self) -> Command {
+        let mut command = self.base_ssh_command();
+        command.arg("-T").arg(self.target());
         command
     }
 
@@ -223,25 +221,30 @@ impl VolumeFileClient {
             })?;
         }
 
-        let output = self
-            .scp_command()
-            .arg(format!("{}:{}", self.target(), remote.display()))
-            .arg(local)
-            .output()
-            .context("Failed to run scp for file download")?;
+        let file = File::create(local)
+            .with_context(|| format!("Failed to create local file {}", local.display()))?;
 
-        if output.status.success() {
+        let status = self
+            .transfer_ssh_command()
+            .arg(format!("cat -- {}", shell_quote(remote)))
+            .stdout(file)
+            .status()
+            .context("Failed to run ssh for file download")?;
+
+        if status.success() {
             Ok(())
         } else {
-            bail!(
-                "scp download failed for {}: {}",
-                remote.display(),
-                String::from_utf8_lossy(&output.stderr).trim()
-            )
+            bail!("File download failed for {}", remote.display())
         }
     }
 
     fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
+        let remote_name = remote
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?;
+        let remote_parent = remote
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
         let local_parent = local
             .parent()
             .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
@@ -253,18 +256,53 @@ impl VolumeFileClient {
             )
         })?;
 
-        self.download_file(remote, local_parent)?;
+        let extracted_path = local_parent.join(remote_name);
+        if extracted_path.exists() {
+            remove_local_path(&extracted_path)?;
+        }
 
-        let downloaded_path = local_parent.join(
-            remote
-                .file_name()
-                .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?,
-        );
-        if downloaded_path != local {
-            fs::rename(&downloaded_path, local).with_context(|| {
+        let mut remote_tar = self.transfer_ssh_command();
+        remote_tar
+            .arg(format!(
+                "tar -C {} -cf - -- {}",
+                shell_quote(remote_parent),
+                shell_quote_path_fragment(remote_name)
+            ))
+            .stdout(Stdio::piped());
+
+        let mut remote_tar = remote_tar
+            .spawn()
+            .context("Failed to start remote tar for directory download")?;
+        let stdout = remote_tar
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture remote tar output"))?;
+
+        let mut local_tar = Command::new("tar")
+            .arg("-xf")
+            .arg("-")
+            .arg("-C")
+            .arg(local_parent)
+            .stdin(stdout)
+            .spawn()
+            .context("Failed to start local tar for directory download")?;
+
+        let local_status = local_tar
+            .wait()
+            .context("Failed waiting for local tar during directory download")?;
+        let remote_status = remote_tar
+            .wait()
+            .context("Failed waiting for remote tar during directory download")?;
+
+        if !remote_status.success() || !local_status.success() {
+            bail!("Directory download failed for {}", remote.display());
+        }
+
+        if extracted_path != local {
+            fs::rename(&extracted_path, local).with_context(|| {
                 format!(
                     "Failed to move downloaded directory from {} to {}",
-                    downloaded_path.display(),
+                    extracted_path.display(),
                     local.display()
                 )
             })?;
@@ -278,32 +316,95 @@ impl VolumeFileClient {
             self.create_dir_all(parent)?;
         }
 
-        let output = self
-            .scp_command()
-            .arg(local)
-            .arg(format!("{}:{}", self.target(), remote.display()))
-            .output()
-            .context("Failed to run scp for file upload")?;
+        let file = File::open(local)
+            .with_context(|| format!("Failed to open local file {}", local.display()))?;
 
-        if output.status.success() {
+        let status = self
+            .transfer_ssh_command()
+            .arg(format!("cat > {}", shell_quote(remote)))
+            .stdin(file)
+            .status()
+            .context("Failed to run ssh for file upload")?;
+
+        if status.success() {
             Ok(())
         } else {
-            bail!(
-                "scp upload failed for {}: {}",
-                local.display(),
-                String::from_utf8_lossy(&output.stderr).trim()
-            )
+            bail!("File upload failed for {}", local.display())
         }
     }
 
     fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
+        let local_name = local
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no name"))?;
+        let local_parent = local
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
         let remote_parent = remote
             .parent()
             .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
 
         self.create_dir_all(remote_parent)?;
 
-        self.upload_file(local, remote)
+        let extracted_path = remote_parent.join(local_name);
+        if extracted_path != remote && self.exists(&extracted_path)? {
+            self.remove_path(&extracted_path)?;
+        }
+
+        let mut local_tar = Command::new("tar")
+            .arg("-C")
+            .arg(local_parent)
+            .arg("-cf")
+            .arg("-")
+            .arg(local_name)
+            .stdout(Stdio::piped())
+            .spawn()
+            .context("Failed to start local tar for directory upload")?;
+        let stdout = local_tar
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture local tar output"))?;
+
+        let mut remote_tar = self.transfer_ssh_command();
+        remote_tar
+            .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
+            .stdin(stdout);
+
+        let mut remote_tar = remote_tar
+            .spawn()
+            .context("Failed to start remote tar for directory upload")?;
+
+        let local_status = local_tar
+            .wait()
+            .context("Failed waiting for local tar during directory upload")?;
+        let remote_status = remote_tar
+            .wait()
+            .context("Failed waiting for remote tar during directory upload")?;
+
+        if !local_status.success() || !remote_status.success() {
+            bail!("Directory upload failed for {}", local.display());
+        }
+
+        if extracted_path != remote {
+            let status = self
+                .ssh_command()
+                .arg(format!(
+                    "mv -- {} {}",
+                    shell_quote(&extracted_path),
+                    shell_quote(remote)
+                ))
+                .status()
+                .context("Failed to rename uploaded remote directory")?;
+            if !status.success() {
+                bail!(
+                    "Failed to move uploaded directory from {} to {}",
+                    extracted_path.display(),
+                    remote.display()
+                );
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -381,4 +482,20 @@ fn control_path(service_instance_id: &str) -> PathBuf {
 fn shell_quote(path: &Path) -> String {
     let value = path.display().to_string();
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn shell_quote_path_fragment(fragment: &std::ffi::OsStr) -> String {
+    let value = fragment.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn remove_local_path(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect local path {}", path.display()))?;
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+    .with_context(|| format!("Failed to remove existing local path {}", path.display()))
 }

--- a/src/controllers/volume_files.rs
+++ b/src/controllers/volume_files.rs
@@ -206,6 +206,12 @@ impl VolumeFileClient {
         command
     }
 
+    fn transfer_ssh_command(&self) -> Command {
+        let mut command = self.base_ssh_command();
+        command.arg("-T").arg(self.target());
+        command
+    }
+
     fn download_file(&self, remote: &Path, local: &Path) -> Result<()> {
         if let Some(parent) = local.parent()
             && !parent.as_os_str().is_empty()
@@ -219,7 +225,7 @@ impl VolumeFileClient {
             .with_context(|| format!("Failed to create local file {}", local.display()))?;
 
         let status = self
-            .ssh_command()
+            .transfer_ssh_command()
             .arg(format!("cat -- {}", shell_quote(remote)))
             .stdout(file)
             .status()
@@ -255,7 +261,7 @@ impl VolumeFileClient {
             remove_local_path(&extracted_path)?;
         }
 
-        let mut remote_tar = self.ssh_command();
+        let mut remote_tar = self.transfer_ssh_command();
         remote_tar
             .arg(format!(
                 "tar -C {} -cf - -- {}",
@@ -314,7 +320,7 @@ impl VolumeFileClient {
             .with_context(|| format!("Failed to open local file {}", local.display()))?;
 
         let status = self
-            .ssh_command()
+            .transfer_ssh_command()
             .arg(format!("cat > {}", shell_quote(remote)))
             .stdin(file)
             .status()
@@ -359,7 +365,7 @@ impl VolumeFileClient {
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture local tar output"))?;
 
-        let mut remote_tar = self.ssh_command();
+        let mut remote_tar = self.transfer_ssh_command();
         remote_tar
             .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
             .stdin(stdout);

--- a/src/controllers/volume_files.rs
+++ b/src/controllers/volume_files.rs
@@ -1,6 +1,5 @@
 use std::{
     env, fs,
-    fs::File,
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
 };
@@ -206,9 +205,12 @@ impl VolumeFileClient {
         command
     }
 
-    fn transfer_ssh_command(&self) -> Command {
-        let mut command = self.base_ssh_command();
-        command.arg("-T").arg(self.target());
+    fn scp_command(&self) -> Command {
+        let mut command = Command::new("scp");
+        if let Some(identity_file) = &self.identity_file {
+            command.arg("-i").arg(identity_file);
+        }
+        command.args(["-r", "-o", "BatchMode=yes"]);
         command
     }
 
@@ -221,30 +223,25 @@ impl VolumeFileClient {
             })?;
         }
 
-        let file = File::create(local)
-            .with_context(|| format!("Failed to create local file {}", local.display()))?;
+        let output = self
+            .scp_command()
+            .arg(format!("{}:{}", self.target(), remote.display()))
+            .arg(local)
+            .output()
+            .context("Failed to run scp for file download")?;
 
-        let status = self
-            .transfer_ssh_command()
-            .arg(format!("cat -- {}", shell_quote(remote)))
-            .stdout(file)
-            .status()
-            .context("Failed to run ssh for file download")?;
-
-        if status.success() {
+        if output.status.success() {
             Ok(())
         } else {
-            bail!("File download failed for {}", remote.display())
+            bail!(
+                "scp download failed for {}: {}",
+                remote.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
         }
     }
 
     fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
-        let remote_name = remote
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?;
-        let remote_parent = remote
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
         let local_parent = local
             .parent()
             .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
@@ -256,53 +253,18 @@ impl VolumeFileClient {
             )
         })?;
 
-        let extracted_path = local_parent.join(remote_name);
-        if extracted_path.exists() {
-            remove_local_path(&extracted_path)?;
-        }
+        self.download_file(remote, local_parent)?;
 
-        let mut remote_tar = self.transfer_ssh_command();
-        remote_tar
-            .arg(format!(
-                "tar -C {} -cf - -- {}",
-                shell_quote(remote_parent),
-                shell_quote_path_fragment(remote_name)
-            ))
-            .stdout(Stdio::piped());
-
-        let mut remote_tar = remote_tar
-            .spawn()
-            .context("Failed to start remote tar for directory download")?;
-        let stdout = remote_tar
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to capture remote tar output"))?;
-
-        let mut local_tar = Command::new("tar")
-            .arg("-xf")
-            .arg("-")
-            .arg("-C")
-            .arg(local_parent)
-            .stdin(stdout)
-            .spawn()
-            .context("Failed to start local tar for directory download")?;
-
-        let local_status = local_tar
-            .wait()
-            .context("Failed waiting for local tar during directory download")?;
-        let remote_status = remote_tar
-            .wait()
-            .context("Failed waiting for remote tar during directory download")?;
-
-        if !remote_status.success() || !local_status.success() {
-            bail!("Directory download failed for {}", remote.display());
-        }
-
-        if extracted_path != local {
-            fs::rename(&extracted_path, local).with_context(|| {
+        let downloaded_path = local_parent.join(
+            remote
+                .file_name()
+                .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?,
+        );
+        if downloaded_path != local {
+            fs::rename(&downloaded_path, local).with_context(|| {
                 format!(
                     "Failed to move downloaded directory from {} to {}",
-                    extracted_path.display(),
+                    downloaded_path.display(),
                     local.display()
                 )
             })?;
@@ -316,95 +278,32 @@ impl VolumeFileClient {
             self.create_dir_all(parent)?;
         }
 
-        let file = File::open(local)
-            .with_context(|| format!("Failed to open local file {}", local.display()))?;
+        let output = self
+            .scp_command()
+            .arg(local)
+            .arg(format!("{}:{}", self.target(), remote.display()))
+            .output()
+            .context("Failed to run scp for file upload")?;
 
-        let status = self
-            .transfer_ssh_command()
-            .arg(format!("cat > {}", shell_quote(remote)))
-            .stdin(file)
-            .status()
-            .context("Failed to run ssh for file upload")?;
-
-        if status.success() {
+        if output.status.success() {
             Ok(())
         } else {
-            bail!("File upload failed for {}", local.display())
+            bail!(
+                "scp upload failed for {}: {}",
+                local.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
         }
     }
 
     fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
-        let local_name = local
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no name"))?;
-        let local_parent = local
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
         let remote_parent = remote
             .parent()
             .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
 
         self.create_dir_all(remote_parent)?;
 
-        let extracted_path = remote_parent.join(local_name);
-        if extracted_path != remote && self.exists(&extracted_path)? {
-            self.remove_path(&extracted_path)?;
-        }
-
-        let mut local_tar = Command::new("tar")
-            .arg("-C")
-            .arg(local_parent)
-            .arg("-cf")
-            .arg("-")
-            .arg(local_name)
-            .stdout(Stdio::piped())
-            .spawn()
-            .context("Failed to start local tar for directory upload")?;
-        let stdout = local_tar
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to capture local tar output"))?;
-
-        let mut remote_tar = self.transfer_ssh_command();
-        remote_tar
-            .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
-            .stdin(stdout);
-
-        let mut remote_tar = remote_tar
-            .spawn()
-            .context("Failed to start remote tar for directory upload")?;
-
-        let local_status = local_tar
-            .wait()
-            .context("Failed waiting for local tar during directory upload")?;
-        let remote_status = remote_tar
-            .wait()
-            .context("Failed waiting for remote tar during directory upload")?;
-
-        if !local_status.success() || !remote_status.success() {
-            bail!("Directory upload failed for {}", local.display());
-        }
-
-        if extracted_path != remote {
-            let status = self
-                .ssh_command()
-                .arg(format!(
-                    "mv -- {} {}",
-                    shell_quote(&extracted_path),
-                    shell_quote(remote)
-                ))
-                .status()
-                .context("Failed to rename uploaded remote directory")?;
-            if !status.success() {
-                bail!(
-                    "Failed to move uploaded directory from {} to {}",
-                    extracted_path.display(),
-                    remote.display()
-                );
-            }
-        }
-
-        Ok(())
+        self.upload_file(local, remote)
     }
 }
 
@@ -482,20 +381,4 @@ fn control_path(service_instance_id: &str) -> PathBuf {
 fn shell_quote(path: &Path) -> String {
     let value = path.display().to_string();
     format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
-fn shell_quote_path_fragment(fragment: &std::ffi::OsStr) -> String {
-    let value = fragment.to_string_lossy();
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
-fn remove_local_path(path: &Path) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("Failed to inspect local path {}", path.display()))?;
-    if metadata.is_dir() {
-        fs::remove_dir_all(path)
-    } else {
-        fs::remove_file(path)
-    }
-    .with_context(|| format!("Failed to remove existing local path {}", path.display()))
 }

--- a/src/controllers/volume_files.rs
+++ b/src/controllers/volume_files.rs
@@ -1,0 +1,495 @@
+use std::{
+    env, fs,
+    fs::File,
+    path::{Path, PathBuf},
+    process::{self, Command, Stdio},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+const SSH_HOST: &str = "ssh.railway.com";
+
+pub struct VolumeFileClient {
+    service_instance_id: String,
+    identity_file: Option<PathBuf>,
+    control_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VolumeFileEntry {
+    pub path: PathBuf,
+    pub name: String,
+    pub kind: VolumeFileKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VolumeFileKind {
+    File,
+    Directory,
+    Symlink,
+    Other,
+}
+
+impl VolumeFileKind {
+    pub fn marker(self) -> &'static str {
+        match self {
+            Self::Directory => "[d]",
+            Self::File => "[f]",
+            Self::Symlink => "[l]",
+            Self::Other => "[?]",
+        }
+    }
+
+    pub fn is_dir(self) -> bool {
+        self == Self::Directory
+    }
+}
+
+impl VolumeFileClient {
+    pub fn connect(service_instance_id: String, identity_file: Option<PathBuf>) -> Result<Self> {
+        let client = Self {
+            control_path: control_path(&service_instance_id),
+            service_instance_id,
+            identity_file,
+        };
+        client.open_master_connection()?;
+        Ok(client)
+    }
+
+    pub fn list_dir(&self, path: &Path) -> Result<Vec<VolumeFileEntry>> {
+        let output = self
+            .ssh_command()
+            .arg(format!("unset LANG; ls -la {}/", shell_quote(path)))
+            .output()
+            .context("Failed to run ssh for remote directory listing")?;
+
+        if !output.status.success() {
+            bail!(
+                "Remote directory listing failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+
+        Ok(parse_ls_output(
+            path,
+            &String::from_utf8_lossy(&output.stdout),
+        ))
+    }
+
+    pub fn exists(&self, path: &Path) -> Result<bool> {
+        let status = self
+            .ssh_command()
+            .arg(format!("test -e {}", shell_quote(path)))
+            .status()
+            .context("Failed to run ssh for remote path check")?;
+        Ok(status.success())
+    }
+
+    pub fn stat_kind(&self, path: &Path) -> Result<VolumeFileKind> {
+        let output = self
+            .ssh_command()
+            .arg(format!(
+                "if test -d {path}; then echo directory; elif test -f {path}; then echo file; elif test -L {path}; then echo symlink; elif test -e {path}; then echo other; else echo missing; exit 1; fi",
+                path = shell_quote(path)
+            ))
+            .output()
+            .context("Failed to run ssh for remote path stat")?;
+
+        if !output.status.success() {
+            bail!("Remote path does not exist: {}", path.display());
+        }
+
+        match String::from_utf8_lossy(&output.stdout).trim() {
+            "directory" => Ok(VolumeFileKind::Directory),
+            "file" => Ok(VolumeFileKind::File),
+            "symlink" => Ok(VolumeFileKind::Symlink),
+            _ => Ok(VolumeFileKind::Other),
+        }
+    }
+
+    pub fn remove_path(&self, path: &Path) -> Result<()> {
+        let status = self
+            .ssh_command()
+            .arg(format!("rm -rf -- {}", shell_quote(path)))
+            .status()
+            .context("Failed to run ssh for remote path removal")?;
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Failed to remove remote path {}", path.display())
+        }
+    }
+
+    pub fn create_dir_all(&self, path: &Path) -> Result<()> {
+        let status = self
+            .ssh_command()
+            .arg(format!("mkdir -p -- {}", shell_quote(path)))
+            .status()
+            .context("Failed to run ssh for remote directory creation")?;
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Failed to create remote directory {}", path.display())
+        }
+    }
+
+    pub fn download(&self, remote: &Path, local: &Path, kind: VolumeFileKind) -> Result<()> {
+        if kind.is_dir() {
+            self.download_dir(remote, local)
+        } else {
+            self.download_file(remote, local)
+        }
+    }
+
+    pub fn upload(&self, local: &Path, remote: &Path) -> Result<()> {
+        if local.is_dir() {
+            self.upload_dir(local, remote)
+        } else {
+            self.upload_file(local, remote)
+        }
+    }
+
+    fn target(&self) -> String {
+        format!("{}@{}", self.service_instance_id, SSH_HOST)
+    }
+
+    fn base_ssh_command(&self) -> Command {
+        let mut command = Command::new("ssh");
+        if let Some(identity_file) = &self.identity_file {
+            command.arg("-i").arg(identity_file);
+        }
+        command
+    }
+
+    fn open_master_connection(&self) -> Result<()> {
+        let _ = fs::remove_file(&self.control_path);
+        let status = self
+            .base_ssh_command()
+            .args([
+                "-M",
+                "-N",
+                "-f",
+                "-o",
+                "ControlMaster=yes",
+                "-o",
+                &format!("ControlPath={}", self.control_path.display()),
+                "-o",
+                "ControlPersist=10m",
+            ])
+            .arg(self.target())
+            .status()
+            .context("Failed to start SSH control connection")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("Failed to start SSH control connection")
+        }
+    }
+
+    fn ssh_command(&self) -> Command {
+        let mut command = self.base_ssh_command();
+        command
+            .args([
+                "-o",
+                &format!("ControlPath={}", self.control_path.display()),
+                "-o",
+                "ControlMaster=no",
+                "-o",
+                "BatchMode=yes",
+            ])
+            .arg("-T")
+            .arg(self.target());
+        command
+    }
+
+    fn download_file(&self, remote: &Path, local: &Path) -> Result<()> {
+        if let Some(parent) = local.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create local directory {}", parent.display())
+            })?;
+        }
+
+        let file = File::create(local)
+            .with_context(|| format!("Failed to create local file {}", local.display()))?;
+
+        let status = self
+            .ssh_command()
+            .arg(format!("cat -- {}", shell_quote(remote)))
+            .stdout(file)
+            .status()
+            .context("Failed to run ssh for file download")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("File download failed for {}", remote.display())
+        }
+    }
+
+    fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
+        let remote_name = remote
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?;
+        let remote_parent = remote
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
+        let local_parent = local
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
+
+        fs::create_dir_all(local_parent).with_context(|| {
+            format!(
+                "Failed to create local directory {}",
+                local_parent.display()
+            )
+        })?;
+
+        let extracted_path = local_parent.join(remote_name);
+        if extracted_path.exists() {
+            remove_local_path(&extracted_path)?;
+        }
+
+        let mut remote_tar = self.ssh_command();
+        remote_tar
+            .arg(format!(
+                "tar -C {} -cf - -- {}",
+                shell_quote(remote_parent),
+                shell_quote_path_fragment(remote_name)
+            ))
+            .stdout(Stdio::piped());
+
+        let mut remote_tar = remote_tar
+            .spawn()
+            .context("Failed to start remote tar for directory download")?;
+        let stdout = remote_tar
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture remote tar output"))?;
+
+        let mut local_tar = Command::new("tar")
+            .arg("-xf")
+            .arg("-")
+            .arg("-C")
+            .arg(local_parent)
+            .stdin(stdout)
+            .spawn()
+            .context("Failed to start local tar for directory download")?;
+
+        let local_status = local_tar
+            .wait()
+            .context("Failed waiting for local tar during directory download")?;
+        let remote_status = remote_tar
+            .wait()
+            .context("Failed waiting for remote tar during directory download")?;
+
+        if !remote_status.success() || !local_status.success() {
+            bail!("Directory download failed for {}", remote.display());
+        }
+
+        if extracted_path != local {
+            fs::rename(&extracted_path, local).with_context(|| {
+                format!(
+                    "Failed to move downloaded directory from {} to {}",
+                    extracted_path.display(),
+                    local.display()
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    fn upload_file(&self, local: &Path, remote: &Path) -> Result<()> {
+        if let Some(parent) = remote.parent() {
+            self.create_dir_all(parent)?;
+        }
+
+        let file = File::open(local)
+            .with_context(|| format!("Failed to open local file {}", local.display()))?;
+
+        let status = self
+            .ssh_command()
+            .arg(format!("cat > {}", shell_quote(remote)))
+            .stdin(file)
+            .status()
+            .context("Failed to run ssh for file upload")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            bail!("File upload failed for {}", local.display())
+        }
+    }
+
+    fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
+        let local_name = local
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no name"))?;
+        let local_parent = local
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
+        let remote_parent = remote
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
+
+        self.create_dir_all(remote_parent)?;
+
+        let extracted_path = remote_parent.join(local_name);
+        if extracted_path != remote && self.exists(&extracted_path)? {
+            self.remove_path(&extracted_path)?;
+        }
+
+        let mut local_tar = Command::new("tar")
+            .arg("-C")
+            .arg(local_parent)
+            .arg("-cf")
+            .arg("-")
+            .arg(local_name)
+            .stdout(Stdio::piped())
+            .spawn()
+            .context("Failed to start local tar for directory upload")?;
+        let stdout = local_tar
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture local tar output"))?;
+
+        let mut remote_tar = self.ssh_command();
+        remote_tar
+            .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
+            .stdin(stdout);
+
+        let mut remote_tar = remote_tar
+            .spawn()
+            .context("Failed to start remote tar for directory upload")?;
+
+        let local_status = local_tar
+            .wait()
+            .context("Failed waiting for local tar during directory upload")?;
+        let remote_status = remote_tar
+            .wait()
+            .context("Failed waiting for remote tar during directory upload")?;
+
+        if !local_status.success() || !remote_status.success() {
+            bail!("Directory upload failed for {}", local.display());
+        }
+
+        if extracted_path != remote {
+            let status = self
+                .ssh_command()
+                .arg(format!(
+                    "mv -- {} {}",
+                    shell_quote(&extracted_path),
+                    shell_quote(remote)
+                ))
+                .status()
+                .context("Failed to rename uploaded remote directory")?;
+            if !status.success() {
+                bail!(
+                    "Failed to move uploaded directory from {} to {}",
+                    extracted_path.display(),
+                    remote.display()
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for VolumeFileClient {
+    fn drop(&mut self) {
+        let _ = self
+            .base_ssh_command()
+            .args([
+                "-O",
+                "exit",
+                "-o",
+                &format!("ControlPath={}", self.control_path.display()),
+            ])
+            .arg(self.target())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let _ = fs::remove_file(&self.control_path);
+    }
+}
+
+fn parse_ls_output(parent: &Path, output: &str) -> Vec<VolumeFileEntry> {
+    let mut entries = Vec::new();
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with("total ") {
+            continue;
+        }
+
+        let mut parts = line.split_whitespace();
+        let Some(mode) = parts.next() else {
+            continue;
+        };
+
+        for _ in 0..7 {
+            parts.next();
+        }
+
+        let name = parts.collect::<Vec<_>>().join(" ");
+        let name = name.split(" -> ").next().unwrap_or(name.as_str());
+        if name.is_empty() || name == "." || name == ".." {
+            continue;
+        }
+
+        let kind = match mode.chars().next() {
+            Some('d') => VolumeFileKind::Directory,
+            Some('-') => VolumeFileKind::File,
+            Some('l') => VolumeFileKind::Symlink,
+            _ => VolumeFileKind::Other,
+        };
+
+        entries.push(VolumeFileEntry {
+            path: parent.join(name),
+            name: name.to_string(),
+            kind,
+        });
+    }
+
+    entries
+}
+
+fn control_path(service_instance_id: &str) -> PathBuf {
+    let service_fragment = service_instance_id
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .take(16)
+        .collect::<String>();
+    env::temp_dir().join(format!(
+        "railway-volume-{}-{}.sock",
+        process::id(),
+        service_fragment
+    ))
+}
+
+fn shell_quote(path: &Path) -> String {
+    let value = path.display().to_string();
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn shell_quote_path_fragment(fragment: &std::ffi::OsStr) -> String {
+    let value = fragment.to_string_lossy();
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn remove_local_path(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect local path {}", path.display()))?;
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_file(path)
+    }
+    .with_context(|| format!("Failed to remove existing local path {}", path.display()))
+}

--- a/src/controllers/volume_files.rs
+++ b/src/controllers/volume_files.rs
@@ -1,19 +1,30 @@
 use std::{
-    env, fs,
-    fs::File,
+    borrow::Cow,
+    future::Future,
     path::{Path, PathBuf},
-    process::{self, Command, Stdio},
+    sync::Arc,
+    time::Duration,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
+use inquire::Password;
+use is_terminal::IsTerminal;
+use russh::{
+    Preferred, client,
+    keys::{PrivateKeyWithHashAlg, load_secret_key},
+};
+use russh_sftp::client::SftpSession;
 use serde::Serialize;
+use tokio::{fs::File, io::AsyncWriteExt};
+
+use crate::controllers::ssh_keys::find_local_ssh_keys;
 
 const SSH_HOST: &str = "ssh.railway.com";
+const SSH_PORT: u16 = 22;
 
 pub struct VolumeFileClient {
-    service_instance_id: String,
-    identity_file: Option<PathBuf>,
-    control_path: PathBuf,
+    sftp: SftpSession,
+    ssh: client::Handle<RailwaySshClient>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -50,357 +61,267 @@ impl VolumeFileKind {
 
 impl VolumeFileClient {
     pub fn connect(service_instance_id: String, identity_file: Option<PathBuf>) -> Result<Self> {
-        let client = Self {
-            control_path: control_path(&service_instance_id),
-            service_instance_id,
-            identity_file,
-        };
-        client.open_master_connection()?;
-        Ok(client)
+        block_on(async {
+            let key_paths = resolve_private_key_paths(identity_file)?;
+            let mut last_error = None;
+
+            for key_path in key_paths {
+                match connect_with_key(&service_instance_id, &key_path).await {
+                    Ok((ssh, sftp)) => {
+                        return Ok(Self {
+                            sftp,
+                            ssh,
+                        });
+                    }
+                    Err(error) => {
+                        last_error = Some((key_path, error));
+                    }
+                }
+            }
+
+            if let Some((key_path, error)) = last_error {
+                bail!(
+                    "Failed to authenticate to {SSH_HOST} as {service_instance_id} using {}: {error}",
+                    key_path.display()
+                );
+            }
+
+            bail!(
+                "No SSH private keys found. Generate one with:\n  ssh-keygen -t ed25519\n\nThen register it with Railway."
+            );
+        })
+        .context("Failed to connect to Railway volume over SFTP")
     }
 
     pub fn list_dir(&self, path: &Path) -> Result<Vec<VolumeFileEntry>> {
-        let output = self
-            .ssh_command()
-            .arg(format!("unset LANG; ls -la {}/", shell_quote(path)))
-            .output()
-            .context("Failed to run ssh for remote directory listing")?;
-
-        if !output.status.success() {
-            bail!(
-                "Remote directory listing failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-
-        Ok(parse_ls_output(
-            path,
-            &String::from_utf8_lossy(&output.stdout),
-        ))
+        block_on(self.list_dir_async(path))
     }
 
     pub fn exists(&self, path: &Path) -> Result<bool> {
-        let status = self
-            .ssh_command()
-            .arg(format!("test -e {}", shell_quote(path)))
-            .status()
-            .context("Failed to run ssh for remote path check")?;
-        Ok(status.success())
+        block_on(async {
+            self.sftp
+                .try_exists(remote_path(path))
+                .await
+                .with_context(|| format!("Failed to check remote path {}", path.display()))
+        })
     }
 
     pub fn stat_kind(&self, path: &Path) -> Result<VolumeFileKind> {
-        let output = self
-            .ssh_command()
-            .arg(format!(
-                "if test -d {path}; then echo directory; elif test -f {path}; then echo file; elif test -L {path}; then echo symlink; elif test -e {path}; then echo other; else echo missing; exit 1; fi",
-                path = shell_quote(path)
-            ))
-            .output()
-            .context("Failed to run ssh for remote path stat")?;
-
-        if !output.status.success() {
-            bail!("Remote path does not exist: {}", path.display());
-        }
-
-        match String::from_utf8_lossy(&output.stdout).trim() {
-            "directory" => Ok(VolumeFileKind::Directory),
-            "file" => Ok(VolumeFileKind::File),
-            "symlink" => Ok(VolumeFileKind::Symlink),
-            _ => Ok(VolumeFileKind::Other),
-        }
+        block_on(self.stat_kind_async(path))
     }
 
     pub fn remove_path(&self, path: &Path) -> Result<()> {
-        let status = self
-            .ssh_command()
-            .arg(format!("rm -rf -- {}", shell_quote(path)))
-            .status()
-            .context("Failed to run ssh for remote path removal")?;
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Failed to remove remote path {}", path.display())
-        }
-    }
-
-    pub fn create_dir_all(&self, path: &Path) -> Result<()> {
-        let status = self
-            .ssh_command()
-            .arg(format!("mkdir -p -- {}", shell_quote(path)))
-            .status()
-            .context("Failed to run ssh for remote directory creation")?;
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Failed to create remote directory {}", path.display())
-        }
+        block_on(self.remove_path_async(path))
     }
 
     pub fn download(&self, remote: &Path, local: &Path, kind: VolumeFileKind) -> Result<()> {
-        if kind.is_dir() {
-            self.download_dir(remote, local)
-        } else {
-            self.download_file(remote, local)
-        }
+        block_on(async {
+            if kind.is_dir() {
+                self.download_dir(remote, local).await
+            } else {
+                self.download_file(remote, local).await
+            }
+        })
     }
 
     pub fn upload(&self, local: &Path, remote: &Path) -> Result<()> {
-        if local.is_dir() {
-            self.upload_dir(local, remote)
-        } else {
-            self.upload_file(local, remote)
+        block_on(async {
+            if local.is_dir() {
+                self.upload_dir(local, remote).await
+            } else {
+                self.upload_file(local, remote).await
+            }
+        })
+    }
+
+    async fn remove_path_async(&self, path: &Path) -> Result<()> {
+        match self.stat_kind_async(path).await? {
+            VolumeFileKind::Directory => {
+                for entry in self.list_dir_async(path).await? {
+                    Box::pin(self.remove_path_async(&entry.path)).await?;
+                }
+                self.sftp
+                    .remove_dir(remote_path(path))
+                    .await
+                    .with_context(|| {
+                        format!("Failed to remove remote directory {}", path.display())
+                    })
+            }
+            _ => self
+                .sftp
+                .remove_file(remote_path(path))
+                .await
+                .with_context(|| format!("Failed to remove remote file {}", path.display())),
         }
     }
 
-    fn target(&self) -> String {
-        format!("{}@{}", self.service_instance_id, SSH_HOST)
-    }
+    async fn create_dir_all_async(&self, path: &Path) -> Result<()> {
+        let mut current = PathBuf::new();
 
-    fn base_ssh_command(&self) -> Command {
-        let mut command = Command::new("ssh");
-        if let Some(identity_file) = &self.identity_file {
-            command.arg("-i").arg(identity_file);
-        }
-        command
-    }
-
-    fn open_master_connection(&self) -> Result<()> {
-        let _ = fs::remove_file(&self.control_path);
-        let status = self
-            .base_ssh_command()
-            .args([
-                "-M",
-                "-N",
-                "-f",
-                "-o",
-                "ControlMaster=yes",
-                "-o",
-                &format!("ControlPath={}", self.control_path.display()),
-                "-o",
-                "ControlPersist=10m",
-            ])
-            .arg(self.target())
-            .status()
-            .context("Failed to start SSH control connection")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("Failed to start SSH control connection")
-        }
-    }
-
-    fn ssh_command(&self) -> Command {
-        let mut command = self.base_ssh_command();
-        command
-            .args([
-                "-o",
-                &format!("ControlPath={}", self.control_path.display()),
-                "-o",
-                "ControlMaster=no",
-                "-o",
-                "BatchMode=yes",
-            ])
-            .arg("-T")
-            .arg(self.target());
-        command
-    }
-
-    fn transfer_ssh_command(&self) -> Command {
-        let mut command = self.base_ssh_command();
-        command.arg("-T").arg(self.target());
-        command
-    }
-
-    fn download_file(&self, remote: &Path, local: &Path) -> Result<()> {
-        if let Some(parent) = local.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("Failed to create local directory {}", parent.display())
-            })?;
-        }
-
-        let file = File::create(local)
-            .with_context(|| format!("Failed to create local file {}", local.display()))?;
-
-        let status = self
-            .transfer_ssh_command()
-            .arg(format!("cat -- {}", shell_quote(remote)))
-            .stdout(file)
-            .status()
-            .context("Failed to run ssh for file download")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("File download failed for {}", remote.display())
-        }
-    }
-
-    fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
-        let remote_name = remote
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no name"))?;
-        let remote_parent = remote
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
-        let local_parent = local
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
-
-        fs::create_dir_all(local_parent).with_context(|| {
-            format!(
-                "Failed to create local directory {}",
-                local_parent.display()
-            )
-        })?;
-
-        let extracted_path = local_parent.join(remote_name);
-        if extracted_path.exists() {
-            remove_local_path(&extracted_path)?;
-        }
-
-        let mut remote_tar = self.transfer_ssh_command();
-        remote_tar
-            .arg(format!(
-                "tar -C {} -cf - -- {}",
-                shell_quote(remote_parent),
-                shell_quote_path_fragment(remote_name)
-            ))
-            .stdout(Stdio::piped());
-
-        let mut remote_tar = remote_tar
-            .spawn()
-            .context("Failed to start remote tar for directory download")?;
-        let stdout = remote_tar
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to capture remote tar output"))?;
-
-        let mut local_tar = Command::new("tar")
-            .arg("-xf")
-            .arg("-")
-            .arg("-C")
-            .arg(local_parent)
-            .stdin(stdout)
-            .spawn()
-            .context("Failed to start local tar for directory download")?;
-
-        let local_status = local_tar
-            .wait()
-            .context("Failed waiting for local tar during directory download")?;
-        let remote_status = remote_tar
-            .wait()
-            .context("Failed waiting for remote tar during directory download")?;
-
-        if !remote_status.success() || !local_status.success() {
-            bail!("Directory download failed for {}", remote.display());
-        }
-
-        if extracted_path != local {
-            fs::rename(&extracted_path, local).with_context(|| {
-                format!(
-                    "Failed to move downloaded directory from {} to {}",
-                    extracted_path.display(),
-                    local.display()
-                )
-            })?;
+        for component in path.components() {
+            current.push(component.as_os_str());
+            if current.as_os_str().is_empty() || current == Path::new("/") {
+                continue;
+            }
+            if !self
+                .sftp
+                .try_exists(remote_path(&current))
+                .await
+                .with_context(|| {
+                    format!("Failed to check remote directory {}", current.display())
+                })?
+            {
+                self.sftp
+                    .create_dir(remote_path(&current))
+                    .await
+                    .with_context(|| {
+                        format!("Failed to create remote directory {}", current.display())
+                    })?;
+            }
         }
 
         Ok(())
     }
 
-    fn upload_file(&self, local: &Path, remote: &Path) -> Result<()> {
-        if let Some(parent) = remote.parent() {
-            self.create_dir_all(parent)?;
+    async fn list_dir_async(&self, path: &Path) -> Result<Vec<VolumeFileEntry>> {
+        let mut entries = Vec::new();
+        for entry in self
+            .sftp
+            .read_dir(remote_path(path))
+            .await
+            .with_context(|| format!("Failed to list remote directory {}", path.display()))?
+        {
+            let name = entry.file_name();
+            entries.push(VolumeFileEntry {
+                path: path.join(&name),
+                name,
+                kind: kind_from_file_type(entry.file_type()),
+            });
         }
-
-        let file = File::open(local)
-            .with_context(|| format!("Failed to open local file {}", local.display()))?;
-
-        let status = self
-            .transfer_ssh_command()
-            .arg(format!("cat > {}", shell_quote(remote)))
-            .stdin(file)
-            .status()
-            .context("Failed to run ssh for file upload")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            bail!("File upload failed for {}", local.display())
-        }
+        entries.sort_by(|a, b| {
+            b.kind
+                .is_dir()
+                .cmp(&a.kind.is_dir())
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+        });
+        Ok(entries)
     }
 
-    fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
-        let local_name = local
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no name"))?;
-        let local_parent = local
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Local directory has no parent"))?;
-        let remote_parent = remote
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Remote directory has no parent"))?;
+    async fn stat_kind_async(&self, path: &Path) -> Result<VolumeFileKind> {
+        let metadata = self
+            .sftp
+            .symlink_metadata(remote_path(path))
+            .await
+            .with_context(|| format!("Remote path does not exist: {}", path.display()))?;
+        Ok(kind_from_file_type(metadata.file_type()))
+    }
 
-        self.create_dir_all(remote_parent)?;
-
-        let extracted_path = remote_parent.join(local_name);
-        if extracted_path != remote && self.exists(&extracted_path)? {
-            self.remove_path(&extracted_path)?;
+    async fn download_file(&self, remote: &Path, local: &Path) -> Result<()> {
+        if let Some(parent) = local.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            tokio::fs::create_dir_all(parent).await.with_context(|| {
+                format!("Failed to create local directory {}", parent.display())
+            })?;
         }
 
-        let mut local_tar = Command::new("tar")
-            .arg("-C")
-            .arg(local_parent)
-            .arg("-cf")
-            .arg("-")
-            .arg(local_name)
-            .stdout(Stdio::piped())
-            .spawn()
-            .context("Failed to start local tar for directory upload")?;
-        let stdout = local_tar
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to capture local tar output"))?;
+        let mut remote_file = self
+            .sftp
+            .open(remote_path(remote))
+            .await
+            .with_context(|| format!("Failed to open remote file {}", remote.display()))?;
+        let mut local_file = File::create(local)
+            .await
+            .with_context(|| format!("Failed to create local file {}", local.display()))?;
 
-        let mut remote_tar = self.transfer_ssh_command();
-        remote_tar
-            .arg(format!("tar -xf - -C {}", shell_quote(remote_parent)))
-            .stdin(stdout);
+        tokio::io::copy(&mut remote_file, &mut local_file)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to download remote file {} to {}",
+                    remote.display(),
+                    local.display()
+                )
+            })?;
+        local_file
+            .flush()
+            .await
+            .with_context(|| format!("Failed to flush local file {}", local.display()))?;
 
-        let mut remote_tar = remote_tar
-            .spawn()
-            .context("Failed to start remote tar for directory upload")?;
+        Ok(())
+    }
 
-        let local_status = local_tar
-            .wait()
-            .context("Failed waiting for local tar during directory upload")?;
-        let remote_status = remote_tar
-            .wait()
-            .context("Failed waiting for remote tar during directory upload")?;
+    async fn download_dir(&self, remote: &Path, local: &Path) -> Result<()> {
+        tokio::fs::create_dir_all(local)
+            .await
+            .with_context(|| format!("Failed to create local directory {}", local.display()))?;
 
-        if !local_status.success() || !remote_status.success() {
-            bail!("Directory upload failed for {}", local.display());
+        for entry in self.list_dir_async(remote).await? {
+            let child_local = local.join(&entry.name);
+            if entry.kind.is_dir() {
+                Box::pin(self.download_dir(&entry.path, &child_local)).await?;
+            } else {
+                self.download_file(&entry.path, &child_local).await?;
+            }
         }
 
-        if extracted_path != remote {
-            let status = self
-                .ssh_command()
-                .arg(format!(
-                    "mv -- {} {}",
-                    shell_quote(&extracted_path),
-                    shell_quote(remote)
-                ))
-                .status()
-                .context("Failed to rename uploaded remote directory")?;
-            if !status.success() {
-                bail!(
-                    "Failed to move uploaded directory from {} to {}",
-                    extracted_path.display(),
+        Ok(())
+    }
+
+    async fn upload_file(&self, local: &Path, remote: &Path) -> Result<()> {
+        if let Some(parent) = remote.parent() {
+            self.create_dir_all_async(parent).await?;
+        }
+
+        let mut local_file = File::open(local)
+            .await
+            .with_context(|| format!("Failed to open local file {}", local.display()))?;
+        let mut remote_file = self
+            .sftp
+            .create(remote_path(remote))
+            .await
+            .with_context(|| format!("Failed to create remote file {}", remote.display()))?;
+
+        tokio::io::copy(&mut local_file, &mut remote_file)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to upload local file {} to {}",
+                    local.display(),
                     remote.display()
-                );
+                )
+            })?;
+        remote_file
+            .flush()
+            .await
+            .with_context(|| format!("Failed to flush remote file {}", remote.display()))?;
+        remote_file
+            .shutdown()
+            .await
+            .with_context(|| format!("Failed to close remote file {}", remote.display()))?;
+
+        Ok(())
+    }
+
+    async fn upload_dir(&self, local: &Path, remote: &Path) -> Result<()> {
+        self.create_dir_all_async(remote).await?;
+
+        let mut entries = tokio::fs::read_dir(local)
+            .await
+            .with_context(|| format!("Failed to read local directory {}", local.display()))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .with_context(|| format!("Failed to read local directory {}", local.display()))?
+        {
+            let file_type = entry.file_type().await.with_context(|| {
+                format!("Failed to inspect local path {}", entry.path().display())
+            })?;
+            let child_remote = remote.join(entry.file_name());
+            if file_type.is_dir() {
+                Box::pin(self.upload_dir(&entry.path(), &child_remote)).await?;
+            } else if file_type.is_file() {
+                self.upload_file(&entry.path(), &child_remote).await?;
             }
         }
 
@@ -410,92 +331,163 @@ impl VolumeFileClient {
 
 impl Drop for VolumeFileClient {
     fn drop(&mut self) {
-        let _ = self
-            .base_ssh_command()
-            .args([
-                "-O",
-                "exit",
-                "-o",
-                &format!("ControlPath={}", self.control_path.display()),
-            ])
-            .arg(self.target())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        let _ = fs::remove_file(&self.control_path);
-    }
-}
-
-fn parse_ls_output(parent: &Path, output: &str) -> Vec<VolumeFileEntry> {
-    let mut entries = Vec::new();
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with("total ") {
-            continue;
-        }
-
-        let mut parts = line.split_whitespace();
-        let Some(mode) = parts.next() else {
-            continue;
-        };
-
-        for _ in 0..7 {
-            parts.next();
-        }
-
-        let name = parts.collect::<Vec<_>>().join(" ");
-        let name = name.split(" -> ").next().unwrap_or(name.as_str());
-        if name.is_empty() || name == "." || name == ".." {
-            continue;
-        }
-
-        let kind = match mode.chars().next() {
-            Some('d') => VolumeFileKind::Directory,
-            Some('-') => VolumeFileKind::File,
-            Some('l') => VolumeFileKind::Symlink,
-            _ => VolumeFileKind::Other,
-        };
-
-        entries.push(VolumeFileEntry {
-            path: parent.join(name),
-            name: name.to_string(),
-            kind,
+        let _ = block_on(async {
+            let _ = self.sftp.close().await;
+            self.ssh
+                .disconnect(russh::Disconnect::ByApplication, "", "en")
+                .await?;
+            Ok::<_, anyhow::Error>(())
         });
     }
-
-    entries
 }
 
-fn control_path(service_instance_id: &str) -> PathBuf {
-    let service_fragment = service_instance_id
-        .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .take(16)
-        .collect::<String>();
-    env::temp_dir().join(format!(
-        "railway-volume-{}-{}.sock",
-        process::id(),
-        service_fragment
-    ))
-}
+#[derive(Clone)]
+struct RailwaySshClient;
 
-fn shell_quote(path: &Path) -> String {
-    let value = path.display().to_string();
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
+impl client::Handler for RailwaySshClient {
+    type Error = anyhow::Error;
 
-fn shell_quote_path_fragment(fragment: &std::ffi::OsStr) -> String {
-    let value = fragment.to_string_lossy();
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
-fn remove_local_path(path: &Path) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("Failed to inspect local path {}", path.display()))?;
-    if metadata.is_dir() {
-        fs::remove_dir_all(path)
-    } else {
-        fs::remove_file(path)
+    async fn check_server_key(
+        &mut self,
+        _server_public_key: &russh::keys::ssh_key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
     }
-    .with_context(|| format!("Failed to remove existing local path {}", path.display()))
+}
+
+async fn connect_with_key(
+    service_instance_id: &str,
+    key_path: &Path,
+) -> Result<(client::Handle<RailwaySshClient>, SftpSession)> {
+    let key_pair = load_key(key_path)
+        .with_context(|| format!("Failed to load SSH key {}", key_path.display()))?;
+    let config = client::Config {
+        inactivity_timeout: Some(Duration::from_secs(30)),
+        preferred: Preferred {
+            kex: Cow::Owned(vec![
+                russh::kex::CURVE25519_PRE_RFC_8731,
+                russh::kex::EXTENSION_SUPPORT_AS_CLIENT,
+            ]),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut ssh = client::connect(Arc::new(config), (SSH_HOST, SSH_PORT), RailwaySshClient {})
+        .await
+        .context("Failed to open SSH connection")?;
+
+    let auth_result = ssh
+        .authenticate_publickey(
+            service_instance_id,
+            PrivateKeyWithHashAlg::new(
+                Arc::new(key_pair),
+                ssh.best_supported_rsa_hash().await?.flatten(),
+            ),
+        )
+        .await
+        .context("Failed to authenticate with SSH key")?;
+    if !auth_result.success() {
+        bail!("SSH key was rejected by Railway");
+    }
+
+    let channel = ssh
+        .channel_open_session()
+        .await
+        .context("Failed to open SSH session channel")?;
+    channel
+        .request_subsystem(true, "sftp")
+        .await
+        .context("Failed to start SFTP subsystem")?;
+    let sftp = SftpSession::new(channel.into_stream())
+        .await
+        .context("Failed to initialize SFTP session")?;
+
+    Ok((ssh, sftp))
+}
+
+fn resolve_private_key_paths(identity_file: Option<PathBuf>) -> Result<Vec<PathBuf>> {
+    if let Some(identity_file) = identity_file {
+        return Ok(vec![expand_tilde(identity_file)]);
+    }
+
+    let mut paths = Vec::new();
+    for key in find_local_ssh_keys()? {
+        let private_key = public_to_private_key_path(&key.path);
+        if private_key.exists() {
+            paths.push(private_key);
+        }
+    }
+
+    Ok(paths)
+}
+
+fn load_key(path: &Path) -> Result<russh::keys::PrivateKey> {
+    match load_secret_key(path, None) {
+        Ok(key) => Ok(key),
+        Err(error) if std::io::stdin().is_terminal() => {
+            let passphrase =
+                Password::new(&format!("Enter passphrase for key '{}':", path.display()))
+                    .without_confirmation()
+                    .prompt()
+                    .context("Failed to read SSH key passphrase")?;
+
+            load_secret_key(path, Some(&passphrase)).map_err(|passphrase_error| {
+                anyhow!(
+                    "Failed to decrypt SSH key with passphrase: {passphrase_error}; initial error: {error}"
+                )
+            })
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn public_to_private_key_path(public_key: &Path) -> PathBuf {
+    match public_key.file_name().and_then(|name| name.to_str()) {
+        Some(name) if name.ends_with(".pub") => public_key.with_file_name(&name[..name.len() - 4]),
+        _ => public_key.to_path_buf(),
+    }
+}
+
+fn expand_tilde(path: PathBuf) -> PathBuf {
+    let Some(path_str) = path.to_str() else {
+        return path;
+    };
+    if path_str == "~" {
+        return dirs::home_dir().unwrap_or(path);
+    }
+    if let Some(rest) = path_str.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    path
+}
+
+fn remote_path(path: &Path) -> String {
+    path.display().to_string()
+}
+
+fn kind_from_file_type(file_type: russh_sftp::protocol::FileType) -> VolumeFileKind {
+    if file_type.is_dir() {
+        VolumeFileKind::Directory
+    } else if file_type.is_file() {
+        VolumeFileKind::File
+    } else if file_type.is_symlink() {
+        VolumeFileKind::Symlink
+    } else {
+        VolumeFileKind::Other
+    }
+}
+
+fn block_on<F, T>(future: F) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(|| handle.block_on(future))
+    } else {
+        tokio::runtime::Runtime::new()
+            .context("Failed to create async runtime")?
+            .block_on(future)
+    }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1135,6 +1135,10 @@ fn is_agent_caller(caller: &str) -> bool {
     true
 }
 
+pub(crate) fn is_agent_invocation() -> bool {
+    is_agent_caller(&detect_caller())
+}
+
 fn error_class(message: Option<&str>) -> String {
     let Some(message) = message else {
         return "UNKNOWN".to_string();


### PR DESCRIPTION
## Summary

Adds volume file browsing and agent-friendly file transfer commands under `railway volume`.

https://github.com/user-attachments/assets/5144e1bf-f274-42a7-bcc7-d0fb6be9a67f


- adds `railway volume browse` with a Ratatui remote browser, download/upload actions, and edit-and-sync for files
- adds non-interactive `volume ls`, `volume download`, and `volume upload` commands with JSON output support
- uses native SSH with a multiplexed control connection; file transfers use `cat`, directory transfers use streamed `tar`
- adds a local upload picker panel in the TUI instead of requiring typed upload paths

## Why

Railway volume files need a simple interactive workflow for humans and simple commands for automation/agents. The SSH control connection also avoids repeated SSH key passphrase prompts during a session.

## Validation

- `cargo fmt --check`
- `cargo check`