### PR TITLE
Include config assets in package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/railwayapp/cli"
 repository = "https://github.com/railwayapp/cli"
 rust-version = "1.85.0"
 default-run = "railway"
-include = ["src/**/*", "build.rs", "LICENSE", "README.md"]
+include = ["src/**/*", "assets/**/*", "build.rs", "LICENSE", "README.md"]
 
 [[bin]]
 name = "railway"


### PR DESCRIPTION
Include Railway configuration support assets in the crate package so release verification can build from the tarball.