### PR TITLE
Add CLI support for creating and publishing templates

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -49,6 +49,23 @@ impl GQLClient {
         Ok(Self::build_client(headers))
     }
 
+    pub fn new_user_authorized(configs: &Configs) -> Result<Client, RailwayError> {
+        let mut headers = HeaderMap::new();
+        if let Some(token) = configs.get_railway_auth_token() {
+            headers.insert(
+                "authorization",
+                HeaderValue::from_str(&format!("Bearer {token}"))?,
+            );
+        } else {
+            return Err(RailwayError::Unauthorized);
+        }
+        headers.insert(
+            "x-source",
+            HeaderValue::from_static(consts::get_user_agent()),
+        );
+        Ok(Self::build_client(headers))
+    }
+
     fn build_client(headers: HeaderMap) -> Client {
         Client::builder()
             .danger_accept_invalid_certs(matches!(Configs::get_environment_id(), Environment::Dev))

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -27,7 +27,7 @@ use tokio::{sync::mpsc, time::Instant};
 use crate::{
     client::post_graphql,
     consts::TICK_STRING,
-    controllers::{environment::get_matched_environment, project::get_project},
+    controllers::project::get_project,
     errors::RailwayError,
     util::{
         progress::create_spinner_if,
@@ -91,8 +91,6 @@ const DEFAULT_README_TEXT: &[&str] = &[
     "[Include Github",
 ];
 const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "avif", "gif", "svg", "ico"];
-const GENERATE_SOURCE_PROJECT: &str = "Entire project (dashboard default)";
-const GENERATE_SOURCE_ENVIRONMENT: &str = "Specific environment";
 const README_SOURCE_EXISTING: &str = "Use existing README";
 const README_SOURCE_GENERATED: &str = "Use generated README";
 const README_SOURCE_FILE: &str = "Read from file";
@@ -158,16 +156,12 @@ struct SearchArgs {
 
 #[derive(Parser, Clone)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --json\n  railway templates create --project project-id --environment production --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it creates an unpublished template from a project.\n  By default generation is project-level. Pass --environment only when you intentionally want to generate from one environment.\n  In interactive mode, omitted project and source choices are prompted."
+    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it clones a project into an unpublished template draft.\n  The generated template opens in the dashboard template editor for cleanup before publishing.\n  In interactive mode, an omitted project is prompted."
 )]
 struct CreateArgs {
     /// Project ID or name. Defaults to the linked project.
     #[arg(short, long)]
     project: Option<String>,
-
-    /// Environment ID or name to generate from. Defaults to the dashboard behavior: project-level generation.
-    #[arg(short, long)]
-    environment: Option<String>,
 
     /// Print the created template as JSON
     #[arg(long)]
@@ -280,23 +274,12 @@ async fn create_command(args: CreateArgs) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_user_authorized(&configs)?;
     let project_id = resolve_template_project(&client, &configs, args.project, interactive).await?;
-    let environment_id = resolve_template_environment(
-        &client,
-        &configs,
-        &project_id,
-        args.environment,
-        interactive,
-    )
-    .await?;
 
     let spinner = create_spinner_if(!args.json, "Creating template...".to_string());
     let response = post_graphql::<mutations::TemplateGenerate, _>(
         &client,
         configs.get_backboard(),
-        mutations::template_generate::Variables {
-            project_id,
-            environment_id,
-        },
+        mutations::template_generate::Variables { project_id },
     )
     .await?;
 
@@ -496,18 +479,6 @@ impl std::fmt::Display for TemplateProjectChoice {
     }
 }
 
-#[derive(Clone)]
-struct TemplateEnvironmentChoice {
-    id: String,
-    name: String,
-}
-
-impl std::fmt::Display for TemplateEnvironmentChoice {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-
 async fn resolve_template_project(
     client: &reqwest::Client,
     configs: &Configs,
@@ -560,63 +531,6 @@ async fn resolve_project_arg(
     let choice = find_project_choice(client, configs, project).await?;
     fake_select("Select project", &choice.to_string());
     Ok(choice.id)
-}
-
-async fn resolve_template_environment(
-    client: &reqwest::Client,
-    configs: &Configs,
-    project_id: &str,
-    environment: Option<String>,
-    interactive: bool,
-) -> Result<Option<String>> {
-    let project = get_project(client, configs, project_id.to_string()).await?;
-    if project.deleted_at.is_some() {
-        bail!(RailwayError::ProjectDeleted);
-    }
-
-    if let Some(environment) = environment {
-        let environment = get_matched_environment(&project, environment)?;
-        fake_select("Select environment", &environment.name);
-        return Ok(Some(environment.id));
-    }
-
-    if !interactive {
-        return Ok(None);
-    }
-
-    let source = prompt_options(
-        "Generate source",
-        vec![
-            GENERATE_SOURCE_PROJECT.to_string(),
-            GENERATE_SOURCE_ENVIRONMENT.to_string(),
-        ],
-    )?;
-    if source == GENERATE_SOURCE_PROJECT {
-        return Ok(None);
-    }
-
-    Ok(Some(prompt_template_environment(&project)?))
-}
-
-fn prompt_template_environment(project: &queries::RailwayProject) -> Result<String> {
-    let all_environments = &project.environments.edges;
-    let environments = all_environments
-        .iter()
-        .filter(|environment| environment.node.can_access && environment.node.deleted_at.is_none())
-        .map(|environment| TemplateEnvironmentChoice {
-            id: environment.node.id.clone(),
-            name: environment.node.name.clone(),
-        })
-        .collect::<Vec<_>>();
-
-    if environments.is_empty() {
-        if all_environments.is_empty() {
-            bail!("Project has no environments");
-        }
-        bail!("All environments in this project are restricted or deleted");
-    }
-
-    Ok(prompt_options("Select environment", environments)?.id)
 }
 
 async fn find_project_choice(

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -31,7 +31,11 @@ use crate::{
     errors::RailwayError,
     util::{
         progress::create_spinner_if,
-        prompt::{fake_select, prompt_options, prompt_text_with_placeholder_disappear},
+        prompt::{
+            fake_select, prompt_confirm_with_default, prompt_options,
+            prompt_text_with_placeholder_disappear, prompt_text_with_placeholder_if_blank,
+        },
+        two_factor::validate_two_factor_if_enabled,
     },
     workspace::workspaces_with_client,
 };
@@ -87,6 +91,11 @@ const DEFAULT_README_TEXT: &[&str] = &[
     "[Include Github",
 ];
 const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "avif", "gif", "svg", "ico"];
+const GENERATE_SOURCE_PROJECT: &str = "Entire project (dashboard default)";
+const GENERATE_SOURCE_ENVIRONMENT: &str = "Specific environment";
+const README_SOURCE_EXISTING: &str = "Use existing README";
+const README_SOURCE_GENERATED: &str = "Use generated README";
+const README_SOURCE_FILE: &str = "Read from file";
 
 #[derive(Clone, Copy)]
 enum TerminalTheme {
@@ -97,7 +106,7 @@ enum TerminalTheme {
 /// Discover Railway templates
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
+    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates unpublish template-code --yes --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -116,6 +125,9 @@ enum Commands {
 
     /// Publish an unpublished template to the marketplace
     Publish(PublishArgs),
+
+    /// Unpublish a published template from the marketplace
+    Unpublish(UnpublishArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -146,7 +158,7 @@ struct SearchArgs {
 
 #[derive(Parser, Clone)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --json\n  railway templates create --project project-id --environment production --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it creates an unpublished template from a project.\n  By default generation is project-level. Pass --environment only when you intentionally want to generate from one environment."
+    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --json\n  railway templates create --project project-id --environment production --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it creates an unpublished template from a project.\n  By default generation is project-level. Pass --environment only when you intentionally want to generate from one environment.\n  In interactive mode, omitted project and source choices are prompted."
 )]
 struct CreateArgs {
     /// Project ID or name. Defaults to the linked project.
@@ -164,11 +176,11 @@ struct CreateArgs {
 
 #[derive(Parser, Clone)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  Use the template ID returned by `railway templates create --json`."
+    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  In interactive mode, omitted template and metadata fields are prompted.\n  Use the template ID returned by `railway templates create --json`."
 )]
 struct PublishArgs {
     /// Template ID or code
-    template: String,
+    template: Option<String>,
 
     /// Marketplace category
     #[arg(long)]
@@ -199,6 +211,27 @@ struct PublishArgs {
     workspace: Option<String>,
 
     /// Print the published template as JSON
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Parser, Clone)]
+#[clap(
+    after_help = "Examples:\n\n  railway templates unpublish template-code\n  railway templates unpublish template-id --yes --json\n\nAutomation notes:\n  Non-interactive unpublish requires --yes.\n  In interactive mode, omitted template is prompted."
+)]
+struct UnpublishArgs {
+    /// Template ID or code
+    template: Option<String>,
+
+    /// Skip confirmation dialog
+    #[arg(short = 'y', long = "yes")]
+    yes: bool,
+
+    /// 2FA code for verification when required by the current auth session
+    #[arg(long = "2fa-code")]
+    two_factor_code: Option<String>,
+
+    /// Print the unpublished template result as JSON
     #[arg(long)]
     json: bool,
 }
@@ -238,15 +271,23 @@ pub async fn command(args: Args) -> Result<()> {
         Commands::Search(args) => search_command(args).await,
         Commands::Create(args) => create_command(args).await,
         Commands::Publish(args) => publish_command(args).await,
+        Commands::Unpublish(args) => unpublish_command(args).await,
     }
 }
 
 async fn create_command(args: CreateArgs) -> Result<()> {
+    let interactive = is_interactive_output(args.json);
     let configs = Configs::new()?;
     let client = GQLClient::new_user_authorized(&configs)?;
-    let project_id = resolve_template_project(&client, &configs, args.project).await?;
-    let environment_id =
-        resolve_template_environment(&client, &configs, &project_id, args.environment).await?;
+    let project_id = resolve_template_project(&client, &configs, args.project, interactive).await?;
+    let environment_id = resolve_template_environment(
+        &client,
+        &configs,
+        &project_id,
+        args.environment,
+        interactive,
+    )
+    .await?;
 
     let spinner = create_spinner_if(!args.json, "Creating template...".to_string());
     let response = post_graphql::<mutations::TemplateGenerate, _>(
@@ -281,38 +322,40 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
         bail!("Use either --readme or --readme-file, not both");
     }
 
+    let interactive = is_interactive_output(args.json);
+    let template_ref = resolve_template_ref(args.template.clone(), interactive, "publish")?;
     let configs = Configs::new()?;
     let client = GQLClient::new_user_authorized(&configs)?;
-    let template = fetch_template_by_ref(&client, &configs, &args.template).await?;
+    let template = fetch_template_by_ref(&client, &configs, &template_ref).await?;
     let is_updating = matches!(
         &template.status,
         queries::template::TemplateStatus::PUBLISHED
     );
 
-    let category = args
-        .category
-        .clone()
-        .or_else(|| template.category.clone())
-        .unwrap_or_else(|| {
-            fake_select("Select category", "Other");
-            "Other".to_string()
-        });
-    let description = args
-        .description
-        .clone()
-        .or_else(|| template.description.clone())
-        .unwrap_or_else(|| short_description(&template.name));
-    let readme = resolve_readme(args.readme, args.readme_file, &template, is_updating)?;
-    let image = args
-        .image
-        .clone()
-        .or_else(|| template.image.clone())
-        .and_then(non_empty_string);
-    let demo_project_id = args
-        .demo_project
-        .clone()
-        .or_else(|| template.demo_project_id.clone())
-        .and_then(non_empty_string);
+    let category = resolve_publish_category(args.category.clone(), &template, interactive)?;
+    let description =
+        resolve_publish_description(args.description.clone(), &template, interactive)?;
+    let readme = resolve_readme(
+        args.readme,
+        args.readme_file,
+        &template,
+        is_updating,
+        interactive,
+    )?;
+    let image = resolve_optional_publish_field(
+        args.image.clone(),
+        template.image.clone(),
+        interactive,
+        "Image URL",
+        "<none>",
+    )?;
+    let demo_project_id = resolve_optional_publish_field(
+        args.demo_project.clone(),
+        template.demo_project_id.clone(),
+        interactive,
+        "Public demo project ID",
+        "<none>",
+    )?;
     let workspace_id = match args.workspace {
         Some(workspace) => Some(resolve_workspace_id(&client, &configs, &workspace).await?),
         None => template.workspace_id.clone(),
@@ -325,6 +368,21 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
         image.as_deref(),
         is_updating,
     )?;
+
+    if interactive
+        && !confirm_publish(
+            &template,
+            &category,
+            &description,
+            &readme,
+            image.as_deref(),
+            demo_project_id.as_deref(),
+            is_updating,
+        )?
+    {
+        println!("Publish cancelled.");
+        return Ok(());
+    }
 
     let spinner = create_spinner_if(!args.json, "Publishing template...".to_string());
     let response = post_graphql::<mutations::TemplatePublish, _>(
@@ -359,6 +417,72 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
     Ok(())
 }
 
+async fn unpublish_command(args: UnpublishArgs) -> Result<()> {
+    let interactive = is_interactive_output(args.json);
+    let template_ref = resolve_template_ref(args.template.clone(), interactive, "unpublish")?;
+    let configs = Configs::new()?;
+    let client = GQLClient::new_user_authorized(&configs)?;
+    let template = fetch_template_by_ref(&client, &configs, &template_ref).await?;
+
+    if !args.yes {
+        if !interactive {
+            bail!(
+                "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip confirmation."
+            );
+        }
+
+        let confirmed = prompt_confirm_with_default(
+            format!(
+                r#"Unpublish template "{}" from the marketplace?"#,
+                template.name.red()
+            )
+            .as_str(),
+            false,
+        )?;
+        if !confirmed {
+            println!("Unpublish cancelled.");
+            return Ok(());
+        }
+    }
+
+    validate_two_factor_if_enabled(&client, &configs, interactive, args.two_factor_code).await?;
+
+    let spinner = create_spinner_if(!args.json, "Unpublishing template...".to_string());
+    let response = post_graphql::<mutations::TemplateUnpublish, _>(
+        &client,
+        configs.get_backboard(),
+        mutations::template_unpublish::Variables {
+            id: template.id.clone(),
+        },
+    )
+    .await?;
+
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": template.id,
+                "code": template.code,
+                "name": template.name,
+                "unpublished": response.template_unpublish,
+            }))?
+        );
+    } else {
+        println!(
+            "{} {} ({})",
+            "Unpublished template".green().bold(),
+            template.name.bold(),
+            template.code
+        );
+    }
+
+    Ok(())
+}
+
 #[derive(Clone)]
 struct TemplateProjectChoice {
     id: String,
@@ -372,10 +496,23 @@ impl std::fmt::Display for TemplateProjectChoice {
     }
 }
 
