### PR TITLE
Add `railway ssh config` for OpenSSH client config blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "pathdiff",
  "rand 0.8.5",
  "ratatui",
+ "regex",
  "reqwest",
  "reqwest-websocket",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.12.12", default-features = false, features = [
   "json",
 ] }
 reqwest-websocket = "0.5.1"
+regex = "1.12.3"
 chrono = { version = "0.4.39", features = [
   "serde",
   "clock",
@@ -105,11 +106,9 @@ rmcp = { version = "0.16", features = ["transport-io"] }
 toml = "0.8"
 termimad = "0.28"
 csv = "1.3"
+tempfile = "3.23.0"
 
 [profile.release]
 lto = "fat"
 opt-level = "z"
 panic = "abort"
-
-[dev-dependencies]
-tempfile = "3.23.0"

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -41,6 +41,23 @@ pub struct Args {
     json: bool,
 }
 
+impl Args {
+    pub(crate) fn for_service_link(
+        project: Option<String>,
+        environment: Option<String>,
+        service: Option<String>,
+    ) -> Self {
+        Self {
+            environment,
+            project,
+            service,
+            team: None,
+            workspace: None,
+            json: false,
+        }
+    }
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LinkOutput {
@@ -55,6 +72,14 @@ struct LinkOutput {
 }
 
 pub async fn command(args: Args) -> Result<()> {
+    link_command(args, false).await
+}
+
+pub(crate) async fn command_requiring_service(args: Args) -> Result<()> {
+    link_command(args, true).await
+}
+
+async fn link_command(args: Args, require_service: bool) -> Result<()> {
     let mut configs = Configs::new()?;
 
     // Support both team (deprecated) and workspace arguments
@@ -84,7 +109,7 @@ pub async fn command(args: Args) -> Result<()> {
     let environment_instances =
         get_environment_instances(&client, &configs, &project.id, &environment.id).await?;
     let service_ids = get_service_ids_in_env(&environment_instances);
-    let service = select_service(&project, &service_ids, args.service)?;
+    let service = select_service(&project, &service_ids, args.service, require_service)?;
 
     configs.link_project(
         project.id.clone(),
@@ -128,6 +153,7 @@ fn select_service(
     project: &NormalisedProject,
     service_ids: &HashSet<String>,
     service: Option<String>,
+    require_service: bool,
 ) -> Result<Option<NormalisedService>, anyhow::Error> {
     let useful_services = project
         .services
@@ -164,7 +190,11 @@ fn select_service(
                 );
             }
         } else if std::io::stdout().is_terminal() {
-            prompt_options_skippable("Select a service <esc to skip>", useful_services)?
+            if require_service {
+                Some(prompt_options("Select a service", useful_services)?)
+            } else {
+                prompt_options_skippable("Select a service <esc to skip>", useful_services)?
+            }
         } else if useful_services.len() == 1 {
             let svc = useful_services.into_iter().next().unwrap();
             eprintln!("No service specified — auto-selecting \"{}\"", svc.name);
@@ -180,6 +210,13 @@ fn select_service(
             } else {
                 String::new()
             };
+            if require_service {
+                bail!(
+                    "Multiple services available — use --service <name> to link one.\nAvailable: {}{}",
+                    names.join(", "),
+                    suffix
+                );
+            }
             eprintln!(
                 "Multiple services available — use --service <name> to link one.\nAvailable: {}{}",
                 names.join(", "),
@@ -188,6 +225,9 @@ fn select_service(
             None
         }
     } else {
+        if require_service {
+            bail!("No services found");
+        }
         None
     };
     Ok(service)

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -553,6 +553,10 @@ async fn link_command(args: LinkArgs) -> Result<()> {
     Ok(())
 }
 
+pub(crate) async fn link_current_project_service(service: Option<String>) -> Result<()> {
+    link_command(LinkArgs { service }).await
+}
+
 async fn status_command(args: StatusArgs) -> Result<()> {
     if args.all {
         eprintln!(

--- a/src/commands/ssh/common.rs
+++ b/src/commands/ssh/common.rs
@@ -10,6 +10,7 @@ use crate::controllers::{
 use super::Args;
 
 pub struct SshConnectParams {
+    pub project_id: String,
     pub environment_id: String,
     pub service_id: String,
     pub service_name: String,
@@ -84,6 +85,7 @@ pub async fn get_ssh_connect_params(
     };
 
     Ok(SshConnectParams {
+        project_id: project.id,
         environment_id,
         service_id,
         service_name,

--- a/src/commands/ssh/common.rs
+++ b/src/commands/ssh/common.rs
@@ -12,16 +12,13 @@ use super::Args;
 pub struct SshConnectParams {
     pub environment_id: String,
     pub service_id: String,
+    pub service_name: String,
 }
 
-pub async fn find_service_by_name(
-    client: &Client,
-    configs: &Configs,
+pub fn find_service_by_name(
     project: &RailwayProject,
     service_id_or_name: &str,
-) -> Result<String> {
-    let project = get_project(client, configs, project.id.clone()).await?;
-
+) -> Result<(String, String)> {
     let services = project.services.edges.iter().collect::<Vec<_>>();
 
     let service = services
@@ -32,10 +29,9 @@ pub async fn find_service_by_name(
         })
         .with_context(|| format!("Service '{service_id_or_name}' not found"))?
         .node
-        .id
         .to_owned();
 
-    Ok(service)
+    Ok((service.id, service.name))
 }
 
 pub async fn get_ssh_connect_params(
@@ -70,16 +66,26 @@ pub async fn get_ssh_connect_params(
     };
     let environment_id = get_matched_environment(&project, environment)?.id;
 
-    let service_id = if let Some(service_id_or_name) = args.service {
-        find_service_by_name(client, configs, &project, &service_id_or_name).await?
+    let (service_id, service_name) = if let Some(service_id_or_name) = args.service {
+        find_service_by_name(&project, &service_id_or_name)?
     } else {
-        get_or_prompt_service(linked_project.clone(), project, None)
+        let service_id = get_or_prompt_service(linked_project.clone(), project.clone(), None)
             .await?
-            .ok_or_else(|| anyhow!("No service found. Please specify a service to connect to via the `--service` flag."))?
+            .ok_or_else(|| anyhow!("No service found. Please specify a service to connect to via the `--service` flag."))?;
+        let service_name = project
+            .services
+            .edges
+            .iter()
+            .find(|service| service.node.id == service_id)
+            .map(|service| service.node.name.clone())
+            .unwrap_or_else(|| service_id.clone());
+
+        (service_id, service_name)
     };
 
     Ok(SshConnectParams {
         environment_id,
         service_id,
+        service_name,
     })
 }

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -1,0 +1,438 @@
+use std::{
+    fmt::Write as _,
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use clap::Parser;
+use regex::{NoExpand, Regex};
+use tempfile::NamedTempFile;
+
+use crate::{client::GQLClient, config::Configs};
+
+use super::{common::get_ssh_connect_params, native};
+
+/// Emit or manage an OpenSSH config block for a Railway service
+#[derive(Parser, Clone)]
+pub struct Args {
+    /// Project to connect to (defaults to linked project)
+    #[clap(short, long)]
+    project: Option<String>,
+
+    /// Service to connect to (defaults to linked service)
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// Environment to connect to (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Host alias to use in the SSH config
+    #[clap(long)]
+    alias: Option<String>,
+
+    /// Path to identity (private key) file to use
+    #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
+    identity_file: Option<PathBuf>,
+
+    /// Upsert the generated block into the SSH config file
+    #[clap(long)]
+    write: bool,
+
+    /// Remove the generated block from the SSH config file
+    #[clap(long)]
+    remove: bool,
+
+    /// SSH config file to update
+    #[clap(long, default_value = "~/.ssh/config")]
+    path: PathBuf,
+}
+
+struct ResolvedConfig {
+    service_name: String,
+    alias: String,
+    service_instance_id: Option<String>,
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    if args.write && args.remove {
+        bail!("--write and --remove cannot be used together");
+    }
+
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let params = get_ssh_connect_params(
+        super::Args {
+            subcommand: None,
+            project: args.project.clone(),
+            service: args.service.clone(),
+            environment: args.environment.clone(),
+            deployment_instance: None,
+            session: None,
+            native: false,
+            identity_file: None,
+            command: Vec::new(),
+        },
+        &configs,
+        &client,
+    )
+    .await?;
+
+    let alias = args
+        .alias
+        .as_deref()
+        .map(sanitize_alias)
+        .unwrap_or_else(|| format!("railway-{}", sanitize_alias(&params.service_name)));
+
+    let service_instance_id = if args.remove {
+        None
+    } else {
+        Some(
+            native::get_service_instance_id(
+                &client,
+                &configs,
+                &params.environment_id,
+                &params.service_id,
+            )
+            .await?,
+        )
+    };
+
+    let resolved = ResolvedConfig {
+        service_name: params.service_name,
+        alias,
+        service_instance_id,
+    };
+
+    if args.remove {
+        let path = expand_tilde(&args.path)?;
+        let removed = remove_config_block(&path, &resolved.service_name)?;
+        if removed {
+            eprintln!("Removed Railway SSH config block from {}", path.display());
+        } else {
+            eprintln!(
+                "No Railway SSH config block found for {} in {}",
+                resolved.service_name,
+                path.display()
+            );
+        }
+        return Ok(());
+    }
+
+    let block = render_config_block(
+        &resolved.service_name,
+        &resolved.alias,
+        resolved
+            .service_instance_id
+            .as_deref()
+            .context("service instance ID is required to render SSH config")?,
+        args.identity_file.as_deref(),
+        &Utc::now().format("%Y-%m-%d").to_string(),
+    );
+
+    if args.write {
+        let path = expand_tilde(&args.path)?;
+        upsert_config_block(&path, &resolved.service_name, &block)?;
+        eprintln!("Wrote Railway SSH config block to {}", path.display());
+    } else {
+        print!("{block}");
+    }
+
+    Ok(())
+}
+
+fn render_config_block(
+    service_name: &str,
+    alias: &str,
+    service_instance_id: &str,
+    identity_file: Option<&Path>,
+    date: &str,
+) -> String {
+    let marker_name = marker_name(service_name);
+    let mut block = String::new();
+    writeln!(
+        block,
+        "# BEGIN railway:{marker_name} ----- written {date} by `railway ssh config`"
+    )
+    .expect("writing to String cannot fail");
+    writeln!(
+        block,
+        "# If you delete and re-add this service, re-run this command."
+    )
+    .expect("writing to String cannot fail");
+    writeln!(block, "Host {alias}").expect("writing to String cannot fail");
+    writeln!(block, "    HostName {}", native::SSH_HOST).expect("writing to String cannot fail");
+    writeln!(block, "    User {service_instance_id}").expect("writing to String cannot fail");
+
+    if let Some(identity_file) = identity_file {
+        writeln!(
+            block,
+            "    IdentityFile {}",
+            identity_file.to_string_lossy()
+        )
+        .expect("writing to String cannot fail");
+    }
+
+    writeln!(block, "    ServerAliveInterval 30").expect("writing to String cannot fail");
+    writeln!(block, "    ServerAliveCountMax 3").expect("writing to String cannot fail");
+    writeln!(block, "# END railway:{marker_name}").expect("writing to String cannot fail");
+
+    block
+}
+
+fn upsert_config_block(path: &Path, service_name: &str, block: &str) -> Result<()> {
+    let existing = read_config(path)?;
+    let pattern = config_block_regex(service_name, false)?;
+    let updated = if pattern.is_match(&existing) {
+        pattern.replace(&existing, NoExpand(block)).into_owned()
+    } else {
+        append_config_block(existing, block)
+    };
+
+    write_config(path, &updated)
+}
+
+fn remove_config_block(path: &Path, service_name: &str) -> Result<bool> {
+    let existing = read_config(path)?;
+    let pattern = config_block_regex(service_name, true)?;
+
+    if !pattern.is_match(&existing) {
+        return Ok(false);
+    }
+
+    let updated = pattern.replace(&existing, "").into_owned();
+    write_config(path, &updated)?;
+
+    Ok(true)
+}
+
+fn read_config(path: &Path) -> Result<String> {
+    match fs::read_to_string(path) {
+        Ok(contents) => Ok(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(String::new()),
+        Err(error) => Err(error).with_context(|| format!("Failed to read {}", path.display())),
+    }
+}
+
+fn write_config(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+        secure_ssh_dir(parent)?;
+    }
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut temp_file = NamedTempFile::new_in(parent)
+        .with_context(|| format!("Failed to create temporary file in {}", parent.display()))?;
+    temp_file
+        .write_all(contents.as_bytes())
+        .context("Failed to write temporary SSH config")?;
+    temp_file
+        .as_file_mut()
+        .sync_all()
+        .context("Failed to sync temporary SSH config")?;
+    secure_file(temp_file.path())?;
+    temp_file
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    secure_file(path)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_ssh_dir(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if path.file_name().and_then(|name| name.to_str()) == Some(".ssh") {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("Failed to set permissions on {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn secure_ssh_dir(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_file(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("Failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn secure_file(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn append_config_block(mut existing: String, block: &str) -> String {
+    if !existing.is_empty() {
+        if !existing.ends_with('\n') {
+            existing.push('\n');
+        }
+
+        if !existing.ends_with("\n\n") {
+            existing.push('\n');
+        }
+    }
+
+    existing.push_str(block);
+    existing
+}
+
+fn config_block_regex(service_name: &str, include_preceding_blank: bool) -> Result<Regex> {
+    let marker = regex::escape(&marker_name(service_name));
+    let preceding_blank = if include_preceding_blank {
+        r"(?:^[ \t]*\r?\n)?"
+    } else {
+        ""
+    };
+    Regex::new(&format!(
+        r"(?ms){preceding_blank}^# BEGIN railway:{marker}(?: .*)?\r?\n.*?^# END railway:{marker}[ \t]*(?:\r?\n)?"
+    ))
+    .context("Failed to build Railway SSH config marker regex")
+}
+
+fn marker_name(service_name: &str) -> String {
+    service_name.replace(['\r', '\n'], " ")
+}
+
+fn sanitize_alias(input: &str) -> String {
+    let mut sanitized = String::new();
+    let mut previous_was_dash = false;
+
+    for byte in input.bytes() {
+        let c = byte.to_ascii_lowercase() as char;
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_') {
+            sanitized.push(c);
+            previous_was_dash = false;
+        } else if c == '-' {
+            if !previous_was_dash {
+                sanitized.push(c);
+            }
+            previous_was_dash = true;
+        } else if !previous_was_dash {
+            sanitized.push('-');
+            previous_was_dash = true;
+        }
+    }
+
+    let sanitized = sanitized.trim_matches('-').to_string();
+    if sanitized.is_empty() {
+        "service".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn expand_tilde(path: &Path) -> Result<PathBuf> {
+    let path = path.to_string_lossy();
+
+    if path == "~" {
+        return dirs::home_dir().context("Could not find home directory");
+    }
+
+    for prefix in ["~/", "~\\"] {
+        if let Some(rest) = path.strip_prefix(prefix) {
+            return dirs::home_dir()
+                .map(|home| home.join(rest))
+                .context("Could not find home directory");
+        }
+    }
+
+    Ok(PathBuf::from(path.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_aliases() {
+        assert_eq!(sanitize_alias("API Service"), "api-service");
+        assert_eq!(sanitize_alias("railway.API_01"), "railway.api_01");
+        assert_eq!(sanitize_alias("!!!"), "service");
+    }
+
+    #[test]
+    fn write_upserts_block_idempotently_and_sets_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".ssh/config");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "Host existing\n    HostName example.com\n").unwrap();
+
+        let old_block = render_config_block("API", "railway-api", "old-id", None, "2026-05-17");
+        let new_block = render_config_block(
+            "API",
+            "railway-api",
+            "new-id",
+            Some(Path::new("~/.ssh/id_ed25519")),
+            "2026-05-18",
+        );
+
+        upsert_config_block(&path, "API", &old_block).unwrap();
+        upsert_config_block(&path, "API", &new_block).unwrap();
+        upsert_config_block(&path, "API", &new_block).unwrap();
+
+        let contents = fs::read_to_string(&path).unwrap();
+
+        assert_eq!(contents.matches("# BEGIN railway:API").count(), 1);
+        assert!(contents.starts_with("Host existing\n    HostName example.com\n\n"));
+        assert!(contents.contains("# BEGIN railway:API ----- written 2026-05-18"));
+        assert!(contents.contains("Host railway-api\n"));
+        assert!(contents.contains("    HostName ssh.railway.com\n"));
+        assert!(contents.contains("    User new-id\n"));
+        assert!(contents.contains("    IdentityFile ~/.ssh/id_ed25519\n"));
+        assert!(!contents.contains("old-id"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let ssh_mode = fs::metadata(dir.path().join(".ssh"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            let file_mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+
+            assert_eq!(ssh_mode, 0o700);
+            assert_eq!(file_mode, 0o600);
+        }
+    }
+
+    #[test]
+    fn remove_deletes_marked_block_and_is_noop_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".ssh/config");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            "\
+Host existing
+
+# BEGIN railway:API ----- written 2026-01-01 by `railway ssh config`
+Host old
+# END railway:API
+Host later
+",
+        )
+        .unwrap();
+
+        assert!(remove_config_block(&path, "API").unwrap());
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "Host existing\nHost later\n"
+        );
+        assert!(!remove_config_block(&path, "API").unwrap());
+    }
+}

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -77,6 +77,7 @@ impl Default for TargetArgs {
 
 struct ResolvedConfig {
     service_name: String,
+    config_marker: String,
     alias: String,
     service_instance_id: String,
 }
@@ -101,6 +102,7 @@ pub async fn command(args: Args) -> Result<()> {
     let resolved = resolve(&args.target, args.alias.as_deref()).await?;
     let block = render_config_block(
         &resolved.service_name,
+        &resolved.config_marker,
         &resolved.alias,
         &resolved.service_instance_id,
         args.identity_file.as_deref(),
@@ -110,7 +112,12 @@ pub async fn command(args: Args) -> Result<()> {
         print!("{block}");
     } else {
         let path = expand_tilde(&args.target.path)?;
-        upsert_config_block(&path, &resolved.service_name, &block)?;
+        upsert_config_block(
+            &path,
+            &resolved.config_marker,
+            &resolved.service_name,
+            &block,
+        )?;
         eprintln!("Wrote Railway SSH config block to {}", path.display());
     }
 
@@ -118,14 +125,23 @@ pub async fn command(args: Args) -> Result<()> {
 }
 
 async fn remove_command(target: TargetArgs) -> Result<()> {
-    let service_name = if let Some(service_name) = target.service.as_deref() {
-        service_name.to_string()
+    let path = expand_tilde(&target.path)?;
+    let should_resolve_target =
+        target.service.is_none() || target.project.is_some() || target.environment.is_some();
+    let (service_name, removed) = if let Some(service_name) =
+        target.service.as_deref().filter(|_| !should_resolve_target)
+    {
+        (
+            service_name.to_string(),
+            remove_config_blocks_by_service_name(&path, service_name)?,
+        )
     } else {
-        resolve_service_name(&target).await?
+        let resolved = resolve_target(&target).await?;
+        let removed =
+            remove_config_block_for_target(&path, &resolved.config_marker, &resolved.service_name)?;
+        (resolved.service_name, removed)
     };
 
-    let path = expand_tilde(&target.path)?;
-    let removed = remove_config_block(&path, &service_name)?;
     if removed {
         eprintln!("Removed Railway SSH config block from {}", path.display());
     } else {
@@ -144,6 +160,9 @@ async fn ensure_default_target_has_linked_service(target: &TargetArgs) -> Result
         return Ok(());
     }
     if !std::io::stdout().is_terminal() {
+        return Ok(());
+    }
+    if Configs::has_env_var_project_config() || Configs::get_railway_token().is_some() {
         return Ok(());
     }
 
@@ -168,10 +187,7 @@ async fn ensure_default_target_has_linked_service(target: &TargetArgs) -> Result
 }
 
 async fn resolve(target: &TargetArgs, alias: Option<&str>) -> Result<ResolvedConfig> {
-    let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
-    let params =
-        get_ssh_connect_params(ssh_args_from_target_args(target), &configs, &client).await?;
+    let (configs, client, params, config_marker) = resolve_params(target).await?;
 
     let alias = alias
         .map(sanitize_alias)
@@ -187,18 +203,45 @@ async fn resolve(target: &TargetArgs, alias: Option<&str>) -> Result<ResolvedCon
 
     Ok(ResolvedConfig {
         service_name: params.service_name,
+        config_marker,
         alias,
         service_instance_id,
     })
 }
 
-async fn resolve_service_name(target: &TargetArgs) -> Result<String> {
+struct ResolvedTarget {
+    service_name: String,
+    config_marker: String,
+}
+
+async fn resolve_target(target: &TargetArgs) -> Result<ResolvedTarget> {
+    let (_configs, _client, params, config_marker) = resolve_params(target).await?;
+
+    Ok(ResolvedTarget {
+        service_name: params.service_name,
+        config_marker,
+    })
+}
+
+async fn resolve_params(
+    target: &TargetArgs,
+) -> Result<(
+    Configs,
+    reqwest::Client,
+    super::common::SshConnectParams,
+    String,
+)> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let params =
         get_ssh_connect_params(ssh_args_from_target_args(target), &configs, &client).await?;
+    let config_marker = target_marker(
+        &params.project_id,
+        &params.environment_id,
+        &params.service_id,
+    );
 
-    Ok(params.service_name)
+    Ok((configs, client, params, config_marker))
 }
 
 fn ssh_args_from_target_args(target: &TargetArgs) -> super::Args {
@@ -217,14 +260,18 @@ fn ssh_args_from_target_args(target: &TargetArgs) -> super::Args {
 
 fn render_config_block(
     service_name: &str,
+    config_marker: &str,
     alias: &str,
     service_instance_id: &str,
     identity_file: Option<&Path>,
 ) -> String {
-    let marker_name = marker_name(service_name);
+    let rendered_marker = marker_name(config_marker);
+    let rendered_service_name = marker_name(service_name);
     let mut block = String::new();
 
-    writeln!(block, "# BEGIN railway:{marker_name}").expect("writing to String cannot fail");
+    writeln!(block, "# BEGIN railway:{rendered_marker}").expect("writing to String cannot fail");
+    writeln!(block, "# Railway service: {rendered_service_name}")
+        .expect("writing to String cannot fail");
     writeln!(block, "Host {alias}").expect("writing to String cannot fail");
     writeln!(block, "    HostName {}", native::SSH_HOST).expect("writing to String cannot fail");
     writeln!(block, "    User {service_instance_id}").expect("writing to String cannot fail");
@@ -240,32 +287,79 @@ fn render_config_block(
 
     writeln!(block, "    ServerAliveInterval 30").expect("writing to String cannot fail");
     writeln!(block, "    ServerAliveCountMax 3").expect("writing to String cannot fail");
-    writeln!(block, "# END railway:{marker_name}").expect("writing to String cannot fail");
+    writeln!(block, "# END railway:{rendered_marker}").expect("writing to String cannot fail");
 
     block
 }
 
-fn upsert_config_block(path: &Path, service_name: &str, block: &str) -> Result<()> {
+fn upsert_config_block(
+    path: &Path,
+    config_marker: &str,
+    service_name: &str,
+    block: &str,
+) -> Result<()> {
     let existing = read_config(path)?;
-    let pattern = config_block_regex_with_case(service_name, false, true)?;
+    let pattern = config_block_regex_with_case(config_marker, false, true)?;
     let updated = if pattern.is_match(&existing) {
         pattern.replace(&existing, NoExpand(block)).into_owned()
     } else {
-        append_config_block(existing, block)
+        let legacy_pattern = config_block_regex_with_case(service_name, false, true)?;
+        if legacy_pattern.is_match(&existing) {
+            legacy_pattern
+                .replace(&existing, NoExpand(block))
+                .into_owned()
+        } else {
+            append_config_block(existing, block)
+        }
     };
 
     write_config(path, &updated)
 }
 
-fn remove_config_block(path: &Path, service_name: &str) -> Result<bool> {
+fn remove_config_block_for_target(
+    path: &Path,
+    config_marker: &str,
+    service_name: &str,
+) -> Result<bool> {
     let existing = read_config(path)?;
-    let pattern = config_block_regex_with_case(service_name, true, true)?;
+    let pattern = config_block_regex_with_case(config_marker, true, true)?;
 
-    if !pattern.is_match(&existing) {
+    let updated = if pattern.is_match(&existing) {
+        pattern.replace(&existing, "").into_owned()
+    } else {
+        let legacy_pattern = config_block_regex_with_case(service_name, true, true)?;
+        if !legacy_pattern.is_match(&existing) {
+            return Ok(false);
+        }
+        legacy_pattern.replace(&existing, "").into_owned()
+    };
+
+    write_config(path, &updated)?;
+
+    Ok(true)
+}
+
+fn remove_config_blocks_by_service_name(path: &Path, service_name: &str) -> Result<bool> {
+    let existing = read_config(path)?;
+    let pattern = any_config_block_regex(true)?;
+    let mut removed = false;
+
+    let updated = pattern
+        .replace_all(&existing, |captures: &regex::Captures<'_>| {
+            let block = captures.get(0).map_or("", |matched| matched.as_str());
+            if block_matches_service_name(block, service_name) {
+                removed = true;
+                String::new()
+            } else {
+                block.to_string()
+            }
+        })
+        .into_owned();
+
+    if !removed {
         return Ok(false);
     }
 
-    let updated = pattern.replace(&existing, "").into_owned();
     write_config(path, &updated)?;
 
     Ok(true)
@@ -355,11 +449,11 @@ fn append_config_block(mut existing: String, block: &str) -> String {
 }
 
 fn config_block_regex_with_case(
-    service_name: &str,
+    config_marker: &str,
     include_preceding_blank: bool,
     case_insensitive: bool,
 ) -> Result<Regex> {
-    let marker = regex::escape(&marker_name(service_name));
+    let marker = regex::escape(&marker_name(config_marker));
     let preceding_blank = if include_preceding_blank {
         r"(?:^[ \t]*\r?\n)?"
     } else {
@@ -370,6 +464,53 @@ fn config_block_regex_with_case(
         r"{flags}{preceding_blank}^# BEGIN railway:{marker}[ \t]*\r?\n.*?^# END railway:{marker}[ \t]*(?:\r?\n)?"
     ))
     .context("Failed to build Railway SSH config marker regex")
+}
+
+fn any_config_block_regex(include_preceding_blank: bool) -> Result<Regex> {
+    let preceding_blank = if include_preceding_blank {
+        r"(?:^[ \t]*\r?\n)?"
+    } else {
+        ""
+    };
+
+    Regex::new(&format!(
+        r"(?ims){preceding_blank}^# BEGIN railway:[^\r\n]*[ \t]*\r?\n.*?^# END railway:[^\r\n]*[ \t]*(?:\r?\n)?"
+    ))
+    .context("Failed to build Railway SSH config block regex")
+}
+
+fn block_matches_service_name(block: &str, service_name: &str) -> bool {
+    block_service_metadata_matches(block, service_name)
+        || block_legacy_marker_matches(block, service_name)
+}
+
+fn block_service_metadata_matches(block: &str, service_name: &str) -> bool {
+    let service_name = marker_name(service_name);
+
+    block.lines().any(|line| {
+        line.strip_prefix("# Railway service:")
+            .is_some_and(|line_service_name| {
+                line_service_name.trim().eq_ignore_ascii_case(&service_name)
+            })
+    })
+}
+
+fn block_legacy_marker_matches(block: &str, service_name: &str) -> bool {
+    let service_name = marker_name(service_name);
+
+    block.lines().any(|line| {
+        line.strip_prefix("# BEGIN railway:")
+            .is_some_and(|marker| marker.trim().eq_ignore_ascii_case(&service_name))
+    })
+}
+
+fn target_marker(project_id: &str, environment_id: &str, service_id: &str) -> String {
+    format!(
+        "{}:{}:{}",
+        marker_name(project_id),
+        marker_name(environment_id),
+        marker_name(service_id)
+    )
 }
 
 fn marker_name(service_name: &str) -> String {
@@ -460,18 +601,25 @@ mod tests {
 
     #[test]
     fn renders_config_block_with_minimal_markers() {
-        let block = render_config_block("api", "railway-api", "instance-id", None);
+        let block = render_config_block(
+            "api",
+            "project-id:environment-id:service-id",
+            "railway-api",
+            "instance-id",
+            None,
+        );
 
         assert_eq!(
             block,
             "\
-# BEGIN railway:api
+# BEGIN railway:project-id:environment-id:service-id
+# Railway service: api
 Host railway-api
     HostName ssh.railway.com
     User instance-id
     ServerAliveInterval 30
     ServerAliveCountMax 3
-# END railway:api
+# END railway:project-id:environment-id:service-id
 "
         );
     }
@@ -481,30 +629,54 @@ Host railway-api
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".ssh/config");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(&path, "Host existing\n    HostName example.com\n").unwrap();
+        fs::write(
+            &path,
+            "\
+Host existing
+    HostName example.com
 
-        let old_block = render_config_block("API", "railway-api", "old-id", None);
+# BEGIN railway:API
+Host railway-api
+    User old-id
+# END railway:API
+",
+        )
+        .unwrap();
+
         let new_block = render_config_block(
             "api",
+            "project-id:environment-id:service-id",
             "railway-api",
             "new-id",
             Some(Path::new("/Users/me/My Keys/id_ed25519")),
         );
 
-        upsert_config_block(&path, "API", &old_block).unwrap();
-        upsert_config_block(&path, "api", &new_block).unwrap();
-        upsert_config_block(&path, "api", &new_block).unwrap();
+        upsert_config_block(
+            &path,
+            "project-id:environment-id:service-id",
+            "api",
+            &new_block,
+        )
+        .unwrap();
+        upsert_config_block(
+            &path,
+            "project-id:environment-id:service-id",
+            "api",
+            &new_block,
+        )
+        .unwrap();
 
         let contents = fs::read_to_string(&path).unwrap();
 
         assert_eq!(contents.matches("# BEGIN railway:").count(), 1);
         assert!(contents.starts_with("Host existing\n    HostName example.com\n\n"));
-        assert!(contents.contains("# BEGIN railway:api\n"));
+        assert!(contents.contains("# BEGIN railway:project-id:environment-id:service-id\n"));
+        assert!(contents.contains("# Railway service: api\n"));
         assert!(contents.contains("Host railway-api\n"));
         assert!(contents.contains("    HostName ssh.railway.com\n"));
         assert!(contents.contains("    User new-id\n"));
         assert!(contents.contains("    IdentityFile \"/Users/me/My Keys/id_ed25519\"\n"));
-        assert!(contents.contains("# END railway:api\n"));
+        assert!(contents.contains("# END railway:project-id:environment-id:service-id\n"));
         assert!(!contents.contains("written"));
         assert!(!contents.contains("If you rename"));
         assert!(!contents.contains("old-id"));
@@ -525,6 +697,112 @@ Host railway-api
         }
     }
 
+    #[test]
+    fn upserts_same_service_name_for_different_targets_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".ssh/config");
+
+        let prod_block = render_config_block(
+            "api",
+            "project-id:production-id:service-id",
+            "railway-api",
+            "prod-instance-id",
+            None,
+        );
+        let staging_block = render_config_block(
+            "api",
+            "project-id:staging-id:service-id",
+            "railway-api-staging",
+            "staging-instance-id",
+            None,
+        );
+        let updated_prod_block = render_config_block(
+            "api",
+            "project-id:production-id:service-id",
+            "railway-api-prod",
+            "updated-prod-instance-id",
+            None,
+        );
+
+        upsert_config_block(
+            &path,
+            "project-id:production-id:service-id",
+            "api",
+            &prod_block,
+        )
+        .unwrap();
+        upsert_config_block(
+            &path,
+            "project-id:staging-id:service-id",
+            "api",
+            &staging_block,
+        )
+        .unwrap();
+        upsert_config_block(
+            &path,
+            "project-id:production-id:service-id",
+            "api",
+            &updated_prod_block,
+        )
+        .unwrap();
+
+        let contents = fs::read_to_string(&path).unwrap();
+
+        assert_eq!(contents.matches("# BEGIN railway:").count(), 2);
+        assert!(contents.contains("Host railway-api-prod\n"));
+        assert!(contents.contains("    User updated-prod-instance-id\n"));
+        assert!(contents.contains("Host railway-api-staging\n"));
+        assert!(contents.contains("    User staging-instance-id\n"));
+        assert!(!contents.contains("    User prod-instance-id\n"));
+    }
+
+    #[test]
+    fn remove_target_keeps_same_service_name_for_other_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".ssh/config");
+
+        let prod_block = render_config_block(
+            "api",
+            "project-id:production-id:service-id",
+            "railway-api",
+            "prod-instance-id",
+            None,
+        );
+        let staging_block = render_config_block(
+            "api",
+            "project-id:staging-id:service-id",
+            "railway-api-staging",
+            "staging-instance-id",
+            None,
+        );
+
+        upsert_config_block(
+            &path,
+            "project-id:production-id:service-id",
+            "api",
+            &prod_block,
+        )
+        .unwrap();
+        upsert_config_block(
+            &path,
+            "project-id:staging-id:service-id",
+            "api",
+            &staging_block,
+        )
+        .unwrap();
+
+        assert!(
+            remove_config_block_for_target(&path, "project-id:production-id:service-id", "api")
+                .unwrap()
+        );
+
+        let contents = fs::read_to_string(&path).unwrap();
+
+        assert_eq!(contents.matches("# BEGIN railway:").count(), 1);
+        assert!(!contents.contains("prod-instance-id"));
+        assert!(contents.contains("staging-instance-id"));
+    }
+
     #[tokio::test]
     async fn remove_with_service_arg_deletes_marked_block_without_resolving() {
         let dir = tempfile::tempdir().unwrap();
@@ -538,6 +816,11 @@ Host existing
 # BEGIN railway:API
 Host old
 # END railway:API
+
+# BEGIN railway:project-id:environment-id:service-id
+# Railway service: API
+Host new
+# END railway:project-id:environment-id:service-id
 Host later
 ",
         )

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -54,7 +54,7 @@ pub struct Args {
 struct ResolvedConfig {
     service_name: String,
     alias: String,
-    service_instance_id: Option<String>,
+    service_instance_id: String,
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -62,73 +62,32 @@ pub async fn command(args: Args) -> Result<()> {
         bail!("--write and --remove cannot be used together");
     }
 
-    let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
-    let params = get_ssh_connect_params(
-        super::Args {
-            subcommand: None,
-            project: args.project.clone(),
-            service: args.service.clone(),
-            environment: args.environment.clone(),
-            deployment_instance: None,
-            session: None,
-            native: false,
-            identity_file: None,
-            command: Vec::new(),
-        },
-        &configs,
-        &client,
-    )
-    .await?;
-
-    let alias = args
-        .alias
-        .as_deref()
-        .map(sanitize_alias)
-        .unwrap_or_else(|| format!("railway-{}", sanitize_alias(&params.service_name)));
-
-    let service_instance_id = if args.remove {
-        None
-    } else {
-        Some(
-            native::get_service_instance_id(
-                &client,
-                &configs,
-                &params.environment_id,
-                &params.service_id,
-            )
-            .await?,
-        )
-    };
-
-    let resolved = ResolvedConfig {
-        service_name: params.service_name,
-        alias,
-        service_instance_id,
-    };
-
     if args.remove {
+        let service_name = if let Some(service_name) = args.service.as_deref() {
+            service_name.to_string()
+        } else {
+            resolve_service_name(args.clone()).await?
+        };
+
         let path = expand_tilde(&args.path)?;
-        let removed = remove_config_block(&path, &resolved.service_name)?;
+        let removed = remove_config_block(&path, &service_name)?;
         if removed {
             eprintln!("Removed Railway SSH config block from {}", path.display());
         } else {
             eprintln!(
                 "No Railway SSH config block found for {} in {}",
-                resolved.service_name,
+                service_name,
                 path.display()
             );
         }
         return Ok(());
     }
 
+    let resolved = resolve(args.clone()).await?;
     let block = render_config_block(
         &resolved.service_name,
         &resolved.alias,
-        resolved
-            .service_instance_id
-            .as_deref()
-            .context("service instance ID is required to render SSH config")?,
+        &resolved.service_instance_id,
         args.identity_file.as_deref(),
         &Utc::now().format("%Y-%m-%d").to_string(),
     );
@@ -142,6 +101,56 @@ pub async fn command(args: Args) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn resolve(args: Args) -> Result<ResolvedConfig> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let params =
+        get_ssh_connect_params(ssh_args_from_config_args(&args), &configs, &client).await?;
+
+    let alias = args
+        .alias
+        .as_deref()
+        .map(sanitize_alias)
+        .unwrap_or_else(|| format!("railway-{}", sanitize_alias(&params.service_name)));
+
+    let service_instance_id = native::get_service_instance_id(
+        &client,
+        &configs,
+        &params.environment_id,
+        &params.service_id,
+    )
+    .await?;
+
+    Ok(ResolvedConfig {
+        service_name: params.service_name,
+        alias,
+        service_instance_id,
+    })
+}
+
+async fn resolve_service_name(args: Args) -> Result<String> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let params =
+        get_ssh_connect_params(ssh_args_from_config_args(&args), &configs, &client).await?;
+
+    Ok(params.service_name)
+}
+
+fn ssh_args_from_config_args(args: &Args) -> super::Args {
+    super::Args {
+        subcommand: None,
+        project: args.project.clone(),
+        service: args.service.clone(),
+        environment: args.environment.clone(),
+        deployment_instance: None,
+        session: None,
+        native: false,
+        identity_file: None,
+        command: Vec::new(),
+    }
 }
 
 fn render_config_block(
@@ -171,7 +180,7 @@ fn render_config_block(
         writeln!(
             block,
             "    IdentityFile {}",
-            identity_file.to_string_lossy()
+            quote_ssh_config_value(&identity_file.to_string_lossy())
         )
         .expect("writing to String cannot fail");
     }
@@ -334,6 +343,31 @@ fn sanitize_alias(input: &str) -> String {
     }
 }
 
+fn quote_ssh_config_value(value: &str) -> String {
+    if !value
+        .chars()
+        .any(|c| c.is_whitespace() || matches!(c, '"' | '\\'))
+    {
+        return value.to_string();
+    }
+
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+
+    for c in value.chars() {
+        match c {
+            '"' => quoted.push_str("\\\""),
+            '\\' => quoted.push_str("\\\\"),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            _ => quoted.push(c),
+        }
+    }
+
+    quoted.push('"');
+    quoted
+}
+
 fn expand_tilde(path: &Path) -> Result<PathBuf> {
     let path = path.to_string_lossy();
 
@@ -375,7 +409,7 @@ mod tests {
             "API",
             "railway-api",
             "new-id",
-            Some(Path::new("~/.ssh/id_ed25519")),
+            Some(Path::new("/Users/me/My Keys/id_ed25519")),
             "2026-05-18",
         );
 
@@ -391,7 +425,7 @@ mod tests {
         assert!(contents.contains("Host railway-api\n"));
         assert!(contents.contains("    HostName ssh.railway.com\n"));
         assert!(contents.contains("    User new-id\n"));
-        assert!(contents.contains("    IdentityFile ~/.ssh/id_ed25519\n"));
+        assert!(contents.contains("    IdentityFile \"/Users/me/My Keys/id_ed25519\"\n"));
         assert!(!contents.contains("old-id"));
 
         #[cfg(unix)]
@@ -410,8 +444,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn remove_deletes_marked_block_and_is_noop_when_absent() {
+    #[tokio::test]
+    async fn remove_with_service_arg_deletes_marked_block_without_resolving() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".ssh/config");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -428,11 +462,35 @@ Host later
         )
         .unwrap();
 
-        assert!(remove_config_block(&path, "API").unwrap());
+        command(Args {
+            project: None,
+            service: Some("API".to_string()),
+            environment: None,
+            alias: None,
+            identity_file: None,
+            write: false,
+            remove: true,
+            path: path.clone(),
+        })
+        .await
+        .unwrap();
+
         assert_eq!(
             fs::read_to_string(&path).unwrap(),
             "Host existing\nHost later\n"
         );
-        assert!(!remove_config_block(&path, "API").unwrap());
+
+        command(Args {
+            project: None,
+            service: Some("API".to_string()),
+            environment: None,
+            alias: None,
+            identity_file: None,
+            write: false,
+            remove: true,
+            path,
+        })
+        .await
+        .unwrap();
     }
 }

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -206,7 +206,7 @@ fn upsert_config_block(path: &Path, service_name: &str, block: &str) -> Result<(
 
 fn remove_config_block(path: &Path, service_name: &str) -> Result<bool> {
     let existing = read_config(path)?;
-    let pattern = config_block_regex(service_name, true)?;
+    let pattern = config_block_regex_with_case(service_name, true, true)?;
 
     if !pattern.is_match(&existing) {
         return Ok(false);
@@ -299,14 +299,23 @@ fn append_config_block(mut existing: String, block: &str) -> String {
 }
 
 fn config_block_regex(service_name: &str, include_preceding_blank: bool) -> Result<Regex> {
+    config_block_regex_with_case(service_name, include_preceding_blank, false)
+}
+
+fn config_block_regex_with_case(
+    service_name: &str,
+    include_preceding_blank: bool,
+    case_insensitive: bool,
+) -> Result<Regex> {
     let marker = regex::escape(&marker_name(service_name));
     let preceding_blank = if include_preceding_blank {
         r"(?:^[ \t]*\r?\n)?"
     } else {
         ""
     };
+    let flags = if case_insensitive { "(?ims)" } else { "(?ms)" };
     Regex::new(&format!(
-        r"(?ms){preceding_blank}^# BEGIN railway:{marker}(?: .*)?\r?\n.*?^# END railway:{marker}[ \t]*(?:\r?\n)?"
+        r"{flags}{preceding_blank}^# BEGIN railway:{marker}(?: .*)?\r?\n.*?^# END railway:{marker}[ \t]*(?:\r?\n)?"
     ))
     .context("Failed to build Railway SSH config marker regex")
 }
@@ -464,7 +473,7 @@ Host later
 
         command(Args {
             project: None,
-            service: Some("API".to_string()),
+            service: Some("api".to_string()),
             environment: None,
             alias: None,
             identity_file: None,

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -5,9 +5,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
-use chrono::Utc;
-use clap::Parser;
+use anyhow::{Context, Result, bail};
+use clap::{Args as ClapArgs, Parser, Subcommand};
 use is_terminal::IsTerminal;
 use regex::{NoExpand, Regex};
 use tempfile::NamedTempFile;
@@ -16,21 +15,14 @@ use crate::{client::GQLClient, config::Configs, errors::RailwayError};
 
 use super::{common::get_ssh_connect_params, native};
 
-/// Emit or manage an OpenSSH config block for a Railway service
+/// Add, preview, or remove an OpenSSH config block for a Railway service
 #[derive(Parser, Clone)]
 pub struct Args {
-    /// Project to connect to (defaults to linked project)
-    #[clap(short, long)]
-    project: Option<String>,
+    #[clap(subcommand)]
+    command: Option<Commands>,
 
-    /// Service to connect to (defaults to linked service).
-    /// With --remove, this can remove a local marker by service name without resolving Railway.
-    #[clap(short, long)]
-    service: Option<String>,
-
-    /// Environment to connect to (defaults to linked environment)
-    #[clap(short, long)]
-    environment: Option<String>,
+    #[clap(flatten)]
+    target: TargetArgs,
 
     /// Host alias to use in the SSH config
     #[clap(long)]
@@ -40,17 +32,47 @@ pub struct Args {
     #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
     identity_file: Option<PathBuf>,
 
-    /// Insert or update the generated block in the SSH config file
-    #[clap(long, conflicts_with = "remove")]
-    write: bool,
+    /// Print the generated block without writing the SSH config file
+    #[clap(long)]
+    dry_run: bool,
+}
 
-    /// Remove the generated block from the SSH config file
-    #[clap(long, conflicts_with = "write")]
-    remove: bool,
+#[derive(Subcommand, Clone)]
+enum Commands {
+    /// Remove the Railway block from the SSH config file
+    #[clap(visible_alias = "rm")]
+    Remove,
+}
 
-    /// SSH config file to update
-    #[clap(long, default_value = "~/.ssh/config")]
+#[derive(ClapArgs, Clone)]
+struct TargetArgs {
+    /// Project to use (defaults to linked project)
+    #[clap(short, long, global = true)]
+    project: Option<String>,
+
+    /// Service to use (defaults to linked service).
+    /// With remove, this can remove a local marker by service name without resolving Railway.
+    #[clap(short, long, global = true)]
+    service: Option<String>,
+
+    /// Environment to use (defaults to linked environment)
+    #[clap(short, long, global = true)]
+    environment: Option<String>,
+
+    /// SSH config file to update or remove from
+    #[clap(long, default_value = "~/.ssh/config", global = true)]
     path: PathBuf,
+}
+
+impl Default for TargetArgs {
+    fn default() -> Self {
+        Self {
+            project: None,
+            service: None,
+            environment: None,
+            path: PathBuf::from("~/.ssh/config"),
+        }
+    }
 }
 
 struct ResolvedConfig {
@@ -60,52 +82,65 @@ struct ResolvedConfig {
 }
 
 pub async fn command(args: Args) -> Result<()> {
-    ensure_default_target_has_linked_service(&args).await?;
-
-    if args.remove {
-        let service_name = if let Some(service_name) = args.service.as_deref() {
-            service_name.to_string()
-        } else {
-            resolve_service_name(args.clone()).await?
-        };
-
-        let path = expand_tilde(&args.path)?;
-        let removed = remove_config_block(&path, &service_name)?;
-        if removed {
-            eprintln!("Removed Railway SSH config block from {}", path.display());
-        } else {
-            eprintln!(
-                "No Railway SSH config block found for {} in {}",
-                service_name,
-                path.display()
-            );
+    if let Some(Commands::Remove) = args.command {
+        if args.alias.is_some() {
+            bail!("--alias cannot be used with remove");
         }
-        return Ok(());
+        if args.identity_file.is_some() {
+            bail!("--identity-file cannot be used with remove");
+        }
+        if args.dry_run {
+            bail!("--dry-run cannot be used with remove");
+        }
+
+        return remove_command(args.target).await;
     }
 
-    let resolved = resolve(args.clone()).await?;
+    ensure_default_target_has_linked_service(&args.target).await?;
+
+    let resolved = resolve(&args.target, args.alias.as_deref()).await?;
     let block = render_config_block(
         &resolved.service_name,
         &resolved.alias,
         &resolved.service_instance_id,
         args.identity_file.as_deref(),
-        &Utc::now().format("%Y-%m-%d").to_string(),
     );
 
-    if args.write {
-        let path = expand_tilde(&args.path)?;
+    if args.dry_run {
+        print!("{block}");
+    } else {
+        let path = expand_tilde(&args.target.path)?;
         upsert_config_block(&path, &resolved.service_name, &block)?;
         eprintln!("Wrote Railway SSH config block to {}", path.display());
-    } else {
-        print!("{block}");
     }
 
     Ok(())
 }
 
-async fn ensure_default_target_has_linked_service(args: &Args) -> Result<()> {
-    if args.remove || args.project.is_some() || args.environment.is_some() || args.service.is_some()
-    {
+async fn remove_command(target: TargetArgs) -> Result<()> {
+    let service_name = if let Some(service_name) = target.service.as_deref() {
+        service_name.to_string()
+    } else {
+        resolve_service_name(&target).await?
+    };
+
+    let path = expand_tilde(&target.path)?;
+    let removed = remove_config_block(&path, &service_name)?;
+    if removed {
+        eprintln!("Removed Railway SSH config block from {}", path.display());
+    } else {
+        eprintln!(
+            "No Railway SSH config block found for {} in {}",
+            service_name,
+            path.display()
+        );
+    }
+
+    Ok(())
+}
+
+async fn ensure_default_target_has_linked_service(target: &TargetArgs) -> Result<()> {
+    if target.project.is_some() || target.environment.is_some() || target.service.is_some() {
         return Ok(());
     }
     if !std::io::stdout().is_terminal() {
@@ -132,15 +167,13 @@ async fn ensure_default_target_has_linked_service(args: &Args) -> Result<()> {
     }
 }
 
-async fn resolve(args: Args) -> Result<ResolvedConfig> {
+async fn resolve(target: &TargetArgs, alias: Option<&str>) -> Result<ResolvedConfig> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let params =
-        get_ssh_connect_params(ssh_args_from_config_args(&args), &configs, &client).await?;
+        get_ssh_connect_params(ssh_args_from_target_args(target), &configs, &client).await?;
 
-    let alias = args
-        .alias
-        .as_deref()
+    let alias = alias
         .map(sanitize_alias)
         .unwrap_or_else(|| format!("railway-{}", sanitize_alias(&params.service_name)));
 
@@ -159,21 +192,21 @@ async fn resolve(args: Args) -> Result<ResolvedConfig> {
     })
 }
 
-async fn resolve_service_name(args: Args) -> Result<String> {
+async fn resolve_service_name(target: &TargetArgs) -> Result<String> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let params =
-        get_ssh_connect_params(ssh_args_from_config_args(&args), &configs, &client).await?;
+        get_ssh_connect_params(ssh_args_from_target_args(target), &configs, &client).await?;
 
     Ok(params.service_name)
 }
 
-fn ssh_args_from_config_args(args: &Args) -> super::Args {
+fn ssh_args_from_target_args(target: &TargetArgs) -> super::Args {
     super::Args {
         subcommand: None,
-        project: args.project.clone(),
-        service: args.service.clone(),
-        environment: args.environment.clone(),
+        project: target.project.clone(),
+        service: target.service.clone(),
+        environment: target.environment.clone(),
         deployment_instance: None,
         session: None,
         native: false,
@@ -187,20 +220,11 @@ fn render_config_block(
     alias: &str,
     service_instance_id: &str,
     identity_file: Option<&Path>,
-    date: &str,
 ) -> String {
     let marker_name = marker_name(service_name);
     let mut block = String::new();
-    writeln!(
-        block,
-        "# BEGIN railway:{marker_name} ----- written {date} by `railway ssh config`"
-    )
-    .expect("writing to String cannot fail");
-    writeln!(
-        block,
-        "# If you rename, delete, or re-add this service, re-run this command."
-    )
-    .expect("writing to String cannot fail");
+
+    writeln!(block, "# BEGIN railway:{marker_name}").expect("writing to String cannot fail");
     writeln!(block, "Host {alias}").expect("writing to String cannot fail");
     writeln!(block, "    HostName {}", native::SSH_HOST).expect("writing to String cannot fail");
     writeln!(block, "    User {service_instance_id}").expect("writing to String cannot fail");
@@ -343,7 +367,7 @@ fn config_block_regex_with_case(
     };
     let flags = if case_insensitive { "(?ims)" } else { "(?ms)" };
     Regex::new(&format!(
-        r"{flags}{preceding_blank}^# BEGIN railway:{marker}(?: .*)?\r?\n.*?^# END railway:{marker}[ \t]*(?:\r?\n)?"
+        r"{flags}{preceding_blank}^# BEGIN railway:{marker}[ \t]*\r?\n.*?^# END railway:{marker}[ \t]*(?:\r?\n)?"
     ))
     .context("Failed to build Railway SSH config marker regex")
 }
@@ -435,19 +459,36 @@ mod tests {
     }
 
     #[test]
-    fn write_upserts_block_idempotently_and_sets_permissions() {
+    fn renders_config_block_with_minimal_markers() {
+        let block = render_config_block("api", "railway-api", "instance-id", None);
+
+        assert_eq!(
+            block,
+            "\
+# BEGIN railway:api
+Host railway-api
+    HostName ssh.railway.com
+    User instance-id
+    ServerAliveInterval 30
+    ServerAliveCountMax 3
+# END railway:api
+"
+        );
+    }
+
+    #[test]
+    fn upserts_block_idempotently_and_sets_permissions() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".ssh/config");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "Host existing\n    HostName example.com\n").unwrap();
 
-        let old_block = render_config_block("API", "railway-api", "old-id", None, "2026-05-17");
+        let old_block = render_config_block("API", "railway-api", "old-id", None);
         let new_block = render_config_block(
             "api",
             "railway-api",
             "new-id",
             Some(Path::new("/Users/me/My Keys/id_ed25519")),
-            "2026-05-18",
         );
 
         upsert_config_block(&path, "API", &old_block).unwrap();
@@ -458,11 +499,14 @@ mod tests {
 
         assert_eq!(contents.matches("# BEGIN railway:").count(), 1);
         assert!(contents.starts_with("Host existing\n    HostName example.com\n\n"));
-        assert!(contents.contains("# BEGIN railway:api ----- written 2026-05-18"));
+        assert!(contents.contains("# BEGIN railway:api\n"));
         assert!(contents.contains("Host railway-api\n"));
         assert!(contents.contains("    HostName ssh.railway.com\n"));
         assert!(contents.contains("    User new-id\n"));
         assert!(contents.contains("    IdentityFile \"/Users/me/My Keys/id_ed25519\"\n"));
+        assert!(contents.contains("# END railway:api\n"));
+        assert!(!contents.contains("written"));
+        assert!(!contents.contains("If you rename"));
         assert!(!contents.contains("old-id"));
 
         #[cfg(unix)]
@@ -491,7 +535,7 @@ mod tests {
             "\
 Host existing
 
-# BEGIN railway:API ----- written 2026-01-01 by `railway ssh config`
+# BEGIN railway:API
 Host old
 # END railway:API
 Host later
@@ -500,14 +544,15 @@ Host later
         .unwrap();
 
         command(Args {
-            project: None,
-            service: Some("api".to_string()),
-            environment: None,
+            command: Some(Commands::Remove),
+            target: TargetArgs {
+                service: Some("api".to_string()),
+                path: path.clone(),
+                ..TargetArgs::default()
+            },
             alias: None,
             identity_file: None,
-            write: false,
-            remove: true,
-            path: path.clone(),
+            dry_run: false,
         })
         .await
         .unwrap();
@@ -518,14 +563,15 @@ Host later
         );
 
         command(Args {
-            project: None,
-            service: Some("API".to_string()),
-            environment: None,
+            command: Some(Commands::Remove),
+            target: TargetArgs {
+                service: Some("API".to_string()),
+                path,
+                ..TargetArgs::default()
+            },
             alias: None,
             identity_file: None,
-            write: false,
-            remove: true,
-            path,
+            dry_run: false,
         })
         .await
         .unwrap();

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -5,13 +5,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use chrono::Utc;
 use clap::Parser;
+use is_terminal::IsTerminal;
 use regex::{NoExpand, Regex};
 use tempfile::NamedTempFile;
 
-use crate::{client::GQLClient, config::Configs};
+use crate::{client::GQLClient, config::Configs, errors::RailwayError};
 
 use super::{common::get_ssh_connect_params, native};
 
@@ -22,7 +23,8 @@ pub struct Args {
     #[clap(short, long)]
     project: Option<String>,
 
-    /// Service to connect to (defaults to linked service)
+    /// Service to connect to (defaults to linked service).
+    /// With --remove, this can remove a local marker by service name without resolving Railway.
     #[clap(short, long)]
     service: Option<String>,
 
@@ -34,16 +36,16 @@ pub struct Args {
     #[clap(long)]
     alias: Option<String>,
 
-    /// Path to identity (private key) file to use
+    /// Emit an IdentityFile directive for this private key path
     #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
     identity_file: Option<PathBuf>,
 
-    /// Upsert the generated block into the SSH config file
-    #[clap(long)]
+    /// Insert or update the generated block in the SSH config file
+    #[clap(long, conflicts_with = "remove")]
     write: bool,
 
     /// Remove the generated block from the SSH config file
-    #[clap(long)]
+    #[clap(long, conflicts_with = "write")]
     remove: bool,
 
     /// SSH config file to update
@@ -58,9 +60,7 @@ struct ResolvedConfig {
 }
 
 pub async fn command(args: Args) -> Result<()> {
-    if args.write && args.remove {
-        bail!("--write and --remove cannot be used together");
-    }
+    ensure_default_target_has_linked_service(&args).await?;
 
     if args.remove {
         let service_name = if let Some(service_name) = args.service.as_deref() {
@@ -101,6 +101,35 @@ pub async fn command(args: Args) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn ensure_default_target_has_linked_service(args: &Args) -> Result<()> {
+    if args.remove || args.project.is_some() || args.environment.is_some() || args.service.is_some()
+    {
+        return Ok(());
+    }
+    if !std::io::stdout().is_terminal() {
+        return Ok(());
+    }
+
+    let configs = Configs::new()?;
+    match configs.get_linked_project().await {
+        Ok(linked_project) if linked_project.service.is_some() => Ok(()),
+        Ok(_) => crate::commands::service::link_current_project_service(None).await,
+        Err(error) => {
+            if error
+                .downcast_ref::<RailwayError>()
+                .is_some_and(|error| matches!(error, RailwayError::NoLinkedProject))
+            {
+                crate::commands::link::command_requiring_service(
+                    crate::commands::link::Args::for_service_link(None, None, None),
+                )
+                .await
+            } else {
+                Err(error)
+            }
+        }
+    }
 }
 
 async fn resolve(args: Args) -> Result<ResolvedConfig> {
@@ -169,7 +198,7 @@ fn render_config_block(
     .expect("writing to String cannot fail");
     writeln!(
         block,
-        "# If you delete and re-add this service, re-run this command."
+        "# If you rename, delete, or re-add this service, re-run this command."
     )
     .expect("writing to String cannot fail");
     writeln!(block, "Host {alias}").expect("writing to String cannot fail");
@@ -194,7 +223,7 @@ fn render_config_block(
 
 fn upsert_config_block(path: &Path, service_name: &str, block: &str) -> Result<()> {
     let existing = read_config(path)?;
-    let pattern = config_block_regex(service_name, false)?;
+    let pattern = config_block_regex_with_case(service_name, false, true)?;
     let updated = if pattern.is_match(&existing) {
         pattern.replace(&existing, NoExpand(block)).into_owned()
     } else {
@@ -227,13 +256,10 @@ fn read_config(path: &Path) -> Result<String> {
 }
 
 fn write_config(path: &Path, contents: &str) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
-        secure_ssh_dir(parent)?;
-    }
+    let parent = writable_parent(path);
+    fs::create_dir_all(parent).with_context(|| format!("Failed to create {}", parent.display()))?;
+    secure_ssh_dir(parent)?;
 
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let mut temp_file = NamedTempFile::new_in(parent)
         .with_context(|| format!("Failed to create temporary file in {}", parent.display()))?;
     temp_file
@@ -251,6 +277,12 @@ fn write_config(path: &Path, contents: &str) -> Result<()> {
     secure_file(path)?;
 
     Ok(())
+}
+
+fn writable_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
 }
 
 #[cfg(unix)]
@@ -296,10 +328,6 @@ fn append_config_block(mut existing: String, block: &str) -> String {
 
     existing.push_str(block);
     existing
-}
-
-fn config_block_regex(service_name: &str, include_preceding_blank: bool) -> Result<Regex> {
-    config_block_regex_with_case(service_name, include_preceding_blank, false)
 }
 
 fn config_block_regex_with_case(
@@ -415,7 +443,7 @@ mod tests {
 
         let old_block = render_config_block("API", "railway-api", "old-id", None, "2026-05-17");
         let new_block = render_config_block(
-            "API",
+            "api",
             "railway-api",
             "new-id",
             Some(Path::new("/Users/me/My Keys/id_ed25519")),
@@ -423,14 +451,14 @@ mod tests {
         );
 
         upsert_config_block(&path, "API", &old_block).unwrap();
-        upsert_config_block(&path, "API", &new_block).unwrap();
-        upsert_config_block(&path, "API", &new_block).unwrap();
+        upsert_config_block(&path, "api", &new_block).unwrap();
+        upsert_config_block(&path, "api", &new_block).unwrap();
 
         let contents = fs::read_to_string(&path).unwrap();
 
-        assert_eq!(contents.matches("# BEGIN railway:API").count(), 1);
+        assert_eq!(contents.matches("# BEGIN railway:").count(), 1);
         assert!(contents.starts_with("Host existing\n    HostName example.com\n\n"));
-        assert!(contents.contains("# BEGIN railway:API ----- written 2026-05-18"));
+        assert!(contents.contains("# BEGIN railway:api ----- written 2026-05-18"));
         assert!(contents.contains("Host railway-api\n"));
         assert!(contents.contains("    HostName ssh.railway.com\n"));
         assert!(contents.contains("    User new-id\n"));

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use crate::{client::GQLClient, config::Configs};
 
 mod common;
+mod config;
 mod keys;
 mod native;
 mod tel;
@@ -55,13 +56,18 @@ pub struct Args {
 
 #[derive(Parser, Clone)]
 enum Commands {
+    /// Emit or manage an OpenSSH config block for a service
+    Config(config::Args),
+
     /// Manage SSH keys registered with Railway
     Keys(keys::Args),
 }
 
 pub async fn command(args: Args) -> Result<()> {
-    if let Some(Commands::Keys(keys_args)) = args.subcommand {
-        return keys::command(keys_args).await;
+    match args.subcommand {
+        Some(Commands::Config(config_args)) => return config::command(config_args).await,
+        Some(Commands::Keys(keys_args)) => return keys::command(keys_args).await,
+        None => {}
     }
 
     if args.native {

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -56,7 +56,7 @@ pub struct Args {
 
 #[derive(Parser, Clone)]
 enum Commands {
-    /// Emit or manage an OpenSSH config block for a service
+    /// Add, preview, or remove an OpenSSH config block for a service
     Config(config::Args),
 
     /// Manage SSH keys registered with Railway

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -12,7 +12,7 @@ use crate::controllers::ssh_keys::{find_local_ssh_keys, register_ssh_key};
 use crate::gql::queries::{ServiceInstance, service_instance};
 use crate::util::prompt::{prompt_confirm_with_default, prompt_select};
 
-const SSH_HOST: &str = "ssh.railway.com";
+pub(super) const SSH_HOST: &str = "ssh.railway.com";
 
 /// Get the service instance ID for a service in an environment
 pub async fn get_service_instance_id(


### PR DESCRIPTION
## Summary

Adds `railway ssh config`, a new subcommand that configures OpenSSH for a Railway service.

This unlocks tools that read `~/.ssh/config`, including VS Code Remote-SSH, Cursor, Zed, JetBrains Gateway, `scp`, `rsync`, and `sshfs`.

## What Changed

- Added `railway ssh config` to idempotently add or update a marked Railway `Host` block in `~/.ssh/config`.
- Added `railway ssh config --dry-run` to print the exact block without writing the SSH config file.
- Added `railway ssh config remove` and `railway ssh config rm` to remove the marked block.
- Added `--path` for alternate SSH config files.
- Added `--alias` for custom `Host` aliases.
- Added `-i/--identity-file` to emit an `IdentityFile` directive.
- Reuses the existing SSH resolution path for project, environment, and service selection.
- Uses the stable `ServiceInstance.id` as the OpenSSH `User`.
- Writes config changes atomically and sets Unix SSH config permissions.
- Allows `remove -s <service>` to remove local blocks without requiring live service resolution.

## Command Structure

```sh
railway ssh config              # add/update ~/.ssh/config
railway ssh config --dry-run    # print block, no write
railway ssh config remove       # remove block
railway ssh config rm           # alias
```

## Example Outputs

Default write:

```txt
Wrote Railway SSH config block to /Users/mahmoud/.ssh/config
```

Dry run:

```sshconfig
# BEGIN railway:codex-anywhere
Host railway-codex-anywhere
    HostName ssh.railway.com
    User 782c77de-d68b-49a3-a2a9-7935b6fedd17
    ServerAliveInterval 30
    ServerAliveCountMax 3
# END railway:codex-anywhere
```

Remove:

```txt
Removed Railway SSH config block from /Users/mahmoud/.ssh/config
```

No-op remove:

```txt
No Railway SSH config block found for codex-anywhere in /Users/mahmoud/.ssh/config
```

## Help Text

```txt
Add, preview, or remove an OpenSSH config block for a service

Usage: railway ssh config [OPTIONS] [COMMAND]

Commands:
  remove  Remove the Railway block from the SSH config file [aliases: rm]
  help    Print this message or the help of the given subcommand(s)

Options:
  -p, --project <PROJECT>          Project to use (defaults to linked project)
  -s, --service <SERVICE>          Service to use (defaults to linked service). With remove, this can remove a local marker by service name without resolving Railway
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
      --path <PATH>                SSH config file to update or remove from [default: ~/.ssh/config]
      --alias <ALIAS>              Host alias to use in the SSH config
  -i, --identity-file <PATH>       Emit an IdentityFile directive for this private key path
      --dry-run                    Print the generated block without writing the SSH config file
  -h, --help                       Print help
  -V, --version                    Print version
```
