### PR TITLE
Support ssh-agent keys for native SSH

### DIFF
--- a/src/commands/ssh/keys.rs
+++ b/src/commands/ssh/keys.rs
@@ -19,16 +19,7 @@ struct LocalKeyOption(LocalSshKey);
 
 impl fmt::Display for LocalKeyOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{} ({})",
-            self.0
-                .path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy(),
-            self.0.fingerprint
-        )
+        write!(f, "{} ({})", self.0.display_name(), self.0.fingerprint)
     }
 }
 
@@ -187,7 +178,12 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
                 println!("    Hostname:    {}", hostname);
             }
             if local_match.is_some() {
-                println!("    Source:      local (~/.ssh/)");
+                println!(
+                    "    Source:      {}",
+                    local_match
+                        .map(|key| key.source_label())
+                        .unwrap_or_default()
+                );
             }
             println!();
         }
@@ -255,22 +251,19 @@ async fn list_keys(workspace_id: Option<String>) -> Result<()> {
     }
 
     if !unregistered.is_empty() {
-        println!("Local Keys (not registered):");
+        println!("Available Keys (not registered):");
         for key in unregistered {
             // Extract hostname from public key
             let parts: Vec<&str> = key.public_key.split_whitespace().collect();
             let hostname = parts.get(2).unwrap_or(&"");
 
-            println!(
-                "  {}",
-                key.path.file_name().unwrap_or_default().to_string_lossy()
-            );
+            println!("  {}", key.display_name());
             println!("    Fingerprint: {}", key.fingerprint);
             println!("    Type:        {}", key.key_type);
             if !hostname.is_empty() {
                 println!("    Hostname:    {}", hostname);
             }
-            println!("    Path:        {}", key.path.display());
+            println!("    Source:      {}", key.display_source());
             println!();
         }
         println!("Add with:\n    railway ssh keys add");
@@ -290,8 +283,9 @@ async fn add_key(
     let local_keys = find_local_ssh_keys()?;
     if local_keys.is_empty() {
         bail!(
-            "No SSH keys found in ~/.ssh/\n\n\
+            "No SSH keys found in ~/.ssh or ssh-agent\n\n\
             Generate one with:\n  ssh-keygen -t ed25519\n\n\
+            If you use ssh-agent, make sure `SSH_AUTH_SOCK` is set and `ssh-add -L` lists your public key.\n\n\
             Then run this command again."
         );
     }
@@ -318,7 +312,11 @@ async fn add_key(
         // Find by path
         local_keys
             .iter()
-            .find(|k| k.path.to_string_lossy().contains(&path))
+            .find(|k| {
+                k.path
+                    .as_ref()
+                    .is_some_and(|key_path| key_path.to_string_lossy().contains(&path))
+            })
             .ok_or_else(|| anyhow::anyhow!("Key not found: {}", path))?
             .clone()
     } else if unregistered.len() == 1 {
@@ -336,18 +334,11 @@ async fn add_key(
     };
 
     // Determine name
-    let key_name = name.unwrap_or_else(|| {
-        key_to_add
-            .path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("ssh-key")
-            .to_string()
-    });
+    let key_name = name.unwrap_or_else(|| key_to_add.default_name());
 
     println!(
         "Registering key: {} ({})",
-        key_to_add.path.display(),
+        key_to_add.display_source(),
         key_to_add.fingerprint
     );
 

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -44,8 +44,9 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
 
     if local_keys.is_empty() {
         bail!(
-            "No SSH keys found in ~/.ssh/\n\n\
+            "No SSH keys found in ~/.ssh or ssh-agent\n\n\
             Generate one with:\n  ssh-keygen -t ed25519\n\n\
+            If you use ssh-agent, make sure `SSH_AUTH_SOCK` is set and `ssh-add -L` lists your public key.\n\n\
             Then run this command again."
         );
     }
@@ -61,7 +62,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
     });
 
     if let Some(key) = registered_local {
-        eprintln!("Using SSH key: {}", key.path.display());
+        eprintln!("Using SSH key: {}", key.display_source());
         return Ok(());
     }
 
@@ -83,7 +84,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
         struct KeyOption<'a>(&'a crate::controllers::ssh_keys::LocalSshKey);
         impl fmt::Display for KeyOption<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{} ({})", self.0.path.display(), self.0.fingerprint)
