### PR TITLE
feat(telemetry): distinguish GitHub vs image source on service source connect

### DIFF
--- a/src/commands/service.rs
+++ b/src/commands/service.rs
@@ -306,6 +306,34 @@ async fn source_command(args: SourceArgs) -> Result<()> {
     }
 }
 
+/// Emit a granular telemetry event distinguishing the source *kind* on
+/// `service source connect|disconnect`.
+///
+/// The `commands!` macro already fires a generic `service` / `source:connect`
+/// event, but it only sees the clap subcommand path — not the `--repo` vs
+/// `--image` argument. That makes a GitHub integration indistinguishable from
+/// a Docker-image source in the funnel (the reason CLI-driven GitHub connects
+/// were invisible in agentic-signup analysis). This additive detail event
+/// — same pattern as the per-tool MCP and per-stage SSH events that sit
+/// alongside the macro's command-level event — records only the source kind.
+///
+/// Deliberately carries NO repo name: `owner/repo` can reveal private repo and
+/// org names, and the kind is all the funnel needs.
+async fn track_service_source(sub_command: &str) {
+    crate::telemetry::send(crate::telemetry::CliTrackEvent {
+        command: "service".to_string(),
+        sub_command: Some(sub_command.to_string()),
+        duration_ms: 0,
+        success: true,
+        error_message: None,
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        cli_version: env!("CARGO_PKG_VERSION"),
+        is_ci: crate::config::Configs::env_is_ci(),
+    })
+    .await;
+}
+
 async fn source_connect_command(args: SourceConnectArgs) -> Result<()> {
     let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
 
@@ -331,6 +359,15 @@ async fn source_connect_command(args: SourceConnectArgs) -> Result<()> {
         },
     )
     .await?;
+
+    // Distinguish a GitHub repo connect from a Docker image connect — the
+    // distinction the macro's generic `source:connect` event can't capture.
+    let source_kind = if repo.is_some() {
+        "source_connect_github"
+    } else {
+        "source_connect_image"
+    };
+    track_service_source(source_kind).await;
 
     let output = ServiceSourceOutput {
         id: result.service_connect.id,
@@ -371,6 +408,8 @@ async fn source_disconnect_command(args: SourceDisconnectArgs) -> Result<()> {
         },
     )
     .await?;
+
+    track_service_source("source_disconnect").await;
 
     let output = ServiceSourceOutput {
         id: result.service_disconnect.id,


### PR DESCRIPTION
## Why

Analyzing the agentic-signup cohort, the event funnel said **zero** users connected GitHub, but the server-side `deploymenttrigger` table showed ~12% had. Investigating the CLI telemetry path turned up the real cause (see "Root cause" below): `railway service source connect`'s telemetry **never lands in the warehouse at all**.

## Root cause (important)

The `commands!` macro builds a nested `sub_command` by joining the clap subcommand path with `:` — so `railway service source connect` emits `command="service"`, `sub_command="source:connect"`. But backboard's `cliEventTrack` validates `subCommand` against `CLI_COMMAND_RE = /^[a-z_]{1,64}$/` (telemetry.ts:18,299), which **disallows colons**. So the event is **rejected server-side and dropped** (the CLI swallows the error; the legacy-retry hits the same regex).

This affects **every nested subcommand**, not just service source (`sandbox template build`, `ssh keys add`, …). Single-level commands (`up`, `login`) have no colon, which is why `cli_create_up` works but `service source:connect` is absent from `fct_agentic_events`.

## What this PR does

Emit a dedicated detail event whose `sub_command` uses **underscores** (so it passes `CLI_COMMAND_RE` and actually lands), recording the source *kind*:

| Action | `sub_command` |
|---|---|
| `source connect --repo …` | `source_connect_github` |
| `source connect --image …` | `source_connect_image` |
| `source disconnect` | `source_disconnect` |

All under `command="service"`, via the existing `cliEventTrack` mutation (no backboard change). `caller` / `agent_session_id` / `service_id` are auto-attached by `TelemetryContext`, so it's attributable to agent-vs-human and to the service. It also captures the **GitHub-vs-image** distinction the macro's (rejected) generic event never could.

### No double-count
The macro's generic `source:connect` event is rejected by the regex and never reaches the warehouse, so this is the **only** surviving row per invocation — not an additive/double event. (Earlier draft of this PR mis-described it as an intentional double-emit; that was wrong.)

### Privacy
Carries **no repo name** — `owner/repo` can leak private repo/org names; the kind is all the funnel needs.

### Behavior
Fires on the **success path only**; failures are still captured by the macro's command-level event (which, being single-token `command="service"` with the colon `sub_command`, drops the sub_command but the command-level row may still record — orthogonal to this change).

## Pressure test
- ✅ `cargo check` clean; no signature changes; no other call sites touched.
- ✅ `sub_command` values are lowercase+underscore, length ≤64 → **pass `CLI_COMMAND_RE`** (the whole point).
- ✅ Format-safe: source-kind selection is a `let` binding (avoids if-as-arg rustfmt churn); added lines ≤100 cols. (rustfmt/clippy not in my env; CI runs both, clippy not `-D warnings`.)
- ✅ `telemetry::send` is best-effort — cannot break the command.

## Recommended companion fix (separate)
The durable fix for the dropped-telemetry class is to reconcile the regex/macro mismatch — **either** loosen `CLI_COMMAND_RE` to allow `:` (one-line backboard change, instantly un-drops all nested-subcommand events) **or** switch the macro's join from `:` to `_`. Worth doing regardless of this PR.

## Related telemetry gaps (follow-ups)
Same "command+subcommand but not resource kind" pattern: `railway add` (db/template type), `railway domain`, `railway volume add`, `railway init`. Most robust GitHub fix overall: have backboard's `serviceConnect` mutation emit a platform event with `provider` — captures CLI + dashboard connects uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)