### PR TITLE
feat(oauth): forward cli_caller on login for agent signup attribution

### DIFF
--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -145,7 +145,9 @@ async fn browser_login(host: &str) -> Result<oauth::TokenResponse> {
 
     let pkce = oauth::generate_pkce();
     let state = oauth::generate_state();
-    let auth_url = oauth::get_authorization_url(host, &redirect_uri, &pkce, &state);
+    let caller = crate::telemetry::detect_caller();
+    let auth_url =
+        oauth::get_authorization_url(host, &redirect_uri, &pkce, &state, &caller);
     // Sign-up vs sign-in is handled entirely server-side (the consent
     // screen adapts for brand-new accounts); the CLI doesn't declare
     // its intent up front.
@@ -391,7 +393,8 @@ async fn send_response(
 
 /// Browserless flow: Device Authorization Grant (RFC 8628).
 async fn device_flow_login(host: &str) -> Result<oauth::TokenResponse> {
-    let device_auth = oauth::request_device_code(host).await?;
+    let caller = crate::telemetry::detect_caller();
+    let device_auth = oauth::request_device_code(host, &caller).await?;
 
     println!();
     println!("  {} Sign in at:", "→".cyan());

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -146,8 +146,7 @@ async fn browser_login(host: &str) -> Result<oauth::TokenResponse> {
     let pkce = oauth::generate_pkce();
     let state = oauth::generate_state();
     let caller = crate::telemetry::detect_caller();
-    let auth_url =
-        oauth::get_authorization_url(host, &redirect_uri, &pkce, &state, &caller);
+    let auth_url = oauth::get_authorization_url(host, &redirect_uri, &pkce, &state, &caller);
     // Sign-up vs sign-in is handled entirely server-side (the consent
     // screen adapts for brand-new accounts); the CLI doesn't declare
     // its intent up front.

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -69,6 +69,7 @@ pub fn get_authorization_url(
     redirect_uri: &str,
     pkce: &PkceChallenge,
     state: &str,
+    caller: &str,
 ) -> String {
     let base = get_oauth_base_url(host);
     let client_id = get_oauth_client_id();
@@ -81,7 +82,12 @@ pub fn get_authorization_url(
         .append_pair("code_challenge", &pkce.code_challenge)
         .append_pair("code_challenge_method", "S256")
         .append_pair("state", state)
-        .append_pair("prompt", "consent");
+        .append_pair("prompt", "consent")
+        // Caller (agent harness / tty) that initiated this login, forwarded so
+        // the OAuth grant confirm event can attribute the signup to the agent
+        // that drove it (mono#30906). Server registers it as a no-op extra
+        // param; analytics-only — same value we stamp on cli_submit_auth.
+        .append_pair("cli_caller", caller);
     url.to_string()
 }
 
@@ -144,14 +150,20 @@ struct TokenErrorResponse {
     error_description: Option<String>,
 }
 
-pub async fn request_device_code(host: &str) -> Result<DeviceAuthResponse> {
+pub async fn request_device_code(host: &str, caller: &str) -> Result<DeviceAuthResponse> {
     let client = build_http_client()?;
     let url = format!("{}/device/auth", get_oauth_base_url(host));
     let client_id = get_oauth_client_id();
 
     let resp = client
         .post(&url)
-        .form(&[("client_id", client_id), ("scope", CLI_SCOPES)])
+        // `cli_caller`: see get_authorization_url — attributes the signup to
+        // the agent/harness that drove it on the grant confirm event.
+        .form(&[
+            ("client_id", client_id),
+            ("scope", CLI_SCOPES),
+            ("cli_caller", caller),
+        ])
         .send()
         .await?;
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1287,7 +1287,7 @@ fn persistent_agent_session_id() -> Option<String> {
 /// lifetime of the process so repeated calls are free and stable across a
 /// session (important for long-lived processes like the local MCP server,
 /// where the same caller value is reported across many tool events).
-fn detect_caller() -> String {
+pub(crate) fn detect_caller() -> String {
     static CALLER: OnceLock<String> = OnceLock::new();
     CALLER.get_or_init(detect_caller_uncached).clone()
 }


### PR DESCRIPTION
## Why

When someone signs up through `railway login` / `railway up`, we want to know **which caller drove it** — an agent harness (claude_code, cursor, codex…) vs. a human at a `tty`. The CLI already stamps that `caller` on its `cli_submit_auth` event, but that event fires **anonymously before auth completes**, so it can't be joined back to the resulting user — leaving ~94% of CLI signups unattributed downstream.

This closes the loop: forward the caller **into the OAuth request itself**, so it lands on the server's grant confirm event next to `is_new_signup`/`transport`.

## What

Both transports now send a `cli_caller` param:
- **Browser** (`get_authorization_url`): `&cli_caller=<caller>` query param on the authorize URL.
- **Device flow** (`request_device_code`): `cli_caller` form field on the device-authorization request.

The value is `detect_caller()` — the **exact same** value already stamped on `cli_submit_auth`, so the grant param and the auth-funnel event agree by construction. `detect_caller()` is made `pub(crate)` (was private); no behavior change.

## Server side

`backboard` (mono#30906) registers `cli_caller` as a **no-op** OAuth extra param (so oidc-provider persists it onto the interaction / device-code records) and reads it onto the OAuthGrant confirm event. `dim_user` (dbt-analytics#159) then reads it directly — deterministic, no post-hoc join.

## Safety

- **Analytics-only, client-asserted** — the server treats `cli_caller` as a no-op param and never gates auth on it.
- **Backwards-safe / no deploy ordering:** if the server hasn't registered the param yet it's simply dropped (unknown params are ignored); nothing breaks. Old CLIs that don't send it → server records `caller = null` (today's behavior).

## Testing

- `cargo check` passes clean.
- Existing oauth/login tests unaffected (no test referenced the changed signatures).
- Staging plan: point at `backboard.railway-develop.com`, run `railway login` (browser) and `railway login --browserless` (device) → confirm `cli_caller` reaches the grant confirm.

Part of the agent-signup attribution work: **mono#30906** (backboard) + **dbt-analytics#159** (dim_user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)