### PR TITLE
feat(mcp): capture clientInfo at the initialize handshake

### DIFF
--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1228,6 +1228,29 @@ impl RailwayMcp {
 }
 
 impl ServerHandler for RailwayMcp {
+    async fn initialize(
+        &self,
+        request: InitializeRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, McpError> {
+        // Capture the client identity at the handshake — the earliest and
+        // most reliable point, and the only one that covers sessions which
+        // enumerate tools but never call one. Without this, those sessions'
+        // `mcp_session` lifecycle event falls back to env/process-tree
+        // detection and lands in `agent_unknown`. OnceLock keeps the first
+        // (handshake) value, so a later tool call won't override it.
+        telemetry::record_mcp_client(&telemetry::McpClientInfo {
+            name: request.client_info.name.clone(),
+        });
+
+        // Preserve the default rmcp behavior: stash peer info for later
+        // `peer_info()` reads, then return our server info.
+        if context.peer.peer_info().is_none() {
+            context.peer.set_peer_info(request);
+        }
+        Ok(self.get_info())
+    }
+
     async fn call_tool(
         &self,
         request: CallToolRequestParams,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1673,14 +1673,30 @@ async fn send_with_caller_override(event: CliTrackEvent, caller_override: Option
     }
 }
 
-/// Process-scoped MCP client caller, captured the first time a tool call
-/// arrives with `clientInfo`. Lets the server-lifecycle telemetry::send
+/// Process-scoped MCP client caller, captured at the JSON-RPC `initialize`
+/// handshake (see [`record_mcp_client`]) or, failing that, the first tool
+/// call that carries `clientInfo`. Lets the server-lifecycle telemetry::send
 /// emitted by the dispatch macro at process exit attribute itself to the
 /// MCP client even though no `clientInfo` is in scope at that point.
+///
+/// Recording at `initialize` matters because a large share of MCP sessions
+/// handshake and enumerate tools but never *call* one (editors connect,
+/// list tools, then idle/disconnect). Those sessions previously had nothing
+/// set here and fell through to env/process-tree detection, landing the
+/// `mcp_session` lifecycle event in `agent_unknown`. `OnceLock` makes the
+/// first writer win, so the handshake value is stable for the session.
 static MCP_CLIENT_CALLER: OnceLock<String> = OnceLock::new();
 
 fn record_mcp_client_caller(client: &McpClientInfo) {
     let _ = MCP_CLIENT_CALLER.set(caller_from_mcp_client_name(&client.name));
+}
+
+/// Record the MCP client identity from the `initialize` handshake so the
+/// server-lifecycle event is attributed even when no tool call follows.
+/// Idempotent and cheap; safe to call once per session from the handler's
+/// `initialize`.
+pub fn record_mcp_client(client: &McpClientInfo) {
+    record_mcp_client_caller(client);
 }
 
 /// Send MCP tool telemetry. The caller is derived from the JSON-RPC


### PR DESCRIPTION
## What

Overrides `ServerHandler::initialize` on the local MCP server (`railway mcp`) to record the client identity from the handshake `clientInfo`, instead of only capturing it on the first tool call.

## Why (Tier 2 of the agent_unknown decomposition)

`MCP_CLIENT_CALLER` was only set in `call_tool`. But a large share of MCP sessions **handshake and enumerate tools without ever calling one** — editors connect on startup, list tools, then idle or disconnect. Those sessions had nothing recorded, so the per-command `mcp_session` lifecycle telemetry fell back to env/process-tree detection and landed in `agent_unknown`.

This is the **single biggest identifiable slice** of the unknown bucket:

| Metric | Value |
|---|---|
| `mcp_session` `agent_unknown` users (7d) | 3,422 |
| Identifiable (seen as a named agent elsewhere) | 2,977 (**87%**) |
| Share of the **entire** `agent_unknown` bucket | **29.1%** |

## How

`initialize` is the earliest and most authoritative hook — every MCP session that completes a handshake sends `clientInfo` there, before any tool call. The override:

1. records the client identity via `telemetry::record_mcp_client(...)` (new thin public wrapper over the existing recorder), then
2. preserves the default rmcp behavior — stash `peer_info`, return `get_info()`.

`MCP_CLIENT_CALLER` is a `OnceLock`, so the **handshake value wins** and a later tool call won't override it; the existing `call_tool` capture remains as a backstop. It reuses the same `caller_from_mcp_client_name` mapping, so recognized clients resolve to their slug and unrecognized ones pass through as `mcp_unknown:<name>` (which then feed the mapping queue, e.g. the recent `claude-code` mapping).

## Scope / notes

- **Forward-only** — takes effect as users upgrade (rollout curve), unlike the Tier 1 dbt reclassification which is retroactive.
- **Also drains part of Tier 3** (`agent_unknown:vscode`): VS Code agents that reach Railway over MCP get named at the handshake even when their terminal env fingerprint is missing (the [claude-code/#55486](https://github.com/anthropics/claude-code/issues/55486) env-propagation bug).
- **Companion (optional) dbt stitch** could backfill history for the same `mcp_session` rows; this PR is the correct source-side fix going forward.

## Testing

- `cargo test` green (300); clippy clean on touched files.
- **Smoke test:** piping a JSON-RPC `initialize` (clientInfo `smoke-test-client`) to `railway mcp` returns the correct `serverInfo` and completes the handshake — confirming the override delegates to `get_info()` correctly and doesn't break initialization.
- The recording path reuses `caller_from_mcp_client_name`, already unit-tested. (The capture itself writes a process-global `OnceLock`, so it's exercised via the smoke test rather than a unit test that would make global state order-dependent.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)