### PR TITLE
feat: Add support for SSH agents in addition to raw keyfiles

### DIFF
--- a/src/commands/ssh/keys.rs
+++ b/src/commands/ssh/keys.rs
@@ -279,7 +279,7 @@ async fn add_key(
     let local_keys = find_local_ssh_keys()?;
     if local_keys.is_empty() {
         bail!(
-            "No SSH keys found in ~/.ssh/\n\n\
+            "No SSH keys found in your SSH agent or ~/.ssh/\n\n\
             Generate one with:\n  ssh-keygen -t ed25519\n\n\
             Then run this command again."
         );

--- a/src/commands/ssh/keys.rs
+++ b/src/commands/ssh/keys.rs
@@ -251,7 +251,7 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
     if !unregistered.is_empty() {
         println!("Local Keys (not registered):");
         for key in unregistered {
-            let comment = key.key_comment.as_deref().unwrap_or(&"");
+            let comment = key.key_comment.as_deref().unwrap_or_default();
 
             println!("  {}", key.key_name());
             println!("    Fingerprint: {}", key.fingerprint);

--- a/src/commands/ssh/keys.rs
+++ b/src/commands/ssh/keys.rs
@@ -19,16 +19,7 @@ struct LocalKeyOption(LocalSshKey);
 
 impl fmt::Display for LocalKeyOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{} ({})",
-            self.0
-                .path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy(),
-            self.0.fingerprint
-        )
+        write!(f, "{} ({})", self.0.key_name(), self.0.fingerprint)
     }
 }
 
@@ -176,18 +167,21 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
             // Extract comment/hostname from public key
             let parts: Vec<&str> = key.public_key.split_whitespace().collect();
             let key_type = parts.first().unwrap_or(&"");
-            let hostname = parts.get(2).unwrap_or(&"");
+            let comment = parts.get(2..).unwrap_or_default().join(" ");
 
             println!("  {}", key.name);
             println!("    Fingerprint: {}", key.fingerprint);
             if !key_type.is_empty() {
                 println!("    Type:        {}", key_type);
             }
-            if !hostname.is_empty() {
-                println!("    Hostname:    {}", hostname);
+            if !comment.is_empty() {
+                println!("    Comment:     {}", comment);
             }
             if local_match.is_some() {
-                println!("    Source:      local (~/.ssh/)");
+                println!(
+                    "    Source:      local ({})",
+                    local_match.unwrap().key_source()
+                );
             }
             println!();
         }
@@ -199,7 +193,7 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
         for key in &github_keys {
             let parts: Vec<&str> = key.key.split_whitespace().collect();
             let key_type = parts.first().unwrap_or(&"unknown");
-            let hostname = parts.get(2).unwrap_or(&"");
+            let comment = parts.get(2..).unwrap_or_default().join(" ");
             let fingerprint = compute_fingerprint_from_pubkey(&key.key).unwrap_or_default();
 
             // Check if already registered
@@ -210,8 +204,8 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
                 println!("    Fingerprint: {}", fingerprint);
             }
             println!("    Type:        {}", key_type);
-            if !hostname.is_empty() {
-                println!("    Hostname:    {}", hostname);
+            if !comment.is_empty() {
+                println!("    Comment:     {}", comment);
             }
             if is_registered {
                 println!("    Status:      registered");
@@ -257,20 +251,15 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
     if !unregistered.is_empty() {
         println!("Local Keys (not registered):");
         for key in unregistered {
-            // Extract hostname from public key
-            let parts: Vec<&str> = key.public_key.split_whitespace().collect();
-            let hostname = parts.get(2).unwrap_or(&"");
+            let comment = key.key_comment.as_deref().unwrap_or_default();
 
-            println!(
-                "  {}",
-                key.path.file_name().unwrap_or_default().to_string_lossy()
-            );
+            println!("  {}", key.key_name());
             println!("    Fingerprint: {}", key.fingerprint);
             println!("    Type:        {}", key.key_type);
-            if !hostname.is_empty() {
-                println!("    Hostname:    {}", hostname);
+            if !comment.is_empty() {
+                println!("    Comment:     {}", comment);
             }
-            println!("    Path:        {}", key.path.display());
+            println!("    Source:      {}", key.key_source());
             println!();
         }
         println!("Add with:\n    railway ssh keys add");
@@ -318,7 +307,11 @@ async fn add_key(
         // Find by path
         local_keys
             .iter()
-            .find(|k| k.path.to_string_lossy().contains(&path))
+            .find(|k| {
+                k.path
+                    .as_ref()
+                    .is_some_and(|p| p.to_string_lossy().contains(&path))
+            })
             .ok_or_else(|| anyhow::anyhow!("Key not found: {}", path))?
             .clone()
     } else if unregistered.len() == 1 {
@@ -336,18 +329,12 @@ async fn add_key(
     };
 
     // Determine name
-    let key_name = name.unwrap_or_else(|| {
-        key_to_add
-            .path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("ssh-key")
-            .to_string()
-    });
+    let key_name = name.unwrap_or_else(|| key_to_add.key_name().to_string());
 
     println!(
-        "Registering key: {} ({})",
-        key_to_add.path.display(),
+        "Registering key from {}: {} ({})",
+        key_to_add.key_source(),
+        key_to_add.key_name(),
         key_to_add.fingerprint
     );
 

--- a/src/commands/ssh/keys.rs
+++ b/src/commands/ssh/keys.rs
@@ -71,7 +71,7 @@ enum Commands {
     /// Add/register a local SSH key with Railway
     #[clap(visible_alias = "create", visible_alias = "register")]
     Add {
-        /// Path to the public key file (defaults to auto-detect)
+        /// Path, fingerprint, or comment of the key to add (defaults to auto-detect)
         #[clap(long, short)]
         key: Option<String>,
 
@@ -251,7 +251,7 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
     if !unregistered.is_empty() {
         println!("Local Keys (not registered):");
         for key in unregistered {
-            let comment = key.key_comment.as_deref().unwrap_or_default();
+            let comment = key.key_comment.as_deref().unwrap_or(&"");
 
             println!("  {}", key.key_name());
             println!("    Fingerprint: {}", key.fingerprint);
@@ -303,16 +303,18 @@ async fn add_key(
     }
 
     // Select key to add
-    let key_to_add = if let Some(path) = key_path {
+    let key_to_add = if let Some(arg) = key_path {
         // Find by path
         local_keys
             .iter()
             .find(|k| {
                 k.path
                     .as_ref()
-                    .is_some_and(|p| p.to_string_lossy().contains(&path))
+                    .is_some_and(|p| p.to_string_lossy().contains(&arg))
+                    || k.fingerprint.contains(&arg)
+                    || k.key_comment.as_ref().is_some_and(|c| c.contains(&arg))
             })
-            .ok_or_else(|| anyhow::anyhow!("Key not found: {}", path))?
+            .ok_or_else(|| anyhow::anyhow!("Key not found: {}", arg))?
             .clone()
     } else if unregistered.len() == 1 {
         unregistered[0].clone()

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -44,7 +44,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
 
     if local_keys.is_empty() {
         bail!(
-            "No SSH keys found in ~/.ssh/\n\n\
+            "No SSH keys found in your SSH agent or ~/.ssh/\n\n\
             Generate one with:\n  ssh-keygen -t ed25519\n\n\
             Then run this command again."
         );

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -61,7 +61,10 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
     });
 
     if let Some(key) = registered_local {
-        eprintln!("Using SSH key: {}", key.path.display());
+        match key.path.as_ref() {
+            Some(path) => eprintln!("Using SSH key from file {}: {}", path.display(), key.key_name()),
+            None => eprintln!("Using SSH key from agent: {}", key.key_name()),
+        }
         return Ok(());
     }
 
@@ -83,7 +86,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
         struct KeyOption<'a>(&'a crate::controllers::ssh_keys::LocalSshKey);
         impl fmt::Display for KeyOption<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{} ({})", self.0.path.display(), self.0.fingerprint)
+                write!(f, "{} ({})", self.0.key_name(), self.0.fingerprint)
             }
         }
         let options: Vec<KeyOption> = local_keys.iter().map(KeyOption).collect();
@@ -91,11 +94,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
         selected.0
     };
 
-    println!(
-        "Key: {} ({})",
-        key_to_register.path.display(),
-        key_to_register.fingerprint
-    );
+    println!("Key: {} ({})", key_to_register.key_name(), key_to_register.fingerprint);
     println!();
 
     let should_register = prompt_confirm_with_default("Register this SSH key with Railway?", true)?;
@@ -107,17 +106,10 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
         );
     }
 
-    let key_name = key_to_register
-        .path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("ssh-key")
-        .to_string();
-
     register_ssh_key(
         client,
         configs,
-        &key_name,
+        &key_to_register.key_name(),
         &key_to_register.public_key,
         None,
     )

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -62,7 +62,11 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
 
     if let Some(key) = registered_local {
         match key.path.as_ref() {
-            Some(path) => eprintln!("Using SSH key from file {}: {}", path.display(), key.key_name()),
+            Some(path) => eprintln!(
+                "Using SSH key from file {}: {}",
+                path.display(),
+                key.key_name()
+            ),
             None => eprintln!("Using SSH key from agent: {}", key.key_name()),
         }
         return Ok(());
@@ -94,7 +98,11 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
         selected.0
     };
 
-    println!("Key: {} ({})", key_to_register.key_name(), key_to_register.fingerprint);
+    println!(
+        "Key: {} ({})",
+        key_to_register.key_name(),
+        key_to_register.fingerprint
+    );
     println!();
 
     let should_register = prompt_confirm_with_default("Register this SSH key with Railway?", true)?;

--- a/src/commands/volume/ssh_key.rs
+++ b/src/commands/volume/ssh_key.rs
@@ -90,13 +90,11 @@ fn discover_private_key_paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
 
     for public_key in find_ssh_key_files()? {
-        if public_key.path.is_none() {
-            continue;
-        }
-
-        if let Some(private_key_path) = private_key_path_for_public_key(&public_key.path.unwrap()) {
-            if private_key_path.is_file() {
-                paths.push(private_key_path);
+        if let Some(public_key_path) = public_key.path {
+            if let Some(private_key_path) = private_key_path_for_public_key(&public_key_path) {
+                if private_key_path.is_file() {
+                    paths.push(private_key_path);
+                }
             }
         }
     }

--- a/src/commands/volume/ssh_key.rs
+++ b/src/commands/volume/ssh_key.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use russh::keys::{Algorithm, HashAlg, PrivateKeyWithHashAlg};
 
-use crate::{controllers::ssh_keys::find_local_ssh_keys, telemetry};
+use crate::{controllers::ssh_keys::find_ssh_key_files, telemetry};
 
 pub(super) async fn authenticate<H>(
     session: &mut russh::client::Handle<H>,
@@ -89,8 +89,12 @@ fn load_secret_key(path: &Path) -> Result<Result<russh::keys::PrivateKey, anyhow
 fn discover_private_key_paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
 
-    for public_key in find_local_ssh_keys()? {
-        if let Some(private_key_path) = private_key_path_for_public_key(&public_key.path) {
+    for public_key in find_ssh_key_files()? {
+        if public_key.path.is_none() {
+            continue;
+        }
+
+        if let Some(private_key_path) = private_key_path_for_public_key(&public_key.path.unwrap()) {
             if private_key_path.is_file() {
                 paths.push(private_key_path);
             }

--- a/src/controllers/db_stats/mod.rs
+++ b/src/controllers/db_stats/mod.rs
@@ -22,7 +22,7 @@ const SSH_HOST: &str = "ssh.railway.com";
 pub fn preflight_db_stats_ssh() -> Result<(), String> {
     match find_local_ssh_keys() {
         Ok(keys) if keys.is_empty() => Err(
-            "no local SSH key found in ~/.ssh\n  \
+            "no SSH keys found in your SSH agent or ~/.ssh/\n\n\
              generate one with `ssh-keygen -t ed25519`, then register it with `railway ssh keys add`"
                 .to_string(),
         ),

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -25,10 +25,9 @@ pub struct LocalSshKey {
 impl LocalSshKey {
     pub fn key_name(&self) -> Cow<'_, str> {
         match (self.key_comment.as_ref(), self.path.as_ref()) {
-            (Some(comment), _) if !comment.is_empty() => comment.into(),
-            (Some(_), None) => "SSH Agent Key".into(),
+            (Some(comment), _) => comment.into(),
             (_, Some(path)) => path.file_stem().unwrap().to_string_lossy(),
-            _ => (&self.fingerprint).into(),
+            (None, None) => (&self.fingerprint).into(),
         }
     }
 
@@ -132,7 +131,7 @@ pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
                 public_key: s.trim().to_string(),
                 fingerprint,
                 key_type: parts[0].to_string(),
-                key_comment: parts[2..].join(" ").into(),
+                key_comment: parts.get(2..).map(|p| p.join(" ")),
             })
         })
         .collect()
@@ -149,7 +148,7 @@ fn read_ssh_key(path: &Path) -> Result<LocalSshKey> {
 
     let key_type = parts[0].to_string();
     let public_key = content.trim().to_string();
-    let key_comment = parts[2..].join(" ").into();
+    let key_comment = parts.get(2..).map(|p| p.join(" "));
 
     // Compute fingerprint using ssh-keygen
     let fingerprint = compute_fingerprint(path)?;

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -112,6 +112,13 @@ pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
         Err(_) => return Ok(vec![]),
     };
 
+    if !output.status.success() {
+        // If we successfully run but can't find keys, it's probably best to just pretend like the
+        // SSH agent doesn't exist at all.
+        
+        return Ok(vec![]);
+    }
+
     String::from_utf8_lossy(&output.stdout)
         .split("\n")
         .filter(|s| !s.is_empty())

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -115,7 +115,7 @@ pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
     if !output.status.success() {
         // If we successfully run but can't find keys, it's probably best to just pretend like the
         // SSH agent doesn't exist at all.
-        
+
         return Ok(vec![]);
     }
 

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -110,11 +110,14 @@ pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
         .output()
         .context("Failed to run ssh-add -L")?;
 
-    if !output.status.success() {
-        bail!(
-            "ssh-add -L failed: {}",
+    if output.status.code().unwrap_or(0) == 1 {
+        return Ok(vec![]);
+    } else if !output.status.success() {
+        eprintln!(
+            "Could not read from SSH agent: {}",
             String::from_utf8_lossy(&output.stderr)
         );
+        return Ok(vec![]);
     }
 
     String::from_utf8_lossy(&output.stdout)

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
 use std::path::{Path, PathBuf};
@@ -14,10 +15,29 @@ use crate::gql::queries::{GitHubSshKeys, SshPublicKeys, git_hub_ssh_keys, ssh_pu
 /// Local SSH key info
 #[derive(Debug, Clone)]
 pub struct LocalSshKey {
-    pub path: PathBuf,
+    pub path: Option<PathBuf>,
     pub public_key: String,
     pub fingerprint: String,
     pub key_type: String,
+    pub key_comment: Option<String>,
+}
+
+impl LocalSshKey {
+    pub fn key_name(&self) -> Cow<'_, str> {
+        match (self.key_comment.as_ref(), self.path.as_ref()) {
+            (Some(comment), _) if !comment.is_empty() => comment.into(),
+            (Some(_), None) => "SSH Agent Key".into(),
+            (_, Some(path)) => path.file_stem().unwrap().to_string_lossy(),
+            _ => (&self.fingerprint).into(),
+        }
+    }
+
+    pub fn key_source(&self) -> Cow<'_, str> {
+        self.path
+            .as_ref()
+            .map(|p| p.to_string_lossy())
+            .unwrap_or_else(|| "SSH Agent".into())
+    }
 }
 
 /// Supported SSH key types (in order of preference)
@@ -30,8 +50,29 @@ const SUPPORTED_KEY_TYPES: &[&str] = &[
     "ssh-dss",
 ];
 
-/// Find local SSH keys by scanning ~/.ssh/ for .pub files
 pub fn find_local_ssh_keys() -> Result<Vec<LocalSshKey>> {
+    let mut seen = std::collections::HashMap::new();
+    for key in fetch_keys_from_ssh_agent()? {
+        seen.entry(key.fingerprint.clone()).or_insert(key);
+    }
+
+    for key in find_ssh_key_files()? {
+        seen.entry(key.fingerprint.clone()).or_insert(key);
+    }
+
+    let mut keys = seen.into_values().collect::<Vec<_>>();
+    keys.sort_by_key(|k| {
+        SUPPORTED_KEY_TYPES
+            .iter()
+            .position(|t| k.key_type.starts_with(t))
+            .unwrap_or(usize::MAX)
+    });
+
+    Ok(keys)
+}
+
+/// Find local SSH keys by scanning ~/.ssh/ for .pub files
+pub fn find_ssh_key_files() -> Result<Vec<LocalSshKey>> {
     let home = dirs::home_dir().context("Could not find home directory")?;
     let ssh_dir = home.join(".ssh");
 
@@ -59,15 +100,39 @@ pub fn find_local_ssh_keys() -> Result<Vec<LocalSshKey>> {
         }
     }
 
-    // Sort by key type preference (ed25519 first, then ecdsa, then rsa, then dss)
-    keys.sort_by_key(|k| {
-        SUPPORTED_KEY_TYPES
-            .iter()
-            .position(|t| k.key_type.starts_with(t))
-            .unwrap_or(usize::MAX)
-    });
-
     Ok(keys)
+}
+
+// Pull SSH keys from the agent directly.
+pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
+    let output = Command::new("ssh-add")
+        .arg("-L")
+        .output()
+        .context("Failed to run ssh-add -L")?;
+
+    if !output.status.success() {
+        bail!(
+            "ssh-add -L failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    String::from_utf8_lossy(&output.stdout)
+        .split("\n")
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            let parts: Vec<_> = s.split_whitespace().collect();
+            let fingerprint = compute_fingerprint_from_pubkey(s)?;
+
+            Ok(LocalSshKey {
+                path: None,
+                public_key: s.trim().to_string(),
+                fingerprint,
+                key_type: parts[0].to_string(),
+                key_comment: parts[2..].join(" ").into(),
+            })
+        })
+        .collect()
 }
 
 /// Read and parse an SSH public key file
@@ -81,15 +146,17 @@ fn read_ssh_key(path: &Path) -> Result<LocalSshKey> {
 
     let key_type = parts[0].to_string();
     let public_key = content.trim().to_string();
+    let key_comment = parts[2..].join(" ").into();
 
     // Compute fingerprint using ssh-keygen
     let fingerprint = compute_fingerprint(path)?;
 
     Ok(LocalSshKey {
-        path: path.to_path_buf(),
+        path: Some(path.into()),
         public_key,
         fingerprint,
         key_type,
+        key_comment,
     })
 }
 

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -122,6 +122,7 @@ pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
     String::from_utf8_lossy(&output.stdout)
         .split("\n")
         .filter(|s| !s.is_empty())
+        .filter(|s| SUPPORTED_KEY_TYPES.iter().any(|kt| s.starts_with(kt)))
         .map(|s| {
             let parts: Vec<_> = s.split_whitespace().collect();
             let fingerprint = compute_fingerprint_from_pubkey(s)?;

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -26,7 +26,10 @@ impl LocalSshKey {
     pub fn key_name(&self) -> Cow<'_, str> {
         match (self.key_comment.as_ref(), self.path.as_ref()) {
             (Some(comment), _) => comment.into(),
-            (_, Some(path)) => path.file_stem().unwrap().to_string_lossy(),
+            (_, Some(path)) => path
+                .file_stem()
+                .map(|stem| stem.to_string_lossy())
+                .unwrap_or_else(|| (&self.fingerprint).into()),
             (None, None) => (&self.fingerprint).into(),
         }
     }
@@ -104,20 +107,10 @@ pub fn find_ssh_key_files() -> Result<Vec<LocalSshKey>> {
 
 // Pull SSH keys from the agent directly.
 pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
-    let output = Command::new("ssh-add")
-        .arg("-L")
-        .output()
-        .context("Failed to run ssh-add -L")?;
-
-    if output.status.code().unwrap_or(0) == 1 {
-        return Ok(vec![]);
-    } else if !output.status.success() {
-        eprintln!(
-            "Could not read from SSH agent: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        return Ok(vec![]);
-    }
+    let output = match Command::new("ssh-add").arg("-L").output() {
+        Ok(output) => output,
+        Err(_) => return Ok(vec![]),
+    };
 
     String::from_utf8_lossy(&output.stdout)
         .split("\n")
@@ -125,13 +118,17 @@ pub fn fetch_keys_from_ssh_agent() -> Result<Vec<LocalSshKey>> {
         .map(|s| {
             let parts: Vec<_> = s.split_whitespace().collect();
             let fingerprint = compute_fingerprint_from_pubkey(s)?;
+            let key_comment = parts
+                .get(2..)
+                .map(|p| p.join(" "))
+                .filter(|s| !s.is_empty());
 
             Ok(LocalSshKey {
                 path: None,
                 public_key: s.trim().to_string(),
                 fingerprint,
                 key_type: parts[0].to_string(),
-                key_comment: parts.get(2..).map(|p| p.join(" ")),
+                key_comment,
             })
         })
         .collect()
@@ -148,7 +145,10 @@ fn read_ssh_key(path: &Path) -> Result<LocalSshKey> {
 
     let key_type = parts[0].to_string();
     let public_key = content.trim().to_string();
-    let key_comment = parts.get(2..).map(|p| p.join(" "));
+    let key_comment = parts
+        .get(2..)
+        .map(|p| p.join(" "))
+        .filter(|s| !s.is_empty());
 
     // Compute fingerprint using ssh-keygen
     let fingerprint = compute_fingerprint(path)?;


### PR DESCRIPTION
Simple-ish attempt to fix #870 since it started to become a headache for me. I'll preface this PR by warning everyone that I am *not* a Rust developer, so I'm pretty sure a lot of things in here are wrong or deeply suboptimal (though I did have some people who are much better at Rust than me look at it and tell me to do arcane things). I'd be more than willing to bring in any fixes.

Changes:

* Read all SSH keys returned by `ssh-add -L` to query the agent, then read keys from `~/.ssh`.
  * If a key is in both locations, prefer the key from the agent.
* Add new methods `LocalSshKey#key_name` and `#key_source` to encapsulate some logic.
  * Key name is decided by comment, then file_stem, then hash.
  * Key source is the path or an SSH agent hint.
* Replace `hostname` with `comment` for semantic clarity.
  * Comments are now everything after the second split.

High level demo:

https://asciinema.org/a/wj2g7MpQf2AC82Wz