### PR TITLE
fix(ssh): derive relay host/port from RAILWAY_ENV instead of hardcoding prod

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -551,7 +551,7 @@ async fn ssh(
     configs.write()?;
 
     // Relay target format (per backboard): sbx:<environmentId>:<sandboxId>.
-    // `run_native_ssh` appends `@ssh.railway.com` internally.
+    // `run_native_ssh` appends the environment's relay host internally.
     let target = format!("sbx:{environment_id}:{sandbox_id}");
 
     // Keep the sandbox alive for the duration of the session.

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -272,8 +272,12 @@ fn render_config_block(
     writeln!(block, "# BEGIN railway:{rendered_marker}").expect("writing to String cannot fail");
     writeln!(block, "# Railway service: {rendered_service_name}")
         .expect("writing to String cannot fail");
+    let (relay_host, relay_port) = native::ssh_relay();
     writeln!(block, "Host {alias}").expect("writing to String cannot fail");
-    writeln!(block, "    HostName {}", native::SSH_HOST).expect("writing to String cannot fail");
+    writeln!(block, "    HostName {relay_host}").expect("writing to String cannot fail");
+    if let Some(port) = relay_port {
+        writeln!(block, "    Port {port}").expect("writing to String cannot fail");
+    }
     writeln!(block, "    User {service_instance_id}").expect("writing to String cannot fail");
 
     if let Some(identity_file) = identity_file {

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -12,7 +12,22 @@ use crate::controllers::ssh::keys::{SshKeySource, find_local_ssh_keys, register_
 use crate::gql::queries::{ServiceInstance, service_instance};
 use crate::util::prompt::{prompt_confirm_with_default, prompt_select};
 
-pub(super) const SSH_HOST: &str = "ssh.railway.com";
+/// SSH relay endpoint (host, non-default port) for the current environment —
+/// must track `Configs::get_backboard()`'s environment, or key registration
+/// is checked against one backboard while the relay authenticates against
+/// another (dev-mode CLIs used to dial the prod relay and get publickey
+/// denials for keys that were registered fine).
+pub(super) fn ssh_relay() -> (&'static str, Option<u16>) {
+    Configs::get_ssh_relay()
+}
+
+/// Append `-p <port>` when the relay listens on a non-default port (the
+/// develop relay uses 2222).
+fn apply_relay_port(cmd: &mut Command, port: Option<u16>) {
+    if let Some(port) = port {
+        cmd.args(["-p", &port.to_string()]);
+    }
+}
 
 /// Get the service instance ID for a service in an environment
 pub async fn get_service_instance_id(
@@ -149,10 +164,12 @@ fn identity_for(key: &crate::controllers::ssh::keys::LocalSshKey) -> Option<Path
 /// Split out from the session loop so that a tmux-install failure is
 /// distinguishable from a session connect failure in telemetry.
 pub fn ensure_tmux_installed(ssh_target: &str, identity_file: Option<&Path>) -> Result<()> {
-    let target = format!("{}@{}", ssh_target, SSH_HOST);
+    let (host, port) = ssh_relay();
+    let target = format!("{ssh_target}@{host}");
 
     eprintln!("Ensuring tmux is installed...");
     let mut install_cmd = Command::new("ssh");
+    apply_relay_port(&mut install_cmd, port);
     if let Some(key) = identity_file {
         install_cmd.arg("-i").arg(key);
     }
@@ -183,7 +200,8 @@ pub fn run_tmux_session(
     session_name: &str,
     identity_file: Option<&Path>,
 ) -> Result<()> {
-    let target = format!("{}@{}", ssh_target, SSH_HOST);
+    let (host, port) = ssh_relay();
+    let target = format!("{ssh_target}@{host}");
     let tmux_cmd = format!(
         "exec tmux new-session -A -s {} \\; set -g mouse on",
         session_name
@@ -191,6 +209,7 @@ pub fn run_tmux_session(
 
     loop {
         let mut session_cmd = Command::new("ssh");
+        apply_relay_port(&mut session_cmd, port);
         if let Some(key) = identity_file {
             session_cmd.arg("-i").arg(key);
         }
@@ -228,11 +247,13 @@ pub fn run_native_ssh(
     command: Option<&[String]>,
     identity_file: Option<&Path>,
 ) -> Result<i32> {
-    let target = format!("{}@{}", service_instance_id, SSH_HOST);
+    let (host, port) = ssh_relay();
+    let target = format!("{service_instance_id}@{host}");
     let stdin_tty = std::io::stdin().is_terminal();
     let stdout_tty = std::io::stdout().is_terminal();
 
     let mut ssh_cmd = Command::new("ssh");
+    apply_relay_port(&mut ssh_cmd, port);
 
     if let Some(key) = identity_file {
         ssh_cmd.arg("-i").arg(key);

--- a/src/commands/volume/sftp.rs
+++ b/src/commands/volume/sftp.rs
@@ -140,7 +140,13 @@ impl VolumeSftpHandler {
     }
 }
 
-const ADDR: &str = "ssh.railway.com";
+/// SSH relay endpoint for the current environment (host, port). Tracks the
+/// same env switching as `Configs::get_backboard()`; the develop relay
+/// listens on 2222.
+fn relay_addr() -> (&'static str, u16) {
+    let (host, port) = crate::config::Configs::get_ssh_relay();
+    (host, port.unwrap_or(22))
+}
 pub(crate) const DEFAULT_TRANSFER_CONCURRENCY: usize = 32;
 const DOWNLOAD_TRANSFER_BUFFER_SIZE: usize = 2 * 1024 * 1024;
 const DIRECTORY_UPLOAD_TRANSFER_BUFFER_SIZE: usize = 2 * 1024 * 1024;
@@ -199,13 +205,14 @@ impl VolumeSftp {
         if self.session.is_none() || self.is_disconnected() {
             self.disconnected.store(false, Ordering::SeqCst);
 
+            let (relay_host, relay_port) = relay_addr();
             let mut session = russh::client::connect(
                 Arc::new(russh::client::Config::default()),
-                (ADDR, 22),
+                (relay_host, relay_port),
                 VolumeSftpHandler::new(Arc::clone(&self.disconnected)),
             )
             .await
-            .with_context(|| format!("Failed to connect to Railway SFTP at {ADDR}"))?;
+            .with_context(|| format!("Failed to connect to Railway SFTP at {relay_host}"))?;
 
             crate::controllers::ssh::authenticate(&mut session, &self.service_instance_id).await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -255,6 +255,17 @@ impl Configs {
         format!("https://backboard.{}/graphql/v2", self.get_host())
     }
 
+    /// SSH relay host and non-default port for the current environment.
+    /// Mirrors backboard's `controllers/ssh` mapping: only the develop relay
+    /// is separate (and listens on 2222); staging falls through to the
+    /// production relay, same as backboard's IS_DEV-only branch.
+    pub fn get_ssh_relay() -> (&'static str, Option<u16>) {
+        match Self::get_environment_id() {
+            Environment::Dev => ("ssh.railway-develop.com", Some(2222)),
+            Environment::Production | Environment::Staging => ("ssh.railway.com", None),
+        }
+    }
+
     pub fn get_current_directory(&self) -> Result<String> {
         let current_dir = std::env::current_dir()?;
         let path = current_dir


### PR DESCRIPTION
## Problem

The SSH relay host was a compile-time constant (`ssh.railway.com`) while backboard URLs follow `RAILWAY_ENV`. A dev-mode CLI therefore registers SSH keys and creates sandboxes against the **develop** backboard but dials the **production** relay — which has never seen the key or the target — yielding a confusing `Permission denied (publickey)` for a key the CLI just said was registered.

Reported by Pierre in raildev:
```
$ railway sandbox ssh
Using SSH key from agent: pborckmans@gmail.com
sbx:f597…:343d…@ssh.railway.com: Permission denied (publickey).
```
Manual workaround that proved the diagnosis: `ssh -p 2222 sbx:…@ssh.railway-develop.com` connects fine.

## Fix

`Configs::get_ssh_relay()` mirrors backboard's `controllers/ssh` mapping:

| env | relay |
|---|---|
| production | `ssh.railway.com` (port 22) |
| staging | `ssh.railway.com` — falls through like backboard's `IS_DEV`-only branch (`ssh.railway-staging.com` does not serve the SSH relay; probes accept TCP then close) |
| dev | `ssh.railway-develop.com` **-p 2222** |

Applied everywhere the constant was used: native ssh (`railway ssh`, `railway sandbox ssh`), tmux install/session, the generated `~/.ssh/config` block (gains a `Port` line only when non-default), and volume SFTP (russh connect tuple).

## Risk

Production behavior is byte-identical by construction: `("ssh.railway.com", None)` produces the same target string, adds zero ssh args, the same `(host, 22)` sftp tuple, and the same config block — the existing config-block tests asserting the literal prod output pass unmodified. The only behavioral change is dev mode, which previously failed 100% of the time.

## Testing

- Full test suite green (214)
- Prod smoke test on the built binary: `sandbox create` → `sandbox ssh -- echo` → `destroy`, all clean
- Dev-mode verification: Pierre has a reliable raildev repro; plain `railway sandbox ssh` should now connect exactly where his manual `-p 2222` command did

🤖 Generated with [Claude Code](https://claude.com/claude-code)