### PR TITLE
Forward --remote to setup agent in cli.new installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,10 @@ help_text="Options
    --agents
    Install or reuse the Railway CLI, then configure Railway agent support
 
+   --remote
+   When used with --agents, configure the remote HTTP MCP server at
+   mcp.railway.com instead of the local stdio server
+
    -r, --remove
    Uninstall railway
 
@@ -393,6 +397,7 @@ is_build_available() {
 UNINSTALL=0
 HELP=0
 AGENTS=0
+REMOTE=0
 RAILWAY_HOME_DIR=""
 RAILWAY_ENV_FILE=""
 RAILWAY_FISH_ENV_FILE=""
@@ -475,6 +480,10 @@ while [ "$#" -gt 0 ]; do
     ;;
   --agents)
     AGENTS=1
+    shift 1
+    ;;
+  --remote)
+    REMOTE=1
     shift 1
     ;;
   -h | --help)
@@ -887,6 +896,7 @@ warn_existing_path_conflict() {
 run_agent_setup() {
   local railway_bin="$1"
   local yes=""
+  local remote=""
 
   if [ -z "${RAILWAY_INSTALL_REQUEST_ID-}" ]; then
     RAILWAY_INSTALL_REQUEST_ID="install_$(od -vAn -N16 -tx1 < /dev/urandom | tr -d ' \n')"
@@ -895,6 +905,10 @@ run_agent_setup() {
 
   if [ -n "${FORCE-}" ] || [ ! -t 0 ]; then
     yes="-y"
+  fi
+
+  if [ "$REMOTE" = 1 ]; then
+    remote="--remote"
   fi
 
   if [ -t 0 ] && [ -z "${FORCE-}" ]; then
@@ -906,7 +920,7 @@ run_agent_setup() {
     fi
   fi
 
-  "$railway_bin" setup agent $yes
+  "$railway_bin" setup agent $yes $remote
 
   if ! "$railway_bin" whoami >/dev/null 2>&1; then
     warn "Next: run '$railway_bin login' to finish setup (opens a browser)."

--- a/install.sh
+++ b/install.sh
@@ -529,6 +529,12 @@ else
   VERBOSE=
 fi
 
+# --remote only takes effect alongside --agents (it routes setup agent to the
+# hosted MCP server). Warn loudly rather than silently no-op.
+if [ "$REMOTE" = 1 ] && [ "$AGENTS" != 1 ]; then
+  warn "--remote has no effect without --agents. Re-run with both flags to configure remote MCP."
+fi
+
 write_env_files() {
   local quoted_railway_home
   local fish_railway_home
@@ -1007,6 +1013,15 @@ if [ "$AGENTS" = 1 ] && has railway; then
   esac
 
   if [ "$BREW_INSTALL" = 1 ]; then
+    if [ "$REMOTE" = 1 ]; then
+      # --remote was added in a newer release. Continuing with an older brewed
+      # CLI would call `setup agent --remote` and fail with an unrecognized-arg
+      # error after we already told the user we were continuing. Refuse early.
+      error "Railway CLI was installed via Homebrew (version $CURRENT_VERSION)."
+      error "The --remote flag requires Railway CLI $RAILWAY_VERSION or newer."
+      error "Run 'brew upgrade railway' first, then re-run cli.new --agents --remote."
+      exit 1
+    fi
     warn "Railway CLI was installed via Homebrew."
     warn "Run 'brew upgrade railway' to update from $CURRENT_VERSION to $RAILWAY_VERSION, then re-run cli.new --agents."
     info "Continuing with $CURRENT_VERSION."


### PR DESCRIPTION
## Summary

- Adds a `--remote` flag to `install.sh` (served as `cli.new`).
- When passed alongside `--agents`, the installer forwards `--remote` to `railway setup agent`, configuring the hosted MCP endpoint at `mcp.railway.com` instead of the local stdio server.
- Lets users opt into remote MCP in a single one-liner that mirrors the existing local flow:

  ```bash
  # Local (existing)
  bash <(curl -fsSL cli.new) --agents -y

  # Remote (new)
  bash <(curl -fsSL cli.new) --agents --remote -y
  ```

The flag is only consumed when `--agents` is set, since that's the only path that invokes `run_agent_setup` / `railway setup agent`.

## Why

The docs previously had to compose three commands for the remote case (`cli.new -y && railway skills install && railway mcp install --remote`), which skipped the login check and universal `.agents` directory that `setup agent` writes. This restores symmetry with the local install path.

Pairs with the upcoming Railway docs PR that switches the [agent install command builder](https://docs.railway.com/agents) to emit the new one-liner.

## Test plan

- [ ] `bash install.sh -h` shows the new `--remote` flag in help output.
- [ ] `./install.sh --agents --remote -y` on a clean machine installs the CLI and runs `railway setup agent --remote -y`.
- [ ] `./install.sh --remote` (without `--agents`) is a no-op for MCP (matches help text constraint).
- [ ] `./install.sh --agents -y` (no `--remote`) still configures the local MCP server as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)