### PR TITLE
feat(volume): include modified time in files JSON

### DIFF
--- a/src/commands/volume/files.rs
+++ b/src/commands/volume/files.rs
@@ -244,6 +244,7 @@ pub(crate) async fn list(target: FileTarget, args: ListArgs) -> Result<()> {
                     "path": entry.path,
                     "type": entry.kind,
                     "size": entry.size,
+                    "modifiedAt": entry.modified_at,
                 })
             })
             .collect();

--- a/src/commands/volume/sftp.rs
+++ b/src/commands/volume/sftp.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
 use colored::Colorize;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use russh_sftp::{
@@ -31,6 +32,7 @@ pub(crate) struct VolumeFileEntry {
     pub(crate) path: String,
     pub(crate) kind: &'static str,
     pub(crate) size: u64,
+    pub(crate) modified_at: Option<DateTime<Utc>>,
 }
 
 pub(crate) struct VolumeFileTree {
@@ -882,6 +884,7 @@ impl VolumeSftp {
                         _ => "other",
                     },
                     size: metadata.len(),
+                    modified_at: metadata.modified().ok().map(DateTime::<Utc>::from),
                 }
             })
             .collect();

--- a/src/controllers/volume_browser/mod.rs
+++ b/src/controllers/volume_browser/mod.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
 use crossterm::{
     cursor::{Hide, Show},
     event::{Event, EventStream, KeyEventKind},
@@ -558,12 +559,17 @@ fn apply_optimistic_upload(app: &mut VolumeBrowserApp, local_path: &Path, remote
     let metadata = std::fs::metadata(local_path).ok();
     let is_dir = metadata.as_ref().is_some_and(|m| m.is_dir());
     let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+    let modified_at = metadata
+        .as_ref()
+        .and_then(|m| m.modified().ok())
+        .map(DateTime::<Utc>::from);
 
     let entry = VolumeFileEntry {
         name: name.clone(),
         path: remote_path.to_string(),
         kind: if is_dir { "directory" } else { "file" },
         size,
+        modified_at,
     };
 
     app.cache.apply_upsert(&parent, entry.clone());


### PR DESCRIPTION
**Problem**
we have a service that is turborepo remote cache that stores the cache on disk.  we have a job that tries to clean up old artifacts (> 2d). the new volume cli is super helpful to modify the filesystem but i can't tell the mtime of the files

**Solution**
add last modified at field to the json output for volumes
