### PR TITLE
fix(skills): unmanaged-install detection + honest install summaries

### DIFF
--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -979,11 +979,7 @@ mod tests {
 
         // A manifest record for the target means it's managed — not an orphan.
         let mut manifest = SkillsManifest::default();
-        manifest.set_record(
-            &rel_key(&skills_dir),
-            "use-railway",
-            SkillRecord::default(),
-        );
+        manifest.set_record(&rel_key(&skills_dir), "use-railway", SkillRecord::default());
         assert!(unmanaged_skill_tools(home.path(), &manifest).is_empty());
 
         // A bare directory without SKILL.md (leftover scaffolding) is not a

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -695,6 +695,7 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
 
     let mut manifest = SkillsManifest::read(&home);
     let mut blocked = 0u32;
+    let mut installed = 0u32;
 
     for target in &targets {
         std::fs::create_dir_all(&target.skills_dir).with_context(|| {
@@ -766,6 +767,7 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
             if action {
                 let new_record = apply_skill(&skill_dir, files, record.as_ref())?;
                 manifest.set_record(&target_key, skill_name, new_record);
+                installed += 1;
                 if !quiet {
                     println!(
                         "{} {}: {} {} \u{2192} {}",
@@ -807,11 +809,34 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
             );
         }
 
-        println!("\n{}", "Skills installed successfully!".green().bold());
-        println!(
-            "{} You may need to restart your tool(s) to load skills.\n",
-            "!".yellow().bold()
-        );
+        // Summarize what actually happened: claiming success after a run
+        // that skipped everything misleads both humans and the agents
+        // parsing this output into "skills are current".
+        if installed > 0 {
+            if blocked > 0 {
+                println!(
+                    "\n{}",
+                    format!("Installed {installed} skill(s); {blocked} skipped.")
+                        .green()
+                        .bold()
+                );
+            } else {
+                println!("\n{}", "Skills installed successfully!".green().bold());
+            }
+            println!(
+                "{} You may need to restart your tool(s) to load skills.\n",
+                "!".yellow().bold()
+            );
+        } else if blocked > 0 {
+            println!(
+                "\n{}\n",
+                "No skills were installed — every pending change was skipped."
+                    .yellow()
+                    .bold()
+            );
+        } else {
+            println!("\n{}\n", "Skills already up to date.".green().bold());
+        }
     }
 
     Ok(())

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -97,6 +97,11 @@ struct SkillsManifest {
     /// user-modified skill the background apply can't touch.
     #[serde(default)]
     auto_applied_sha: Option<String>,
+    /// The upstream SHA we last nagged about unmanaged (pre-manifest /
+    /// externally-synced) skill installs, so the banner fires once per
+    /// upstream commit rather than on every command.
+    #[serde(default)]
+    orphan_nag_sha: Option<String>,
     #[serde(default)]
     targets: BTreeMap<String, BTreeMap<String, SkillRecord>>,
 }
@@ -355,7 +360,11 @@ pub(crate) async fn refresh_skill_update_state() {
         return;
     };
     let mut manifest = SkillsManifest::read(&home);
-    if !manifest.has_installed_skills() {
+    // Run the check for managed installs AND for unmanaged-but-present
+    // railway skills (pre-manifest installs), so the orphan nag can key
+    // off a real upstream SHA and re-arm when upstream moves. Machines
+    // with no railway skills anywhere still never hit the network.
+    if !manifest.has_installed_skills() && unmanaged_skill_tools(&home, &manifest).is_empty() {
         return;
     }
 
@@ -461,6 +470,71 @@ pub(super) fn resolve_tools(home: &Path, agent_filter: &[String]) -> Result<Vec<
         }
         Ok(selected)
     }
+}
+
+/// Skills this CLI distributes, by directory name. Used to recognize
+/// railway skill installs that pre-date the manifest (or were synced
+/// externally) without claiming unrelated skills that live in the same
+/// shared skills directories.
+const RAILWAY_SKILL_NAMES: &[&str] = &["use-railway"];
+
+/// Coding tools that have a railway skill on disk with no manifest record
+/// for that target — installs made before the CLI tracked skills, or
+/// external syncs. We never write to these without the user asking;
+/// `orphan_skills_nag_due` surfaces a banner pointing at
+/// `railway skills update` instead (which adopts up-to-date copies and
+/// safely skips modified ones).
+fn unmanaged_skill_tools(home: &Path, manifest: &SkillsManifest) -> Vec<&'static str> {
+    coding_tools(home)
+        .into_iter()
+        .filter(|tool| {
+            let skills_dir = tool.global_parent.join(tool.skills_dir_name);
+            let manifested = manifest
+                .targets
+                .get(&rel_key(&skills_dir))
+                .is_some_and(|skills| !skills.is_empty());
+            if manifested {
+                return false;
+            }
+            RAILWAY_SKILL_NAMES
+                .iter()
+                .any(|skill| skills_dir.join(skill).join("SKILL.md").is_file())
+        })
+        .map(|tool| tool.name)
+        .collect()
+}
+
+/// Banner check for unmanaged railway skills: returns the affected tool
+/// names when a nag is due and stamps the dedupe key so it fires once per
+/// upstream SHA (re-arming when upstream moves), not on every command.
+/// No network; a couple of stat calls per known tool.
+fn orphan_skills_nag(home: &Path) -> Option<Vec<String>> {
+    let mut manifest = SkillsManifest::read(home);
+    let orphans = unmanaged_skill_tools(home, &manifest);
+    if orphans.is_empty() {
+        return None;
+    }
+    // Key the nag to the last-seen upstream SHA; before the first
+    // background check lands there's no SHA yet, so a sentinel gives us
+    // exactly one pre-check nag.
+    let key = manifest
+        .latest_sha
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    if manifest.orphan_nag_sha.as_deref() == Some(key.as_str()) {
+        return None;
+    }
+    manifest.orphan_nag_sha = Some(key);
+    let _ = manifest.save(home);
+    Some(orphans.into_iter().map(str::to_string).collect())
+}
+
+/// No-network banner entry point for `main`: unmanaged railway skills
+/// found on disk (see `unmanaged_skill_tools`), at most once per upstream
+/// SHA.
+pub(crate) fn orphan_skills_nag_due() -> Option<Vec<String>> {
+    let home = dirs::home_dir()?;
+    orphan_skills_nag(&home)
 }
 
 pub(super) fn skills_configured_for_slug(home: &Path, slug: &str) -> bool {
@@ -849,6 +923,80 @@ mod tests {
 
         assert!(skills_configured_for_slug(home.path(), "universal"));
         assert!(!skills_configured_for_slug(home.path(), "cursor"));
+    }
+
+    // --- unmanaged (pre-manifest) skill detection --------------------------
+
+    /// Lay down a railway skill on disk for the universal target, the way a
+    /// pre-manifest install (or an external sync) would have.
+    fn plant_orphan_skill(home: &Path) -> PathBuf {
+        let skills_dir = home.join(".agents").join("skills");
+        let skill = skills_dir.join("use-railway");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(skill.join("SKILL.md"), "content").unwrap();
+        skills_dir
+    }
+
+    #[test]
+    fn unmanaged_tools_found_when_skill_on_disk_without_manifest_record() {
+        let home = tempfile::tempdir().unwrap();
+        plant_orphan_skill(home.path());
+
+        let manifest = SkillsManifest::default();
+        let tools = unmanaged_skill_tools(home.path(), &manifest);
+        assert_eq!(tools, vec!["Universal (.agents)"]);
+    }
+
+    #[test]
+    fn unmanaged_ignores_manifested_targets_and_bare_dirs() {
+        let home = tempfile::tempdir().unwrap();
+        let skills_dir = plant_orphan_skill(home.path());
+
+        // A manifest record for the target means it's managed — not an orphan.
+        let mut manifest = SkillsManifest::default();
+        manifest.set_record(
+            &rel_key(&skills_dir),
+            "use-railway",
+            SkillRecord::default(),
+        );
+        assert!(unmanaged_skill_tools(home.path(), &manifest).is_empty());
+
+        // A bare directory without SKILL.md (leftover scaffolding) is not a
+        // skill install and must not nag.
+        let home2 = tempfile::tempdir().unwrap();
+        let bare = home2
+            .path()
+            .join(".cursor")
+            .join("skills")
+            .join("use-railway");
+        std::fs::create_dir_all(&bare).unwrap();
+        assert!(unmanaged_skill_tools(home2.path(), &SkillsManifest::default()).is_empty());
+    }
+
+    #[test]
+    fn orphan_nag_fires_once_per_upstream_sha() {
+        let home = tempfile::tempdir().unwrap();
+        plant_orphan_skill(home.path());
+
+        // First sighting nags (pre-check sentinel key) and stamps the manifest.
+        assert!(orphan_skills_nag(home.path()).is_some());
+        // Same key again: deduped.
+        assert!(orphan_skills_nag(home.path()).is_none());
+
+        // Upstream moved (background check recorded a new SHA): re-arms once.
+        let mut manifest = SkillsManifest::read(home.path());
+        manifest.latest_sha = Some("a".repeat(40));
+        manifest.save(home.path()).unwrap();
+        assert!(orphan_skills_nag(home.path()).is_some());
+        assert!(orphan_skills_nag(home.path()).is_none());
+    }
+
+    #[test]
+    fn orphan_nag_silent_when_no_skills_anywhere() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(orphan_skills_nag(home.path()).is_none());
+        // And it must not create a manifest as a side effect.
+        assert!(!SkillsManifest::path(home.path()).exists());
     }
 
     // --- modification detection -------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,20 @@ async fn main() -> Result<()> {
                 "railway skills update".cyan(),
             );
         }
