### PR TITLE
feat(sandbox): show loading state for exec

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -1094,7 +1094,8 @@ async fn exec(
     configs.set_active_sandbox(&sandbox_id);
     configs.write()?;
 
-    let res = post_graphql::<mutations::SandboxExec, _>(
+    let mut spinner = create_shimmer_spinner("Executing command");
+    let exec_result = post_graphql::<mutations::SandboxExec, _>(
         client,
         configs.get_backboard(),
         mutations::sandbox_exec::Variables {
@@ -1104,7 +1105,15 @@ async fn exec(
             timeout_sec: args.timeout,
         },
     )
-    .await?;
+    .await;
+    let res = match exec_result {
+        Ok(res) => res,
+        Err(e) => {
+            fail_spinner(&mut spinner, "Failed to execute command".to_string());
+            return Err(e.into());
+        }
+    };
+    spinner.finish_and_clear();
     let result = res.sandbox_exec;
 
     print!("{}", result.stdout);


### PR DESCRIPTION
## Summary
- add a shimmer loading indicator while sandbox exec waits for the GraphQL mutation
- clear the spinner before printing stdout/stderr
- show a failure spinner message when the exec mutation fails

## Testing
- Not run: cargo is not installed in this environment
- Ran: git diff --check origin/master...HEAD