### PR TITLE
Avoid duplicated domain verification TXT prefixes

### DIFF
--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -10,6 +10,8 @@ use crate::{consts::TICK_STRING, controllers::project::resolve_service_context};
 
 use super::*;
 
+const RAILWAY_VERIFY_PREFIX: &str = "railway-verify=";
+
 /// Add a custom domain or generate a railway provided domain for a service.
 ///
 /// There is a maximum of 1 railway provided domain per service.
@@ -296,7 +298,7 @@ fn print_dns(
             (Some(host), Some(token)) => {
                 // Strip the zone suffix from the verification DNS host (e.g., "_railway-verify.example.com" -> "_railway-verify")
                 let host_label = host.strip_suffix(&format!(".{}", zone)).unwrap_or(host);
-                Some((host_label.to_string(), format!("railway-verify={}", token)))
+                Some((host_label.to_string(), verification_txt_value(token)))
             }
             _ => None,
         }
@@ -370,6 +372,32 @@ fn print_dns(
             width_type = padding_type,
             width_host = padding_hostlabel,
             width_value = padding_value
+        );
+    }
+}
+
+pub(crate) fn verification_txt_value(token: &str) -> String {
+    if token.starts_with(RAILWAY_VERIFY_PREFIX) {
+        token.to_string()
+    } else {
+        format!("{RAILWAY_VERIFY_PREFIX}{token}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::verification_txt_value;
+
+    #[test]
+    fn verification_txt_value_adds_prefix_to_raw_token() {
+        assert_eq!(verification_txt_value("abc123"), "railway-verify=abc123");
+    }
+
+    #[test]
+    fn verification_txt_value_preserves_prefixed_token() {
+        assert_eq!(
+            verification_txt_value("railway-verify=abc123"),
+            "railway-verify=abc123"
         );
     }
 }

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 
 use super::params::*;
 
+use crate::commands::domain::verification_txt_value;
+
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -656,8 +658,9 @@ impl RailwayMcp {
                         .map(|r| r.zone.as_str())
                         .unwrap_or("");
                     let host_label = host.strip_suffix(&format!(".{zone}")).unwrap_or(host);
+                    let value = verification_txt_value(token);
                     output.push_str(&format!(
-                        "\nVerification TXT record (required):\n  TXT {host_label} -> railway-verify={token}\n"
+                        "\nVerification TXT record (required):\n  TXT {host_label} -> {value}\n"
                     ));
                 }
             }


### PR DESCRIPTION
Fixes #851.

Custom domain instructions were always rendering `railway-verify={token}`. If the API response already includes the `railway-verify=` prefix, the CLI output becomes `railway-verify=railway-verify=<hash>`.

This normalizes the displayed TXT value so both raw tokens and already-prefixed values render with exactly one `railway-verify=` prefix. I also used the same helper in the MCP domain output for consistency.

Verification:
- `PATH="$HOME/.cargo/bin:$PATH" cargo test verification_txt_value`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test domain`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test`
- `git diff --check`