### PR TITLE
feat(connect): tunnel to private databases over SSH

### DIFF
--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -1,10 +1,14 @@
 use anyhow::bail;
 use is_terminal::IsTerminal;
+use reqwest::Client;
 use std::{collections::BTreeMap, fmt::Display};
 use tokio::process::Command;
 use url::Url;
 use which::which;
 
+use crate::commands::ssh::{
+    PortForward, ensure_ssh_key, get_service_instance_id, spawn_native_ssh_forward,
+};
 use crate::controllers::{
     database::DatabaseType,
     environment::get_matched_environment,
@@ -33,6 +37,20 @@ pub struct Args {
     /// Project ID to use (defaults to linked project)
     #[clap(short = 'p', long, value_name = "PROJECT_ID")]
     project: Option<String>,
+
+    /// Tunnel to the database over SSH instead of a public TCP proxy. Works
+    /// without a public domain; auto-enabled when the service has no public
+    /// proxy URL.
+    #[clap(long)]
+    ssh: bool,
+
+    /// Force the public TCP proxy path and never fall back to SSH.
+    #[clap(long = "no-ssh", conflicts_with = "ssh")]
+    no_ssh: bool,
+
+    /// Local port to bind for the SSH tunnel (defaults to an ephemeral port).
+    #[clap(short = 'P', long)]
+    port: Option<u16>,
 }
 
 impl Display for ProjectProjectServicesEdgesNode {
@@ -128,17 +146,39 @@ pub async fn command(args: Args) -> Result<()> {
             })
     };
     if let Some(db_type) = database_type {
-        let (cmd_name, args) = get_connect_command(db_type, variables)?;
+        let use_ssh = if args.no_ssh {
+            false
+        } else if args.ssh {
+            true
+        } else {
+            // Auto: fall back to SSH when there's no public proxy URL to use.
+            !has_public_proxy(&db_type, &variables)
+        };
 
-        if which(cmd_name.clone()).is_err() {
-            bail!("{} must be installed to continue", cmd_name);
-        }
-
-        Command::new(cmd_name.as_str())
-            .args(args)
-            .spawn()?
-            .wait()
+        if use_ssh {
+            run_ssh_connect(
+                &client,
+                &configs,
+                &db_type,
+                &variables,
+                &environment_id,
+                &service_id,
+                args.port,
+            )
             .await?;
+        } else {
+            let (cmd_name, cmd_args) = get_connect_command(&db_type, &variables)?;
+
+            if which(cmd_name.clone()).is_err() {
+                bail!("{} must be installed to continue", cmd_name);
+            }
+
+            Command::new(cmd_name.as_str())
+                .args(cmd_args)
+                .spawn()?
+                .wait()
+                .await?;
+        }
 
         Ok(())
     } else {
@@ -147,19 +187,184 @@ pub async fn command(args: Args) -> Result<()> {
 }
 
 fn get_connect_command(
-    database_type: DatabaseType,
-    variables: BTreeMap<String, String>,
+    database_type: &DatabaseType,
+    variables: &BTreeMap<String, String>,
 ) -> Result<(String, Vec<String>)> {
-    match &database_type {
-        DatabaseType::PostgreSQL => get_postgres_command(&variables),
-        DatabaseType::Redis => get_redis_command(&variables),
-        DatabaseType::MongoDB => get_mongo_command(&variables),
-        DatabaseType::MySQL => get_mysql_command(&variables),
+    match database_type {
+        DatabaseType::PostgreSQL => get_postgres_command(variables),
+        DatabaseType::Redis => get_redis_command(variables),
+        DatabaseType::MongoDB => get_mongo_command(variables),
+        DatabaseType::MySQL => get_mysql_command(variables),
     }
 }
 
 fn host_is_tcp_proxy(connect_url: String) -> bool {
     connect_url.contains("proxy.rlwy.net")
+}
+
+/// Whether the service exposes a public TCP-proxy URL for this engine — the
+/// variable `connect`'s public path needs. Drives auto-fallback: when there's
+/// no public proxy, `connect` tunnels over SSH instead of erroring.
+fn has_public_proxy(database_type: &DatabaseType, variables: &BTreeMap<String, String>) -> bool {
+    let (public_key, private_key) = connection_url_keys(database_type);
+    variables
+        .get(public_key)
+        .or_else(|| variables.get(private_key))
+        .map(|url| host_is_tcp_proxy(url.clone()))
+        .unwrap_or(false)
+}
+
+/// The `(public, private)` connection-URL variable names and the engine's
+/// in-container default port.
+fn connection_url_keys(database_type: &DatabaseType) -> (&'static str, &'static str) {
+    match database_type {
+        DatabaseType::PostgreSQL => ("DATABASE_PUBLIC_URL", "DATABASE_URL"),
+        DatabaseType::Redis => ("REDIS_PUBLIC_URL", "REDIS_URL"),
+        DatabaseType::MongoDB => ("MONGO_PUBLIC_URL", "MONGO_URL"),
+        DatabaseType::MySQL => ("MYSQL_PUBLIC_URL", "MYSQL_URL"),
+    }
+}
+
+fn default_remote_port(database_type: &DatabaseType) -> u16 {
+    match database_type {
+        DatabaseType::PostgreSQL => 5432,
+        DatabaseType::Redis => 6379,
+        DatabaseType::MongoDB => 27017,
+        DatabaseType::MySQL => 3306,
+    }
+}
+
+/// Connect to the database through an SSH tunnel into the service's container,
+/// forwarding a local port to the engine's loopback listener. Needs no public
+/// domain or TCP proxy.
+#[allow(clippy::too_many_arguments)]
+async fn run_ssh_connect(
+    client: &Client,
+    configs: &Configs,
+    database_type: &DatabaseType,
+    variables: &BTreeMap<String, String>,
+    environment_id: &str,
+    service_id: &str,
+    requested_port: Option<u16>,
+) -> Result<()> {
+    let local_port = match requested_port {
+        Some(port) => port,
+        None => pick_ephemeral_port()?,
+    };
+
+    let (cmd_name, cmd_args, remote_port) =
+        get_ssh_connect_command(database_type, variables, local_port)?;
+
+    if which(cmd_name.clone()).is_err() {
+        bail!("{} must be installed to continue", cmd_name);
+    }
+
+    let identity = ensure_ssh_key(client, configs).await?;
+    let ssh_target = get_service_instance_id(client, configs, environment_id, service_id).await?;
+
+    eprintln!("Opening SSH tunnel: 127.0.0.1:{local_port} → service :{remote_port} ...");
+
+    // Hold the guard for the lifetime of the client; dropping it kills ssh.
+    let _forward = spawn_native_ssh_forward(
+        &ssh_target,
+        identity.as_deref(),
+        &[PortForward {
+            local_port,
+            remote_port,
+        }],
+    )?;
+
+    Command::new(cmd_name.as_str())
+        .args(cmd_args)
+        .spawn()?
+        .wait()
+        .await?;
+
+    Ok(())
+}
+
+/// Reserve an ephemeral local port by binding then immediately releasing it so
+/// ssh can claim it for the `-L` forward. (Small TOCTOU window, same as any
+/// pick-a-free-port approach.)
+fn pick_ephemeral_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .context("Failed to reserve a local port for the SSH tunnel")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// Build the client invocation for the SSH path: rewrite the engine's private
+/// connection URL to point at the local tunnel (`127.0.0.1:<local_port>`) while
+/// keeping credentials and database name intact. Returns the client binary, its
+/// args, and the remote (in-container) port the tunnel must reach.
+fn get_ssh_connect_command(
+    database_type: &DatabaseType,
+    variables: &BTreeMap<String, String>,
+    local_port: u16,
+) -> Result<(String, Vec<String>, u16)> {
+    let (url, remote_port) = local_tunnel_url(database_type, variables, local_port)?;
+
+    let (cmd, args) = match database_type {
+        DatabaseType::PostgreSQL => ("psql".to_string(), vec![url.to_string()]),
+        DatabaseType::Redis => (
+            "redis-cli".to_string(),
+            vec!["-u".to_string(), url.to_string()],
+        ),
+        DatabaseType::MongoDB => ("mongosh".to_string(), vec![url.to_string()]),
+        DatabaseType::MySQL => {
+            let user = url.username().to_string();
+            let password = url.password().unwrap_or("").to_string();
+            let database = url.path().trim_start_matches('/').to_string();
+            (
+                "mysql".to_string(),
+                vec![
+                    "-h".to_string(),
+                    "127.0.0.1".to_string(),
+                    "-u".to_string(),
+                    user,
+                    "-P".to_string(),
+                    local_port.to_string(),
+                    "-D".to_string(),
+                    database,
+                    format!("-p{password}"),
+                ],
+            )
+        }
+    };
+
+    Ok((cmd, args, remote_port))
+}
+
+/// Parse the engine's private connection URL (falling back to the public one
+/// only for credentials) and rewrite host/port to the local tunnel endpoint.
+/// Returns the rewritten URL plus the in-container port the tunnel must reach.
+fn local_tunnel_url(
+    database_type: &DatabaseType,
+    variables: &BTreeMap<String, String>,
+    local_port: u16,
+) -> Result<(Url, u16)> {
+    let (public_key, private_key) = connection_url_keys(database_type);
+    let default_port = default_remote_port(database_type);
+
+    // Prefer the internal URL: it carries the real in-container port. The public
+    // proxy URL is only a credentials fallback — its port is the proxy's, not
+    // the engine's, so fall back to the default in-container port there.
+    let (raw, remote_port_override) = if let Some(internal) = variables.get(private_key) {
+        (internal.clone(), None)
+    } else if let Some(public) = variables.get(public_key) {
+        (public.clone(), Some(default_port))
+    } else {
+        return Err(RailwayError::ConnectionVariableNotFound(private_key.to_string()).into());
+    };
+
+    let mut url = Url::parse(&raw).map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+    let remote_port = remote_port_override.unwrap_or_else(|| url.port().unwrap_or(default_port));
+
+    url.set_host(Some("127.0.0.1"))
+        .map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+    url.set_port(Some(local_port))
+        .map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+
+    Ok((url, remote_port))
 }
 
 fn get_postgres_command(variables: &BTreeMap<String, String>) -> Result<(String, Vec<String>)> {
@@ -259,6 +464,91 @@ mod test {
         assert!(host_is_tcp_proxy("roundhouse.proxy.rlwy.net".to_string()));
         assert!(!host_is_tcp_proxy("localhost".to_string()));
         assert!(!host_is_tcp_proxy("postgres.railway.internal".to_string()));
+    }
+
+    #[test]
+    fn test_has_public_proxy() {
+        let mut variables = BTreeMap::new();
+        variables.insert(
+            "DATABASE_URL".to_string(),
+            "postgresql://postgres:secret@db.railway.internal:5432/railway".to_string(),
+        );
+        // Only a private URL → no public proxy → auto path uses SSH.
+        assert!(!has_public_proxy(&DatabaseType::PostgreSQL, &variables));
+
+        variables.insert(
+            "DATABASE_PUBLIC_URL".to_string(),
+            "postgresql://postgres:secret@monorail.proxy.rlwy.net:55555/railway".to_string(),
+        );
+        assert!(has_public_proxy(&DatabaseType::PostgreSQL, &variables));
+    }
+
+    #[test]
+    fn test_ssh_connect_command_rewrites_to_local_tunnel() {
+        let mut variables = BTreeMap::new();
+        variables.insert(
+            "DATABASE_URL".to_string(),
+            "postgresql://postgres:secret@monorail.railway.internal:5432/railway".to_string(),
+        );
+
+        let (cmd, args, remote_port) =
+            get_ssh_connect_command(&DatabaseType::PostgreSQL, &variables, 49152).unwrap();
+
+        assert_eq!(cmd, "psql");
+        assert_eq!(remote_port, 5432);
+        assert_eq!(
+            args,
+            vec!["postgresql://postgres:secret@127.0.0.1:49152/railway".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_ssh_connect_command_falls_back_to_public_url_for_creds() {
+        // No private URL — only the public proxy URL is present. We reuse it for
+        // credentials but must NOT use its (proxy) port as the remote port.
+        let mut variables = BTreeMap::new();
+        variables.insert(
+            "DATABASE_PUBLIC_URL".to_string(),
+            "postgresql://postgres:secret@monorail.proxy.rlwy.net:55555/railway".to_string(),
+        );
+
+        let (_cmd, args, remote_port) =
+            get_ssh_connect_command(&DatabaseType::PostgreSQL, &variables, 6000).unwrap();
+
+        assert_eq!(remote_port, 5432);
+        assert_eq!(
+            args,
+            vec!["postgresql://postgres:secret@127.0.0.1:6000/railway".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_ssh_connect_command_mysql_args() {
+        let mut variables = BTreeMap::new();
+        variables.insert(
+            "MYSQL_URL".to_string(),
+            "mysql://user:password@mysql.railway.internal:3306/railway".to_string(),
+        );
+
+        let (cmd, args, remote_port) =
+            get_ssh_connect_command(&DatabaseType::MySQL, &variables, 33060).unwrap();
+
+        assert_eq!(cmd, "mysql");
+        assert_eq!(remote_port, 3306);
+        assert_eq!(
+            args,
+            vec![
+                "-h".to_string(),
+                "127.0.0.1".to_string(),
+                "-u".to_string(),
+                "user".to_string(),
+                "-P".to_string(),
+                "33060".to_string(),
+                "-D".to_string(),
+                "railway".to_string(),
+                "-ppassword".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -262,6 +262,13 @@ async fn run_ssh_connect(
     let identity = ensure_ssh_key(client, configs).await?;
     let ssh_target = get_service_instance_id(client, configs, environment_id, service_id).await?;
 
+    // The database clients trap SIGINT themselves (Ctrl+C cancels the running
+    // query, it doesn't exit) — but the terminal delivers it to this parent
+    // too, and dying here would skip the guard's Drop and strand the session.
+    // Ignore it, same as `run` and `shell`; the session ends when the client
+    // exits and the guard tears the tunnel down.
+    ctrlc::set_handler(move || {})?;
+
     eprintln!("Opening SSH tunnel: 127.0.0.1:{local_port} → service :{remote_port} ...");
 
     // Hold the guard for the lifetime of the client; dropping it kills ssh.

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -17,7 +17,8 @@ use common::*;
 // Re-exported for the `sandbox` command, which reuses the same native SSH
 // transport (key registration + `ssh <target>@<env relay host>`).
 pub use native::{
-    DurableResume, PortForward, ensure_ssh_key, run_native_ssh, run_native_ssh_forward,
+    DurableResume, PortForward, ensure_ssh_key, get_service_instance_id, run_native_ssh,
+    run_native_ssh_forward, spawn_native_ssh_forward,
 };
 
 /// Connect to a service via SSH or manage SSH keys

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -431,6 +431,23 @@ pub fn spawn_native_ssh_forward(
     ssh_cmd.stdout(Stdio::null());
     ssh_cmd.stderr(Stdio::inherit());
 
+    // Detach ssh from the terminal's foreground process group. Ctrl+C in the
+    // foreground client (e.g. cancelling a long psql query) is delivered to
+    // the whole group, and ssh doesn't trap SIGINT — left in the group, a
+    // routine query-cancel would kill the tunnel mid-session. Detached, ssh
+    // only goes down via the guard.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        ssh_cmd.process_group(0);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        ssh_cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    }
+
     let child = ssh_cmd.spawn().context("Failed to spawn ssh forward")?;
     let mut guard = ForwardGuard { child };
     wait_for_forward_ready(&mut guard, forwards)?;

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context, Result, bail};
 use is_terminal::IsTerminal;
 use reqwest::Client;
+use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::client::post_graphql;
 use crate::config::Configs;
@@ -340,8 +341,30 @@ pub fn run_native_ssh_forward(
     forwards: &[PortForward],
 ) -> Result<i32> {
     let (mut ssh_cmd, target) = base_ssh_command(ssh_target, identity_file);
+    apply_forward_options(&mut ssh_cmd, forwards);
+    ssh_cmd.arg(&target);
 
-    ssh_cmd.args([
+    // `-N` runs no command; keep stderr inherited so relay/auth errors and
+    // per-connection forward failures stay visible.
+    ssh_cmd.stdin(Stdio::null());
+    ssh_cmd.stdout(Stdio::null());
+    ssh_cmd.stderr(Stdio::inherit());
+
+    let status = ssh_cmd.status().context("Failed to execute ssh command")?;
+    // `code()` is None when ssh died from a signal — for a forward that's the
+    // user's Ctrl+C (delivered to the whole foreground process group).
+    Ok(status.code().unwrap_or(0))
+}
+
+/// Apply the `-N` forward-mode options and `-L` specs shared by the blocking
+/// (`run_native_ssh_forward`) and backgrounded (`spawn_native_ssh_forward`)
+/// paths, so their flags can't drift. The remote side of every forward is
+/// pinned to the `127.0.0.1` literal — names like `localhost` go through the
+/// relay's resolver (which doesn't honor the target's `/etc/hosts`) and resolve
+/// to unreachable mesh addresses, so a literal is the only thing that reliably
+/// reaches the port the target itself listens on.
+fn apply_forward_options(cmd: &mut Command, forwards: &[PortForward]) {
+    cmd.args([
         "-N",
         // `-N` runs with stdin closed, so an interactive host-key prompt can't
         // be answered — a fresh machine that hasn't trusted the relay yet would
@@ -364,7 +387,7 @@ pub fn run_native_ssh_forward(
     ]);
 
     for forward in forwards {
-        ssh_cmd.args([
+        cmd.args([
             "-L",
             &format!(
                 "127.0.0.1:{}:127.0.0.1:{}",
@@ -372,17 +395,67 @@ pub fn run_native_ssh_forward(
             ),
         ]);
     }
+}
 
+/// A backgrounded `ssh -N -L` forward. The child ssh process is killed when the
+/// guard is dropped, so a caller can keep the tunnel up for the lifetime of a
+/// foreground client (e.g. `railway connect` launching psql) and tear it down
+/// automatically when that client exits.
+pub struct ForwardGuard {
+    child: std::process::Child,
+}
+
+impl Drop for ForwardGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn a forward-only SSH session in the background and block until the
+/// forwarded local port(s) accept connections, so the caller can immediately
+/// point a client at `127.0.0.1:<local_port>` without racing an unbound
+/// listener. Returns a guard that kills ssh on drop.
+pub fn spawn_native_ssh_forward(
+    ssh_target: &str,
+    identity_file: Option<&Path>,
+    forwards: &[PortForward],
+) -> Result<ForwardGuard> {
+    let (mut ssh_cmd, target) = base_ssh_command(ssh_target, identity_file);
+    apply_forward_options(&mut ssh_cmd, forwards);
     ssh_cmd.arg(&target);
 
-    // `-N` runs no command; keep stderr inherited so relay/auth errors and
-    // per-connection forward failures stay visible.
+    // Backgrounded: no stdin (host-key prompts are handled by accept-new),
+    // stderr stays visible so relay/auth errors surface, stdout is unused.
     ssh_cmd.stdin(Stdio::null());
     ssh_cmd.stdout(Stdio::null());
     ssh_cmd.stderr(Stdio::inherit());
 
-    let status = ssh_cmd.status().context("Failed to execute ssh command")?;
-    // `code()` is None when ssh died from a signal — for a forward that's the
-    // user's Ctrl+C (delivered to the whole foreground process group).
-    Ok(status.code().unwrap_or(0))
+    let child = ssh_cmd.spawn().context("Failed to spawn ssh forward")?;
+    let mut guard = ForwardGuard { child };
+    wait_for_forward_ready(&mut guard, forwards)?;
+    Ok(guard)
+}
+
+/// Poll the forwarded local ports until they accept a TCP connection. Bails if
+/// ssh exits first (e.g. `ExitOnForwardFailure` tripping on a busy local port)
+/// or the tunnel doesn't come up within the deadline.
+fn wait_for_forward_ready(guard: &mut ForwardGuard, forwards: &[PortForward]) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = guard.child.try_wait()? {
+            bail!("SSH tunnel exited before it was ready ({status})");
+        }
+        let all_up = forwards.iter().all(|forward| {
+            let addr = SocketAddr::from(([127, 0, 0, 1], forward.local_port));
+            TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_ok()
+        });
+        if all_up {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("Timed out waiting for the SSH tunnel to become ready on 127.0.0.1");
+        }
+        sleep(Duration::from_millis(150));
+    }
 }


### PR DESCRIPTION
## Why

`railway connect` only works when the database is exposed through a public TCP proxy — it errors on a private-only service. This makes it impossible to `railway connect` to a database you've deliberately kept off the public internet.

## What

Adds an SSH path: `connect` tunnels into the service's container and forwards a local port to the engine's loopback listener, so you can reach a database with **no public port**.

- `--ssh` forces the SSH tunnel
- `--no-ssh` forces the public-proxy path (previous behavior)
- bare `railway connect <db>` **auto-falls back to SSH** when the service has no public proxy URL
- `-P/--port` pins the local port (ephemeral by default)

Works for Postgres, MySQL, Redis, and MongoDB.

## How

- Resolves the deployment-instance ID as the SSH user and ensures a registered key, reusing the existing native-SSH helpers (`get_service_instance_id`, `ensure_ssh_key`).
- New `spawn_native_ssh_forward` in `ssh/native.rs` backgrounds `ssh -N -L`, polls until the forwarded local port accepts, and returns a `ForwardGuard` that **kills ssh on drop** — so the tunnel lives exactly as long as the client and never leaks. The shared `-N`/`-L` option building is factored into `apply_forward_options` so the blocking (`sandbox`) and backgrounded (`connect`) paths can't drift.
- The private connection URL (`DATABASE_URL`, etc.) is rewritten to `127.0.0.1:<local_port>`, preserving credentials and database name; the public URL is used only as a credentials fallback (never its proxy port).

### Why the `127.0.0.1` literal (not `localhost`)

Forwards are pinned to the `127.0.0.1` literal. A hostname like `localhost` is resolved **by the relay's resolver**, which doesn't honor the target container's `/etc/hosts` — so it resolves to an unreachable mesh address and the forward silently confirms-then-closes. A literal skips resolution and reaches the port the target itself listens on. (This already matched the existing `run_native_ssh_forward` behavior; the new path keeps it and documents the reasoning.)

## Testing

- `cargo check` clean (no warnings), `cargo test --bin railway connect` → 11 passed.
- New unit tests: URL rewrite to the local tunnel, public-proxy detection (auto-fallback), public-URL credential fallback, and MySQL arg building.
- **Live end-to-end** against a real private Postgres:
  \`\`\`
  Opening SSH tunnel: 127.0.0.1:55445 → service :5432 ...
    result   | current_database | server_ip | server_port
  -----------+------------------+-----------+-------------
   tunnel_ok | railway          | 127.0.0.1 |        5432
  \`\`\`
  \`inet_server_addr() = 127.0.0.1\` confirms the client reached the DB via the in-container loopback tunnel, with no public proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)