### PR TITLE
Rephrase agent advisory and gate by CLI version

### DIFF
--- a/src/util/agent_advisory.rs
+++ b/src/util/agent_advisory.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fs::File, io::Read, path::PathBuf};
+use std::{fs::File, io::Read, path::PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use crate::{telemetry, util};
 
 const STATE_VERSION: u32 = 1;
-const ADVISORY_INTERVAL_HOURS: i64 = 24;
 const DISABLE_ENV: &str = "RAILWAY_AGENT_ADVISORY";
 const FORCE_ENV: &str = "RAILWAY_AGENT";
 
@@ -18,7 +17,7 @@ struct AgentState {
     #[serde(default)]
     setup: SetupState,
     #[serde(default)]
-    advisories: BTreeMap<String, AdvisoryState>,
+    advisory: AdvisoryState,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -31,6 +30,7 @@ struct SetupState {
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AdvisoryState {
+    last_shown_cli_version: Option<String>,
     last_shown_at: Option<DateTime<Utc>>,
 }
 
@@ -156,15 +156,14 @@ fn should_skip_for_args(raw_args: &[String]) -> bool {
     })
 }
 
-fn advisory_is_recent(state: &AgentState, command: &str) -> bool {
+// Suppress the advisory if we've already shown it for the currently running
+// CLI version. Upgrading the CLI re-arms the advisory exactly once.
+fn advisory_already_shown_for_current_cli(state: &AgentState) -> bool {
     state
-        .advisories
-        .get(command)
-        .and_then(|advisory| advisory.last_shown_at)
-        .map(|last_shown_at| {
-            Utc::now() - last_shown_at < chrono::Duration::hours(ADVISORY_INTERVAL_HOURS)
-        })
-        .unwrap_or(false)
+        .advisory
+        .last_shown_cli_version
+        .as_deref()
+        .is_some_and(|shown| shown == env!("CARGO_PKG_VERSION"))
 }
 
 pub async fn maybe_show(raw_args: &[String], command: Option<&str>) {
@@ -180,25 +179,20 @@ pub async fn maybe_show(raw_args: &[String], command: Option<&str>) {
     }
 
     let mut state = read_state();
-    if agent_setup_is_current(&state) || advisory_is_recent(&state, command) {
+    if agent_setup_is_current(&state) || advisory_already_shown_for_current_cli(&state) {
         return;
     }
 
     eprintln!(
-        "\n{}\n\n{}\n\n{}",
-        "IMPORTANT: Railway agent tooling not detected.".yellow().bold(),
-        "Ask the user if they would like this agent to run `railway setup agent -y` to configure the Railway agent tooling (agent skills and MCP configurations)."
-            .yellow(),
-        "Your agent will work much more effectively in Railway with these installed.".yellow()
-            .yellow()
+        "\n{}\n{}",
+        "Railway agent tooling (skills + MCP) isn't installed.".yellow(),
+        "Run `railway setup agent` to configure it.".dimmed(),
     );
 
-    state.advisories.insert(
-        command.to_string(),
-        AdvisoryState {
-            last_shown_at: Some(Utc::now()),
-        },
-    );
+    state.advisory = AdvisoryState {
+        last_shown_cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        last_shown_at: Some(Utc::now()),
+    };
 
     let _ = write_state(&state);
 


### PR DESCRIPTION
## Summary

The previous agent advisory was flagged as prompt-injection by Claude and other agents that scan for directive framing. Users reported the warning firing on roughly every other Railway command during agent sessions.

Two changes:

### 1. Rephrase to neutral status

**Before:**
```
IMPORTANT: Railway agent tooling not detected.

Ask the user if they would like this agent to run `railway setup agent -y`
to configure the Railway agent tooling (agent skills and MCP configurations).

Your agent will work much more effectively in Railway with these installed.
```

**After:**
```
Railway agent tooling (skills + MCP) isn't installed.
Run `railway setup agent` to configure it.
```

- No "ask the user," no "this agent" framing — that combination is the textbook prompt-injection pattern.
- Drops `-y` from the suggested command so the user stays in the loop on the install.

### 2. Gate by CLI version instead of 24h timer

The advisory now fires once per installed CLI version, instead of once per 24h per command. Upgrading the CLI re-arms it exactly once. This eliminates the "fired again because you used a different subcommand" surprise.

### State file changes

`~/.railway/agent-state.json` gains `advisory.lastShownCliVersion`. The old per-command `advisories` map is dropped from the schema:

```json
{
  "setup": { ... },
  "advisory": {
    "lastShownCliVersion": "4.62.0",
    "lastShownAt": "2026-05-26T..."
  }
}
```

Existing state files deserialize cleanly (extra fields ignored). Users on the old schema will see the new advisory at most one more time after upgrading.

## Behavior matrix

| State | Pre | Post |
|---|---|---|
| First run, agent env, setup not done | shown | shown |
| Same CLI version, next command | suppressed for 24h, then shown | suppressed |
| 25h later, same CLI version | shown again | suppressed |
| After CLI upgrade | shown again | shown once |
| After `railway setup agent` | suppressed permanently | suppressed permanently |
| `RAILWAY_AGENT_ADVISORY=0` | suppressed | suppressed |

## Test plan

- [ ] Fresh agent env (e.g. CLAUDECODE=1), no `~/.railway/agent-state.json`: advisory shows, state file written with `lastShownCliVersion` matching `cargo pkgid`.
- [ ] Re-run same command at same CLI version: advisory suppressed.
- [ ] Bump version, re-run: advisory shows again, state updated.
- [ ] `RAILWAY_AGENT_ADVISORY=0`: suppressed regardless of state.
- [ ] `railway setup agent` then any other command: suppressed regardless of state.
- [ ] Old state file with `advisories: { "up": { ... } }` still loads and the new advisory shows at most once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)