### PR TITLE
Add service source connection support

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -5,7 +5,10 @@ use strum::{Display, EnumIs, EnumIter, IntoEnumIterator};
 
 use crate::{
     controllers::{
-        database::DatabaseType, project::ensure_project_and_environment_exist, variables::Variable,
+        database::DatabaseType,
+        github::{resolve_repo_branch, validate_repo_name},
+        project::ensure_project_and_environment_exist,
+        variables::Variable,
     },
     util::{
         progress::create_spinner_if,
@@ -21,7 +24,7 @@ use super::*;
 /// Add a service to your project
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway add --service api --json\n  railway add --database postgres --json\n  railway add --repo railwayapp/starters --service web --json\n  railway add --image nginx:latest --service web --json\n\nAutomation notes:\n  Non-interactive runs must pass one of --service, --database, --repo, or --image.\n  Use --json for machine-readable output and read stderr separately for progress or selection echoes."
+    after_help = "Examples:\n\n  railway add --service api --json\n  railway add --database postgres --json\n  railway add --repo railwayapp/starters --branch main --service web --json\n  railway add --image nginx:latest --service web --json\n\nAutomation notes:\n  Non-interactive runs must pass one of --service, --database, --repo, or --image.\n  Use --json for machine-readable output and read stderr separately for progress or selection echoes."
 )]
 pub struct Args {
     /// The name of the database to add
@@ -35,6 +38,10 @@ pub struct Args {
     /// The repo to link to the service
     #[clap(short, long)]
     repo: Option<String>,
+
+    /// Branch to deploy from when creating a service from a GitHub repo
+    #[clap(long, requires = "repo")]
+    branch: Option<String>,
 
     /// The docker image to link to the service
     #[clap(short, long)]
@@ -73,6 +80,7 @@ pub async fn command(args: Args) -> Result<()> {
         fake_select("What do you need?", "GitHub Repo");
         CreateKind::GithubRepo {
             repo: prompt_repo(args.repo)?,
+            branch: args.branch,
             variables: prompt_variables(args.variables)?,
             name: prompt_name(args.service)?,
         }
@@ -111,6 +119,7 @@ pub async fn command(args: Args) -> Result<()> {
                 let variables = prompt_variables(args.variables)?;
                 CreateKind::GithubRepo {
                     repo,
+                    branch: args.branch,
                     variables,
                     name: prompt_name(args.service)?,
                 }
@@ -165,6 +174,7 @@ pub async fn command(args: Args) -> Result<()> {
                 &client,
                 &mut configs,
                 None,
+                None,
                 Some(image),
                 variables,
                 verbose,
@@ -174,6 +184,7 @@ pub async fn command(args: Args) -> Result<()> {
         }
         CreateKind::GithubRepo {
             repo,
+            branch,
             variables,
             name,
         } => {
@@ -183,6 +194,7 @@ pub async fn command(args: Args) -> Result<()> {
                 &client,
                 &mut configs,
                 Some(repo),
+                branch,
                 None,
                 variables,
                 verbose,
@@ -196,6 +208,7 @@ pub async fn command(args: Args) -> Result<()> {
                 &linked_project,
                 &client,
                 &mut configs,
+                None,
                 None,
                 None,
                 variables,
@@ -294,6 +307,7 @@ async fn create_service(
     client: &reqwest::Client,
     configs: &mut Configs,
     repo: Option<String>,
+    branch: Option<String>,
     image: Option<String>,
     variables: Variables,
     verbose: bool,
@@ -302,21 +316,11 @@ async fn create_service(
     let spinner = create_spinner_if(!json, "Creating service...".into());
     let source = mutations::service_create::ServiceSourceInput { repo, image };
     let branch = if let Some(repo) = &source.repo {
+        validate_repo_name(repo)?;
         if verbose {
             eprintln!("fetching branch for github repo {repo}")
         }
-        let repos = post_graphql::<queries::GitHubRepos, _>(
-            client,
-            &configs.get_backboard(),
-            queries::git_hub_repos::Variables {},
-        )
-        .await?
-        .github_repos;
-        let repo = repos
-            .iter()
-            .find(|r| r.full_name == *repo)
-            .ok_or(anyhow::anyhow!("repo not found"))?;
-        Some(repo.default_branch.clone())
+        Some(resolve_repo_branch(client, configs, repo, branch).await?)
     } else {
         None
     };
@@ -354,6 +358,7 @@ enum CreateKind {
     #[strum(to_string = "GitHub Repo")]
     GithubRepo {
         repo: String,
+        branch: Option<String>,
         variables: Variables,
         name: Option<String>,
     },

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -927,6 +927,24 @@ impl RailwayMcp {
     }
 
     #[tool(
+        description = "Connect an existing Railway service to a GitHub repo or Docker image. For GitHub repos, this enables Railway-managed deployment triggers when the project has GitHub App access."
+    )]
+    async fn connect_service_source(
+        &self,
+        Parameters(params): Parameters<ConnectServiceSourceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_connect_service_source(params).await
+    }
+
+    #[tool(description = "Disconnect an existing Railway service from its current source.")]
+    async fn disconnect_service_source(
+        &self,
+        Parameters(params): Parameters<ServiceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_disconnect_service_source(params).await
+    }
+
+    #[tool(
         description = "Remove a service from a Railway project. This is irreversible. Returns a preview first.",
         annotations(destructive_hint = true)
     )]

--- a/src/commands/mcp/params.rs
+++ b/src/commands/mcp/params.rs
@@ -210,7 +210,32 @@ pub struct CreateServiceParams {
     /// GitHub repo to connect (e.g. "owner/repo").
     #[serde(default)]
     pub source_repo: Option<String>,
+    /// Git branch to deploy when source_repo is set. Defaults to the repo default branch when Railway can see it.
+    #[serde(default)]
+    pub branch: Option<String>,
     /// Docker image to use (e.g. "nginx:latest").
+    #[serde(default)]
+    pub source_image: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ConnectServiceSourceParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// GitHub repo to connect, in owner/repo format.
+    #[serde(default)]
+    pub source_repo: Option<String>,
+    /// Git branch to deploy when source_repo is set. Defaults to the repo default branch when Railway can see it.
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// Docker image to connect (e.g. "nginx:latest").
     #[serde(default)]
     pub source_image: Option<String>,
 }

--- a/src/commands/mcp/tools/project.rs
+++ b/src/commands/mcp/tools/project.rs
@@ -3,6 +3,7 @@ use rmcp::{ErrorData as McpError, model::*};
 use crate::{
     client::post_graphql,
     controllers::{
+        github::{resolve_repo_branch, validate_repo_name},
         project::{get_environment_instances, service_instances_in_env},
         regions::{fetch_regions_for_project, resolve_deploy_region_id},
     },
@@ -12,8 +13,8 @@ use crate::{
 
 use super::super::handler::RailwayMcp;
 use super::super::params::{
-    CreateEnvironmentParams, CreateProjectParams, CreateServiceParams, EnvironmentStatusParams,
-    RemoveServiceParams, UpdateServiceParams,
+    ConnectServiceSourceParams, CreateEnvironmentParams, CreateProjectParams, CreateServiceParams,
+    EnvironmentStatusParams, RemoveServiceParams, ServiceParams, UpdateServiceParams,
 };
 
 impl RailwayMcp {
@@ -133,10 +134,32 @@ impl RailwayMcp {
                 None,
             ));
         }
+        if params.branch.is_some() && params.source_repo.is_none() {
+            return Err(McpError::invalid_params(
+                "branch can only be used with source_repo.",
+                None,
+            ));
+        }
 
         let ctx = self
             .resolve_context(params.project_id, params.environment_id)
             .await?;
+
+        let branch = if let Some(repo) = params.source_repo.as_deref() {
+            validate_repo_name(repo).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+            Some(
+                resolve_repo_branch(&self.client, &self.configs, repo, params.branch)
+                    .await
+                    .map_err(|e| {
+                        McpError::invalid_params(
+                            format!("Failed to resolve repo branch: {e}"),
+                            None,
+                        )
+                    })?,
+            )
+        } else {
+            None
+        };
 
         let source = if params.source_image.is_some() || params.source_repo.is_some() {
             Some(mutations::service_create::ServiceSourceInput {
@@ -152,7 +175,7 @@ impl RailwayMcp {
             project_id: ctx.project_id,
             environment_id: ctx.environment_id,
             source,
-            branch: None,
+            branch,
             variables: None,
         };
 
@@ -167,6 +190,94 @@ impl RailwayMcp {
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Service created: {} (id: {})",
             result.service_create.name, result.service_create.id
+        ))]))
+    }
+
+    pub(crate) async fn do_connect_service_source(
+        &self,
+        params: ConnectServiceSourceParams,
+    ) -> Result<CallToolResult, McpError> {
+        if params.source_image.is_some() == params.source_repo.is_some() {
+            return Err(McpError::invalid_params(
+                "Provide exactly one of source_repo or source_image.",
+                None,
+            ));
+        }
+        if params.branch.is_some() && params.source_repo.is_none() {
+            return Err(McpError::invalid_params(
+                "branch can only be used with source_repo.",
+                None,
+            ));
+        }
+
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+
+        let (repo, branch, image) = if let Some(repo) = params.source_repo {
+            validate_repo_name(&repo).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+            let branch = resolve_repo_branch(&self.client, &self.configs, &repo, params.branch)
+                .await
+                .map_err(|e| {
+                    McpError::invalid_params(format!("Failed to resolve repo branch: {e}"), None)
+                })?;
+            (Some(repo), Some(branch), None)
+        } else {
+            (None, None, params.source_image)
+        };
+
+        let result = post_graphql::<mutations::ServiceConnect, _>(
+            &self.client,
+            self.configs.get_backboard(),
+            mutations::service_connect::Variables {
+                id: ctx.service_id.clone(),
+                input: mutations::service_connect::ServiceConnectInput {
+                    repo: repo.clone(),
+                    branch: branch.clone(),
+                    image: image.clone(),
+                },
+            },
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to connect service source: {e}"), None)
+        })?;
+
+        let source = match (&repo, &branch, &image) {
+            (Some(repo), Some(branch), _) => format!("{repo}@{branch}"),
+            (_, _, Some(image)) => image.clone(),
+            _ => "source".to_string(),
+        };
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Connected service source: {} (id: {}) -> {}",
+            result.service_connect.name, result.service_connect.id, source
+        ))]))
+    }
+
+    pub(crate) async fn do_disconnect_service_source(
+        &self,
+        params: ServiceParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+
+        let result = post_graphql::<mutations::ServiceDisconnect, _>(
+            &self.client,
+            self.configs.get_backboard(),
+            mutations::service_disconnect::Variables {
+                id: ctx.service_id.clone(),
+            },
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to disconnect service source: {e}"), None)
+        })?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Disconnected service source: {} (id: {})",
+            result.service_disconnect.name, result.service_disconnect.id
         ))]))
     }
 

