### PR TITLE
feat(sandbox): `railway sandbox` commands (create/list/ssh/exec/destroy)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod project;
 pub mod redeploy;
 pub mod restart;
 pub mod run;
+pub mod sandbox;
 pub mod scale;
 pub mod service;
 pub mod setup;

--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -10,8 +10,8 @@ use crate::config::{Configs, StoredSandbox};
 use crate::controllers::environment::get_matched_environment;
 use crate::controllers::project::get_project;
 use crate::gql::{mutations, queries};
-use crate::util::progress::{create_cube_spinner, fail_spinner};
-use crate::util::prompt::{prompt_options, prompt_options_skippable};
+use crate::util::progress::{create_shimmer_spinner, fail_spinner};
+use crate::util::prompt::prompt_options_skippable_indented;
 
 /// Manage ephemeral sandboxes
 #[derive(Parser)]
@@ -223,7 +223,7 @@ async fn prompt_workspace_project_env(
                 name: w.name().to_string(),
             })
             .collect();
-        let ws_id = match prompt_options_skippable("Select a workspace", ws_choices)? {
+        let ws_id = match prompt_options_skippable_indented("Select a workspace", ws_choices)? {
             Some(choice) => choice.id,
             None => bail!("Cancelled."),
         };
@@ -246,7 +246,7 @@ async fn prompt_workspace_project_env(
                     name: p.name().to_string(),
                 })
                 .collect();