+#[derive(Clone)]
+struct TemplateEnvironmentChoice {
+    id: String,
+    name: String,
+}
+
+impl std::fmt::Display for TemplateEnvironmentChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
 async fn resolve_template_project(
     client: &reqwest::Client,
     configs: &Configs,
     project: Option<String>,
+    interactive: bool,
 ) -> Result<String> {
     if let Some(project) = project {
         return resolve_project_arg(client, configs, &project).await;
@@ -392,7 +529,7 @@ async fn resolve_template_project(
         return Ok(linked_project.project);
     }
 
-    if !std::io::stdout().is_terminal() {
+    if !interactive {
         bail!("Project required in non-interactive mode. Use --project <id or name>.");
     }
 
@@ -430,19 +567,56 @@ async fn resolve_template_environment(
     configs: &Configs,
     project_id: &str,
     environment: Option<String>,
+    interactive: bool,
 ) -> Result<Option<String>> {
     let project = get_project(client, configs, project_id.to_string()).await?;
     if project.deleted_at.is_some() {
         bail!(RailwayError::ProjectDeleted);
     }
 
-    let Some(environment) = environment else {
-        return Ok(None);
-    };
+    if let Some(environment) = environment {
+        let environment = get_matched_environment(&project, environment)?;
+        fake_select("Select environment", &environment.name);
+        return Ok(Some(environment.id));
+    }
 
-    let environment = get_matched_environment(&project, environment)?;
-    fake_select("Select environment", &environment.name);
-    Ok(Some(environment.id))
+    if !interactive {
+        return Ok(None);
+    }
+
+    let source = prompt_options(
+        "Generate source",
+        vec![
+            GENERATE_SOURCE_PROJECT.to_string(),
+            GENERATE_SOURCE_ENVIRONMENT.to_string(),
+        ],
+    )?;
+    if source == GENERATE_SOURCE_PROJECT {
+        return Ok(None);
+    }
+
+    Ok(Some(prompt_template_environment(&project)?))
+}
+
+fn prompt_template_environment(project: &queries::RailwayProject) -> Result<String> {
+    let all_environments = &project.environments.edges;
+    let environments = all_environments
+        .iter()
+        .filter(|environment| environment.node.can_access && environment.node.deleted_at.is_none())
+        .map(|environment| TemplateEnvironmentChoice {
+            id: environment.node.id.clone(),
+            name: environment.node.name.clone(),
+        })
+        .collect::<Vec<_>>();
+
+    if environments.is_empty() {
+        if all_environments.is_empty() {
+            bail!("Project has no environments");
+        }
+        bail!("All environments in this project are restricted or deleted");
+    }
+
+    Ok(prompt_options("Select environment", environments)?.id)
 }
 
 async fn find_project_choice(
@@ -576,11 +750,78 @@ async fn resolve_workspace_id(
     }
 }
 
+fn resolve_template_ref(
+    template: Option<String>,
+    interactive: bool,
+    action: &str,
+) -> Result<String> {
+    if let Some(template) = template.and_then(non_empty_string) {
+        return Ok(template);
+    }
+
+    if !interactive {
+        bail!("Template required in non-interactive mode. Pass a template ID or code to {action}.");
+    }
+
+    let template =
+        prompt_text_with_placeholder_disappear("Template ID or code", "template-id-or-code")?;
+    non_empty_string(template).with_context(|| "Template ID or code is required")
+}
+
+fn resolve_publish_category(
+    category: Option<String>,
+    template: &TemplateDetailItem,
+    interactive: bool,
+) -> Result<String> {
+    if let Some(category) = category.and_then(non_empty_string) {
+        return Ok(category);
+    }
+
+    let default = template
+        .category
+        .clone()
+        .and_then(non_empty_string)
+        .filter(|category| is_template_category(category))
+        .unwrap_or_else(|| "Other".to_string());
+
+    if interactive {
+        return prompt_options("Select category", category_options(&default));
+    }
+
+    fake_select("Select category", &default);
+    Ok(default)
+}
+
+fn resolve_publish_description(
+    description: Option<String>,
+    template: &TemplateDetailItem,
+    interactive: bool,
+) -> Result<String> {
+    if let Some(description) = description.and_then(non_empty_string) {
+        return Ok(description);
+    }
+
+    let default = template
+        .description
+        .clone()
+        .and_then(non_empty_string)
+        .unwrap_or_else(|| short_description(&template.name));
+
+    if interactive {
+        let description =
+            prompt_text_with_placeholder_if_blank("Short description", &default, &default)?;
+        return Ok(non_empty_string(description).unwrap_or(default));
+    }
+
+    Ok(default)
+}
+
 fn resolve_readme(
     readme: Option<String>,
     readme_file: Option<PathBuf>,
     template: &TemplateDetailItem,
     is_updating: bool,
+    interactive: bool,
 ) -> Result<String> {
     if let Some(readme) = readme {
         fake_select("Template overview", "<provided inline>");
@@ -591,20 +832,66 @@ fn resolve_readme(
         return read_readme_file(path);
     }
 
-    if let Some(readme) = &template.readme {
+    let existing_readme = template.readme.as_ref().and_then(|readme| {
+        if readme.trim().is_empty() {
+            None
+        } else {
+            Some(readme.clone())
+        }
+    });
+
+    if interactive {
+        if let Some(existing_readme) = existing_readme {
+            let choice = prompt_options(
+                "Template overview",
+                vec![
+                    README_SOURCE_EXISTING.to_string(),
+                    README_SOURCE_FILE.to_string(),
+                ],
+            )?;
+            if choice == README_SOURCE_EXISTING {
+                return Ok(existing_readme);
+            }
+            return prompt_readme_file();
+        }
+
+        if is_updating {
+            let choice = prompt_options(
+                "Template overview",
+                vec![
+                    README_SOURCE_GENERATED.to_string(),
+                    README_SOURCE_FILE.to_string(),
+                ],
+            )?;
+            if choice == README_SOURCE_GENERATED {
+                return Ok(default_readme(&template.name));
+            }
+            return prompt_readme_file();
+        }
+
+        return prompt_readme_file();
+    }
+
+    if let Some(readme) = existing_readme {
         fake_select("Template overview", "<existing template readme>");
-        return Ok(readme.clone());
+        return Ok(readme);
     }
 
     if is_updating {
         return Ok(default_readme(&template.name));
     }
 
-    if !std::io::stdout().is_terminal() {
+    if !interactive {
         bail!("Template overview required. Use --readme-file <path> or --readme <markdown>.");
     }
 
-    let path = prompt_text_with_placeholder_disappear("Template overview file", "README.md")?;
+    prompt_readme_file()
+}
+
+fn prompt_readme_file() -> Result<String> {
+    let path =
+        prompt_text_with_placeholder_if_blank("Template overview file", "README.md", "README.md")?;
+    let path = non_empty_string(path).unwrap_or_else(|| "README.md".to_string());
     read_readme_file(PathBuf::from(path))
 }
 
@@ -619,6 +906,32 @@ fn read_readme_file(path: PathBuf) -> Result<String> {
     fake_select("Template overview file", &path.display().to_string());
     Ok(fs::read_to_string(&path)
         .with_context(|| format!("Failed to read template overview from {}", path.display()))?)
+}
+
+fn resolve_optional_publish_field(
+    value: Option<String>,
+    existing: Option<String>,
+    interactive: bool,
+    message: &str,
+    empty_placeholder: &str,
+) -> Result<Option<String>> {
+    if let Some(value) = value {
+        return Ok(non_empty_string(value));
+    }
+
+    let existing = existing.and_then(non_empty_string);
+    if !interactive {
+        return Ok(existing);
+    }
+
+    let default = existing.unwrap_or_default();
+    let placeholder = if default.is_empty() {
+        empty_placeholder
+    } else {
+        &default
+    };
+    let value = prompt_text_with_placeholder_if_blank(message, placeholder, &default)?;
+    Ok(non_empty_string(value).or_else(|| non_empty_string(default)))
 }
 
 fn validate_publish_fields(
@@ -639,6 +952,33 @@ fn validate_publish_fields(
     Ok(())
 }
 
+fn confirm_publish(
+    template: &TemplateDetailItem,
+    category: &str,
+    description: &str,
+    readme: &str,
+    image: Option<&str>,
+    demo_project_id: Option<&str>,
+    is_updating: bool,
+) -> Result<bool> {
+    println!();
+    println!("Review template:");
+    println!("  Template: {}", template.name);
+    println!("  Category: {category}");
+    println!("  Description: {description}");
+    println!("  README: {} characters", js_string_len(readme));
+    println!("  Image: {}", image.unwrap_or("none"));
+    println!("  Demo project: {}", demo_project_id.unwrap_or("none"));
+    println!();
+
+    let message = if is_updating {
+        "Update template info?"
+    } else {
+        "Publish template to the marketplace?"
+    };
+    prompt_confirm_with_default(message, true)
+}
+
 fn validate_description(description: &str) -> Result<()> {
     let len = js_string_len(description.trim());
     if len < DESCRIPTION_MIN {
@@ -651,16 +991,30 @@ fn validate_description(description: &str) -> Result<()> {
 }
 
 fn validate_category(category: &str) -> Result<()> {
-    if !TEMPLATE_CATEGORIES
-        .iter()
-        .any(|item| *item == category.trim())
-    {
+    if !is_template_category(category) {
         bail!(
             "category: Invalid category. Valid categories: {}",
             TEMPLATE_CATEGORIES.join(", ")
         );
     }
     Ok(())
+}
+
+fn is_template_category(category: &str) -> bool {
+    TEMPLATE_CATEGORIES
+        .iter()
+        .any(|item| *item == category.trim())
+}
+
+fn category_options(default: &str) -> Vec<String> {
+    let mut options = vec![default.to_string()];
+    options.extend(
+        TEMPLATE_CATEGORIES
+            .iter()
+            .filter(|category| **category != default)
+            .map(|category| category.to_string()),
+    );
+    options
 }
 
 fn validate_readme(readme: &str) -> Result<()> {
@@ -719,6 +1073,10 @@ fn validate_image(image: &str) -> Result<()> {
 
 fn js_string_len(value: &str) -> usize {
     value.encode_utf16().count()
+}
+
+fn is_interactive_output(json: bool) -> bool {
+    std::io::stdout().is_terminal() && !json
 }
 
 fn short_description(name: &str) -> String {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -107,7 +107,7 @@ enum TerminalTheme {
 /// Discover Railway templates
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates unpublish template-code --yes --json\n  railway templates delete template-id --yes --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
+    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates update template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates unpublish template-code --yes --json\n  railway templates delete template-id --yes --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -124,7 +124,8 @@ enum Commands {
     #[clap(visible_alias = "generate")]
     Create(CreateArgs),
 
-    /// Publish an unpublished template to the marketplace
+    /// Publish or update a template in the marketplace
+    #[clap(visible_alias = "update")]
     Publish(PublishArgs),
 
     /// Unpublish a published template from the marketplace
@@ -181,7 +182,7 @@ struct CreateArgs {
 
 #[derive(Parser, Clone)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  In interactive mode, omitted template and metadata fields are prompted.\n  Use the template ID returned by `railway templates create --json`."
+    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates update template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  Use `templates update` as an alias when replacing metadata on an already published template.\n  In interactive mode, omitted template and metadata fields are prompted.\n  Use the template ID returned by `railway templates create --json`."
 )]
 struct PublishArgs {
     /// Template ID or code

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -125,6 +125,7 @@ enum Commands {
     Create(CreateArgs),
 
     /// Publish or update a template in the marketplace
+    // The backend updates published templates through the same templatePublish mutation.
     #[clap(visible_alias = "update")]
     Publish(PublishArgs),
 
@@ -182,7 +183,7 @@ struct CreateArgs {
 
 #[derive(Parser, Clone)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates update template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  Use `templates update` as an alias when replacing metadata on an already published template.\n  In interactive mode, omitted template and metadata fields are prompted.\n  Use the template ID returned by `railway templates create --json`."
+    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates update template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  Use `templates update` as an alias when replacing metadata on an already published template.\n  Use none, clear, or an empty string for --image/--demo-project to clear optional fields.\n  In interactive mode, omitted template and metadata fields are prompted.\n  Use the template ID returned by `railway templates create --json`."
 )]
 struct PublishArgs {
     /// Template ID or code
@@ -204,11 +205,11 @@ struct PublishArgs {
     #[arg(long)]
     readme_file: Option<PathBuf>,
 
-    /// Image URL for the marketplace card
+    /// Image URL for the marketplace card. Use "none" or "clear" to clear it.
     #[arg(long)]
     image: Option<String>,
 
-    /// Public demo project ID
+    /// Public demo project ID. Use "none" or "clear" to clear it.
     #[arg(long)]
     demo_project: Option<String>,
 
@@ -305,6 +306,27 @@ struct TemplateDetailItem {
     demo_project_id: Option<String>,
     status: String,
     workspace_id: Option<String>,
+}
+
+struct ResolvedReadme {
+    value: String,
+    should_validate: bool,
+}
+
+impl ResolvedReadme {
+    fn supplied(value: String) -> Self {
+        Self {
+            value,
+            should_validate: true,
+        }
+    }
+
+    fn existing(value: String, is_updating: bool) -> Self {
+        Self {
+            value,
+            should_validate: !is_updating,
+        }
+    }
 }
 
 impl From<RootTemplateItem> for TemplateDetailItem {
@@ -436,9 +458,9 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
     validate_publish_fields(
         &category,
         &description,
-        readme.as_str(),
+        readme.value.as_str(),
         image.as_deref(),
-        is_updating,
+        readme.should_validate,
     )?;
 
     if interactive
@@ -446,7 +468,7 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
             &template,
             &category,
             &description,
-            &readme,
+            &readme.value,
             image.as_deref(),
             demo_project_id.as_deref(),
             is_updating,
@@ -464,7 +486,7 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
             id: template.id,
             description,
             category,
-            readme,
+            readme: readme.value,
             image,
             demo_project_id,
             workspace_id,
@@ -632,6 +654,7 @@ fn ensure_template_can_unpublish(status: &str, name: &str) -> Result<()> {
 }
 
 fn is_published_status(status: &str) -> bool {
+    // status_label uses Debug output from GraphQL enum variants generated without rust-style normalization.
     status == "PUBLISHED"
 }
 
@@ -1038,14 +1061,14 @@ fn resolve_readme(
     template: &TemplateDetailItem,
     is_updating: bool,
     interactive: bool,
-) -> Result<String> {
+) -> Result<ResolvedReadme> {
     if let Some(readme) = readme {
         fake_select("Template overview", "<provided inline>");
-        return Ok(readme);
+        return Ok(ResolvedReadme::supplied(readme));
     }
 
     if let Some(path) = readme_file {
-        return read_readme_file(path);
+        return read_readme_file(path).map(ResolvedReadme::supplied);
     }
 
     let existing_readme = template.readme.as_ref().and_then(|readme| {
@@ -1056,8 +1079,8 @@ fn resolve_readme(
         }
     });
 
-    if interactive {
-        if let Some(existing_readme) = existing_readme {
+    match (interactive, existing_readme, is_updating) {
+        (true, Some(existing_readme), _) => {
             let choice = prompt_options(
                 "Template overview",
                 vec![
@@ -1066,12 +1089,11 @@ fn resolve_readme(
                 ],
             )?;
             if choice == README_SOURCE_EXISTING {
-                return Ok(existing_readme);
+                return Ok(ResolvedReadme::existing(existing_readme, is_updating));
             }
-            return prompt_readme_file();
+            prompt_readme_file().map(ResolvedReadme::supplied)
         }
-
-        if is_updating {
+        (true, None, true) => {
             let choice = prompt_options(
                 "Template overview",
                 vec![
@@ -1080,28 +1102,20 @@ fn resolve_readme(
                 ],
             )?;
             if choice == README_SOURCE_GENERATED {
-                return Ok(default_readme(&template.name));
+                return Ok(ResolvedReadme::supplied(default_readme(&template.name)));
             }
-            return prompt_readme_file();
+            prompt_readme_file().map(ResolvedReadme::supplied)
         }
-
-        return prompt_readme_file();
+        (true, None, false) => prompt_readme_file().map(ResolvedReadme::supplied),
+        (false, Some(readme), is_updating) => {
+            fake_select("Template overview", "<existing template readme>");
+            Ok(ResolvedReadme::existing(readme, is_updating))
+        }
+        (false, None, true) => Ok(ResolvedReadme::supplied(default_readme(&template.name))),
+        (false, None, false) => {
+            bail!("Template overview required. Use --readme-file <path> or --readme <markdown>.")
+        }
     }
-
-    if let Some(readme) = existing_readme {
-        fake_select("Template overview", "<existing template readme>");
-        return Ok(readme);
-    }
-
-    if is_updating {
-        return Ok(default_readme(&template.name));
-    }
-
-    if !interactive {
-        bail!("Template overview required. Use --readme-file <path> or --readme <markdown>.");
-    }
-
-    prompt_readme_file()
 }
 
 fn prompt_readme_file() -> Result<String> {
@@ -1176,11 +1190,11 @@ fn validate_publish_fields(
     description: &str,
     readme: &str,
     image: Option<&str>,
-    is_updating: bool,
+    should_validate_readme: bool,
 ) -> Result<()> {
     validate_description(description)?;
     validate_category(category)?;
-    if !is_updating {
+    if should_validate_readme {
         validate_readme(readme)?;
     }
     if let Some(image) = image {
@@ -1288,20 +1302,23 @@ fn validate_image(image: &str) -> Result<()> {
         return Ok(());
     }
 
-    let path = if let Some(path) = image.strip_prefix("http://") {
-        path
-    } else if let Some(path) = image.strip_prefix("https://") {
-        path
-    } else {
+    if image.contains(['\n', '\r']) {
         bail!("image: Invalid image URL");
-    };
+    }
 
-    if image.contains(['\n', '\r'])
-        || !IMAGE_EXTENSIONS.iter().any(|extension| {
-            let suffix = format!(".{extension}");
-            image.ends_with(&suffix) && path.len() > suffix.len()
-        })
-    {
+    let url = url::Url::parse(image).map_err(|_| anyhow::anyhow!("image: Invalid image URL"))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        bail!("image: Invalid image URL");
+    }
+
+    let file_name = url.path().rsplit('/').next().unwrap_or_default();
+    let file_name_lower = file_name.to_ascii_lowercase();
+    let has_image_extension = IMAGE_EXTENSIONS.iter().any(|extension| {
+        let suffix = format!(".{extension}");
+        file_name_lower.ends_with(&suffix) && file_name.len() > suffix.len()
+    });
+
+    if !has_image_extension {
         bail!("image: Invalid image URL");
     }
 
@@ -2218,9 +2235,23 @@ fn truncate_chars(value: &str, max: usize) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn unpublish_guard_accepts_published_templates() {
-        assert!(ensure_template_can_unpublish("PUBLISHED", "App").is_ok());
+    fn valid_description() -> &'static str {
+        "Deploy and Host Test Apps"
+    }
+
+    fn template_detail(readme: Option<String>, status: &str) -> TemplateDetailItem {
+        TemplateDetailItem {
+            id: "template-id".to_string(),
+            code: "template-code".to_string(),
+            name: "Test App".to_string(),
+            description: Some(valid_description().to_string()),
+            image: None,
+            category: Some("Other".to_string()),
+            readme,
+            demo_project_id: None,
+            status: status.to_string(),
+            workspace_id: Some("workspace-id".to_string()),
+        }
     }
 
     #[test]
@@ -2234,17 +2265,7 @@ mod tests {
     }
 
     #[test]
-    fn unpublish_guard_rejects_hidden_templates() {
-        let error = ensure_template_can_unpublish("HIDDEN", "Hidden App")
-            .unwrap_err()
-            .to_string();
-
-        assert!(error.contains("Template \"Hidden App\" is HIDDEN"));
-        assert!(error.contains("Only published templates can be unpublished"));
-    }
-
-    #[test]
-    fn optional_publish_field_treats_explicit_empty_as_clear() {
+    fn optional_publish_field_clear_values_clear_existing_value() {
         assert_eq!(
             resolve_optional_publish_field(
                 Some("".to_string()),
@@ -2256,10 +2277,6 @@ mod tests {
             .unwrap(),
             None
         );
-    }
-
-    #[test]
-    fn optional_publish_field_treats_clear_sentinel_as_clear() {
         assert_eq!(
             resolve_optional_publish_field(
                 Some(" none ".to_string()),
@@ -2285,18 +2302,77 @@ mod tests {
     }
 
     #[test]
-    fn optional_publish_field_keeps_existing_when_unspecified() {
-        assert_eq!(
-            resolve_optional_publish_field(
+    fn update_preserves_existing_readme_without_revalidating() {
+        let existing_readme = "Legacy short readme".to_string();
+        let template = template_detail(Some(existing_readme.clone()), "PUBLISHED");
+        let readme = resolve_readme(None, None, &template, true, false).unwrap();
+
+        assert_eq!(readme.value, existing_readme);
+        assert!(!readme.should_validate);
+        assert!(
+            validate_publish_fields(
+                "Other",
+                valid_description(),
+                &readme.value,
                 None,
-                Some("demo-project-id".to_string()),
-                false,
-                "Public demo project ID",
-                "<none>",
+                readme.should_validate,
             )
-            .unwrap(),
-            Some("demo-project-id".to_string())
+            .is_ok()
         );
+    }
+
+    #[test]
+    fn update_validates_supplied_readme() {
+        let template = template_detail(Some(default_readme("Test App")), "PUBLISHED");
+        let readme =
+            resolve_readme(Some("Too short".to_string()), None, &template, true, false).unwrap();
+
+        assert!(readme.should_validate);
+        let error = validate_publish_fields(
+            "Other",
+            valid_description(),
+            &readme.value,
+            None,
+            readme.should_validate,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("readme: Must be"));
+    }
+
+    #[test]
+    fn validate_description_counts_utf16_code_units() {
+        let astral_char = char::from_u32(0x1D11E).unwrap().to_string();
+        let description = astral_char.repeat(13);
+
+        assert!(description.chars().count() < DESCRIPTION_MIN);
+        assert!(js_string_len(&description) >= DESCRIPTION_MIN);
+        assert!(validate_description(&description).is_ok());
+    }
+
+    #[test]
+    fn validate_image_accepts_query_fragment_and_uppercase_extension() {
+        assert!(validate_image("https://cdn.example.com/assets/card.PNG?v=1#hero").is_ok());
+    }
+
+    #[tokio::test]
+    async fn publish_rejects_inline_and_file_readme() {
+        let error = publish_command(PublishArgs {
+            template: Some("template-id".to_string()),
+            category: None,
+            description: None,
+            readme: Some("inline readme".to_string()),
+            readme_file: Some(PathBuf::from("README.md")),
+            image: None,
+            demo_project: None,
+            workspace: None,
+            json: true,
+        })
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert_eq!(error, "Use either --readme or --readme-file, not both");
     }
 
     #[test]

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -406,6 +406,7 @@ async fn unpublish_command(args: UnpublishArgs) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_user_authorized(&configs)?;
     let template = fetch_template_by_ref(&client, &configs, &template_ref).await?;
+    ensure_template_can_unpublish(&template.status, &template.name)?;
 
     if !args.yes {
         if !interactive {
@@ -464,6 +465,21 @@ async fn unpublish_command(args: UnpublishArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn ensure_template_can_unpublish(
+    status: &queries::template::TemplateStatus,
+    name: &str,
+) -> Result<()> {
+    if matches!(status, queries::template::TemplateStatus::PUBLISHED) {
+        return Ok(());
+    }
+
+    bail!(
+        "Template \"{}\" is {}. Only published templates can be unpublished.",
+        name,
+        status_label(status)
+    )
 }
 
 #[derive(Clone)]
@@ -1888,5 +1904,42 @@ fn truncate_chars(value: &str, max: usize) -> String {
         format!("{truncated}...")
     } else {
         truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unpublish_guard_accepts_published_templates() {
+        assert!(
+            ensure_template_can_unpublish(&queries::template::TemplateStatus::PUBLISHED, "App")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn unpublish_guard_rejects_unpublished_templates() {
+        let error = ensure_template_can_unpublish(
+            &queries::template::TemplateStatus::UNPUBLISHED,
+            "Draft App",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("Template \"Draft App\" is UNPUBLISHED"));
+        assert!(error.contains("Only published templates can be unpublished"));
+    }
+
+    #[test]
+    fn unpublish_guard_rejects_hidden_templates() {
+        let error =
+            ensure_template_can_unpublish(&queries::template::TemplateStatus::HIDDEN, "Hidden App")
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("Template \"Hidden App\" is HIDDEN"));
+        assert!(error.contains("Only published templates can be unpublished"));
     }
 }

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -107,7 +107,7 @@ enum TerminalTheme {
 /// Discover Railway templates
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates unpublish template-code --yes --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
+    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates unpublish template-code --yes --json\n  railway templates delete template-id --yes --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -129,6 +129,10 @@ enum Commands {
 
     /// Unpublish a published template from the marketplace
     Unpublish(UnpublishArgs),
+
+    /// Delete a template
+    #[clap(visible_alias = "remove", visible_alias = "rm")]
+    Delete(DeleteArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -237,6 +241,27 @@ struct UnpublishArgs {
     json: bool,
 }
 
+#[derive(Parser, Clone)]
+#[clap(
+    after_help = "Examples:\n\n  railway templates delete template-code --yes --json\n  railway templates delete template-id --yes\n\nAliases:\n  delete: remove, rm\n\nAutomation notes:\n  Non-interactive delete requires --yes.\n  Deleting a template removes the template draft or marketplace template from the workspace."
+)]
+struct DeleteArgs {
+    /// Template ID or code
+    template: Option<String>,
+
+    /// Skip confirmation dialog
+    #[arg(short = 'y', long = "yes")]
+    yes: bool,
+
+    /// 2FA code for verification when required by the current auth session
+    #[arg(long = "2fa-code")]
+    two_factor_code: Option<String>,
+
+    /// Print the deleted template result as JSON
+    #[arg(long)]
+    json: bool,
+}
+
 #[derive(Clone)]
 struct TemplateSearchRequest {
     query: String,
@@ -321,6 +346,7 @@ pub async fn command(args: Args) -> Result<()> {
         Commands::Create(args) => create_command(args).await,
         Commands::Publish(args) => publish_command(args).await,
         Commands::Unpublish(args) => unpublish_command(args).await,
+        Commands::Delete(args) => delete_command(args).await,
     }
 }
 
@@ -521,6 +547,69 @@ async fn unpublish_command(args: UnpublishArgs) -> Result<()> {
         println!(
             "{} {} ({})",
             "Unpublished template".green().bold(),
+            template.name.bold(),
+            template.code
+        );
+    }
+
+    Ok(())
+}
+
+async fn delete_command(args: DeleteArgs) -> Result<()> {
+    let interactive = is_interactive_output(args.json);
+    let template_ref = resolve_template_ref(args.template.clone(), interactive, "delete")?;
+    let configs = Configs::new()?;
+    let client = GQLClient::new_user_authorized(&configs)?;
+    let template = fetch_template_by_ref(&client, &configs, &template_ref).await?;
+
+    if !args.yes {
+        if !interactive {
+            bail!(
+                "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip confirmation."
+            );
+        }
+
+        let confirmed = prompt_confirm_with_default(
+            format!(r#"Delete template "{}"?"#, template.name.red()).as_str(),
+            false,
+        )?;
+        if !confirmed {
+            println!("Delete cancelled.");
+            return Ok(());
+        }
+    }
+
+    validate_two_factor_if_enabled(&client, &configs, interactive, args.two_factor_code).await?;
+
+    let spinner = create_spinner_if(!args.json, "Deleting template...".to_string());
+    let response = post_graphql::<mutations::TemplateDelete, _>(
+        &client,
+        configs.get_backboard(),
+        mutations::template_delete::Variables {
+            id: template.id.clone(),
+            workspace_id: template.workspace_id.clone(),
+        },
+    )
+    .await?;
+
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": template.id,
+                "code": template.code,
+                "name": template.name,
+                "deleted": response.template_delete,
+            }))?
+        );
+    } else {
+        println!(
+            "{} {} ({})",
+            "Deleted template".green().bold(),
             template.name.bold(),
             template.code
         );
@@ -2232,6 +2321,24 @@ mod tests {
             value
                 .get("workspaceId")
                 .is_some_and(serde_json::Value::is_null)
+        );
+    }
+
+    #[test]
+    fn template_delete_variables_include_workspace_id() {
+        let value = serde_json::to_value(mutations::template_delete::Variables {
+            id: "template-id".to_string(),
+            workspace_id: Some("workspace-id".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(
+            value.get("id").and_then(|v| v.as_str()),
+            Some("template-id")
+        );
+        assert_eq!(
+            value.get("workspaceId").and_then(|v| v.as_str()),
+            Some("workspace-id")
         );
     }
 }

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -51,6 +51,7 @@ const MAX_LIMIT: i64 = 50;
 const SEARCH_DEBOUNCE: Duration = Duration::from_millis(200);
 const FRAME_INTERVAL: Duration = Duration::from_millis(33);
 const RESULT_PADDING: &str = "  ";
+
 const DESCRIPTION_MIN: usize = 25;
 const DESCRIPTION_MAX: usize = 75;
 const README_MIN: usize = 250;
@@ -85,6 +86,7 @@ const DEFAULT_README_TEXT: &[&str] = &[
     "[Include any external links",
     "[Include Github",
 ];
+const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "avif", "gif", "svg", "ico"];
 
 #[derive(Clone, Copy)]
 enum TerminalTheme {
@@ -282,7 +284,10 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let template = fetch_template_by_ref(&client, &configs, &args.template).await?;
-    let is_updating = status_label(&template.status) == "PUBLISHED";
+    let is_updating = matches!(
+        &template.status,
+        queries::template::TemplateStatus::PUBLISHED
+    );
 
     let category = args
         .category
@@ -624,7 +629,7 @@ fn validate_publish_fields(
 }
 
 fn validate_description(description: &str) -> Result<()> {
-    let len = description.trim().chars().count();
+    let len = js_string_len(description.trim());
     if len < DESCRIPTION_MIN {
         bail!("description: Must be {DESCRIPTION_MIN} or more characters long");
     }
@@ -648,7 +653,7 @@ fn validate_category(category: &str) -> Result<()> {
 }
 
 fn validate_readme(readme: &str) -> Result<()> {
-    let len = readme.trim().chars().count();
+    let len = js_string_len(readme.trim());
     if len < README_MIN {
         bail!("readme: Must be {README_MIN} or more characters long");
     }
@@ -681,20 +686,28 @@ fn validate_image(image: &str) -> Result<()> {
         return Ok(());
     }
 
-    let url = url::Url::parse(image).context("image: Invalid image URL")?;
-    if !matches!(url.scheme(), "http" | "https") {
+    let path = if let Some(path) = image.strip_prefix("http://") {
+        path
+    } else if let Some(path) = image.strip_prefix("https://") {
+        path
+    } else {
         bail!("image: Invalid image URL");
-    }
+    };
 
-    let path = url.path().to_lowercase();
-    if !["jpg", "jpeg", "png", "webp", "avif", "gif", "svg", "ico"]
-        .iter()
-        .any(|extension| path.ends_with(&format!(".{extension}")))
+    if image.contains(['\n', '\r'])
+        || !IMAGE_EXTENSIONS.iter().any(|extension| {
+            let suffix = format!(".{extension}");
+            image.ends_with(&suffix) && path.len() > suffix.len()
+        })
     {
         bail!("image: Invalid image URL");
     }
 
     Ok(())
+}
+
+fn js_string_len(value: &str) -> usize {
+    value.encode_utf16().count()
 }
 
 fn short_description(name: &str) -> String {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -27,7 +27,7 @@ use tokio::{sync::mpsc, time::Instant};
 use crate::{
     client::post_graphql,
     consts::TICK_STRING,
-    controllers::project::get_project,
+    controllers::{environment::get_matched_environment, project::get_project},
     errors::RailwayError,
     util::{
         progress::create_spinner_if,
@@ -94,6 +94,7 @@ const IMAGE_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "webp", "avif", "gif",
 const README_SOURCE_EXISTING: &str = "Use existing README";
 const README_SOURCE_GENERATED: &str = "Use generated README";
 const README_SOURCE_FILE: &str = "Read from file";
+const OPTIONAL_FIELD_CLEAR_HINT: &str = "none";
 
 #[derive(Clone, Copy)]
 enum TerminalTheme {
@@ -156,12 +157,16 @@ struct SearchArgs {
 
 #[derive(Parser, Clone)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it clones a project into an unpublished template draft.\n  The generated template opens in the dashboard template editor for cleanup before publishing.\n  In interactive mode, an omitted project is prompted."
+    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --environment production --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it clones a project into an unpublished template draft.\n  The generated template opens in the dashboard template editor for cleanup before publishing.\n  In interactive mode, an omitted project is prompted."
 )]
 struct CreateArgs {
     /// Project ID or name. Defaults to the linked project.
     #[arg(short, long)]
     project: Option<String>,
+
+    /// Environment ID or name. Defaults to the linked environment when available.
+    #[arg(short, long)]
+    environment: Option<String>,
 
     /// Print the created template as JSON
     #[arg(long)]
@@ -273,13 +278,23 @@ async fn create_command(args: CreateArgs) -> Result<()> {
     let interactive = is_interactive_output(args.json);
     let configs = Configs::new()?;
     let client = GQLClient::new_user_authorized(&configs)?;
-    let project_id = resolve_template_project(&client, &configs, args.project, interactive).await?;
+    let project = resolve_template_project(
+        &client,
+        &configs,
+        args.project,
+        args.environment,
+        interactive,
+    )
+    .await?;
 
     let spinner = create_spinner_if(!args.json, "Creating template...".to_string());
     let response = post_graphql::<mutations::TemplateGenerate, _>(
         &client,
         configs.get_backboard(),
-        mutations::template_generate::Variables { project_id },
+        mutations::template_generate::Variables {
+            project_id: project.id,
+            environment_id: project.environment_id,
+        },
     )
     .await?;
 
@@ -489,6 +504,11 @@ struct TemplateProjectChoice {
     workspace_name: String,
 }
 
+struct TemplateProjectContext {
+    id: String,
+    environment_id: Option<String>,
+}
+
 impl std::fmt::Display for TemplateProjectChoice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{} ({})", self.name, self.workspace_name)
@@ -499,10 +519,21 @@ async fn resolve_template_project(
     client: &reqwest::Client,
     configs: &Configs,
     project: Option<String>,
+    environment: Option<String>,
     interactive: bool,
-) -> Result<String> {
+) -> Result<TemplateProjectContext> {
     if let Some(project) = project {
-        return resolve_project_arg(client, configs, &project).await;
+        let project_id = resolve_project_arg(client, configs, &project).await?;
+        let environment_id = match environment {
+            Some(environment) => {
+                Some(resolve_project_environment(client, configs, &project_id, &environment).await?)
+            }
+            None => resolve_linked_environment_for_project(client, configs, &project_id).await?,
+        };
+        return Ok(TemplateProjectContext {
+            id: project_id,
+            environment_id,
+        });
     }
 
     if let Ok(linked_project) = configs.get_linked_project().await {
@@ -513,7 +544,17 @@ async fn resolve_template_project(
                 .as_deref()
                 .unwrap_or(linked_project.project.as_str()),
         );
-        return Ok(linked_project.project);
+        let environment_id = match environment.or(linked_project.environment) {
+            Some(environment) => Some(
+                resolve_project_environment(client, configs, &linked_project.project, &environment)
+                    .await?,
+            ),
+            None => None,
+        };
+        return Ok(TemplateProjectContext {
+            id: linked_project.project,
+            environment_id,
+        });
     }
 
     if !interactive {
@@ -526,7 +567,16 @@ async fn resolve_template_project(
     }
 
     let choice = prompt_options("Select project", choices)?;
-    Ok(choice.id)
+    let environment_id = match environment {
+        Some(environment) => {
+            Some(resolve_project_environment(client, configs, &choice.id, &environment).await?)
+        }
+        None => None,
+    };
+    Ok(TemplateProjectContext {
+        id: choice.id,
+        environment_id,
+    })
 }
 
 async fn resolve_project_arg(
@@ -547,6 +597,47 @@ async fn resolve_project_arg(
     let choice = find_project_choice(client, configs, project).await?;
     fake_select("Select project", &choice.to_string());
     Ok(choice.id)
+}
+
+async fn resolve_linked_environment_for_project(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project_id: &str,
+) -> Result<Option<String>> {
+    let Ok(linked_project) = configs.get_linked_project().await else {
+        return Ok(None);
+    };
+
+    if linked_project.project != project_id {
+        return Ok(None);
+    }
+
+    match linked_project.environment {
+        Some(environment) => Ok(Some(
+            resolve_project_environment(client, configs, project_id, &environment).await?,
+        )),
+        None => Ok(None),
+    }
+}
+
+async fn resolve_project_environment(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project_id: &str,
+    environment: &str,
+) -> Result<String> {
+    let project = get_project(client, configs, project_id.to_string()).await?;
+    if project.deleted_at.is_some() {
+        bail!(RailwayError::ProjectDeleted);
+    }
+
+    let environment = get_matched_environment(&project, environment.to_string())?;
+    if environment.deleted_at.is_some() {
+        bail!(RailwayError::EnvironmentDeleted);
+    }
+
+    fake_select("Select environment", &environment.name);
+    Ok(environment.id)
 }
 
 async fn find_project_choice(
@@ -846,7 +937,7 @@ fn resolve_optional_publish_field(
     empty_placeholder: &str,
 ) -> Result<Option<String>> {
     if let Some(value) = value {
-        return Ok(non_empty_string(value));
+        return Ok(normalize_optional_publish_value(value));
     }
 
     let existing = existing.and_then(non_empty_string);
@@ -860,8 +951,29 @@ fn resolve_optional_publish_field(
     } else {
         &default
     };
-    let value = prompt_text_with_placeholder_if_blank(message, placeholder, &default)?;
+    let prompt = if default.is_empty() {
+        message.to_string()
+    } else {
+        format!("{message} (type {OPTIONAL_FIELD_CLEAR_HINT} to clear)")
+    };
+    let value = prompt_text_with_placeholder_if_blank(&prompt, placeholder, &default)?;
+    if is_optional_field_clear_value(&value) {
+        return Ok(None);
+    }
+
     Ok(non_empty_string(value).or_else(|| non_empty_string(default)))
+}
+
+fn normalize_optional_publish_value(value: String) -> Option<String> {
+    if is_optional_field_clear_value(&value) {
+        None
+    } else {
+        non_empty_string(value)
+    }
+}
+
+fn is_optional_field_clear_value(value: &str) -> bool {
+    matches!(value.trim().to_ascii_lowercase().as_str(), "none" | "clear")
 }
 
 fn validate_publish_fields(
@@ -1941,5 +2053,87 @@ mod tests {
 
         assert!(error.contains("Template \"Hidden App\" is HIDDEN"));
         assert!(error.contains("Only published templates can be unpublished"));
+    }
+
+    #[test]
+    fn optional_publish_field_treats_explicit_empty_as_clear() {
+        assert_eq!(
+            resolve_optional_publish_field(
+                Some("".to_string()),
+                Some("https://example.com/image.png".to_string()),
+                false,
+                "Image URL",
+                "<none>",
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn optional_publish_field_treats_clear_sentinel_as_clear() {
+        assert_eq!(
+            resolve_optional_publish_field(
+                Some(" none ".to_string()),
+                Some("https://example.com/image.png".to_string()),
+                false,
+                "Image URL",
+                "<none>",
+            )
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            resolve_optional_publish_field(
+                Some("CLEAR".to_string()),
+                Some("demo-project-id".to_string()),
+                false,
+                "Public demo project ID",
+                "<none>",
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn optional_publish_field_keeps_existing_when_unspecified() {
+        assert_eq!(
+            resolve_optional_publish_field(
+                None,
+                Some("demo-project-id".to_string()),
+                false,
+                "Public demo project ID",
+                "<none>",
+            )
+            .unwrap(),
+            Some("demo-project-id".to_string())
+        );
+    }
+
+    #[test]
+    fn template_publish_variables_serialize_clearable_fields_as_null() {
+        let value = serde_json::to_value(mutations::template_publish::Variables {
+            id: "template-id".to_string(),
+            description: "Deploy and Host Test App".to_string(),
+            category: "Other".to_string(),
+            readme: default_readme("Test App"),
+            image: None,
+            demo_project_id: None,
+            workspace_id: None,
+        })
+        .unwrap();
+
+        assert!(value.get("image").is_some_and(serde_json::Value::is_null));
+        assert!(
+            value
+                .get("demoProjectId")
+                .is_some_and(serde_json::Value::is_null)
+        );
+        assert!(
+            value
+                .get("workspaceId")
+                .is_some_and(serde_json::Value::is_null)
+        );
     }
 }

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -1,7 +1,8 @@
 use std::{
-    env,
-    io::stdout,
+    env, fs,
+    io::{Read, stdout},
     panic,
+    path::PathBuf,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -23,7 +24,17 @@ use ratatui::{
 };
 use tokio::{sync::mpsc, time::Instant};
 
-use crate::{client::post_graphql, consts::TICK_STRING};
+use crate::{
+    client::post_graphql,
+    consts::TICK_STRING,
+    controllers::{environment::get_matched_environment, project::get_project},
+    errors::RailwayError,
+    util::{
+        progress::create_spinner_if,
+        prompt::{fake_select, prompt_options, prompt_text_with_placeholder_disappear},
+    },
+    workspace::workspaces,
+};
 
 use super::*;
 
@@ -31,12 +42,49 @@ type TemplateSearchResponse = queries::template_search::ResponseData;
 type TemplateSearchConnection = queries::template_search::TemplateSearchTemplateSearch;
 type TemplateSearchEdge = queries::template_search::TemplateSearchTemplateSearchEdges;
 type TemplateSearchItem = queries::template_search::TemplateSearchTemplateSearchEdgesNode;
+type TemplateDetailItem = queries::template::TemplateTemplate;
+type GeneratedTemplate = mutations::template_generate::TemplateGenerateTemplateGenerate;
+type PublishedTemplate = mutations::template_publish::TemplatePublishTemplatePublish;
 
 const DEFAULT_LIMIT: i64 = 20;
 const MAX_LIMIT: i64 = 50;
 const SEARCH_DEBOUNCE: Duration = Duration::from_millis(200);
 const FRAME_INTERVAL: Duration = Duration::from_millis(33);
 const RESULT_PADDING: &str = "  ";
+const DESCRIPTION_MIN: usize = 25;
+const DESCRIPTION_MAX: usize = 75;
+const README_MIN: usize = 250;
+const README_MAX: usize = 10_000;
+const TEMPLATE_CATEGORIES: &[&str] = &[
+    "AI/ML",
+    "Analytics",
+    "Authentication",
+    "Automation",
+    "Blogs",
+    "Bots",
+    "CMS",
+    "Observability",
+    "Other",
+    "Starters",
+    "Storage",
+    "Queues",
+];
+const REQUIRED_README_SECTIONS: &[&str] = &[
+    "# Deploy and Host",
+    "## About Hosting",
+    "## Why Deploy",
+    "## Common Use Cases",
+    "## Dependencies for",
+    "### Deployment Dependencies",
+];
+const DEFAULT_README_TEXT: &[&str] = &[
+    "[What is X?",
+    "[Roughly 100 word",
+    "[Use case",
+    "[Dependency",
+    "[Include any external links",
+    "[Include Github",
+];
 
 #[derive(Clone, Copy)]
 enum TerminalTheme {
@@ -47,7 +95,7 @@ enum TerminalTheme {
 /// Discover Railway templates
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
+    after_help = "Examples:\n\n  railway templates search postgres --json\n  railway templates create --project project-id --json\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway template find redis --limit 5 --json\n  railway templates ls --category database --json"
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -59,6 +107,13 @@ enum Commands {
     /// Search published templates
     #[clap(visible_alias = "find", visible_alias = "list", visible_alias = "ls")]
     Search(SearchArgs),
+
+    /// Create an unpublished template from a project
+    #[clap(visible_alias = "generate")]
+    Create(CreateArgs),
+
+    /// Publish an unpublished template to the marketplace
+    Publish(PublishArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -85,6 +140,65 @@ struct SearchArgs {
     /// Filter by verification state
     #[arg(long)]
     verified: Option<bool>,
+}
+
+#[derive(Parser, Clone)]
+#[clap(
+    after_help = "Examples:\n\n  railway templates create --json\n  railway templates create --project project-id --json\n  railway templates create --project project-id --environment production --json\n\nAutomation notes:\n  This matches the dashboard Generate Template action: it creates an unpublished template from a project.\n  By default generation is project-level. Pass --environment only when you intentionally want to generate from one environment."
+)]
+struct CreateArgs {
+    /// Project ID or name. Defaults to the linked project.
+    #[arg(short, long)]
+    project: Option<String>,
+
+    /// Environment ID or name to generate from. Defaults to the dashboard behavior: project-level generation.
+    #[arg(short, long)]
+    environment: Option<String>,
+
+    /// Print the created template as JSON
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Parser, Clone)]
+#[clap(
+    after_help = "Examples:\n\n  railway templates publish template-id --category Other --description \"Deploy and Host My App with Railway\" --readme-file README.md --json\n  railway templates publish template-id --category AI/ML --description \"Deploy and Host My Agent with Railway\" --readme-file - --json\n\nValid categories:\n  AI/ML, Analytics, Authentication, Automation, Blogs, Bots, CMS,\n  Observability, Other, Starters, Storage, Queues\n\nAutomation notes:\n  First publish requires a template overview via --readme-file or --readme.\n  Use the template ID returned by `railway templates create --json`."
+)]
+struct PublishArgs {
+    /// Template ID or code
+    template: String,
+
+    /// Marketplace category
+    #[arg(long)]
+    category: Option<String>,
+
+    /// Short marketplace description
+    #[arg(long)]
+    description: Option<String>,
+
+    /// Template overview markdown. Prefer --readme-file for multi-line content.
+    #[arg(long)]
+    readme: Option<String>,
+
+    /// File containing the template overview markdown. Use "-" to read from stdin.
+    #[arg(long)]
+    readme_file: Option<PathBuf>,
+
+    /// Image URL for the marketplace card
+    #[arg(long)]
+    image: Option<String>,
+
+    /// Public demo project ID
+    #[arg(long)]
+    demo_project: Option<String>,
+
+    /// Workspace ID or name. Defaults to the template workspace.
+    #[arg(short, long)]
+    workspace: Option<String>,
+
+    /// Print the published template as JSON
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Clone)]
@@ -120,7 +234,580 @@ struct SearchMessage {
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
         Commands::Search(args) => search_command(args).await,
+        Commands::Create(args) => create_command(args).await,
+        Commands::Publish(args) => publish_command(args).await,
     }
+}
+
+async fn create_command(args: CreateArgs) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let project_id = resolve_template_project(&client, &configs, args.project).await?;
+    let environment_id =
+        resolve_template_environment(&client, &configs, &project_id, args.environment).await?;
+
+    let spinner = create_spinner_if(!args.json, "Creating template...".to_string());
+    let response = post_graphql::<mutations::TemplateGenerate, _>(
+        &client,
+        configs.get_backboard(),
+        mutations::template_generate::Variables {
+            project_id,
+            environment_id,
+        },
+    )
+    .await?;
+
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+
+    let template = response.template_generate;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&template_json(&configs, &template))?
+        );
+    } else {
+        print_created_template(&configs, &template);
+    }
+
+    Ok(())
+}
+
+async fn publish_command(args: PublishArgs) -> Result<()> {
+    if args.readme.is_some() && args.readme_file.is_some() {
+        bail!("Use either --readme or --readme-file, not both");
+    }
+
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let template = fetch_template_by_ref(&client, &configs, &args.template).await?;
+    let is_updating = status_label(&template.status) == "PUBLISHED";
+
+    let category = args
+        .category
+        .clone()
+        .or_else(|| template.category.clone())
+        .unwrap_or_else(|| {
+            fake_select("Select category", "Other");
+            "Other".to_string()
+        });
+    let description = args
+        .description
+        .clone()
+        .or_else(|| template.description.clone())
+        .unwrap_or_else(|| short_description(&template.name));
+    let readme = resolve_readme(args.readme, args.readme_file, &template, is_updating)?;
+    let image = args
+        .image
+        .clone()
+        .or_else(|| template.image.clone())
+        .and_then(non_empty_string);
+    let demo_project_id = args
+        .demo_project
+        .clone()
+        .or_else(|| template.demo_project_id.clone())
+        .and_then(non_empty_string);
+    let workspace_id = match args.workspace {
+        Some(workspace) => Some(resolve_workspace_id(&workspace).await?),
+        None => template.workspace_id.clone(),
+    };
+
+    validate_publish_fields(
+        &category,
+        &description,
+        readme.as_str(),
+        image.as_deref(),
+        is_updating,
+    )?;
+
+    let spinner = create_spinner_if(!args.json, "Publishing template...".to_string());
+    let response = post_graphql::<mutations::TemplatePublish, _>(
+        &client,
+        configs.get_backboard(),
+        mutations::template_publish::Variables {
+            id: template.id,
+            description,
+            category,
+            readme,
+            image,
+            demo_project_id,
+            workspace_id,
+        },
+    )
+    .await?;
+
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+
+    let template = response.template_publish;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&published_template_json(&configs, &template))?
+        );
+    } else {
+        print_published_template(&configs, &template, is_updating);
+    }
+
+    Ok(())
+}
+
+#[derive(Clone)]
+struct TemplateProjectChoice {
+    id: String,
+    name: String,
+    workspace_name: String,
+}
+
+impl std::fmt::Display for TemplateProjectChoice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.name, self.workspace_name)
+    }
+}
+
+async fn resolve_template_project(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project: Option<String>,
+) -> Result<String> {
+    if let Some(project) = project {
+        return resolve_project_arg(client, configs, &project).await;
+    }
+
+    if let Ok(linked_project) = configs.get_linked_project().await {
+        fake_select(
+            "Select project",
+            linked_project
+                .name
+                .as_deref()
+                .unwrap_or(linked_project.project.as_str()),
+        );
+        return Ok(linked_project.project);
+    }
+
+    if !std::io::stdout().is_terminal() {
+        bail!("Project required in non-interactive mode. Use --project <id or name>.");
+    }
+
+    let choices = project_choices().await?;
+    if choices.is_empty() {
+        bail!(RailwayError::NoProjects);
+    }
+
+    let choice = prompt_options("Select project", choices)?;
+    Ok(choice.id)
+}
+
+async fn resolve_project_arg(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project: &str,
+) -> Result<String> {
+    match get_project(client, configs, project.to_string()).await {
+        Ok(project) => {
+            fake_select("Select project", &project.name);
+            return Ok(project.id);
+        }
+        Err(RailwayError::ProjectNotFound) => {}
+        Err(RailwayError::GraphQLError(message)) if message.contains("Project not found") => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    let choice = find_project_choice(project).await?;
+    fake_select("Select project", &choice.to_string());
+    Ok(choice.id)
+}
+
+async fn resolve_template_environment(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project_id: &str,
+    environment: Option<String>,
+) -> Result<Option<String>> {
+    let project = get_project(client, configs, project_id.to_string()).await?;
+    if project.deleted_at.is_some() {
+        bail!(RailwayError::ProjectDeleted);
+    }
+
+    let Some(environment) = environment else {
+        return Ok(None);
+    };
+
+    let environment = get_matched_environment(&project, environment)?;
+    fake_select("Select environment", &environment.name);
+    Ok(Some(environment.id))
+}
+
+async fn find_project_choice(project: &str) -> Result<TemplateProjectChoice> {
+    let choices = project_choices().await?;
+    let id_matches = choices
+        .iter()
+        .filter(|choice| choice.id.eq_ignore_ascii_case(project))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if let Some(choice) = single_match(id_matches, project, "project ID")? {
+        return Ok(choice);
+    }
+
+    let name_matches = choices
+        .into_iter()
+        .filter(|choice| choice.name.eq_ignore_ascii_case(project))
+        .collect::<Vec<_>>();
+
+    if let Some(choice) = single_match(name_matches, project, "project name")? {
+        return Ok(choice);
+    }
+
+    bail!("Project \"{}\" not found", project)
+}
+
+fn single_match(
+    matches: Vec<TemplateProjectChoice>,
+    input: &str,
+    kind: &str,
+) -> Result<Option<TemplateProjectChoice>> {
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.into_iter().next()),
+        _ => {
+            let available = matches
+                .iter()
+                .map(|choice| format!("{} ({})", choice.id, choice.workspace_name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("Ambiguous {kind} \"{input}\". Use one of these project IDs: {available}");
+        }
+    }
+}
+
+async fn project_choices() -> Result<Vec<TemplateProjectChoice>> {
+    let mut choices = Vec::new();
+    for workspace in workspaces().await? {
+        let workspace_name = workspace.name().to_string();
+        choices.extend(
+            workspace
+                .projects()
+                .into_iter()
+                .filter(|project| project.deleted_at().is_none())
+                .map(|project| TemplateProjectChoice {
+                    id: project.id().to_string(),
+                    name: project.name().to_string(),
+                    workspace_name: workspace_name.clone(),
+                }),
+        );
+    }
+    Ok(choices)
+}
+
+async fn fetch_template_by_ref(
+    client: &reqwest::Client,
+    configs: &Configs,
+    template_ref: &str,
+) -> Result<TemplateDetailItem> {
+    match fetch_template(client, configs, Some(template_ref.to_string()), None).await {
+        Ok(template) => Ok(template),
+        Err(RailwayError::GraphQLError(message)) if message.contains("Template not found") => {
+            fetch_template(client, configs, None, Some(template_ref.to_string()))
+                .await
+                .map_err(Into::into)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn fetch_template(
+    client: &reqwest::Client,
+    configs: &Configs,
+    id: Option<String>,
+    code: Option<String>,
+) -> Result<TemplateDetailItem, RailwayError> {
+    let response = post_graphql::<queries::Template, _>(
+        client,
+        configs.get_backboard(),
+        queries::template::Variables { id, code },
+    )
+    .await?;
+    Ok(response.template)
+}
+
+async fn resolve_workspace_id(workspace: &str) -> Result<String> {
+    let matches = workspaces()
+        .await?
+        .into_iter()
+        .filter(|candidate| {
+            candidate.id().eq_ignore_ascii_case(workspace)
+                || candidate.name().eq_ignore_ascii_case(workspace)
+                || candidate
+                    .team_id()
+                    .is_some_and(|team_id| team_id.eq_ignore_ascii_case(workspace))
+        })
+        .collect::<Vec<_>>();
+
+    match matches.len() {
+        0 => bail!(RailwayError::WorkspaceNotFound(workspace.to_string())),
+        1 => {
+            let workspace = matches[0].clone();
+            fake_select("Select workspace", workspace.name());
+            Ok(workspace.id().to_string())
+        }
+        _ => bail!(
+            "Workspace \"{}\" is ambiguous. Use the workspace ID.",
+            workspace
+        ),
+    }
+}
+
+fn resolve_readme(
+    readme: Option<String>,
+    readme_file: Option<PathBuf>,
+    template: &TemplateDetailItem,
+    is_updating: bool,
+) -> Result<String> {
+    if let Some(readme) = readme {
+        fake_select("Template overview", "<provided inline>");
+        return Ok(readme);
+    }
+
+    if let Some(path) = readme_file {
+        return read_readme_file(path);
+    }
+
+    if let Some(readme) = &template.readme {
+        fake_select("Template overview", "<existing template readme>");
+        return Ok(readme.clone());
+    }
+
+    if is_updating {
+        return Ok(default_readme(&template.name));
+    }
+
+    if !std::io::stdout().is_terminal() {
+        bail!("Template overview required. Use --readme-file <path> or --readme <markdown>.");
+    }
+
+    let path = prompt_text_with_placeholder_disappear("Template overview file", "README.md")?;
+    read_readme_file(PathBuf::from(path))
+}
+
+fn read_readme_file(path: PathBuf) -> Result<String> {
+    if path.as_os_str() == "-" {
+        fake_select("Template overview file", "<stdin>");
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input)?;
+        return Ok(input);
+    }
+
+    fake_select("Template overview file", &path.display().to_string());
+    Ok(fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read template overview from {}", path.display()))?)
+}
+
+fn validate_publish_fields(
+    category: &str,
+    description: &str,
+    readme: &str,
+    image: Option<&str>,
+    is_updating: bool,
+) -> Result<()> {
+    validate_description(description)?;
+    validate_category(category)?;
+    if !is_updating {
+        validate_readme(readme)?;
+    }
+    if let Some(image) = image {
+        validate_image(image)?;
+    }
+    Ok(())
+}
+
+fn validate_description(description: &str) -> Result<()> {
+    let len = description.trim().chars().count();
+    if len < DESCRIPTION_MIN {
+        bail!("description: Must be {DESCRIPTION_MIN} or more characters long");
+    }
+    if len > DESCRIPTION_MAX {
+        bail!("description: Must be {DESCRIPTION_MAX} or fewer characters long");
+    }
+    Ok(())
+}
+
+fn validate_category(category: &str) -> Result<()> {
+    if !TEMPLATE_CATEGORIES
+        .iter()
+        .any(|item| *item == category.trim())
+    {
+        bail!(
+            "category: Invalid category. Valid categories: {}",
+            TEMPLATE_CATEGORIES.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn validate_readme(readme: &str) -> Result<()> {
+    let len = readme.trim().chars().count();
+    if len < README_MIN {
+        bail!("readme: Must be {README_MIN} or more characters long");
+    }
+    if len > README_MAX {
+        bail!("readme: Must be {README_MAX} or fewer characters long");
+    }
+
+    let missing = REQUIRED_README_SECTIONS
+        .iter()
+        .filter(|section| !readme.contains(**section))
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!("readme: Missing required sections: {}", missing.join(", "));
+    }
+
+    if DEFAULT_README_TEXT
+        .iter()
+        .any(|default_text| readme.contains(default_text))
+    {
+        bail!("readme: Please update the default text in each section.");
+    }
+
+    Ok(())
+}
+
+fn validate_image(image: &str) -> Result<()> {
+    let image = image.trim();
+    if image.is_empty() {
+        return Ok(());
+    }
+
+    let url = url::Url::parse(image).context("image: Invalid image URL")?;
+    if !matches!(url.scheme(), "http" | "https") {
+        bail!("image: Invalid image URL");
+    }
+
+    let path = url.path().to_lowercase();
+    if !["jpg", "jpeg", "png", "webp", "avif", "gif", "svg", "ico"]
+        .iter()
+        .any(|extension| path.ends_with(&format!(".{extension}")))
+    {
+        bail!("image: Invalid image URL");
+    }
+
+    Ok(())
+}
+
+fn short_description(name: &str) -> String {
+    format!("Deploy and Host {name} with Railway")
+}
+
+fn default_readme(name: &str) -> String {
+    format!(
+        "# Deploy and Host {name} on Railway\n\n\
+         ## About Hosting {name}\n\n\
+         ## Common Use Cases\n\n\
+         ## Dependencies for {name} Hosting\n\n\
+         ### Deployment Dependencies\n\n\
+         ## Why Deploy {name} on Railway?\n\n\
+         Railway is a singular platform to deploy your infrastructure stack. Railway will host your infrastructure so you don't have to deal with configuration, while allowing you to vertically and horizontally scale it.\n"
+    )
+}
+
+fn non_empty_string(value: String) -> Option<String> {
+    let value = value.trim().to_string();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+fn print_created_template(configs: &Configs, template: &GeneratedTemplate) {
+    println!(
+        "{} {} ({})",
+        "Created template".green().bold(),
+        template.name.bold(),
+        template.id
+    );
+    println!("Status: {}", status_label(&template.status));
+    println!();
+    println!("Edit in dashboard:");
+    println!(
+        "  {}",
+        template_editor_url(configs, &template.id)
+            .bold()
+            .underline()
+    );
+    println!();
+    println!("Publish with:");
+    println!(
+        "  railway templates publish {} --category Other --description {} --readme-file README.md",
+        shell_arg(&template.id),
+        shell_arg(&short_description(&template.name))
+    );
+}
+
+fn print_published_template(configs: &Configs, template: &PublishedTemplate, is_updating: bool) {
+    let action = if is_updating {
+        "Updated template"
+    } else {
+        "Published template"
+    };
+    println!(
+        "{} {} ({})",
+        action.green().bold(),
+        template.name.bold(),
+        template.code
+    );
+    println!("Status: {}", status_label(&template.status));
+    println!();
+    println!(
+        "{}",
+        template_url(configs, &template.code).bold().underline()
+    );
+}
+
+fn template_json(configs: &Configs, template: &GeneratedTemplate) -> serde_json::Value {
+    serde_json::json!({
+        "id": template.id,
+        "code": template.code,
+        "name": template.name,
+        "description": template.description,
+        "status": status_label(&template.status),
+        "workspaceId": template.workspace_id,
+        "editorUrl": template_editor_url(configs, &template.id),
+    })
+}
+
+fn published_template_json(configs: &Configs, template: &PublishedTemplate) -> serde_json::Value {
+    serde_json::json!({
+        "id": template.id,
+        "code": template.code,
+        "name": template.name,
+        "description": template.description,
+        "image": template.image,
+        "category": template.category,
+        "readme": template.readme,
+        "demoProjectId": template.demo_project_id,
+        "status": status_label(&template.status),
+        "workspaceId": template.workspace_id,
+        "url": template_url(configs, &template.code),
+    })
+}
+
+fn template_editor_url(configs: &Configs, template_id: &str) -> String {
+    format!(
+        "https://{}/workspace/templates/{template_id}",
+        configs.get_host()
+    )
+}
+
+fn template_url(configs: &Configs, code: &str) -> String {
+    template_url_from_host(configs.get_host(), code)
+}
+
+fn template_url_from_host(host: &str, code: &str) -> String {
+    format!("https://{host}/deploy/{code}")
+}
+
+fn status_label<T: std::fmt::Debug>(status: &T) -> String {
+    format!("{status:?}")
 }
 
 async fn search_command(args: SearchArgs) -> Result<()> {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -33,7 +33,7 @@ use crate::{
         progress::create_spinner_if,
         prompt::{fake_select, prompt_options, prompt_text_with_placeholder_disappear},
     },
-    workspace::workspaces,
+    workspace::workspaces_with_client,
 };
 
 use super::*;
@@ -243,7 +243,7 @@ pub async fn command(args: Args) -> Result<()> {
 
 async fn create_command(args: CreateArgs) -> Result<()> {
     let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
+    let client = GQLClient::new_user_authorized(&configs)?;
     let project_id = resolve_template_project(&client, &configs, args.project).await?;
     let environment_id =
         resolve_template_environment(&client, &configs, &project_id, args.environment).await?;
@@ -282,7 +282,7 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
     }
 
     let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
+    let client = GQLClient::new_user_authorized(&configs)?;
     let template = fetch_template_by_ref(&client, &configs, &args.template).await?;
     let is_updating = matches!(
         &template.status,
@@ -314,7 +314,7 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
         .or_else(|| template.demo_project_id.clone())
         .and_then(non_empty_string);
     let workspace_id = match args.workspace {
-        Some(workspace) => Some(resolve_workspace_id(&workspace).await?),
+        Some(workspace) => Some(resolve_workspace_id(&client, &configs, &workspace).await?),
         None => template.workspace_id.clone(),
     };
 
@@ -396,7 +396,7 @@ async fn resolve_template_project(
         bail!("Project required in non-interactive mode. Use --project <id or name>.");
     }
 
-    let choices = project_choices().await?;
+    let choices = project_choices(client, configs).await?;
     if choices.is_empty() {
         bail!(RailwayError::NoProjects);
     }
@@ -420,7 +420,7 @@ async fn resolve_project_arg(
         Err(error) => return Err(error.into()),
     }
 
-    let choice = find_project_choice(project).await?;
+    let choice = find_project_choice(client, configs, project).await?;
     fake_select("Select project", &choice.to_string());
     Ok(choice.id)
 }
@@ -445,8 +445,12 @@ async fn resolve_template_environment(
     Ok(Some(environment.id))
 }
 
-async fn find_project_choice(project: &str) -> Result<TemplateProjectChoice> {
-    let choices = project_choices().await?;
+async fn find_project_choice(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project: &str,
+) -> Result<TemplateProjectChoice> {
+    let choices = project_choices(client, configs).await?;
     let id_matches = choices
         .iter()
         .filter(|choice| choice.id.eq_ignore_ascii_case(project))
@@ -488,9 +492,12 @@ fn single_match(
     }
 }
 
-async fn project_choices() -> Result<Vec<TemplateProjectChoice>> {
+async fn project_choices(
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<Vec<TemplateProjectChoice>> {
     let mut choices = Vec::new();
-    for workspace in workspaces().await? {
+    for workspace in workspaces_with_client(client, configs).await? {
         let workspace_name = workspace.name().to_string();
         choices.extend(
             workspace
@@ -538,8 +545,12 @@ async fn fetch_template(
     Ok(response.template)
 }
 
-async fn resolve_workspace_id(workspace: &str) -> Result<String> {
-    let matches = workspaces()
+async fn resolve_workspace_id(
+    client: &reqwest::Client,
+    configs: &Configs,
+    workspace: &str,
+) -> Result<String> {
+    let matches = workspaces_with_client(client, configs)
         .await?
         .into_iter()
         .filter(|candidate| {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -46,7 +46,9 @@ type TemplateSearchResponse = queries::template_search::ResponseData;
 type TemplateSearchConnection = queries::template_search::TemplateSearchTemplateSearch;
 type TemplateSearchEdge = queries::template_search::TemplateSearchTemplateSearchEdges;
 type TemplateSearchItem = queries::template_search::TemplateSearchTemplateSearchEdgesNode;
-type TemplateDetailItem = queries::template::TemplateTemplate;
+type RootTemplateItem = queries::template::TemplateTemplate;
+type WorkspaceTemplateItem =
+    queries::workspace_templates::WorkspaceTemplatesWorkspaceTemplatesEdgesNode;
 type GeneratedTemplate = mutations::template_generate::TemplateGenerateTemplateGenerate;
 type PublishedTemplate = mutations::template_publish::TemplatePublishTemplatePublish;
 
@@ -265,6 +267,54 @@ struct SearchMessage {
     result: Result<TemplateSearchConnection, String>,
 }
 
+#[derive(Clone)]
+struct TemplateDetailItem {
+    id: String,
+    code: String,
+    name: String,
+    description: Option<String>,
+    image: Option<String>,
+    category: Option<String>,
+    readme: Option<String>,
+    demo_project_id: Option<String>,
+    status: String,
+    workspace_id: Option<String>,
+}
+
+impl From<RootTemplateItem> for TemplateDetailItem {
+    fn from(template: RootTemplateItem) -> Self {
+        Self {
+            id: template.id,
+            code: template.code,
+            name: template.name,
+            description: template.description,
+            image: template.image,
+            category: template.category,
+            readme: template.readme,
+            demo_project_id: template.demo_project_id,
+            status: status_label(&template.status),
+            workspace_id: template.workspace_id,
+        }
+    }
+}
+
+impl From<WorkspaceTemplateItem> for TemplateDetailItem {
+    fn from(template: WorkspaceTemplateItem) -> Self {
+        Self {
+            id: template.id,
+            code: template.code,
+            name: template.name,
+            description: template.description,
+            image: template.image,
+            category: template.category,
+            readme: template.readme,
+            demo_project_id: template.demo_project_id,
+            status: status_label(&template.status),
+            workspace_id: template.workspace_id,
+        }
+    }
+}
+
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
         Commands::Search(args) => search_command(args).await,
@@ -325,10 +375,7 @@ async fn publish_command(args: PublishArgs) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_user_authorized(&configs)?;
     let template = fetch_template_by_ref(&client, &configs, &template_ref).await?;
-    let is_updating = matches!(
-        &template.status,
-        queries::template::TemplateStatus::PUBLISHED
-    );
+    let is_updating = is_published_status(&template.status);
 
     let category = resolve_publish_category(args.category.clone(), &template, interactive)?;
     let description =
@@ -482,19 +529,20 @@ async fn unpublish_command(args: UnpublishArgs) -> Result<()> {
     Ok(())
 }
 
-fn ensure_template_can_unpublish(
-    status: &queries::template::TemplateStatus,
-    name: &str,
-) -> Result<()> {
-    if matches!(status, queries::template::TemplateStatus::PUBLISHED) {
+fn ensure_template_can_unpublish(status: &str, name: &str) -> Result<()> {
+    if is_published_status(status) {
         return Ok(());
     }
 
     bail!(
         "Template \"{}\" is {}. Only published templates can be unpublished.",
         name,
-        status_label(status)
+        status
     )
+}
+
+fn is_published_status(status: &str) -> bool {
+    status == "PUBLISHED"
 }
 
 #[derive(Clone)]
@@ -717,11 +765,28 @@ async fn fetch_template_by_ref(
     match fetch_template(client, configs, Some(template_ref.to_string()), None).await {
         Ok(template) => Ok(template),
         Err(RailwayError::GraphQLError(message)) if message.contains("Template not found") => {
-            fetch_template(client, configs, None, Some(template_ref.to_string()))
-                .await
-                .map_err(Into::into)
+            match fetch_template(client, configs, None, Some(template_ref.to_string())).await {
+                Ok(template) => Ok(template),
+                Err(error) if should_try_workspace_template_lookup(&error) => {
+                    fetch_workspace_template_by_ref(client, configs, template_ref).await
+                }
+                Err(error) => Err(error.into()),
+            }
+        }
+        Err(error) if should_try_workspace_template_lookup(&error) => {
+            fetch_workspace_template_by_ref(client, configs, template_ref).await
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+fn should_try_workspace_template_lookup(error: &RailwayError) -> bool {
+    match error {
+        RailwayError::Unauthorized | RailwayError::UnauthorizedLogin => true,
+        RailwayError::GraphQLError(message) => {
+            message.contains("Template not found") || message.contains("Not Authorized")
+        }
+        _ => false,
     }
 }
 
@@ -737,7 +802,47 @@ async fn fetch_template(
         queries::template::Variables { id, code },
     )
     .await?;
-    Ok(response.template)
+    Ok(response.template.into())
+}
+
+async fn fetch_workspace_template_by_ref(
+    client: &reqwest::Client,
+    configs: &Configs,
+    template_ref: &str,
+) -> Result<TemplateDetailItem> {
+    for workspace in workspaces_with_client(client, configs).await? {
+        let mut after = None;
+        loop {
+            let response = post_graphql::<queries::WorkspaceTemplates, _>(
+                client,
+                configs.get_backboard(),
+                queries::workspace_templates::Variables {
+                    workspace_id: workspace.id().to_string(),
+                    first: Some(MAX_LIMIT),
+                    after,
+                },
+            )
+            .await?;
+
+            for edge in response.workspace_templates.edges {
+                let template = edge.node;
+                if template.id.eq_ignore_ascii_case(template_ref)
+                    || template.code.eq_ignore_ascii_case(template_ref)
+                {
+                    fake_select("Select workspace", workspace.name());
+                    return Ok(template.into());
+                }
+            }
+
+            if !response.workspace_templates.page_info.has_next_page {
+                break;
+            }
+
+            after = response.workspace_templates.page_info.end_cursor;
+        }
+    }
+
+    bail!("Template \"{}\" not found", template_ref)
 }
 
 async fn resolve_workspace_id(
@@ -2025,20 +2130,14 @@ mod tests {
 
     #[test]
     fn unpublish_guard_accepts_published_templates() {
-        assert!(
-            ensure_template_can_unpublish(&queries::template::TemplateStatus::PUBLISHED, "App")
-                .is_ok()
-        );
+        assert!(ensure_template_can_unpublish("PUBLISHED", "App").is_ok());
     }
 
     #[test]
     fn unpublish_guard_rejects_unpublished_templates() {
-        let error = ensure_template_can_unpublish(
-            &queries::template::TemplateStatus::UNPUBLISHED,
-            "Draft App",
-        )
-        .unwrap_err()
-        .to_string();
+        let error = ensure_template_can_unpublish("UNPUBLISHED", "Draft App")
+            .unwrap_err()
+            .to_string();
 
         assert!(error.contains("Template \"Draft App\" is UNPUBLISHED"));
         assert!(error.contains("Only published templates can be unpublished"));
@@ -2046,10 +2145,9 @@ mod tests {
 
     #[test]
     fn unpublish_guard_rejects_hidden_templates() {
-        let error =
-            ensure_template_can_unpublish(&queries::template::TemplateStatus::HIDDEN, "Hidden App")
-                .unwrap_err()
-                .to_string();
+        let error = ensure_template_can_unpublish("HIDDEN", "Hidden App")
+            .unwrap_err()
+            .to_string();
 
         assert!(error.contains("Template \"Hidden App\" is HIDDEN"));
         assert!(error.contains("Only published templates can be unpublished"));

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -63,6 +63,24 @@ pub type SerializedTemplateConfig = serde_json::Value;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/TemplateGenerate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct TemplateGenerate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/TemplatePublish.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct TemplatePublish;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/TemplateDeploy.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -81,6 +81,14 @@ pub struct TemplatePublish;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/TemplateUnpublish.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct TemplateUnpublish;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/TemplateDeploy.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -88,6 +88,14 @@ pub struct TemplateUnpublish;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/TemplateDelete.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct TemplateDelete;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/TemplateDeploy.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -73,8 +73,7 @@ pub struct TemplateGenerate;
 #[graphql(
     schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/TemplatePublish.graphql",
-    response_derives = "Debug, Serialize, Clone",
-    skip_serializing_none
+    response_derives = "Debug, Serialize, Clone"
 )]
 pub struct TemplatePublish;
 

--- a/src/gql/mutations/strings/TemplateDelete.graphql
+++ b/src/gql/mutations/strings/TemplateDelete.graphql
@@ -1,0 +1,3 @@
+mutation TemplateDelete($id: String!, $workspaceId: String) {
+  templateDelete(id: $id, input: { workspaceId: $workspaceId })
+}

--- a/src/gql/mutations/strings/TemplateGenerate.graphql
+++ b/src/gql/mutations/strings/TemplateGenerate.graphql
@@ -1,5 +1,5 @@
-mutation TemplateGenerate($projectId: String!, $environmentId: String) {
-  templateGenerate(input: { projectId: $projectId, environmentId: $environmentId }) {
+mutation TemplateGenerate($projectId: String!) {
+  templateGenerate(input: { projectId: $projectId }) {
     id
     code
     name

--- a/src/gql/mutations/strings/TemplateGenerate.graphql
+++ b/src/gql/mutations/strings/TemplateGenerate.graphql
@@ -1,0 +1,10 @@
+mutation TemplateGenerate($projectId: String!, $environmentId: String) {
+  templateGenerate(input: { projectId: $projectId, environmentId: $environmentId }) {
+    id
+    code
+    name
+    description
+    status
+    workspaceId
+  }
+}

--- a/src/gql/mutations/strings/TemplateGenerate.graphql
+++ b/src/gql/mutations/strings/TemplateGenerate.graphql
@@ -1,5 +1,5 @@
-mutation TemplateGenerate($projectId: String!) {
-  templateGenerate(input: { projectId: $projectId }) {
+mutation TemplateGenerate($projectId: String!, $environmentId: String) {
+  templateGenerate(input: { projectId: $projectId, environmentId: $environmentId }) {
     id
     code
     name

--- a/src/gql/mutations/strings/TemplatePublish.graphql
+++ b/src/gql/mutations/strings/TemplatePublish.graphql
@@ -1,0 +1,32 @@
+mutation TemplatePublish(
+  $id: String!
+  $description: String!
+  $category: String!
+  $readme: String!
+  $image: String
+  $demoProjectId: String
+  $workspaceId: String
+) {
+  templatePublish(
+    id: $id
+    input: {
+      description: $description
+      category: $category
+      readme: $readme
+      image: $image
+      demoProjectId: $demoProjectId
+      workspaceId: $workspaceId
+    }
+  ) {
+    id
+    code
+    name
+    description
+    image
+    category
+    readme
+    demoProjectId
+    status
+    workspaceId
+  }
+}

--- a/src/gql/mutations/strings/TemplateUnpublish.graphql
+++ b/src/gql/mutations/strings/TemplateUnpublish.graphql
@@ -1,0 +1,3 @@
+mutation TemplateUnpublish($id: String!) {
+  templateUnpublish(id: $id)
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -157,6 +157,14 @@ pub struct TemplateDetail;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/WorkspaceTemplates.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct WorkspaceTemplates;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/GitHubRepos.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -141,6 +141,14 @@ pub type EnvironmentConfig = serde_json::Value;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/Template.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct Template;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/TemplateDetail.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/Template.graphql
+++ b/src/gql/queries/strings/Template.graphql
@@ -1,0 +1,14 @@
+query Template($id: String, $code: String) {
+  template(id: $id, code: $code) {
+    id
+    code
+    name
+    description
+    image
+    category
+    readme
+    demoProjectId
+    status
+    workspaceId
+  }
+}

--- a/src/gql/queries/strings/WorkspaceTemplates.graphql
+++ b/src/gql/queries/strings/WorkspaceTemplates.graphql
@@ -1,0 +1,22 @@
+query WorkspaceTemplates($workspaceId: String!, $first: Int, $after: String) {
+  workspaceTemplates(workspaceId: $workspaceId, first: $first, after: $after) {
+    edges {
+      node {
+        id
+        code
+        name
+        description
+        image
+        category
+        readme
+        demoProjectId
+        status
+        workspaceId
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,6 +664,7 @@ mod cli_tests {
             let find = parse(&["template", "find", "postgres"]).unwrap();
             let create = parse(&["templates", "create", "--environment", "production"]).unwrap();
             let publish = parse(&["templates", "publish", "template-id"]).unwrap();
+            let update = parse(&["templates", "update", "template-id"]).unwrap();
             let unpublish = parse(&["templates", "unpublish", "template-id"]).unwrap();
             let delete = parse(&["templates", "delete", "template-id"]).unwrap();
 
@@ -671,6 +672,7 @@ mod cli_tests {
             assert!(!command_needs_refresh(&find));
             assert!(command_needs_refresh(&create));
             assert!(command_needs_refresh(&publish));
+            assert!(command_needs_refresh(&update));
             assert!(command_needs_refresh(&unpublish));
             assert!(command_needs_refresh(&delete));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -322,32 +322,7 @@ async fn main() -> Result<()> {
         eprintln!("{suggestion}");
     }
 
-    // Commands that do not require authentication -- skip token refresh for these.
-    const NO_AUTH_COMMANDS: &[&str] = &[
-        "login",
-        "logout",
-        "completion",
-        "docs",
-        "setup",
-        "skills",
-        "upgrade",
-        "autoupdate",
-        "telemetry_cmd",
-        "templates",
-        "check_updates",
-    ];
-
-    let is_mcp_install = matches!(
-        cli.subcommand(),
-        Some(("mcp", mcp_matches)) if mcp_matches.subcommand_name() == Some("install")
-    );
-
-    let needs_refresh = cli
-        .subcommand_name()
-        .map(|cmd| !NO_AUTH_COMMANDS.contains(&cmd) && !is_mcp_install)
-        .unwrap_or(false);
-
-    if needs_refresh {
+    if command_needs_refresh(&cli) {
         if let Ok(mut configs) = Configs::new() {
             if let Err(e) = client::ensure_valid_token(&mut configs).await {
                 eprintln!("{}: {e}", "Warning: failed to refresh OAuth token".yellow());
@@ -395,6 +370,42 @@ async fn main() -> Result<()> {
     handle_update_task(check_updates_handle).await;
 
     Ok(())
+}
+
+fn command_needs_refresh(cli: &clap::ArgMatches) -> bool {
+    // Commands that do not require authentication -- skip token refresh for these.
+    const NO_AUTH_COMMANDS: &[&str] = &[
+        "login",
+        "logout",
+        "completion",
+        "docs",
+        "setup",
+        "skills",
+        "upgrade",
+        "autoupdate",
+        "telemetry_cmd",
+        "check_updates",
+    ];
+
+    let is_mcp_install = matches!(
+        cli.subcommand(),
+        Some(("mcp", mcp_matches)) if mcp_matches.subcommand_name() == Some("install")
+    );
+
+    let is_public_templates_command = matches!(
+        cli.subcommand(),
+        Some(("templates", template_matches))
+            if matches!(
+                template_matches.subcommand_name(),
+                Some("search" | "find" | "list" | "ls")
+            )
+    );
+
+    cli.subcommand_name()
+        .map(|cmd| {
+            !NO_AUTH_COMMANDS.contains(&cmd) && !is_mcp_install && !is_public_templates_command
+        })
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -645,6 +656,21 @@ mod cli_tests {
             assert_parses(&["setup", "agent", "-y"]);
             assert_parses(&["setup", "agent", "--remote"]);
             assert_parses(&["setup", "agent", "--remote", "-y"]);
+        }
+
+        #[test]
+        fn template_auth_refresh_is_subcommand_aware() {
+            let search = parse(&["templates", "search"]).unwrap();
+            let find = parse(&["template", "find", "postgres"]).unwrap();
+            let create = parse(&["templates", "create", "--environment", "production"]).unwrap();
+            let publish = parse(&["templates", "publish", "template-id"]).unwrap();
+            let unpublish = parse(&["templates", "unpublish", "template-id"]).unwrap();
+
+            assert!(!command_needs_refresh(&search));
+            assert!(!command_needs_refresh(&find));
+            assert!(command_needs_refresh(&create));
+            assert!(command_needs_refresh(&publish));
+            assert!(command_needs_refresh(&unpublish));
         }
 
         #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -665,12 +665,14 @@ mod cli_tests {
             let create = parse(&["templates", "create", "--environment", "production"]).unwrap();
             let publish = parse(&["templates", "publish", "template-id"]).unwrap();
             let unpublish = parse(&["templates", "unpublish", "template-id"]).unwrap();
+            let delete = parse(&["templates", "delete", "template-id"]).unwrap();
 
             assert!(!command_needs_refresh(&search));
             assert!(!command_needs_refresh(&find));
             assert!(command_needs_refresh(&create));
             assert!(command_needs_refresh(&publish));
             assert!(command_needs_refresh(&unpublish));
+            assert!(command_needs_refresh(&delete));
         }
 
         #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -13,10 +13,17 @@ use super::{
 
 pub async fn workspaces() -> Result<Vec<Workspace>> {
     let configs = Configs::new()?;
-    let vars = queries::user_projects::Variables {};
     let client = GQLClient::new_authorized(&configs)?;
+    workspaces_with_client(&client, &configs).await
+}
+
+pub async fn workspaces_with_client(
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<Vec<Workspace>> {
+    let vars = queries::user_projects::Variables {};
     let response =
-        post_graphql::<queries::UserProjects, _>(&client, configs.get_backboard(), vars).await?;
+        post_graphql::<queries::UserProjects, _>(client, configs.get_backboard(), vars).await?;
 
     // Member variants are yielded first so that a workspace the user both owns
     // and is an external member of keeps the richer Member representation.


### PR DESCRIPTION
## Summary

Adds CLI support for creating, publishing/updating, unpublishing, and deleting Railway templates, matching the dashboard lifecycle while keeping the workflow usable for agents.

## Changes

- Add `railway templates create` / `generate`
  - Creates an unpublished template draft from a project via `templateGenerate`
  - Matches the dashboard Generate Template action by passing project/environment context
  - Prompts for an omitted project in interactive mode
  - Supports `--json` output for agent workflows

- Add `railway templates publish [template]`
  - Publishes or updates a template via `templatePublish`
  - Accepts category, description, README, image, demo project, and workspace
  - Prompts for omitted template/metadata fields in interactive mode
  - Supports README via inline text, file, or stdin
  - Includes dashboard-aligned validation for category, description, README, and image
  - Supports clearing optional fields like `--image ""`

- Add `railway templates update [template]` as an alias for `publish`
  - Mirrors the dashboard behavior: marketplace template info updates go through `templatePublish`
  - Keeps the CLI wording clear when replacing metadata on an already published template
  - Uses the same user-auth refresh path as `templates publish`

- Add `railway templates unpublish [template]`
  - Unpublishes a published template via `templateUnpublish`
  - Prompts for template and confirmation in interactive mode
  - Requires `--yes` for non-interactive use
  - Supports `--2fa-code` and `--json`

- Add `railway templates delete [template]`
  - Deletes a template via `templateDelete`
  - Exposes `delete`, `remove`, and `rm`
  - Prompts for confirmation in interactive mode
  - Requires `--yes` for non-interactive use
  - Supports `--2fa-code` and `--json`

- Use user-scoped auth for template create/publish/update/unpublish/delete
  - Uses OAuth or `RAILWAY_API_TOKEN`
  - Avoids accidentally using project-scoped `RAILWAY_TOKEN`, since these template operations require user context
  - Threads the same user-auth client through project/workspace/template resolution used by these flows
- Add GraphQL operations for template generate, publish, unpublish, delete, lookup, and workspace-template lookup


Notes:

- A truly source-less empty service cannot currently generate a template; the backend returns that the service has no source usable for template generation. The live lifecycle test used `nginx:latest` as the smallest source-backed service.
- The dashboard also uses `templatePublish` for marketplace info updates; `templateUpdateV2` exists, but it updates serialized template config/editor state rather than the publish metadata fields exposed by this CLI flow.
