### PR TITLE
fix: sandbox `list`/`exec` ergonomics + MCP `claude-code` caller attribution

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -20,6 +20,7 @@ use crate::util::progress::{create_shimmer_spinner, fail_spinner};
 use crate::util::prompt::{
     prompt_confirm_with_default_with_cancel, prompt_options, prompt_options_skippable,
 };
+use crate::util::shell::shell_join;
 
 /// Manage ephemeral sandboxes
 #[derive(Parser)]
@@ -223,6 +224,10 @@ struct ListArgs {
     /// Output as JSON
     #[clap(long)]
     json: bool,
+
+    /// Include destroyed sandboxes (hidden by default)
+    #[clap(long)]
+    all: bool,
 }
 
 /// `railway sandbox ssh [--id <id>] [-- command...]`. The id is a flag (not a
@@ -1131,7 +1136,16 @@ async fn list(
         },
     )
     .await?;
-    let nodes: Vec<_> = res.sandboxes.edges.into_iter().map(|e| e.node).collect();
+    let mut nodes: Vec<_> = res.sandboxes.edges.into_iter().map(|e| e.node).collect();
+
+    // Tombstones quickly outnumber live sandboxes; hide them unless --all.
+    let hidden = if args.all {
+        0
+    } else {
+        let before = nodes.len();
+        nodes.retain(|n| !matches!(n.status, queries::sandboxes::SandboxStatus::DESTROYED));
+        before - nodes.len()
+    };
 
     // Refresh the local id -> environment cache so `--id` works for any listed
     // sandbox. Does not change which sandbox is active.
@@ -1154,7 +1168,13 @@ async fn list(
     }
 
     if nodes.is_empty() {
-        println!("No sandboxes in this environment.");
+        if hidden > 0 {
+            println!(
+                "No active sandboxes in this environment ({hidden} destroyed; use --all to show them)."
+            );
+        } else {
+            println!("No sandboxes in this environment.");
+        }
         return Ok(());
     }
 
@@ -1176,6 +1196,9 @@ async fn list(
             node.region,
             node.created_at.format("%Y-%m-%d %H:%M").to_string()
         );
+    }
+    if hidden > 0 {
+        println!("\n({hidden} destroyed sandboxes hidden; use --all to show them)");
     }
     Ok(())
 }
@@ -1247,7 +1270,15 @@ async fn exec(
     );
 
     let options = sandbox_exec::ExecOptions {
-        command: (!args.command.is_empty()).then(|| args.command.join(" ")),
+        // A single argument passes through as a full shell command so pipes
+        // and redirects work (`exec -- "ls | head"`). Multiple arguments are
+        // argv: quote each so the remote shell sees the same boundaries —
+        // `exec -- bash -lc 'echo a | b'` must not re-split on the pipe.
+        command: match args.command.as_slice() {
+            [] => None,
+            [cmd] => Some(cmd.clone()),
+            argv => Some(shell_join(argv)),
+        },
         session: args.session.clone(),
         resume_from_last_read: args.resume_from_last_read,
         timeout: args

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -884,6 +884,16 @@ fn known_caller_from_mcp_client_name(name: &str) -> Option<&'static str> {
         }
         return Some("claude_desktop");
     }
+    if lower == "claude-code" || lower == "claude code" {
+        // Distinct from the `claude-ai` handshake above: this literal name
+        // is Claude Code identifying itself directly (no Claude Desktop
+        // ambiguity — Desktop reports `claude-ai`), so no env disambiguation
+        // is needed. Surfaced by the `mcp_unknown:` passthrough after the
+        // 5.5.0 rollout: ~80 users/day were landing in agent_unknown as
+        // `mcp_unknown:claude-code` (warehouse 2026-06-08), the largest
+        // identifiable slice of the local-MCP `mcp_unknown` bucket.
+        return Some("claude_code");
+    }
     if lower == "codex-mcp-client" || lower.contains("codex") {
         return Some("codex");
     }
