### PR TITLE
feat(sandbox): show loading spinner during sandbox exec

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -1094,7 +1094,8 @@ async fn exec(
     configs.set_active_sandbox(&sandbox_id);
     configs.write()?;
 
-    let res = post_graphql::<mutations::SandboxExec, _>(
+    let mut spinner = create_shimmer_spinner("Executing command");
+    let res = match post_graphql::<mutations::SandboxExec, _>(
         client,
         configs.get_backboard(),
         mutations::sandbox_exec::Variables {
@@ -1104,7 +1105,15 @@ async fn exec(
             timeout_sec: args.timeout,
         },
     )
-    .await?;
+    .await
+    {
+        Ok(res) => res,
+        Err(e) => {
+            fail_spinner(&mut spinner, "Failed to run command".to_string());
+            return Err(e.into());
+        }
+    };
+    spinner.finish_and_clear();
     let result = res.sandbox_exec;
 
     print!("{}", result.stdout);


### PR DESCRIPTION
## What

`railway sandbox exec` now shows the shimmer loading spinner (`Executing command...`) while the command runs, matching the existing loading states for sandbox create, fork, and destroy.

## Why

The `sandboxExec` mutation runs the command server-side and returns nothing until it completes — longer-running commands left the terminal completely silent, looking like a hang.

## Details

- Spinner uses the existing `create_shimmer_spinner` (no new util code)
- `fail_spinner` ("✗ Failed to run command") on mutation error
- `finish_and_clear()` before printing the command's stdout/stderr; indicatif draws to stderr, so piped stdout stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)