### PR TITLE
feat(sandbox): show loading state for exec

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -1094,7 +1094,8 @@ async fn exec(
     configs.set_active_sandbox(&sandbox_id);
     configs.write()?;
 
-    let res = post_graphql::<mutations::SandboxExec, _>(
+    let mut spinner = create_shimmer_spinner("Executing command");
+    let exec_result = post_graphql::<mutations::SandboxExec, _>(
         client,
         configs.get_backboard(),
         mutations::sandbox_exec::Variables {
@@ -1104,7 +1105,15 @@ async fn exec(
             timeout_sec: args.timeout,
         },
     )
-    .await?;
+    .await;
+    let res = match exec_result {
+        Ok(res) => res,
+        Err(e) => {
+            fail_spinner(&mut spinner, "Failed to execute command".to_string());
+            return Err(e.into());
+        }
+    };
+    spinner.finish_and_clear();
     let result = res.sandbox_exec;
 
     print!("{}", result.stdout);


### PR DESCRIPTION
## Summary
- add the existing shimmer loading indicator around sandbox exec requests
- clear the spinner before printing captured command output
- show a matching failure spinner message when sandbox exec fails before returning output

## Testing
- Not run: cargo/rustfmt are not installed in this environment