+                write!(f, "{} ({})", self.0.display_source(), self.0.fingerprint)
             }
         }
         let options: Vec<KeyOption> = local_keys.iter().map(KeyOption).collect();
@@ -93,7 +94,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
 
     println!(
         "Key: {} ({})",
-        key_to_register.path.display(),
+        key_to_register.display_source(),
         key_to_register.fingerprint
     );
     println!();
@@ -107,12 +108,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
         );
     }
 
-    let key_name = key_to_register
-        .path
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or("ssh-key")
-        .to_string();
+    let key_name = key_to_register.default_name();
 
     register_ssh_key(
         client,

--- a/src/controllers/db_stats/mod.rs
+++ b/src/controllers/db_stats/mod.rs
@@ -21,11 +21,10 @@ const SSH_HOST: &str = "ssh.railway.com";
 /// so we can surface actionable guidance instead of a cryptic failure.
 pub fn preflight_db_stats_ssh() -> Result<(), String> {
     match find_local_ssh_keys() {
-        Ok(keys) if keys.is_empty() => Err(
-            "no local SSH key found in ~/.ssh\n  \
-             generate one with `ssh-keygen -t ed25519`, then register it with `railway ssh keys add`"
-                .to_string(),
-        ),
+        Ok(keys) if keys.is_empty() => Err("no SSH key found in ~/.ssh or ssh-agent\n  \
+             generate one with `ssh-keygen -t ed25519`, or make sure `ssh-add -L` lists an \
+             agent key, then register it with `railway ssh keys add`"
+            .to_string()),
         Ok(_) => Ok(()),
         Err(e) => Err(format!(
             "unable to read ~/.ssh: {e}\n  \

--- a/src/controllers/ssh_keys.rs
+++ b/src/controllers/ssh_keys.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -14,10 +15,46 @@ use crate::gql::queries::{GitHubSshKeys, SshPublicKeys, git_hub_ssh_keys, ssh_pu
 /// Local SSH key info
 #[derive(Debug, Clone)]
 pub struct LocalSshKey {
-    pub path: PathBuf,
+    pub path: Option<PathBuf>,
     pub public_key: String,
     pub fingerprint: String,
     pub key_type: String,
+}
+
+impl LocalSshKey {
+    pub fn display_name(&self) -> String {
+        self.path
+            .as_ref()
+            .and_then(|path| path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .or_else(|| ssh_key_comment(&self.public_key).map(ToString::to_string))
+            .unwrap_or_else(|| "ssh-agent".to_string())
+    }
+
+    pub fn display_source(&self) -> String {
+        self.path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "ssh-agent".to_string())
+    }
+
+    pub fn default_name(&self) -> String {
+        self.path
+            .as_ref()
+            .and_then(|path| path.file_stem())
+            .and_then(|name| name.to_str())
+            .map(ToString::to_string)
+            .or_else(|| ssh_key_comment(&self.public_key).map(sanitize_key_name))
+            .unwrap_or_else(|| "ssh-agent-key".to_string())
+    }
+
+    pub fn source_label(&self) -> &'static str {
+        if self.path.is_some() {
+            "local (~/.ssh/)"
+        } else {
+            "ssh-agent"
+        }
+    }
 }
 
 /// Supported SSH key types (in order of preference)
@@ -30,19 +67,17 @@ const SUPPORTED_KEY_TYPES: &[&str] = &[
     "ssh-dss",
 ];
 
-/// Find local SSH keys by scanning ~/.ssh/ for .pub files
+/// Find SSH keys available to local ssh, from ~/.ssh/*.pub and ssh-agent.
 pub fn find_local_ssh_keys() -> Result<Vec<LocalSshKey>> {
     let home = dirs::home_dir().context("Could not find home directory")?;
     let ssh_dir = home.join(".ssh");
 
-    if !ssh_dir.exists() {
-        return Ok(vec![]);
-    }
-
     let mut keys = Vec::new();
 
     // Scan for all .pub files in ~/.ssh/
-    if let Ok(entries) = std::fs::read_dir(&ssh_dir) {
+    if ssh_dir.exists()
+        && let Ok(entries) = std::fs::read_dir(&ssh_dir)
+    {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().is_some_and(|ext| ext == "pub") {
@@ -59,6 +94,16 @@ pub fn find_local_ssh_keys() -> Result<Vec<LocalSshKey>> {
         }
     }
 
+    let mut seen = keys
+        .iter()
+        .map(|key| key.fingerprint.clone())
+        .collect::<HashSet<_>>();
+    for key in find_agent_ssh_keys() {
+        if seen.insert(key.fingerprint.clone()) {
+            keys.push(key);
+        }
+    }
+
     // Sort by key type preference (ed25519 first, then ecdsa, then rsa, then dss)
     keys.sort_by_key(|k| {
         SUPPORTED_KEY_TYPES
@@ -68,6 +113,50 @@ pub fn find_local_ssh_keys() -> Result<Vec<LocalSshKey>> {
     });
 
     Ok(keys)
+}
+
+fn find_agent_ssh_keys() -> Vec<LocalSshKey> {
+    if std::env::var_os("SSH_AUTH_SOCK").is_none() {
+        return Vec::new();
+    }
+
+    let Ok(output) = Command::new("ssh-add").arg("-L").output() else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    agent_keys_from_output(&stdout, compute_fingerprint_from_pubkey)
+}
+
+fn agent_keys_from_output<F>(output: &str, mut fingerprint: F) -> Vec<LocalSshKey>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    output
+        .lines()
+        .filter_map(|line| {
+            let public_key = line.trim();
+            let key_type = supported_key_type(public_key)?;
+            let fingerprint = fingerprint(public_key).ok()?;
+            Some(LocalSshKey {
+                path: None,
+                public_key: public_key.to_string(),
+                fingerprint,
+                key_type,
+            })
+        })
+        .collect()
+}
+
+fn supported_key_type(public_key: &str) -> Option<String> {
+    let key_type = public_key.split_whitespace().next()?;
+    SUPPORTED_KEY_TYPES
+        .iter()
+        .any(|supported| key_type.starts_with(supported))
+        .then(|| key_type.to_string())
 }
 
 /// Read and parse an SSH public key file
@@ -86,7 +175,7 @@ fn read_ssh_key(path: &Path) -> Result<LocalSshKey> {
     let fingerprint = compute_fingerprint(path)?;
 
     Ok(LocalSshKey {
-        path: path.to_path_buf(),
+        path: Some(path.to_path_buf()),
         public_key,
         fingerprint,
         key_type,
@@ -226,4 +315,65 @@ pub async fn get_github_ssh_keys(
     let response = post_graphql::<GitHubSshKeys, _>(client, configs.get_backboard(), vars).await?;
 
     Ok(response.git_hub_ssh_keys)
+}
+
+fn ssh_key_comment(public_key: &str) -> Option<&str> {
+    public_key.split_whitespace().nth(2)
+}
+
+fn sanitize_key_name(value: &str) -> String {
+    let name = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+
+    if name.is_empty() {
+        "ssh-agent-key".to_string()
+    } else {
+        name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ED25519_KEY: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA laptop";
+
+    #[test]
+    fn agent_keys_parse_supported_public_keys() {
+        let output = format!("{ED25519_KEY}\nssh-unsupported AAAAC3Nza unsupported\n\nnot-a-key\n");
+
+        let keys = agent_keys_from_output(&output, |key| Ok(format!("fp-{}", key.len())));
+
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].path, None);
+        assert_eq!(keys[0].key_type, "ssh-ed25519");
+        assert_eq!(keys[0].public_key, ED25519_KEY);
+        assert!(keys[0].fingerprint.starts_with("fp-"));
+    }
+
+    #[test]
+    fn agent_key_display_name_prefers_comment() {
+        let key = LocalSshKey {
+            path: None,
+            public_key: ED25519_KEY.to_string(),
+            fingerprint: "SHA256:test".to_string(),
+            key_type: "ssh-ed25519".to_string(),
+        };
+
+        assert_eq!(key.display_name(), "laptop");
+        assert_eq!(key.default_name(), "laptop");
+        assert_eq!(key.display_source(), "ssh-agent");
+        assert_eq!(key.source_label(), "ssh-agent");
+    }
 }


### PR DESCRIPTION
## Summary
- include public keys from `ssh-add -L` when checking/registering SSH keys
- keep file-backed `~/.ssh/*.pub` keys preferred when the same fingerprint is also exposed by the agent
- update SSH key and DB stats messaging so agent-backed setups do not get told only to create files in `~/.ssh`

Fixes #870.

## Testing
- `PATH="$HOME/.cargo/bin:$PATH" cargo test`