### PR TITLE
fix(skills): install summary reflects actual outcome (no success banner on all-skipped runs)

### DIFF
--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -621,6 +621,7 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
 
     let mut manifest = SkillsManifest::read(&home);
     let mut blocked = 0u32;
+    let mut installed = 0u32;
 
     for target in &targets {
         std::fs::create_dir_all(&target.skills_dir).with_context(|| {
@@ -692,6 +693,7 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
             if action {
                 let new_record = apply_skill(&skill_dir, files, record.as_ref())?;
                 manifest.set_record(&target_key, skill_name, new_record);
+                installed += 1;
                 if !quiet {
                     println!(
                         "{} {}: {} {} \u{2192} {}",
@@ -733,11 +735,34 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
             );
         }
 
-        println!("\n{}", "Skills installed successfully!".green().bold());
-        println!(
-            "{} You may need to restart your tool(s) to load skills.\n",
-            "!".yellow().bold()
-        );
+        // Summarize what actually happened: claiming success after a run
+        // that skipped everything misleads both humans and the agents
+        // parsing this output into "skills are current".
+        if installed > 0 {
+            if blocked > 0 {
+                println!(
+                    "\n{}",
+                    format!("Installed {installed} skill(s); {blocked} skipped.")
+                        .green()
+                        .bold()
+                );
+            } else {
+                println!("\n{}", "Skills installed successfully!".green().bold());
+            }
+            println!(
+                "{} You may need to restart your tool(s) to load skills.\n",
+                "!".yellow().bold()
+            );
+        } else if blocked > 0 {
+            println!(
+                "\n{}\n",
+                "No skills were installed — every pending change was skipped."
+                    .yellow()
+                    .bold()
+            );
+        } else {
+            println!("\n{}\n", "Skills already up to date.".green().bold());
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

`railway skills` ended every run with **"Skills installed successfully!"** — including runs where *every* skill was skipped due to local changes, printed directly under the skip warning:

```
! 7 skill(s) skipped because of local changes. Re-run with railway skills update --force to overwrite them.

Skills installed successfully!
```

That misleads humans and — worse — agents parsing the transcript, who conclude skills are current when nothing was written.

This tracks `installed` alongside the existing `blocked` counter and summarizes honestly:

| Outcome | Message |
|---|---|
| All applied | `Skills installed successfully!` (+ restart hint) |
| Partial | `Installed N skill(s); M skipped.` (+ restart hint) |
| All skipped | `No skills were installed — every pending change was skipped.` |
| Nothing to do | `Skills already up to date.` |

Restart hint only prints when something was actually written.

Found live during the v5.3.0 skills auto-update rollout test (a machine with pre-manifest skill installs hits the all-skipped case on first managed install).

## Test plan
- `cargo test`: 272/272
- Live repro on the affected machine: all-skipped run now prints the skip warning + "No skills were installed" with no success banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)