-            let project_id = match prompt_options_skippable("Select a project", proj_choices)? {
+            let project_id = match prompt_options_skippable_indented("Select a project", proj_choices)? {
                 Some(choice) => choice.id,
                 None => break 'project,
             };
@@ -268,7 +268,7 @@ async fn prompt_workspace_project_env(
             }
 
             // Environment level. Esc steps back to project selection.
-            match prompt_options_skippable("Select an environment", env_choices)? {
+            match prompt_options_skippable_indented("Select an environment", env_choices)? {
                 Some(choice) => return Ok((project_obj.id, choice.id)),
                 None => continue 'project,
             }
@@ -291,7 +291,10 @@ fn prompt_environment(project: &queries::RailwayProject) -> Result<String> {
     if choices.is_empty() {
         bail!("No accessible environments in this project.");
     }
-    Ok(prompt_options("Select an environment", choices)?.id)
+    match prompt_options_skippable_indented("Select an environment", choices)? {
+        Some(choice) => Ok(choice.id),
+        None => bail!("Cancelled."),
+    }
 }
 
 /// Resolve which sandbox a command should act on: an explicit id (using the
@@ -338,7 +341,7 @@ async fn create(
     let (project_id, environment_id) =
         resolve_project_and_env(configs, client, project, environment).await?;
 
-    let mut spinner = create_cube_spinner("Creating sandbox…".to_string());
+    let mut spinner = create_shimmer_spinner("Creating sandbox");
     let sandbox = match post_graphql::<mutations::SandboxCreate, _>(
         client,
         configs.get_backboard(),
@@ -498,7 +501,7 @@ async fn destroy(
     let (sandbox_id, environment_id) =
         resolve_target(configs, client, args.explicit_id(), project, environment).await?;
 
-    let mut spinner = create_cube_spinner("Destroying sandbox…".to_string());
+    let mut spinner = create_shimmer_spinner("Destroying sandbox");
     if let Err(e) = post_graphql::<mutations::SandboxDestroy, _>(
         client,
         configs.get_backboard(),

--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use clap::Parser;
 use is_terminal::IsTerminal;
 
-use crate::client::{post_graphql, GQLClient};
+use crate::client::{GQLClient, post_graphql};
 use crate::commands::ssh::{ensure_ssh_key, run_native_ssh};
 use crate::config::{Configs, StoredSandbox};
 use crate::controllers::environment::get_matched_environment;
@@ -176,9 +176,9 @@ async fn resolve_project_and_env(
     let project_id = match project.or_else(|| linked.as_ref().map(|l| l.project.clone())) {
         Some(id) => id,
         None if interactive => return prompt_workspace_project_env(client, configs).await,
-        None => bail!(
-            "No project selected. Pass --project and --environment, or run `railway link`."
-        ),
+        None => {
+            bail!("No project selected. Pass --project and --environment, or run `railway link`.")
+        }
     };
 
     let project_obj = get_project(client, configs, project_id).await?;
@@ -313,7 +313,9 @@ async fn resolve_target(
             } else if let Some(stored) = configs.get_sandbox(&id) {
                 stored.environment_id
             } else {
-                resolve_project_and_env(configs, client, None, None).await?.1
+                resolve_project_and_env(configs, client, None, None)
+                    .await?
+                    .1
             };
             Ok((id, environment_id))
         }

--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -1,0 +1,608 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use clap::Parser;
+use is_terminal::IsTerminal;
+
+use crate::client::{post_graphql, GQLClient};
+use crate::commands::ssh::{ensure_ssh_key, run_native_ssh};
+use crate::config::{Configs, StoredSandbox};
+use crate::controllers::environment::get_matched_environment;
+use crate::controllers::project::get_project;
+use crate::gql::{mutations, queries};
+use crate::util::progress::{create_cube_spinner, fail_spinner};
+use crate::util::prompt::{prompt_options, prompt_options_skippable};
+
+/// Manage ephemeral sandboxes
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway sandbox create            # create + remember it as active\n  railway sandbox list              # list sandboxes in the environment\n  railway sandbox ssh               # connect to the active (last) sandbox\n  railway sandbox ssh --id <id>     # connect to a specific sandbox\n  railway sandbox exec --id <id> -- ls -la\n  railway sandbox destroy --id <id>\n\nNote: requires the PROJECT_SANDBOXES feature to be enabled."
+)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Environment name or ID (defaults to the linked environment)
+    #[clap(long, short, global = true)]
+    environment: Option<String>,
+
+    /// Project ID (defaults to the linked project)
+    #[clap(long, short, global = true)]
+    project: Option<String>,
+}
+
+#[derive(Parser)]
+enum Commands {
+    /// Create a sandbox and remember it as the active sandbox
+    #[clap(visible_alias = "new")]
+    Create(CreateArgs),
+
+    /// List sandboxes in the environment
+    #[clap(visible_alias = "ls")]
+    List(ListArgs),
+
+    /// Connect to a sandbox over SSH (defaults to the active sandbox)
+    #[clap(visible_alias = "connect")]
+    Ssh(SshArgs),
+
+    /// Run a single command inside a sandbox (defaults to the active sandbox)
+    Exec(ExecArgs),
+
+    /// Destroy a sandbox (defaults to the active sandbox)
+    #[clap(visible_alias = "rm", visible_alias = "delete")]
+    Destroy(DestroyArgs),
+}
+
+#[derive(Parser)]
+struct CreateArgs {
+    /// Minutes the sandbox may sit idle before it is auto-destroyed
+    #[clap(long)]
+    idle_timeout_minutes: Option<i64>,
+
+    /// Output the created sandbox as JSON
+    #[clap(long)]
+    json: bool,
+}
+
+#[derive(Parser)]
+struct ListArgs {
+    /// Output as JSON
+    #[clap(long)]
+    json: bool,
+}
+
+/// `railway sandbox ssh [--id <id>] [-- command...]`. The id is a flag (not a
+/// positional) so it's unambiguous against the trailing command; omitted → the
+/// active sandbox.
+#[derive(Parser)]
+struct SshArgs {
+    /// Sandbox ID to connect to (defaults to the active sandbox)
+    #[clap(long = "id", value_name = "ID")]
+    id: Option<String>,
+
+    /// Path to an identity (private key) file, like `ssh -i`
+    #[clap(short = 'i', long = "identity-file", value_name = "PATH")]
+    identity_file: Option<std::path::PathBuf>,
+
+    /// Command to run instead of an interactive shell
+    #[clap(trailing_var_arg = true)]
+    command: Vec<String>,
+}
+
+#[derive(Parser)]
+struct ExecArgs {
+    /// Sandbox ID to run in (defaults to the active sandbox)
+    #[clap(long = "id", value_name = "ID")]
+    id: Option<String>,
+
+    /// Per-command timeout in seconds
+    #[clap(long)]
+    timeout: Option<i64>,
+
+    /// Command to run (everything after `--`)
+    #[clap(trailing_var_arg = true, required = true)]
+    command: Vec<String>,
+}
+
+/// Destroy has no trailing command, so a positional id is unambiguous; `--id`
+/// is also accepted. Omitted → the active sandbox.
+#[derive(Parser)]
+struct DestroyArgs {
+    /// Sandbox ID to destroy (defaults to the active sandbox)
+    #[clap(value_name = "ID")]
+    id_positional: Option<String>,
+
+    /// Sandbox ID (alternative to the positional argument)
+    #[clap(long = "id", value_name = "ID")]
+    id: Option<String>,
+}
+
+impl DestroyArgs {
+    fn explicit_id(&self) -> Option<String> {
+        self.id.clone().or_else(|| self.id_positional.clone())
+    }
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let project = args.project;
+    let environment = args.environment;
+
+    match args.command {
+        Commands::Create(sub) => create(&mut configs, &client, project, environment, sub).await,
+        Commands::List(sub) => list(&mut configs, &client, project, environment, sub).await,
+        Commands::Ssh(sub) => ssh(&mut configs, &client, project, environment, sub).await,
+        Commands::Exec(sub) => exec(&mut configs, &client, project, environment, sub).await,
+        Commands::Destroy(sub) => destroy(&mut configs, &client, project, environment, sub).await,
+    }
+}
+
+/// A selectable `{id, name}` shown by name in interactive pickers.
+struct Choice {
+    id: String,
+    name: String,
+}
+
+impl std::fmt::Display for Choice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+/// Resolve `(project_id, environment_id)` for create/list. Precedence:
+/// explicit `--project`/`--environment` flags → the linked project/environment
+/// → an interactive picker (when attached to a TTY) → a helpful error in
+/// non-interactive contexts.
+async fn resolve_project_and_env(
+    configs: &Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+) -> Result<(String, String)> {
+    let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+
+    // The linked project only matters when a flag is missing. Swallow its
+    // errors (no link, or the RAILWAY_ENVIRONMENT_ID-without-PROJECT_ID guard)
+    // and fall back to prompting when interactive.
+    let linked = if project.is_none() || environment.is_none() {
+        configs.get_linked_project().await.ok()
+    } else {
+        None
+    };
+
+    // No project from a flag or the link: run the full workspace → project →
+    // environment picker, which returns both ids.
+    let project_id = match project.or_else(|| linked.as_ref().map(|l| l.project.clone())) {
+        Some(id) => id,
+        None if interactive => return prompt_workspace_project_env(client, configs).await,
+        None => bail!(
+            "No project selected. Pass --project and --environment, or run `railway link`."
+        ),
+    };
+
+    let project_obj = get_project(client, configs, project_id).await?;
+
+    let environment_id = if let Some(env) = environment {
+        get_matched_environment(&project_obj, env)?.id
+    } else if let Some(env_id) = linked
+        .as_ref()
+        .filter(|l| l.project == project_obj.id)
+        .and_then(|l| l.environment.clone())
+    {
+        get_matched_environment(&project_obj, env_id)?.id
+    } else if interactive {
+        prompt_environment(&project_obj)?
+    } else {
+        bail!("No environment selected. Pass --environment, or run `railway link`.");
+    };
+
+    Ok((project_obj.id, environment_id))
+}
+
+/// Full interactive picker: workspace → project → environment. `Esc` steps back
+/// to the previous selection (`Esc` at the workspace level cancels). Returns
+/// `(project_id, environment_id)`. Uses the OAuth-safe `UserProjects` listing
+/// (what `railway list` uses) — the `projects(workspaceId:)` root field is not
+/// authorized for plain user tokens.
+async fn prompt_workspace_project_env(
+    client: &reqwest::Client,
+    configs: &Configs,
+) -> Result<(String, String)> {
+    let workspaces = crate::workspace::workspaces_with_client(client, configs).await?;
+    if workspaces.is_empty() {
+        bail!("No workspaces found. Create a project at https://railway.com/new");
+    }
+
+    // Workspace level. Esc here cancels the whole operation.
+    loop {
+        let ws_choices: Vec<Choice> = workspaces
+            .iter()
+            .map(|w| Choice {
+                id: w.id().to_string(),
+                name: w.name().to_string(),
+            })
+            .collect();
+        let ws_id = match prompt_options_skippable("Select a workspace", ws_choices)? {
+            Some(choice) => choice.id,
+            None => bail!("Cancelled."),
+        };
+        let workspace = workspaces
+            .iter()
+            .find(|w| w.id() == ws_id)
+            .expect("selected workspace exists");
+        let projects = workspace.projects();
+        if projects.is_empty() {
+            eprintln!("That workspace has no projects.");
+            continue; // back to workspace selection
+        }
+
+        // Project level. Esc steps back to workspace selection.
+        'project: loop {
+            let proj_choices: Vec<Choice> = projects
+                .iter()
+                .map(|p| Choice {
+                    id: p.id().to_string(),
+                    name: p.name().to_string(),
+                })
+                .collect();
+            let project_id = match prompt_options_skippable("Select a project", proj_choices)? {
+                Some(choice) => choice.id,
+                None => break 'project,
+            };
+
+            let project_obj = get_project(client, configs, project_id).await?;
+            let env_choices: Vec<Choice> = project_obj
+                .environments
+                .edges
+                .iter()
+                .filter(|e| e.node.can_access)
+                .map(|e| Choice {
+                    id: e.node.id.clone(),
+                    name: e.node.name.clone(),
+                })
+                .collect();
+            if env_choices.is_empty() {
+                eprintln!("That project has no accessible environments.");
+                continue 'project;
+            }
+
+            // Environment level. Esc steps back to project selection.
+            match prompt_options_skippable("Select an environment", env_choices)? {
+                Some(choice) => return Ok((project_obj.id, choice.id)),
+                None => continue 'project,
+            }
+        }
+    }
+}
+
+/// Interactively pick an accessible environment from a project.
+fn prompt_environment(project: &queries::RailwayProject) -> Result<String> {
+    let choices: Vec<Choice> = project
+        .environments
+        .edges
+        .iter()
+        .filter(|e| e.node.can_access)
+        .map(|e| Choice {
+            id: e.node.id.clone(),
+            name: e.node.name.clone(),
+        })
+        .collect();
+    if choices.is_empty() {
+        bail!("No accessible environments in this project.");
+    }
+    Ok(prompt_options("Select an environment", choices)?.id)
+}
+
+/// Resolve which sandbox a command should act on: an explicit id (using the
+/// local store / flags / linked project to recover its environment), or the
+/// active sandbox when none is given.
+async fn resolve_target(
+    configs: &Configs,
+    client: &reqwest::Client,
+    explicit_id: Option<String>,
+    project: Option<String>,
+    environment: Option<String>,
+) -> Result<(String, String)> {
+    match explicit_id {
+        Some(id) => {
+            let environment_id = if project.is_some() || environment.is_some() {
+                resolve_project_and_env(configs, client, project, environment)
+                    .await?
+                    .1
+            } else if let Some(stored) = configs.get_sandbox(&id) {
+                stored.environment_id
+            } else {
+                resolve_project_and_env(configs, client, None, None).await?.1
+            };
+            Ok((id, environment_id))
+        }
+        None => {
+            let stored = configs.get_active_sandbox().ok_or_else(|| {
+                anyhow!(
+                    "No active sandbox. Create one with `railway sandbox create`, or pass --id <id>."
+                )
+            })?;
+            Ok((stored.id, stored.environment_id))
+        }
+    }
+}
+
+async fn create(
+    configs: &mut Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+    args: CreateArgs,
+) -> Result<()> {
+    let (project_id, environment_id) =
+        resolve_project_and_env(configs, client, project, environment).await?;
+
+    let mut spinner = create_cube_spinner("Creating sandbox…".to_string());
+    let sandbox = match post_graphql::<mutations::SandboxCreate, _>(
+        client,
+        configs.get_backboard(),
+        mutations::sandbox_create::Variables {
+            input: mutations::sandbox_create::SandboxCreateInput {
+                environment_id: environment_id.clone(),
+                idle_timeout_minutes: args.idle_timeout_minutes,
+                template: None,
+            },
+        },
+    )
+    .await
+    {
+        Ok(res) => res.sandbox_create,
+        Err(e) => {
+            fail_spinner(&mut spinner, "Failed to create sandbox".to_string());
+            return Err(e.into());
+        }
+    };
+    spinner.finish_and_clear();
+
+    configs.upsert_sandbox(
+        StoredSandbox {
+            id: sandbox.id.clone(),
+            environment_id,
+            project_id: Some(project_id),
+            created_at: Some(sandbox.created_at.to_rfc3339()),
+        },
+        true,
+    );
+    configs.write()?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&sandbox)?);
+    } else {
+        println!("✓ Created sandbox {} (now active)", sandbox.id);
+        println!("  status: {:?}", sandbox.status);
+        println!("  region: {}", sandbox.region);
+        if let Some(idle) = sandbox.idle_timeout_minutes {
+            println!("  idle timeout: {idle}m");
+        }
+        println!("\nConnect with:\n  railway sandbox ssh");
+    }
+    Ok(())
+}
+
+async fn list(
+    configs: &mut Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+    args: ListArgs,
+) -> Result<()> {
+    let (project_id, environment_id) =
+        resolve_project_and_env(configs, client, project, environment).await?;
+
+    let res = post_graphql::<queries::Sandboxes, _>(
+        client,
+        configs.get_backboard(),
+        queries::sandboxes::Variables {
+            environment_id: environment_id.clone(),
+            first: Some(100),
+            after: None,
+        },
+    )
+    .await?;
+    let nodes: Vec<_> = res.sandboxes.edges.into_iter().map(|e| e.node).collect();
+
+    // Refresh the local id -> environment cache so `--id` works for any listed
+    // sandbox. Does not change which sandbox is active.
+    for node in &nodes {
+        configs.upsert_sandbox(
+            StoredSandbox {
+                id: node.id.clone(),
+                environment_id: environment_id.clone(),
+                project_id: Some(project_id.clone()),
+                created_at: Some(node.created_at.to_rfc3339()),
+            },
+            false,
+        );
+    }
+    configs.write()?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&nodes)?);
+        return Ok(());
+    }
+
+    if nodes.is_empty() {
+        println!("No sandboxes in this environment.");
+        return Ok(());
+    }
+
+    let active = configs.get_active_sandbox().map(|s| s.id);
+    println!(
+        "{:<38}  {:<10}  {:<10}  {:<16}",
+        "ID", "STATUS", "REGION", "CREATED"
+    );
+    for node in nodes {
+        let marker = if active.as_deref() == Some(node.id.as_str()) {
+            "*"
+        } else {
+            " "
+        };
+        println!(
+            "{marker} {:<38}  {:<10}  {:<10}  {:<16}",
+            node.id,
+            format!("{:?}", node.status),
+            node.region,
+            node.created_at.format("%Y-%m-%d %H:%M").to_string()
+        );
+    }
+    Ok(())
+}
+
+async fn exec(
+    configs: &mut Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+    args: ExecArgs,
+) -> Result<()> {
+    let (sandbox_id, environment_id) =
+        resolve_target(configs, client, args.id, project, environment).await?;
+
+    configs.set_active_sandbox(&sandbox_id);
+    configs.write()?;
+
+    let res = post_graphql::<mutations::SandboxExec, _>(
+        client,
+        configs.get_backboard(),
+        mutations::sandbox_exec::Variables {
+            id: sandbox_id,
+            environment_id,
+            command: args.command.join(" "),
+            timeout_sec: args.timeout,
+        },
+    )
+    .await?;
+    let result = res.sandbox_exec;
+
+    print!("{}", result.stdout);
+    eprint!("{}", result.stderr);
+    if result.timed_out {
+        eprintln!("\n(command timed out)");
+    }
+    std::process::exit(result.exit_code as i32);
+}
+
+async fn destroy(
+    configs: &mut Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+    args: DestroyArgs,
+) -> Result<()> {
+    let (sandbox_id, environment_id) =
+        resolve_target(configs, client, args.explicit_id(), project, environment).await?;
+
+    let mut spinner = create_cube_spinner("Destroying sandbox…".to_string());
+    if let Err(e) = post_graphql::<mutations::SandboxDestroy, _>(
+        client,
+        configs.get_backboard(),
+        mutations::sandbox_destroy::Variables {
+            id: sandbox_id.clone(),
+            environment_id,
+        },
+    )
+    .await
+    {
+        fail_spinner(&mut spinner, "Failed to destroy sandbox".to_string());
+        return Err(e.into());
+    }
+    spinner.finish_and_clear();
+
+    configs.remove_sandbox(&sandbox_id);
+    configs.write()?;
+    println!("✓ Destroyed sandbox {sandbox_id}");
+    Ok(())
+}
+
+/// How often to extend the sandbox's idle lifetime during an interactive
+/// session. The backboard SSH handshake extends once on connect; this keeps a
+/// long-lived shell alive against the idle reaper.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+
+async fn ssh(
+    configs: &mut Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+    args: SshArgs,
+) -> Result<()> {
+    let (sandbox_id, environment_id) =
+        resolve_target(configs, client, args.id.clone(), project, environment).await?;
+
+    // Reuse the native-SSH key registration flow from `railway ssh`. When the
+    // user didn't pass `-i`, use the registered key it resolves so a
+    // non-default-named key (e.g. ~/.ssh/raildesk_railway_ed25519) is actually
+    // offered to the relay instead of just ssh's default identities.
+    let auto_identity = if args.identity_file.is_none() {
+        ensure_ssh_key(client, configs).await?
+    } else {
+        None
+    };
+
+    configs.set_active_sandbox(&sandbox_id);
+    configs.write()?;
+
+    // Relay target format (per backboard): sbx:<environmentId>:<sandboxId>.
+    // `run_native_ssh` appends `@ssh.railway.com` internally.
+    let target = format!("sbx:{environment_id}:{sandbox_id}");
+
+    // Keep the sandbox alive for the duration of the session.
+    let heartbeat = spawn_heartbeat(
+        client.clone(),
+        configs.get_backboard(),
+        environment_id,
+        sandbox_id,
+    );
+
+    let command = if args.command.is_empty() {
+        None
+    } else {
+        Some(args.command.clone())
+    };
+    let identity = args.identity_file.clone().or(auto_identity);
+
+    // `run_native_ssh` is blocking (inherits the terminal); run it off the
+    // async runtime so the heartbeat task keeps ticking.
+    let exit_code = tokio::task::spawn_blocking(move || {
+        run_native_ssh(&target, command.as_deref(), identity.as_deref())
+    })
+    .await??;
+
+    heartbeat.abort();
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+fn spawn_heartbeat(
+    client: reqwest::Client,
+    backboard: String,
+    environment_id: String,
+    sandbox_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+        // Skip the immediate first tick — backboard already extended on connect.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            let _ = post_graphql::<mutations::SandboxHeartbeat, _>(
+                &client,
+                backboard.clone(),
+                mutations::sandbox_heartbeat::Variables {
+                    id: sandbox_id.clone(),
+                    environment_id: environment_id.clone(),
+                },
+            )
+            .await;
+        }
+    })
+}

