### PR TITLE
feat(sandbox): request the `sandbox` OAuth scope on login

### DIFF
--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub const CLI_SCOPES: &str =
-    "openid email profile offline_access workspace:admin project:admin ssh_keys";
+    "openid email profile offline_access workspace:admin project:admin ssh_keys sandbox";
 
 const DEFAULT_OAUTH_CLIENT_ID: &str = "rlwy_oaci_onEklvmksh1hRUiCo7E2zX12";
 


### PR DESCRIPTION
Follow-up to the merged `railway sandbox` commands (#925).

Backboard is adding a required **`sandbox` OAuth scope** for all sandbox operations (least-privilege: a sandbox-scoped token can't reach the rest of the account, and is safe to inject into a sandbox). This adds `sandbox` to `CLI_SCOPES` so `railway login` requests/grants it.

**Rollout / UX note:** this is a one-line, non-breaking CLI change on its own. But once backboard *enforces* the scope, **existing sessions must `railway login` again** — a token *refresh* keeps the originally-granted scopes, so only a fresh consent picks up `sandbox`. Ship + roll out this CLI change before enabling backboard enforcement to avoid locking out current users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)