@@ -1958,6 +1968,9 @@ mod tests {
         // claude-ai disambiguation depends on env (CLAUDECODE etc.). This
         // test pins the subset that doesn't need env state.
         assert_eq!(caller_from_mcp_client_name("codex-mcp-client"), "codex");
+        // `claude-code` is unambiguous (unlike env-gated `claude-ai`).
+        assert_eq!(caller_from_mcp_client_name("claude-code"), "claude_code");
+        assert_eq!(caller_from_mcp_client_name("Claude Code"), "claude_code");
         assert_eq!(caller_from_mcp_client_name("Cline"), "cline");
         assert_eq!(caller_from_mcp_client_name("Roo Code"), "roo_code");
         assert_eq!(caller_from_mcp_client_name("kilo"), "kilo_code");

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -11,6 +11,7 @@ pub mod prompt;
 pub mod reporter;
 pub mod retry;
 pub mod self_update;
+pub mod shell;
 pub mod time;
 pub mod two_factor;
 pub mod watcher;

--- a/src/util/shell.rs
+++ b/src/util/shell.rs
@@ -1,0 +1,65 @@
+/// POSIX shell quoting for command strings sent to a remote `sh -c`.
+///
+/// Plain words pass through untouched so quoted commands stay readable;
+/// anything else is single-quoted with embedded quotes escaped via the
+/// standard `'\''` dance.
+pub fn shell_quote(value: &str) -> String {
+    if !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | ':' | '='))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+/// Join argv into a single shell command, quoting each argument so the
+/// remote shell sees exactly the args the user passed. `exec -- bash -lc
+/// 'echo a | b'` must arrive as `bash -lc 'echo a | b'`, not re-split on
+/// the pipe.
+pub fn shell_join(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_words_pass_through() {
+        assert_eq!(shell_quote("ls"), "ls");
+        assert_eq!(shell_quote("/usr/bin/env"), "/usr/bin/env");
+        assert_eq!(shell_quote("FOO=bar"), "FOO=bar");
+    }
+
+    #[test]
+    fn metacharacters_are_quoted() {
+        assert_eq!(shell_quote("a | b"), "'a | b'");
+        assert_eq!(shell_quote("a && b"), "'a && b'");
+        assert_eq!(shell_quote("$HOME"), "'$HOME'");
+        assert_eq!(shell_quote(""), "''");
+    }
+
+    #[test]
+    fn single_quotes_are_escaped() {
+        assert_eq!(shell_quote("it's"), r#"'it'\''s'"#);
+    }
+
+    #[test]
+    fn join_preserves_arg_boundaries() {
+        let args = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "echo hi | base64 -d > /tmp/f && cat /tmp/f".to_string(),
+        ];
+        assert_eq!(
+            shell_join(&args),
+            "bash -lc 'echo hi | base64 -d > /tmp/f && cat /tmp/f'"
+        );
+    }
+}


### PR DESCRIPTION
Three small, independent bug- and gap-fixes, split out of the same working branch as #953 (rebased onto it). Two are sandbox ergonomics; the third closes a caller-attribution gap in telemetry.

## 1. `sandbox list` hides destroyed sandboxes by default (gap)

Destroyed sandboxes (tombstones) pile up fast and drowned the live rows in `list`. Now `DESTROYED` is hidden by default, with a count + hint; `--all` shows everything.

```
railway sandbox list          # active only — footer: "(N destroyed sandboxes hidden; use --all to show them)"
railway sandbox list --all    # include destroyed
```

If everything is destroyed, the empty-state message says so and points at `--all`.

## 2. `sandbox exec` shell-quoting (bug)

- **Single argument** passes through as a full shell command, so pipes/redirects work as written: `railway sandbox exec -- "ls | head"`.
- **Multiple arguments** (argv) are shell-quoted per-arg so the remote shell sees the same boundaries the user typed — `railway sandbox exec -- bash -lc 'echo a | b'` no longer re-splits on the pipe.

Before, `args.join(" ")` flattened argv and let the remote shell re-interpret metacharacters. Quoting now lives in a small, tested `util::shell` (`shell_quote` / `shell_join`).

## 3. Map MCP clientInfo `claude-code` → `claude_code` (attribution gap)

The `mcp_unknown:<name>` passthrough shipped in 5.5.0 (#952) surfaced `claude-code` as the largest *identifiable* slice of the local-MCP `mcp_unknown` bucket — ~80 users/day landing in `agent_unknown` as `mcp_unknown:claude-code` (warehouse 2026-06-08). It's Claude Code identifying itself directly via clientInfo, distinct from the env-gated `claude-ai` handshake, and unambiguous (Claude Desktop reports `claude-ai`, not `claude-code`). Maps straight to `claude_code` so those events land in `agent_named`/`claude_code` instead of `agent_unknown` on the MCP surface.

## Testing

- Unit tests for `shell_quote`/`shell_join` (plain words pass through, metacharacters quoted, embedded single-quotes escaped, argv boundaries preserved).
- Telemetry mapping test extended to pin `claude-code` / `Claude Code` → `claude_code`.
- Full `cargo test` green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