--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -11,7 +11,7 @@ use crate::controllers::environment::get_matched_environment;
 use crate::controllers::project::get_project;
 use crate::gql::{mutations, queries};
 use crate::util::progress::{create_shimmer_spinner, fail_spinner};
-use crate::util::prompt::prompt_options_skippable_indented;
+use crate::util::prompt::{prompt_options, prompt_options_skippable};
 
 /// Manage ephemeral sandboxes
 #[derive(Parser)]
@@ -223,7 +223,7 @@ async fn prompt_workspace_project_env(
                 name: w.name().to_string(),
             })
             .collect();
-        let ws_id = match prompt_options_skippable_indented("Select a workspace", ws_choices)? {
+        let ws_id = match prompt_options_skippable("Select a workspace", ws_choices)? {
             Some(choice) => choice.id,
             None => bail!("Cancelled."),
         };
@@ -246,7 +246,7 @@ async fn prompt_workspace_project_env(
                     name: p.name().to_string(),
                 })
                 .collect();
-            let project_id = match prompt_options_skippable_indented("Select a project", proj_choices)? {
+            let project_id = match prompt_options_skippable("Select a project", proj_choices)? {
                 Some(choice) => choice.id,
                 None => break 'project,
             };
@@ -268,7 +268,7 @@ async fn prompt_workspace_project_env(
             }
 
             // Environment level. Esc steps back to project selection.
-            match prompt_options_skippable_indented("Select an environment", env_choices)? {
+            match prompt_options_skippable("Select an environment", env_choices)? {
                 Some(choice) => return Ok((project_obj.id, choice.id)),
                 None => continue 'project,
             }
@@ -291,10 +291,7 @@ fn prompt_environment(project: &queries::RailwayProject) -> Result<String> {
     if choices.is_empty() {
         bail!("No accessible environments in this project.");
     }
-    match prompt_options_skippable_indented("Select an environment", choices)? {
-        Some(choice) => Ok(choice.id),
-        None => bail!("Cancelled."),
-    }
+    Ok(prompt_options("Select an environment", choices)?.id)
 }
 
 /// Resolve which sandbox a command should act on: an explicit id (using the

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -13,6 +13,10 @@ mod tel;
 
 use common::*;
 
+// Re-exported for the `sandbox` command, which reuses the same native SSH
+// transport (key registration + `ssh <target>@ssh.railway.com`).
+pub use native::{ensure_ssh_key, run_native_ssh};
+
 /// Connect to a service via SSH or manage SSH keys
 #[derive(Parser, Clone)]
 pub struct Args {

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use is_terminal::IsTerminal;
 use reqwest::Client;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
@@ -39,7 +39,7 @@ pub async fn get_service_instance_id(
 /// its workspace's keys; session and user tokens get personal keys. The
 /// CLI doesn't need to distinguish — it passes `workspaceId: null` and
 /// the resolver defaults from `ctx.workspace.id` when present.
-pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
+pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<Option<PathBuf>> {
     let local_keys = find_local_ssh_keys().await?;
 
     if local_keys.is_empty() {
@@ -69,7 +69,7 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
             ),
             SshKeySource::Agent => eprintln!("Using SSH key from agent: {}", key.key_name()),
         }
-        return Ok(());
+        return Ok(identity_for(key));
     }
 
     // No local key is registered - need to register one
@@ -125,7 +125,23 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<()> {
 
     println!("SSH key registered successfully!");
 
-    Ok(())
+    Ok(identity_for(key_to_register))
+}
+
+/// The path to hand `ssh -i` for a registered local key. File-backed keys point
+/// at the private key beside the `.pub`; agent-backed keys return `None` (the
+/// agent offers them automatically, and there's no file to pass).
+fn identity_for(key: &crate::controllers::ssh::keys::LocalSshKey) -> Option<PathBuf> {
+    match &key.source {
+        SshKeySource::File(path) => {
+            if path.extension().and_then(|e| e.to_str()) == Some("pub") {
+                Some(path.with_extension(""))
+            } else {
+                Some(path.to_path_buf())
+            }
+        }
+        SshKeySource::Agent => None,
+    }
 }
 
 /// Ensure tmux is installed inside the target container.

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,7 +51,20 @@ pub struct RailwayUser {
     pub token_expires_at: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+/// A sandbox the CLI has created or seen, cached locally so `railway sandbox
+/// ssh`/`exec`/`destroy` can recover its environment (the connection string is
+/// `sbx:<environmentId>:<id>`) without re-specifying `--environment`.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde_with::skip_serializing_none]
+#[serde(rename_all = "camelCase")]
+pub struct StoredSandbox {
+    pub id: String,
+    pub environment_id: String,
+    pub project_id: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
 #[serde_with::skip_serializing_none]
 #[serde(rename_all = "camelCase")]
 pub struct RailwayConfig {
@@ -60,6 +73,11 @@ pub struct RailwayConfig {
     pub editor: Option<String>,
     /// (path, id)
     pub linked_functions: Option<Vec<(String, String)>>,
+    /// Sandboxes the CLI knows about (id -> environment cache).
+    pub sandboxes: Option<Vec<StoredSandbox>>,
+    /// The most recently created/used sandbox; the default target for
+    /// `railway sandbox ssh` when no id is given.
+    pub active_sandbox: Option<String>,
 }
 
 #[derive(Debug)]
@@ -94,12 +112,7 @@ impl Configs {
             let root_config: RailwayConfig = serde_json::from_slice(&serialized_config)
                 .unwrap_or_else(|_| {
                     eprintln!("{}", "Unable to parse config file, regenerating".yellow());
-                    RailwayConfig {
-                        projects: BTreeMap::new(),
-                        user: RailwayUser::default(),
-                        editor: None,
-                        linked_functions: None,
-                    }
+                    RailwayConfig::default()
                 });
 
             let config = Self {
@@ -112,22 +125,12 @@ impl Configs {
 
         Ok(Self {
             root_config_path,
-            root_config: RailwayConfig {
-                projects: BTreeMap::new(),
-                user: RailwayUser::default(),
-                editor: None,
-                linked_functions: None,
-            },
+            root_config: RailwayConfig::default(),
         })
     }
 
     pub fn reset(&mut self) -> Result<()> {
-        self.root_config = RailwayConfig {
-            projects: BTreeMap::new(),
-            user: RailwayUser::default(),
-            editor: None,
-            linked_functions: None,
-        };
+        self.root_config = RailwayConfig::default();
         Ok(())
     }
 
@@ -394,6 +397,53 @@ impl Configs {
 
         self.root_config.projects.insert(path, project);
         Ok(())
+    }
+
+    /// Record a sandbox the CLI created/saw. When `set_active` is true it also
+    /// becomes the default target for `railway sandbox ssh`. Caller persists
+    /// with `write()`.
+    pub fn upsert_sandbox(&mut self, sandbox: StoredSandbox, set_active: bool) {
+        let id = sandbox.id.clone();
+        let sandboxes = self.root_config.sandboxes.get_or_insert_with(Vec::new);
+        match sandboxes.iter_mut().find(|s| s.id == sandbox.id) {
+            Some(existing) => *existing = sandbox,
+            None => sandboxes.push(sandbox),
+        }
+        if set_active {
+            self.root_config.active_sandbox = Some(id);
+        }
+    }
+
+    /// The active sandbox (most recently created/used), if it is still known.
+    pub fn get_active_sandbox(&self) -> Option<StoredSandbox> {
+        let id = self.root_config.active_sandbox.as_ref()?;
+        self.get_sandbox(id)
+    }
+
+    /// Look up a known sandbox by id.
+    pub fn get_sandbox(&self, id: &str) -> Option<StoredSandbox> {
+        self.root_config
+            .sandboxes
+            .as_ref()?
+            .iter()
+            .find(|s| s.id == id)
+            .cloned()
+    }
+
+    /// Mark a known sandbox active. Caller persists with `write()`.
+    pub fn set_active_sandbox(&mut self, id: &str) {
+        self.root_config.active_sandbox = Some(id.to_string());
+    }
+
+    /// Forget a sandbox (e.g. after destroy), clearing the active pointer if it
+    /// referenced this id. Caller persists with `write()`.
+    pub fn remove_sandbox(&mut self, id: &str) {
+        if let Some(sandboxes) = self.root_config.sandboxes.as_mut() {
+            sandboxes.retain(|s| s.id != id);
+        }
+        if self.root_config.active_sandbox.as_deref() == Some(id) {
+            self.root_config.active_sandbox = None;
+        }
     }
 
     pub fn link_service(&mut self, service_id: String) -> Result<()> {

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -332,6 +332,41 @@ pub struct SshPublicKeyCreate;
 )]
 pub struct SshPublicKeyDelete;
 
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/SandboxCreate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct SandboxCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/SandboxExec.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct SandboxExec;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/SandboxDestroy.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct SandboxDestroy;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/SandboxHeartbeat.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+#[allow(dead_code)]
+pub struct SandboxHeartbeat;
+
 impl std::fmt::Display for custom_domain_create::DNSRecordType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/gql/mutations/strings/SandboxCreate.graphql
+++ b/src/gql/mutations/strings/SandboxCreate.graphql
@@ -1,0 +1,10 @@
+mutation SandboxCreate($input: SandboxCreateInput!) {
+  sandboxCreate(input: $input) {
+    id
+    status
+    region
+    environmentId
+    createdAt
+    idleTimeoutMinutes
+  }
+}

--- a/src/gql/mutations/strings/SandboxDestroy.graphql
+++ b/src/gql/mutations/strings/SandboxDestroy.graphql
@@ -1,0 +1,6 @@
+mutation SandboxDestroy($id: String!, $environmentId: String!) {
+  sandboxDestroy(id: $id, environmentId: $environmentId) {
+    id
+    status
+  }
+}

--- a/src/gql/mutations/strings/SandboxExec.graphql
+++ b/src/gql/mutations/strings/SandboxExec.graphql
@@ -1,0 +1,19 @@
+mutation SandboxExec(
+  $id: String!
+  $environmentId: String!
+  $command: String!
+  $timeoutSec: Int
+) {
+  sandboxExec(
+    id: $id
+    environmentId: $environmentId
+    command: $command
+    timeoutSec: $timeoutSec
+  ) {
+    exitCode
+    stdout
+    stderr
+    truncated
+    timedOut
+  }
+}

--- a/src/gql/mutations/strings/SandboxHeartbeat.graphql
+++ b/src/gql/mutations/strings/SandboxHeartbeat.graphql
@@ -1,0 +1,7 @@
+mutation SandboxHeartbeat($id: String!, $environmentId: String!) {
+  sandboxHeartbeat(id: $id, environmentId: $environmentId) {
+    id
+    status
+    idleTimeoutMinutes
+  }
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -264,6 +264,15 @@ pub struct SshPublicKeys;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/Sandboxes.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct Sandboxes;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/TemplateSearch.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/queries/strings/Sandboxes.graphql
+++ b/src/gql/queries/strings/Sandboxes.graphql
@@ -1,0 +1,14 @@
+query Sandboxes($environmentId: String!, $first: Int, $after: String) {
+  sandboxes(environmentId: $environmentId, first: $first, after: $after) {
+    edges {
+      node {
+        id
+        status
+        region
+        environmentId
+        createdAt
+        idleTimeoutMinutes
+      }
+    }
+  }
+}

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -18900,6 +18900,188 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "name": "sandboxCreate",
+              "description": "Create a sandbox in an environment.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SandboxCreateInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Sandbox",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sandboxExec",
+              "description": "Execute a command inside a running sandbox.",
+              "args": [
+                {
+                  "name": "command",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "environmentId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "timeoutSec",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SandboxExecResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sandboxDestroy",
+              "description": "Destroy a sandbox.",
+              "args": [
+                {
+                  "name": "environmentId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sandbox",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sandboxHeartbeat",
+              "description": "Extend a sandbox's lifetime.",
+              "args": [
+                {
+                  "name": "environmentId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Sandbox",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -32995,6 +33177,77 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "name": "sandboxes",
+              "description": "List sandboxes in an environment.",
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "environmentId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "QuerySandboxesConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -49378,6 +49631,423 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "customerTogglePayoutsToCreditsInput",
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Sandbox",
+          "description": null,
+          "fields": [
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "environmentId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "idleTimeoutMinutes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "region",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SandboxStatus",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "SandboxStatus",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "CREATING",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DESTROYED",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DESTROYING",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FAILED",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "RUNNING",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SandboxExecResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "exitCode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stderr",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stdout",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timedOut",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "truncated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SandboxCreateInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "environmentId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "idleTimeoutMinutes",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "template",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SandboxTemplateInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SandboxTemplateInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "baseImageDigest",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "instructions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QuerySandboxesConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "QuerySandboxesConnectionEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "QuerySandboxesConnectionEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Sandbox",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
           "possibleTypes": null
         }
       ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ commands!(
     open,
     project,
     run(local),
+    sandbox(sandboxes, sbx),
     service,
     setup,
     shell,

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -3,6 +3,25 @@ use tokio::time::Duration;
 
 use crate::consts::TICK_STRING;
 
+/// Single-line "rotating cube" frames: a white square whose lit quadrant spins
+/// clockwise, reading like a tumbling cube face.
+const CUBE_TICK_STRING: &str = "◰◳◲◱◼";
+
+/// A spinner that animates a small rotating cube. Use for create/destroy waits.
+pub fn create_cube_spinner(message: String) -> ProgressBar {
+    let spinner = ProgressBar::new_spinner()
+        .with_style(
+            ProgressStyle::default_spinner()
+                .tick_chars(CUBE_TICK_STRING)
+                .template("{spinner:.cyan} {msg}")
+                .expect("Failed to create cube spinner template"),
+        )
+        .with_message(message);
+
+    spinner.enable_steady_tick(Duration::from_millis(120));
+    spinner
+}
+
 pub fn create_spinner(message: String) -> ProgressBar {
     let spinner = ProgressBar::new_spinner()
         .with_style(

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -1,24 +1,61 @@
+use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 use tokio::time::Duration;
 
 use crate::consts::TICK_STRING;
 
-/// Single-line "rotating cube" frames: a white square whose lit quadrant spins
-/// clockwise, reading like a tumbling cube face.
-const CUBE_TICK_STRING: &str = "◰◳◲◱◼";
+/// Half-shaded rotating-cube glyphs: the lit face moves top → right → bottom →
+/// left, reading like a tumbling cube.
+const CUBE_HALF_FRAMES: [&str; 4] = ["⬒", "◨", "⬓", "◧"];
 
-/// A spinner that animates a small rotating cube. Use for create/destroy waits.
-pub fn create_cube_spinner(message: String) -> ProgressBar {
-    let spinner = ProgressBar::new_spinner()
-        .with_style(
-            ProgressStyle::default_spinner()
-                .tick_chars(CUBE_TICK_STRING)
-                .template("{spinner:.cyan} {msg}")
-                .expect("Failed to create cube spinner template"),
-        )
-        .with_message(message);
+const SHIMMER_DIM: (u8, u8, u8) = (120, 128, 140);
+const SHIMMER_BRIGHT: (u8, u8, u8) = (170, 225, 255);
 
-    spinner.enable_steady_tick(Duration::from_millis(120));
+fn lerp_rgb(a: (u8, u8, u8), b: (u8, u8, u8), t: f32) -> (u8, u8, u8) {
+    let l = |x: u8, y: u8| (x as f32 + (y as f32 - x as f32) * t).round() as u8;
+    (l(a.0, b.0), l(a.1, b.1), l(a.2, b.2))
+}
+
+/// A single-line animated "shimmer" spinner: a rotating half-shaded cube, the
+/// label with a light gradient sweeping left→right across it, and trailing dots
+/// that build up one at a time on a loop. The whole animation is precomputed as
+/// indicatif tick frames so the message itself animates (not just a glyph).
+/// `colored` auto-disables ANSI when stdout isn't a TTY, so this degrades to
+/// plain text in pipes/CI.
+pub fn create_shimmer_spinner(label: &str) -> ProgressBar {
+    let chars: Vec<char> = label.chars().collect();
+    let n = chars.len();
+    // One sweep: highlight enters from off the left edge and exits past the end.
+    let sweep = n + 6;
+
+    let frames: Vec<String> = (0..sweep)
+        .map(|i| {
+            let center = i as isize - 3;
+            let cube = CUBE_HALF_FRAMES[i % 4];
+            let dots = ".".repeat((i / 2) % 4); // 0,1,2,3 building up, slower than the sweep
+            let mut text = String::new();
+            for (c, ch) in chars.iter().enumerate() {
+                let dist = (c as isize - center).abs();
+                let intensity = (1.0 - dist as f32 / 3.0).clamp(0.0, 1.0);
+                let (r, g, b) = lerp_rgb(SHIMMER_DIM, SHIMMER_BRIGHT, intensity);
+                text.push_str(&ch.to_string().truecolor(r, g, b).to_string());
+            }
+            let (cr, cg, cb) = SHIMMER_BRIGHT;
+            format!("{} {text}{dots}", cube.truecolor(cr, cg, cb))
+        })
+        // Reserved trailing "finished" frame (never shown — we finish_and_clear).
+        .chain(std::iter::once(label.to_string()))
+        .collect();
+
+    let frame_refs: Vec<&str> = frames.iter().map(String::as_str).collect();
+    let spinner = ProgressBar::new_spinner().with_style(
+        ProgressStyle::default_spinner()
+            .tick_strings(&frame_refs)
+            .template("{spinner}")
+            .expect("Failed to create shimmer spinner template"),
+    );
+
+    spinner.enable_steady_tick(Duration::from_millis(90));
     spinner
 }
 

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -32,6 +32,32 @@ pub fn prompt_options_skippable<T: Display>(message: &str, options: Vec<T>) -> R
         .context("Failed to prompt for options")
 }
 
+/// Render config that indents the prompt and its options ~2 columns, so a
+/// selection menu reads as running "under" the command that launched it.
+fn indented_render_config() -> inquire::ui::RenderConfig<'static> {
+    use inquire::ui::{Attributes, Color, StyleSheet, Styled};
+    Configs::get_render_config()
+        .with_prompt_prefix(
+            Styled::new("  ?").with_style_sheet(
+                StyleSheet::new()
+                    .with_fg(Color::LightCyan)
+                    .with_attr(Attributes::BOLD),
+            ),
+        )
+        .with_highlighted_option_prefix(Styled::new("  ❯"))
+}
+
+/// Like [`prompt_options_skippable`] but indented under the launching command.
+pub fn prompt_options_skippable_indented<T: Display>(
+    message: &str,
+    options: Vec<T>,
+) -> Result<Option<T>> {
+    inquire::Select::new(message, options)
+        .with_render_config(indented_render_config())
+        .prompt_skippable()
+        .context("Failed to prompt for options")
+}
+
 pub fn prompt_options_skippable_with_default<T: Display>(
     message: &str,
     options: Vec<T>,

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -32,32 +32,6 @@ pub fn prompt_options_skippable<T: Display>(message: &str, options: Vec<T>) -> R
         .context("Failed to prompt for options")
 }
 
-/// Render config that indents the prompt and its options ~2 columns, so a
-/// selection menu reads as running "under" the command that launched it.
-fn indented_render_config() -> inquire::ui::RenderConfig<'static> {
-    use inquire::ui::{Attributes, Color, StyleSheet, Styled};
-    Configs::get_render_config()
-        .with_prompt_prefix(
-            Styled::new("  ?").with_style_sheet(
-                StyleSheet::new()
-                    .with_fg(Color::LightCyan)
-                    .with_attr(Attributes::BOLD),
-            ),
-        )
-        .with_highlighted_option_prefix(Styled::new("  ❯"))
-}
-
-/// Like [`prompt_options_skippable`] but indented under the launching command.
-pub fn prompt_options_skippable_indented<T: Display>(
-    message: &str,
-    options: Vec<T>,
-) -> Result<Option<T>> {
-    inquire::Select::new(message, options)
-        .with_render_config(indented_render_config())
-        .prompt_skippable()
-        .context("Failed to prompt for options")
-}
-
 pub fn prompt_options_skippable_with_default<T: Display>(
     message: &str,
     options: Vec<T>,


### PR DESCRIPTION
## What

Adds a `railway sandbox` command group for **Project Sandboxes** (gated by the `PROJECT_SANDBOXES` backend flag). The backend is already shipped — this is **CLI-only**.

### Commands
- **`railway sandbox create`** — provisions a sandbox and remembers it as the *active* one. Interactive **workspace → project → environment** picker when no project is linked (Esc steps back a level); `--project`/`--environment` for non-interactive use.
- **`railway sandbox list`** (`ls`) — sandboxes in the environment, with a `CREATED` column; the active sandbox is marked `*`.
- **`railway sandbox ssh`** (`connect`) — connects over the native SSH relay (`sbx:<env>:<id>@ssh.railway.com`). Defaults to the active sandbox, or `--id <id>` (environment recovered from the local store). Reuses the existing `railway ssh` key-registration flow and auto-selects the registered key; sends periodic `sandboxHeartbeat`s to keep the session alive.
- **`railway sandbox exec -- <cmd>`** — one-shot command via `sandboxExec`.
- **`railway sandbox destroy`** (`rm`/`delete`) — tears down a sandbox.

### Notes
- **Local store**: `~/.railway/config.json` gains `sandboxes` (id→environment cache) + `active_sandbox`, so `ssh`/`exec`/`destroy` work without re-specifying `--environment`.
- **No credentials injected** into sandbox SSH sessions — the backend deliberately returns an empty shell env for sandbox targets; only `RAILWAY_PROJECT_ID`/`ENVIRONMENT_ID`/`SANDBOX_ID` context vars are present.
- **Auth**: a standard `railway login` (user OAuth) is sufficient; `RAILWAY_API_TOKEN` is not required.
- **`schema.json`**: additively adds only the `Sandbox*` types + the sandbox query/mutation fields (no reformat/reorder of the existing schema).
- A single-line **rotating-cube spinner** covers the create/destroy waits.

### Testing
Verified end-to-end against production: `create → list → ssh → exec → destroy`, the active-sandbox default, `--id` resolution, the interactive picker's data path, and the no-injection behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)