### PR TITLE
SSH Command: Handle Identity Files

### DIFF
--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -83,8 +83,10 @@ pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
 
+    let mut auto_ssh_identity = None;
     if args.identity_file.is_none() {
-        tel::track("key_setup", native::ensure_ssh_key(&client, &configs).await).await?;
+        auto_ssh_identity =
+            tel::track("key_setup", ensure_ssh_key(&client, &configs).await).await?;
     }
 
     let ssh_target = if let Some(ref instance_id) = args.deployment_instance {
@@ -108,17 +110,20 @@ pub async fn command(args: Args) -> Result<()> {
         .await?
     };
 
-    let identity_file = args.identity_file.as_deref();
+    let effective_identity = args
+        .identity_file
+        .as_deref()
+        .or(auto_ssh_identity.as_deref());
 
     if let Some(session_name) = args.session {
         tel::track(
             "tmux_install",
-            native::ensure_tmux_installed(&ssh_target, identity_file),
+            native::ensure_tmux_installed(&ssh_target, effective_identity),
         )
         .await?;
         return tel::track(
             "session_connect",
-            native::run_tmux_session(&ssh_target, &session_name, identity_file),
+            native::run_tmux_session(&ssh_target, &session_name, effective_identity),
         )
         .await;
     }
@@ -130,7 +135,7 @@ pub async fn command(args: Args) -> Result<()> {
     };
     let exit_code = tel::track(
         "spawn",
-        native::run_native_ssh(&ssh_target, command, identity_file),
+        native::run_native_ssh(&ssh_target, command, effective_identity),
     )
     .await?;
     if exit_code != 0 {

--- a/src/controllers/ssh/keys.rs
+++ b/src/controllers/ssh/keys.rs
@@ -75,10 +75,16 @@ pub async fn find_local_ssh_keys() -> Result<Vec<LocalSshKey>> {
 
     let mut keys = seen.into_values().collect::<Vec<_>>();
     keys.sort_by_key(|k| {
-        SUPPORTED_KEY_TYPES
+        let source_priority = match k.source {
+            SshKeySource::Agent => 0,
+            SshKeySource::File(_) => 1,
+        };
+        let type_priority = SUPPORTED_KEY_TYPES
             .iter()
             .position(|t| k.key_type.starts_with(t))
-            .unwrap_or(usize::MAX)
+            .unwrap_or(usize::MAX);
+
+        (source_priority, type_priority)
     });
 
     Ok(keys)


### PR DESCRIPTION
Inspired by #925. If Railway wants to use a file-based SSH key, it will explicitly pass that key to the SSH command via `-i`. This helps cases where a user has a key at e.g., `railway_key`, which would not automatically be used by the SSH command. Should fix, e.g., #922.

Also fixes key sorting to always prioritize agent keys over file keys, as agents *generally* have tighter security guarantees.