+
+        // Railway skills on disk that this CLI isn't managing yet —
+        // installed before the manifest existed or synced externally.
+        // Nag (once per upstream SHA) toward the managed path; we never
+        // write to them without the user asking.
+        if let Some(tools) = commands::skills::orphan_skills_nag_due() {
+            eprintln!(
+                "{} ({}) — run {} to keep them current ({} overwrites local changes)",
+                "Unmanaged Railway skills found".yellow().bold(),
+                tools.join(", "),
+                "railway skills update".cyan(),
+                "--force".cyan(),
+            );
+        }
     }
 
     // Spawn the background version check for all invocations (including


### PR DESCRIPTION
## Summary

Two tightly-coupled fixes to the skills updater, found and verified together during the v5.3.0 rollout test (supersedes #945, now folded in here):

### 1. Pre-manifest installs are invisible to the updater — detect and nag

The auto-updater only manages installs recorded in `~/.railway/skills.json`. **Every install made before the manifest existed (pre-v5.3.0) is permanently invisible**: never checked, never updated — and `setup agent` skips already-present targets, so re-running it doesn't adopt them either.

- `unmanaged_skill_tools()`: a railway skill on disk (`SKILL.md` present, scoped to `RAILWAY_SKILL_NAMES` so co-located third-party skills are never claimed) for a target with no manifest record.
- Startup banner mirroring the CLI-version nag (TTY-only), deduped **once per upstream SHA** (`orphan_nag_sha`), re-arming when upstream moves:
  ```
  Unmanaged Railway skills found (Claude Code, Cursor, …) — run railway skills update to keep them current (--force overwrites local changes)
  ```
- The 12h background check now also runs when unmanaged skills exist so the nag keys off a real SHA; machines with **no** railway skills anywhere remain untouched — zero network, zero nag, no manifest side-effect.
- **No silent writes, ever**: adoption happens through user-run `railway skills update` (adopts up-to-date copies, safely skips modified ones).

### 2. The install summary lied on all-skipped runs

`railway skills` ended every run with "Skills installed successfully!" — including runs where *every* skill was skipped for local changes, printed directly under the skip warning. Agents parsing the transcript concluded skills were current when nothing was written. Now:

| Outcome | Message |
|---|---|
| All applied | `Skills installed successfully!` (+ restart hint) |
| Partial | `Installed N skill(s); M skipped.` (+ restart hint) |
| All skipped | `No skills were installed — every pending change was skipped.` |
| Nothing to do | `Skills already up to date.` |

These compose: the nag's remediation (`skills update`) is exactly where the honest summary matters.

## Test plan
- `cargo test`: 276/276 (4 new: orphan detection, manifested/bare-dir exclusions, once-per-SHA dedupe + re-arm, silent-when-absent with no manifest side-effect)
- Live on a real pre-manifest machine (7 unmanaged targets): manifest deleted → first command nags naming all 7 tools → SHA arrives, one re-arm → silence; `targets` untouched throughout. All-skipped `skills update` prints the skip warning + "No skills were installed" with no success banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)