### PR TITLE
fix(cli): allow `railway login` from non-interactive shells

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -23,14 +23,13 @@ pub struct Args {
 }
 
 pub async fn command(args: Args) -> Result<()> {
-    if !crate::macros::is_stdout_terminal() {
-        if args.browserless {
-            bail!(
-                "Browserless login requires an interactive terminal. For non-interactive environments, set RAILWAY_API_TOKEN or RAILWAY_TOKEN."
-            );
-        }
+    let is_tty = crate::macros::is_stdout_terminal();
+
+    // --browserless prints a user code the human types into another
+    // browser; without a terminal the code has nowhere visible to land.
+    if !is_tty && args.browserless {
         bail!(
-            "Cannot login in non-interactive mode. For non-interactive environments, set RAILWAY_API_TOKEN or RAILWAY_TOKEN."
+            "Browserless login requires an interactive terminal. For non-interactive environments, set RAILWAY_API_TOKEN or RAILWAY_TOKEN."
         );
     }
 
@@ -65,6 +64,13 @@ pub async fn command(args: Args) -> Result<()> {
 
     let token_resp = if args.browserless {
         device_flow_login(host).await?
+    } else if !is_tty {
+        // Non-interactive shell (agent invocation, CI, etc.): skip the
+        // "Open the browser?" prompt and go straight to browser_login.
+        // It opens a browser and waits on a local TCP listener for the
+        // OAuth callback — neither needs stdin or a TTY. If opening
+        // the browser fails, browser_login falls back to device_flow.
+        browser_login(host).await?
     } else {
         let confirm = prompt_confirm_with_default_with_cancel("Open the browser?", true)?;
         match confirm {


### PR DESCRIPTION
## Summary

Removes the over-broad TTY gate on `railway login` that blocks agent invocations (Claude Code, Cursor, Windsurf, etc.) from running the command via a captured shell.

**Today:** `railway login` from a non-TTY shell exits immediately with `Cannot login in non-interactive mode. For non-interactive environments, set RAILWAY_API_TOKEN or RAILWAY_TOKEN.` Agents can't drive the auth flow — the user has to manually re-invoke with `!railway login` (interactive mode) or paste a long-lived API token.

**Why the gate existed:** to protect the interactive `Open the browser?` prompt that asks the user to pick between browser flow and device-code flow.

**Why it was over-broad:** the browser-launch path itself doesn't need stdin or a TTY. `browser_login` opens a browser via `::open::that(&auth_url)` and waits on a localhost TCP listener for the OAuth callback. Both work fine from any shell. If opening the browser fails (rare), `browser_login` already falls back to `device_flow_login`.

**The fix:** when stdout isn't a TTY and `--browserless` wasn't passed, skip the prompt and default straight to `browser_login`.

**Preserved:** `--browserless` + non-TTY still bails. That flow prints a user code the human types into another browser — without a terminal, the code has nowhere visible to land. `RAILWAY_API_TOKEN` / `RAILWAY_TOKEN` env vars remain the canonical path for true headless automation.

## Test plan

- [x] Smoke-tested from a non-TTY shell — `railway login` now reaches the auth flow (timeout at 3s) instead of exiting immediately with `Cannot login in non-interactive mode`.
- [ ] Manual: run `railway login` from a TTY → still prompts `Open the browser?` (unchanged).
- [ ] Manual: run `railway login` from a non-TTY shell (e.g., via an agent) → browser opens, OAuth completes, CLI gets the token.
- [ ] Manual: run `railway login --browserless` from a TTY → device flow works as before.
- [ ] Manual: run `railway login --browserless` from a non-TTY shell → bails with the existing browserless-specific error.

## Context

First commit in a larger Phase 1 of the [Agentic CLI Signup RFC](https://www.notion.so/3670e4c545638130b4a0f061ddafbbc4). This single fix unblocks every agent-driven flow; the rest of the RFC (signup-flow polish, success page, intent resume) layers on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)