### PR TITLE
ci: use pull_request_target so fork PRs can auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,7 +1,7 @@
 name: Auto Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [master]
 


### PR DESCRIPTION
## Summary

- Switch `auto-release.yml` trigger from `pull_request` to `pull_request_target` so the workflow has access to `secrets.RELEASE_TOKEN` when a fork PR is merged.

Repro: #902 was merged from a fork and the auto-release run failed at the checkout step with `Input required and not supplied: token` because `pull_request` events from forks have secrets stripped. See: https://github.com/railwayapp/cli/actions/runs/26240568076

`pull_request_target` runs in the base repo's context and gets the full secret set. Safe here because the job already does `ref: master` in checkout and only reads PR metadata (labels, merge state) — it never executes code from the PR. The workflow file itself is also always loaded from master under `pull_request_target`, so a fork can't modify this workflow to exfiltrate the token.

No behavior change for same-repo branch PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)