--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -8,6 +8,7 @@ use crate::{
     commands::output::service_summary::{ServiceOutput, build_service_output, print_service_card},
     controllers::{
         environment::get_matched_environment,
+        github::{resolve_repo_branch, validate_repo_name},
         project::{
             ensure_project_and_environment_exist, ensure_service_has_active_deployment,
             find_service_instance, get_environment_instances, get_project, get_service_ids_in_env,
@@ -35,7 +36,7 @@ pub fn get_dynamic_args(cmd: clap::Command) -> clap::Command {
 /// Manage services
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway service list --json\n  railway service delete --service api --environment production --yes --json\n  railway service link api\n  railway service files list /app --json\n  railway service files browse /app\n  railway service files download /app/data.db ./data.db --json\n  railway service files upload ./seed.db /app/seed.db --json\n  railway service files delete /app/data.db --yes --json\n  railway service files rename /app/data.db /app/data-old.db --json\n\nAutomation notes:\n  Destructive non-interactive runs must pass exact selectors and --yes.\n  Prefer service IDs from `railway service list --json` when names may collide."
+    after_help = "Examples:\n\n  railway service list --json\n  railway service delete --service api --environment production --yes --json\n  railway service link api\n  railway service source connect --repo owner/repo --branch main --service api\n  railway service source disconnect --service api\n  railway service files list /app --json\n  railway service files browse /app\n  railway service files download /app/data.db ./data.db --json\n  railway service files upload ./seed.db /app/seed.db --json\n  railway service files delete /app/data.db --yes --json\n  railway service files rename /app/data.db /app/data-old.db --json\n\nAutomation notes:\n  Destructive non-interactive runs must pass exact selectors and --yes.\n  Prefer service IDs from `railway service list --json` when names may collide."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -57,6 +58,9 @@ enum Commands {
 
     /// Link a service to the current project
     Link(LinkArgs),
+
+    /// Connect or disconnect a service source
+    Source(SourceArgs),
 
     /// Show deployment status for services
     Status(StatusArgs),
@@ -103,6 +107,75 @@ struct FilesArgs {
 struct LinkArgs {
     /// The service ID/name to link
     service: Option<String>,
+}
+
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway service source connect --repo owner/repo --branch main --service web\n  railway service source connect --repo owner/repo --service web --json\n  railway service source connect --image nginx:latest --service web\n  railway service source disconnect --service web\n\nAutomation notes:\n  Use --branch for repos that are not visible through the Railway GitHub App.\n  GitHub sources are connected at the service level and create deployment triggers for matching project environments."
+)]
+struct SourceArgs {
+    #[clap(subcommand)]
+    command: SourceCommands,
+}
+
+#[derive(Parser)]
+enum SourceCommands {
+    /// Connect a service to a GitHub repo or Docker image
+    Connect(SourceConnectArgs),
+
+    /// Disconnect the service from its current source
+    Disconnect(SourceDisconnectArgs),
+}
+
+#[derive(Parser)]
+#[clap(group(clap::ArgGroup::new("source").args(["repo", "image"]).required(true).multiple(false)))]
+struct SourceConnectArgs {
+    /// Service name or ID (defaults to linked service)
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// Environment to use for resolving the service (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
+    /// GitHub repo to connect, in owner/repo format
+    #[clap(long)]
+    repo: Option<String>,
+
+    /// Branch to deploy from when connecting a GitHub repo
+    #[clap(long, requires = "repo")]
+    branch: Option<String>,
+
+    /// Docker image to connect, e.g. nginx:latest
+    #[clap(long)]
+    image: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
+}
+
+#[derive(Parser)]
+struct SourceDisconnectArgs {
+    /// Service name or ID (defaults to linked service)
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// Environment to use for resolving the service (defaults to linked environment)
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long)]
+    json: bool,
 }
 
 #[derive(Parser)]
@@ -159,6 +232,17 @@ struct ServiceStatusOutput {
     stopped: bool,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ServiceSourceOutput {
+    id: String,
+    name: String,
+    repo: Option<String>,
+    branch: Option<String>,
+    image: Option<String>,
+    disconnected: bool,
+}
+
 #[derive(Parser)]
 struct StatusArgs {
     /// Service name or ID to show status for (defaults to linked service)
@@ -198,6 +282,7 @@ pub async fn command(args: Args) -> Result<()> {
         Some(Commands::List(list_args)) => list_command(list_args).await,
         Some(Commands::Delete(delete_args)) => delete_command(delete_args).await,
         Some(Commands::Link(link_args)) => link_command(link_args).await,
+        Some(Commands::Source(source_args)) => source_command(source_args).await,
         Some(Commands::Status(status_args)) => status_command(status_args).await,
         Some(Commands::Logs(logs_args)) => crate::commands::logs::command(logs_args).await,
         Some(Commands::Redeploy(redeploy_args)) => {
@@ -210,6 +295,102 @@ pub async fn command(args: Args) -> Result<()> {
         Some(Commands::Files(files_args)) => files_command(files_args).await,
         None => unreachable!(),
     }
+}
+
+async fn source_command(args: SourceArgs) -> Result<()> {
+    match args.command {
+        SourceCommands::Connect(connect_args) => source_connect_command(connect_args).await,
+        SourceCommands::Disconnect(disconnect_args) => {
+            source_disconnect_command(disconnect_args).await
+        }
+    }
+}
+
+async fn source_connect_command(args: SourceConnectArgs) -> Result<()> {
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
+
+    let (repo, branch, image) = if let Some(repo) = args.repo {
+        validate_repo_name(&repo)?;
+        let branch = resolve_repo_branch(&ctx.client, &ctx.configs, &repo, args.branch).await?;
+        (Some(repo), Some(branch), None)
+    } else {
+        (None, None, args.image)
+    };
+
+    let spinner = create_spinner_if(!args.json, "Connecting service source...".into());
+    let result = post_graphql::<mutations::ServiceConnect, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        mutations::service_connect::Variables {
+            id: ctx.service_id.clone(),
+            input: mutations::service_connect::ServiceConnectInput {
+                repo: repo.clone(),
+                branch: branch.clone(),
+                image: image.clone(),
+            },
+        },
+    )
+    .await?;
+
+    let output = ServiceSourceOutput {
+        id: result.service_connect.id,
+        name: result.service_connect.name,
+        repo,
+        branch,
+        image,
+        disconnected: false,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else if let Some(spinner) = spinner {
+        let source = match (&output.repo, &output.branch, &output.image) {
+            (Some(repo), Some(branch), _) => format!("{repo}@{branch}"),
+            (_, _, Some(image)) => image.clone(),
+            _ => "source".to_string(),
+        };
+        spinner.finish_with_message(format!(
+            "Connected service \"{}\" to {}",
+            output.name.blue(),
+            source.blue()
+        ));
+    }
+
+    Ok(())
+}
+
+async fn source_disconnect_command(args: SourceDisconnectArgs) -> Result<()> {
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
+    let spinner = create_spinner_if(!args.json, "Disconnecting service source...".into());
+
+    let result = post_graphql::<mutations::ServiceDisconnect, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        mutations::service_disconnect::Variables {
+            id: ctx.service_id.clone(),
+        },
+    )
+    .await?;
+
+    let output = ServiceSourceOutput {
+        id: result.service_disconnect.id,
+        name: result.service_disconnect.name,
+        repo: None,
+        branch: None,
+        image: None,
+        disconnected: true,
+    };
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else if let Some(spinner) = spinner {
+        spinner.finish_with_message(format!(
+            "Disconnected source from service \"{}\"",
+            output.name.blue()
+        ));
+    }
+
+    Ok(())
 }
 
 async fn files_command(args: FilesArgs) -> Result<()> {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -25,7 +25,7 @@ use super::*;
 /// Upload and deploy project from the current directory
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway up --service api --environment production\n  railway up ./apps/api --path-as-root --service api\n  railway up --detach --json --message \"deploy api\"\n\nAutomation notes:\n  `railway up --detach --json` starts an upload and deployment, but it does not wait for the deployment to become healthy.\n  Poll with `railway deployment list --json` and inspect logs with `railway logs --json --lines 100`."
+    after_help = "Examples:\n\n  railway up --service api --environment production\n  railway up ./apps/api --path-as-root --service api\n  railway up --detach --json --message \"deploy api\"\n\nAutomation notes:\n  `railway up --detach --json` starts an upload and deployment, but it does not wait for the deployment to become healthy.\n  Poll with `railway deployment list --json` and inspect logs with `railway logs --json --lines 100`.\n  To switch a locally uploaded service to GitHub autodeploys, run `railway service source connect --repo owner/repo --branch main --service api`."
 )]
 pub struct Args {
     path: Option<PathBuf>,

--- a/src/controllers/github.rs
+++ b/src/controllers/github.rs
@@ -1,0 +1,52 @@
+use anyhow::{Result, bail};
+use reqwest::Client;
+
+use crate::{
+    client::post_graphql,
+    config::Configs,
+    gql::queries::{self, git_hub_repos::GitHubReposGithubRepos},
+};
+
+pub async fn resolve_repo_branch(
+    client: &Client,
+    configs: &Configs,
+    repo: &str,
+    branch: Option<String>,
+) -> Result<String> {
+    if let Some(branch) = branch {
+        return Ok(branch);
+    }
+
+    let repos = post_graphql::<queries::GitHubRepos, _>(
+        client,
+        configs.get_backboard(),
+        queries::git_hub_repos::Variables {},
+    )
+    .await?
+    .github_repos;
+
+    default_branch_for_repo(&repos, repo).map(str::to_string).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Branch is required because repo `{repo}` was not found in your connected GitHub repos. Pass --branch or connect the repo to the Railway GitHub App."
+        )
+    })
+}
+
+pub fn default_branch_for_repo<'a>(
+    repos: &'a [GitHubReposGithubRepos],
+    repo: &str,
+) -> Option<&'a str> {
+    repos
+        .iter()
+        .find(|candidate| candidate.full_name.eq_ignore_ascii_case(repo))
+        .map(|repo| repo.default_branch.as_str())
+}
+
+pub fn validate_repo_name(repo: &str) -> Result<()> {
+    let parts: Vec<_> = repo.split('/').collect();
+    if parts.len() != 2 || parts.iter().any(|part| part.trim().is_empty()) {
+        bail!("Repo must be in owner/repo format");
+    }
+
+    Ok(())
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -5,6 +5,7 @@ pub mod db_stats;
 pub mod deployment;
 pub mod develop;
 pub mod environment;
+pub mod github;
 pub mod local_override;
 pub mod metrics;
 pub mod metrics_tui;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -204,6 +204,23 @@ pub struct ServiceCreate;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/ServiceConnect.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct ServiceConnect;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/ServiceDisconnect.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ServiceDisconnect;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/CustomDomainCreate.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/strings/ServiceConnect.graphql
+++ b/src/gql/mutations/strings/ServiceConnect.graphql
@@ -1,0 +1,6 @@
+mutation ServiceConnect($id: String!, $input: ServiceConnectInput!) {
+  serviceConnect(id: $id, input: $input) {
+    id
+    name
+  }
+}

--- a/src/gql/mutations/strings/ServiceDisconnect.graphql
+++ b/src/gql/mutations/strings/ServiceDisconnect.graphql
@@ -1,0 +1,6 @@
+mutation ServiceDisconnect($id: String!) {
+  serviceDisconnect(id: $id) {
+    id
+    name
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -594,6 +594,27 @@ mod cli_tests {
             assert_parses(&["service", "redeploy"]);
             assert_parses(&["service", "redeploy", "-s", "myservice"]);
             assert_parses(&["service", "restart"]);
+            assert_parses(&[
+                "service",
+                "source",
+                "connect",
+                "--repo",
+                "owner/repo",
+                "--branch",
+                "main",
+                "--service",
+                "web",
+            ]);
+            assert_parses(&[
+                "service",
+                "source",
+                "connect",
+                "--image",
+                "nginx:latest",
+                "--service",
+                "web",
+            ]);
+            assert_parses(&["service", "source", "disconnect", "--service", "web"]);
             assert_parses(&["service", "scale"]);
             assert_parses(&["service", "scale", "eu-west=2"]);
             assert_parses(&["service", "scale", "--eu-west", "2"]);
@@ -605,6 +626,11 @@ mod cli_tests {
                 "eu-west=2",
                 "us-east=1",
             ]);
+        }
+
+        #[test]
+        fn add_repo_branch() {
+            assert_parses(&["add", "--repo", "owner/repo", "--branch", "main"]);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Adds first-class service source management to the CLI so an existing Railway service can be connected to, or disconnected from, a GitHub repo or Docker image without going through the dashboard.

Docker image service creation via `railway add --image` already existed; this PR adds Docker-image handling only to the new existing-service source connection path. That matches the dashboard's `Connect Source` setting, which offers both `Connect Repo` and `Connect Image` for source-less services, and matches the backend `serviceConnect` input.

## What changed

- Added `railway service source connect` and `railway service source disconnect` for existing services.
- Added GraphQL bindings for `serviceConnect` and `serviceDisconnect`.
- Added shared GitHub repo validation/default-branch resolution.
- Added `--branch` support for `railway add --repo` so non-dashboard flows can target a specific branch.
- Added MCP tools for connecting and disconnecting service sources.
- Added a `railway up` help note pointing users from local upload deploys to GitHub autodeploy setup.

## Why

Users can create and deploy locally with `railway up`, but there was no CLI path to attach the resulting service to a GitHub repo for ongoing automatic deploys. This adds that missing bridge and keeps the same capability available through MCP automation.

## Validation

- `cargo fmt`
- `cargo test` - 214 passed
- Manual end-to-end smoke test:
  - Created a temporary hello-world Node service.
  - Created Railway project `src-test-20260604102238`.
  - Deployed once with `railway up --detach --json`.
  - Created and pushed GitHub repo `m-abdelwahab/src-test-20260604102238`.
  - Ran `railway service source connect --repo m-abdelwahab/src-test-20260604102238 --branch main --json`.
  - Confirmed Railway reported `source.repo` as `m-abdelwahab/src-test-20260604102238` and the GitHub-source deployment succeeded.
  - Confirmed the generated Railway domain returned the hello-world response.
- Manual Docker image source smoke test:
  - Created Railway project `img-src-smoke-t7sx8n`.
  - Created source-less service `image-web`.
  - Confirmed `railway service list --json` reported `source: null`.
  - Ran `railway service source connect --image traefik/whoami:v1.10 --service image-web --json`.
  - Confirmed Railway reported `source.image` as `traefik/whoami:v1.10` and the image deployment succeeded.
  - Set `PORT=80`, generated a Railway domain, and confirmed it returned HTTP 200 from the container.
