### PR TITLE
feat(agent): agent readiness — help health check, advisory re-arm, link prompt

### DIFF
--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -313,7 +313,7 @@ fn select_service(
             if require_service {
                 Some(prompt_options("Select a service", useful_services)?)
             } else {
-                prompt_options_skippable("Select a service <esc to skip>", useful_services)?
+                prompt_options_skippable("Select a service (optional) <esc to skip>", useful_services)?
             }
         } else if useful_services.len() == 1 {
             let svc = useful_services.into_iter().next().unwrap();

--- a/src/commands/link.rs
+++ b/src/commands/link.rs
@@ -313,7 +313,10 @@ fn select_service(
             if require_service {
                 Some(prompt_options("Select a service", useful_services)?)
             } else {
-                prompt_options_skippable("Select a service (optional) <esc to skip>", useful_services)?
+                prompt_options_skippable(
+                    "Select a service (optional) <esc to skip>",
+                    useful_services,
+                )?
             }
         } else if useful_services.len() == 1 {
             let svc = useful_services.into_iter().next().unwrap();

--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -93,7 +93,7 @@ pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool) -> Result
     Ok(())
 }
 
-fn supports_mcp(slug: &str) -> bool {
+pub(crate) fn supports_mcp(slug: &str) -> bool {
     matches!(
         slug,
         "claude-code" | "cursor" | "opencode" | "codex" | "copilot" | "factory-droid"

--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -113,6 +113,32 @@ fn config_path(slug: &str, home: &Path) -> PathBuf {
     }
 }
 
+/// True when a railway MCP entry is configured for either transport — the
+/// help health check doesn't care which one `setup agent` installed. Reads
+/// each config file once instead of once per transport.
+pub(crate) fn mcp_configured_any_transport(home: &Path, slug: &str) -> bool {
+    let path = config_path(slug, home);
+    match slug {
+        "claude-code" | "cursor" | "copilot" | "factory-droid" => read_json_or_empty(&path)
+            .ok()
+            .and_then(|root| root.pointer("/mcpServers/railway").cloned())
+            .is_some_and(|entry| {
+                json_mcp_entry_matches(&entry, false) || json_mcp_entry_matches(&entry, true)
+            }),
+        "opencode" => read_json_or_empty(&path)
+            .ok()
+            .and_then(|root| root.pointer("/mcp/railway").cloned())
+            .is_some_and(|entry| {
+                opencode_mcp_entry_matches(&entry, false)
+                    || opencode_mcp_entry_matches(&entry, true)
+            }),
+        // Codex keeps its TOML matching in one place at the cost of a second
+        // read for this one tool.
+        "codex" => codex_mcp_configured(&path, false) || codex_mcp_configured(&path, true),
+        _ => false,
+    }
+}
+
 pub(crate) fn mcp_configured_for_slug(home: &Path, slug: &str, remote: bool) -> bool {
     let path = config_path(slug, home);
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -252,6 +252,101 @@ async fn agent_setup_inner(args: AgentArgs) -> Result<Vec<String>> {
     Ok(configured_clients)
 }
 
+/// Health check for the root help screen: green/red status lines for Railway
+/// skills and MCP configuration across detected editors — exactly the set
+/// `railway setup agent -y` would install for. No network; a handful of stat
+/// calls and local config-file parses. Prints nothing when no coding tools
+/// are detected or in CI.
+pub(crate) fn print_agent_health_check() {
+    if Configs::env_is_ci() {
+        return;
+    }
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+
+    let detected: Vec<_> = coding_tools(&home)
+        .into_iter()
+        .filter(|tool| tool.slug == "universal" || tool.global_parent.is_dir())
+        .collect();
+
+    // The universal `.agents` target alone doesn't indicate agent usage — only
+    // run the health check for users with an actual coding tool installed.
+    if !detected.iter().any(|tool| tool.slug != "universal") {
+        return;
+    }
+
+    let missing_skills: Vec<&str> = detected
+        .iter()
+        .filter(|tool| !skills::skills_configured_for_slug(&home, tool.slug))
+        .map(|tool| tool.name)
+        .collect();
+
+    // Either transport counts as configured — `setup agent` installs one of
+    // the two, and a remote-configured editor isn't unhealthy.
+    let missing_mcp: Vec<&str> = detected
+        .iter()
+        .filter(|tool| mcp_install::supports_mcp(tool.slug))
+        .filter(|tool| {
+            !mcp_install::mcp_configured_for_slug(&home, tool.slug, false)
+                && !mcp_install::mcp_configured_for_slug(&home, tool.slug, true)
+        })
+        .map(|tool| tool.name)
+        .collect();
+
+    let skills_ok = missing_skills.is_empty();
+    let mcp_ok = missing_mcp.is_empty();
+
+    // Styled as a section of the help output (it only prints after root
+    // help), with the verdict line last — the spot the eye lands on.
+    eprintln!("\n{}", "Agent tooling:".dimmed());
+
+    if skills_ok {
+        eprintln!(
+            "  {} {}",
+            "\u{2713}".green(),
+            "Railway skills installed".green()
+        );
+    } else {
+        eprintln!(
+            "  {} {}",
+            "\u{2717}".red(),
+            format!(
+                "Railway skills not installed: {}",
+                missing_skills.join(", ")
+            )
+            .red()
+        );
+    }
+
+    if mcp_ok {
+        eprintln!(
+            "  {} {}",
+            "\u{2713}".green(),
+            "Railway MCP server configured".green()
+        );
+    } else {
+        eprintln!(
+            "  {} {}",
+            "\u{2717}".red(),
+            format!(
+                "Railway MCP server not configured: {}",
+                missing_mcp.join(", ")
+            )
+            .red()
+        );
+    }
+
+    if skills_ok && mcp_ok {
+        eprintln!("  {}", "Agent tooling is healthy".green());
+    } else {
+        eprintln!(
+            "  Run {} to install missing configuration.",
+            "railway setup agent".cyan()
+        );
+    }
+}
+
 async fn install_missing_mcp(
     home: &std::path::Path,
     selected_slugs: &[String],

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -287,10 +287,7 @@ pub(crate) fn print_agent_health_check() {
     let missing_mcp: Vec<&str> = detected
         .iter()
         .filter(|tool| mcp_install::supports_mcp(tool.slug))
-        .filter(|tool| {
-            !mcp_install::mcp_configured_for_slug(&home, tool.slug, false)
-                && !mcp_install::mcp_configured_for_slug(&home, tool.slug, true)
-        })
+        .filter(|tool| !mcp_install::mcp_configured_any_transport(&home, tool.slug))
         .map(|tool| tool.name)
         .collect();
 
@@ -304,7 +301,9 @@ pub(crate) fn print_agent_health_check() {
     if skills_ok {
         let revision = match skills::installed_skills_revision(&home) {
             Some((installed, skills::SkillsStaleness::UpdateAvailable(newer))) => {
-                format!(" (rev {installed} \u{2192} {newer} available, run `railway skills update`)")
+                format!(
+                    " (rev {installed} \u{2192} {newer} available, run `railway skills update`)"
+                )
             }
             Some((installed, skills::SkillsStaleness::UpToDate)) => {
                 format!(" (rev {installed}, up to date)")

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -302,10 +302,22 @@ pub(crate) fn print_agent_health_check() {
     eprintln!("\n{}", "Agent tooling:".dimmed());
 
     if skills_ok {
+        let revision = match skills::installed_skills_revision(&home) {
+            Some((installed, skills::SkillsStaleness::UpdateAvailable(newer))) => {
+                format!(" (rev {installed} \u{2192} {newer} available, run `railway skills update`)")
+            }
+            Some((installed, skills::SkillsStaleness::UpToDate)) => {
+                format!(" (rev {installed}, up to date)")
+            }
+            // No staleness evidence yet — show the revision, claim nothing.
+            Some((installed, skills::SkillsStaleness::Unknown)) => format!(" (rev {installed})"),
+            None => String::new(),
+        };
         eprintln!(
-            "  {} {}",
+            "  {} {}{}",
             "\u{2713}".green(),
-            "Railway skills installed".green()
+            "Railway skills installed".green(),
+            revision.dimmed()
         );
     } else {
         eprintln!(

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -537,6 +537,38 @@ pub(crate) fn orphan_skills_nag_due() -> Option<Vec<String>> {
     orphan_skills_nag(&home)
 }
 
+/// What the background staleness check knows about an install, distinguishing
+/// "verified current" from "never checked" so the health check doesn't claim
+/// freshness it has no evidence for.
+pub(super) enum SkillsStaleness {
+    /// The last upstream check matched the installed commit.
+    UpToDate,
+    /// Upstream has moved past the install (short SHA of the newer commit).
+    UpdateAvailable(String),
+    /// No upstream check result yet — staleness unknown.
+    Unknown,
+}
+
+/// Skills install/staleness info for the help-screen health check: the short
+/// commit SHA we last installed from, plus what the background staleness
+/// check knows about it. Reads only what the manifest already tracks — no
+/// network. None when there's no manifest-tracked install (e.g.
+/// pre-manifest/orphan copies).
+pub(super) fn installed_skills_revision(home: &Path) -> Option<(String, SkillsStaleness)> {
+    let manifest = SkillsManifest::read(home);
+    if !manifest.has_installed_skills() {
+        return None;
+    }
+    let installed = manifest.source_sha.as_deref()?;
+    let short = |sha: &str| sha.chars().take(7).collect::<String>();
+    let staleness = match manifest.latest_sha.as_deref() {
+        Some(latest) if latest == installed => SkillsStaleness::UpToDate,
+        Some(latest) => SkillsStaleness::UpdateAvailable(short(latest)),
+        None => SkillsStaleness::Unknown,
+    };
+    Some((short(installed), staleness))
+}
+
 pub(super) fn skills_configured_for_slug(home: &Path, slug: &str) -> bool {
     coding_tools(home)
         .into_iter()

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! commands {
                     .propagate_version(true)
                     .about(concat!(
                         clap::crate_description!(),
-                        "\n\nTip: Using an AI coding agent? Run `railway setup agent -y` to install Railway skills and MCP configuration."
+                        "\n\nTip: Using an AI coding agent? Run `railway setup agent -y` to install Railway skills and the Railway MCP server."
                     ))
                     .long_about(None)
                     .version(clap::crate_version!());
@@ -102,6 +102,9 @@ macro_rules! commands {
                     _ => {
                         build_args().print_help()?;
                         println!();
+                        // Bare `railway` shows the same root help as --help;
+                        // mirror its agent-tooling health check.
+                        $crate::commands::setup::print_agent_health_check();
                     }
                 }
                 Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,6 +384,15 @@ async fn main() -> Result<()> {
         // printed to stdout and exit with a status of 0.
         Err(e) if e.kind() == ErrorKind::DisplayHelp || e.kind() == ErrorKind::DisplayVersion => {
             println!("{e}");
+            // Root help doubles as a lightweight health check: tell users
+            // with coding tools installed when Railway skills/MCP config is
+            // missing, pointing at `railway setup agent`. Scoped to root
+            // help only — `railway <cmd> --help` stays clean.
+            if e.kind() == ErrorKind::DisplayHelp
+                && matches!(raw_subcommand.as_deref(), None | Some("help"))
+            {
+                commands::setup::print_agent_health_check();
+            }
             handle_update_task(check_updates_handle).await;
             std::process::exit(0);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -387,9 +387,13 @@ async fn main() -> Result<()> {
             // Root help doubles as a lightweight health check: tell users
             // with coding tools installed when Railway skills/MCP config is
             // missing, pointing at `railway setup agent`. Scoped to root
-            // help only — `railway <cmd> --help` stays clean.
+            // help only — both `railway <cmd> --help` and `railway help
+            // <cmd>` stay clean (the count guard catches the latter, where
+            // the first non-flag arg is still "help").
+            let non_flag_args = raw_args.iter().filter(|a| !a.starts_with('-')).count();
             if e.kind() == ErrorKind::DisplayHelp
                 && matches!(raw_subcommand.as_deref(), None | Some("help"))
+                && non_flag_args <= 1
             {
                 commands::setup::print_agent_health_check();
             }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1824,6 +1824,18 @@ fn resolve_agent_session_id(caller: &str) -> Option<String> {
         })
 }
 
+/// The agent session id for the current invocation, resolved exactly as the
+/// telemetry event context resolves it, so per-session gating (e.g. the agent
+/// advisory) keys on the same id the warehouse sees. `None` for human/CI
+/// callers.
+pub(crate) fn current_agent_session_id() -> Option<String> {
+    let caller = MCP_CLIENT_CALLER
+        .get()
+        .cloned()
+        .unwrap_or_else(detect_caller);
+    resolve_agent_session_id(&caller)
+}
+
 /// Attribution for the deploy tarball upload (`x-railway-caller` /
 /// `x-railway-agent-session` headers). Returns `Some` only when the CLI
 /// detects an agent harness driving it — backboard treats header presence

--- a/src/util/agent_advisory.rs
+++ b/src/util/agent_advisory.rs
@@ -215,14 +215,15 @@ pub async fn maybe_show(raw_args: &[String], command: Option<&str>) {
         return;
     }
 
-    // Declarative facts only: what's missing, what that makes unavailable,
-    // and what the remediation command does. No imperatives addressed at the
-    // agent and no consent-skipping flags — the directive phrasing this
-    // replaced was flagged as prompt injection by agent harnesses (#919).
+    // Declarative facts only: what this session is missing and the setup
+    // command, stated as a label rather than an instruction. No imperatives
+    // addressed at the agent and no consent-skipping flags — the directive
+    // phrasing this replaced was flagged as prompt injection by agent
+    // harnesses (#919).
     eprintln!(
         "\n{}\n{}",
-        "Railway agent tooling isn't installed — the use-railway skill and Railway MCP tools (docs lookup, deploy and log debugging, service management) are unavailable in this session.".yellow(),
-        "`railway setup agent` installs them. It is idempotent, auto-detects installed editors, and uses non-interactive defaults when stdout is not a TTY.".dimmed(),
+        "This session is missing Railway's agent tooling. That includes Railway skills (use-railway) and the Railway MCP server, which provides tooling for deployments, logs, status, and docs.".yellow(),
+        "Setup: `railway setup agent`".dimmed(),
     );
 
     state.advisory = AdvisoryState {

--- a/src/util/agent_advisory.rs
+++ b/src/util/agent_advisory.rs
@@ -335,3 +335,67 @@ pub fn record_setup_complete() -> Result<()> {
     };
     write_state(&state)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_shown(days_ago: i64, session: Option<&str>) -> AgentState {
+        AgentState {
+            advisory: AdvisoryState {
+                last_shown_cli_version: Some("5.0.0".to_string()),
+                last_shown_at: Some(Utc::now() - chrono::Duration::days(days_ago)),
+                last_shown_agent_session_id: session.map(str::to_string),
+            },
+            ..AgentState::default()
+        }
+    }
+
+    #[test]
+    fn never_shown_is_not_suppressed() {
+        assert!(!advisory_suppressed(&AgentState::default(), Some("s1")));
+        assert!(!advisory_suppressed(&AgentState::default(), None));
+    }
+
+    #[test]
+    fn same_session_is_suppressed_even_outside_window() {
+        let state = state_shown(ADVISORY_REARM_DAYS + 7, Some("s1"));
+        assert!(advisory_suppressed(&state, Some("s1")));
+    }
+
+    #[test]
+    fn new_session_within_window_is_suppressed() {
+        let state = state_shown(1, Some("s1"));
+        assert!(advisory_suppressed(&state, Some("s2")));
+    }
+
+    #[test]
+    fn new_session_outside_window_is_shown() {
+        let state = state_shown(ADVISORY_REARM_DAYS + 1, Some("s1"));
+        assert!(!advisory_suppressed(&state, Some("s2")));
+    }
+
+    #[test]
+    fn missing_session_id_falls_back_to_window_only() {
+        assert!(advisory_suppressed(&state_shown(1, None), None));
+        assert!(!advisory_suppressed(
+            &state_shown(ADVISORY_REARM_DAYS + 1, None),
+            None
+        ));
+    }
+
+    // Pre-#919 state files (no lastShownAgentSessionId) and post-#919 files
+    // (no field at all) must keep deserializing; the field defaults to None.
+    #[test]
+    fn old_state_files_deserialize() {
+        let state: AgentState = serde_json::from_str(
+            r#"{"advisory":{"lastShownCliVersion":"4.63.0","lastShownAt":"2026-05-20T00:00:00Z"}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            state.advisory.last_shown_cli_version.as_deref(),
+            Some("4.63.0")
+        );
+        assert!(state.advisory.last_shown_agent_session_id.is_none());
+    }
+}

--- a/src/util/agent_advisory.rs
+++ b/src/util/agent_advisory.rs
@@ -11,6 +11,12 @@ use crate::{telemetry, util};
 const STATE_VERSION: u32 = 1;
 const DISABLE_ENV: &str = "RAILWAY_AGENT_ADVISORY";
 const FORCE_ENV: &str = "RAILWAY_AGENT";
+// Global floor between advisory impressions on a machine. Re-arming on a
+// timer (rather than only on CLI upgrade) is deliberate: the once-per-version
+// gate from #919 cut fresh-user setup conversion from 9.1% to 3.3%, while the
+// "firing constantly" complaints it fixed are prevented by the per-session
+// gate below, not by the version gate.
+const ADVISORY_REARM_DAYS: i64 = 3;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,6 +41,7 @@ struct SetupState {
 struct AdvisoryState {
     last_shown_cli_version: Option<String>,
     last_shown_at: Option<DateTime<Utc>>,
+    last_shown_agent_session_id: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -166,14 +173,28 @@ fn should_skip_for_args(raw_args: &[String]) -> bool {
     })
 }
 
-// Suppress the advisory if we've already shown it for the currently running
-// CLI version. Upgrading the CLI re-arms the advisory exactly once.
-fn advisory_already_shown_for_current_cli(state: &AgentState) -> bool {
+// Suppress the advisory when this agent session has already seen it, or when
+// any session on this machine saw it within the re-arm window. An agent
+// session gets at most one impression (no context spam), and a machine gets
+// at most one impression per ADVISORY_REARM_DAYS. When the harness doesn't
+// expose a stable session id (`current_session` is None or per-process), the
+// time window is the only gate.
+fn advisory_suppressed(state: &AgentState, current_session: Option<&str>) -> bool {
+    let shown_to_this_session = matches!(
+        (
+            current_session,
+            state.advisory.last_shown_agent_session_id.as_deref(),
+        ),
+        (Some(current), Some(last)) if current == last
+    );
+    if shown_to_this_session {
+        return true;
+    }
+
     state
         .advisory
-        .last_shown_cli_version
-        .as_deref()
-        .is_some_and(|shown| shown == env!("CARGO_PKG_VERSION"))
+        .last_shown_at
+        .is_some_and(|shown_at| Utc::now() - shown_at < chrono::Duration::days(ADVISORY_REARM_DAYS))
 }
 
 pub async fn maybe_show(raw_args: &[String], command: Option<&str>) {
@@ -188,20 +209,26 @@ pub async fn maybe_show(raw_args: &[String], command: Option<&str>) {
         return;
     }
 
+    let agent_session_id = telemetry::current_agent_session_id();
     let mut state = read_state();
-    if agent_setup_is_current(&state) || advisory_already_shown_for_current_cli(&state) {
+    if agent_setup_is_current(&state) || advisory_suppressed(&state, agent_session_id.as_deref()) {
         return;
     }
 
+    // Declarative facts only: what's missing, what that makes unavailable,
+    // and what the remediation command does. No imperatives addressed at the
+    // agent and no consent-skipping flags — the directive phrasing this
+    // replaced was flagged as prompt injection by agent harnesses (#919).
     eprintln!(
         "\n{}\n{}",
-        "Railway agent tooling (skills + MCP) isn't installed.".yellow(),
-        "Run `railway setup agent` to configure it.".dimmed(),
+        "Railway agent tooling isn't installed — the use-railway skill and Railway MCP tools (docs lookup, deploy and log debugging, service management) are unavailable in this session.".yellow(),
+        "`railway setup agent` installs them. It is idempotent, auto-detects installed editors, and uses non-interactive defaults when stdout is not a TTY.".dimmed(),
     );
 
     state.advisory = AdvisoryState {
         last_shown_cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         last_shown_at: Some(Utc::now()),
+        last_shown_agent_session_id: agent_session_id,
     };
 
     let _ = write_state(&state);

--- a/src/util/agent_advisory.rs
+++ b/src/util/agent_advisory.rs
@@ -180,14 +180,10 @@ fn should_skip_for_args(raw_args: &[String]) -> bool {
 // expose a stable session id (`current_session` is None or per-process), the
 // time window is the only gate.
 fn advisory_suppressed(state: &AgentState, current_session: Option<&str>) -> bool {
-    let shown_to_this_session = matches!(
-        (
-            current_session,
-            state.advisory.last_shown_agent_session_id.as_deref(),
-        ),
-        (Some(current), Some(last)) if current == last
-    );
-    if shown_to_this_session {
+    // `is_some` guard: two unknown sessions (None == None) are not a match.
+    if current_session.is_some()
+        && current_session == state.advisory.last_shown_agent_session_id.as_deref()
+    {
         return true;
     }
 


### PR DESCRIPTION
## What

Three surfaces driving one behavior — agent tooling adoption — plus a link-prompt nudge toward project-only linking:

**1. Agent tooling health check on root help** (`railway --help`, `railway help`, bare `railway`)

A new `Agent tooling:` section closes root help with green/red status for Railway skills and the MCP server across detected editors, the installed skills revision, and a verdict line:

```
Agent tooling:
  ✓ Railway skills installed (rev 72299c6, up to date)
  ✓ Railway MCP server configured
  Agent tooling is healthy
```

When something's missing, failing lines go red and name the affected editors, and the footer points at `railway setup agent`. When the background staleness check has seen a newer upstream commit, the skills line shows it: `(rev 72299c6 → 1a2b3c4 available, run railway skills update)`. With no staleness evidence yet, it shows the bare revision and claims nothing.

Properties:
- Detection reuses the exact functions `setup agent -y` uses (`skills_configured_for_slug`, `mcp_configured_for_slug`, either MCP transport counts) — the health check can never recommend a setup that would no-op.
- stderr only; `railway --help 2>/dev/null` yields pristine clap output for parsers.
- Silent in CI, on subcommand help (both `railway <cmd> --help` and `railway help <cmd>`), and when no coding tool is detected (the universal `.agents` target alone doesn't trigger it).
- No network; stat calls and local config parses, reading only what `~/.railway/skills.json` already tracks.

**2. Agent advisory: per-session re-arm + rewritten copy**

The once-per-CLI-version gate from #919 cut fresh-user setup conversion from 9.1% to 3.3%. Replaced with a two-layer gate: at most one impression per agent session (keyed on the same session id telemetry resolves, via a new `telemetry::current_agent_session_id()`), and at most one per machine per 3 days. The "firing constantly" complaints #919 fixed are prevented by the session gate, not the version gate — rationale encoded in a comment with the numbers.

Copy rewritten to declarative facts (the directive phrasing was flagged as prompt injection by agent harnesses, #919):

> This session is missing Railway's agent tooling. That includes Railway skills (use-railway) and the Railway MCP server, which provides tooling for deployments, logs, status, and docs.
> Setup: `railway setup agent`

Fires only in agent environments, only after a successful, non-exempt command. Suppression matrix is unit-tested, including back-compat deserialization of existing `agent-state.json` files. `last_shown_cli_version` is still written for warehouse continuity.

**3. Link prompt:** `Select a service (optional) <esc to skip>` — signals project-only linking is a first-class outcome while keeping the repo-wide `<esc to skip>` convention.

## Deliberate non-goals

- **Skills version identity** (semver from frontmatter / AGENTS.md checklist) was descoped to keep upgrade mechanics untouched — that's why the health check shows commit revisions, not versions. The workstream is parked on `railway-skills#cody/skill-versioning-frontmatter`.
- **No off-switch for the health check** beyond CI suppression. If it proves too loud, the designated escape hatch is honoring `RAILWAY_AGENT_ADVISORY=0` (three lines).
- **Known overlap:** a TTY user with a pending skills update sees both the startup banner and the health-check revision line on root help. The banner predates this PR; suppressing it on the help path is a clean follow-up.

## Testing

- 309 tests pass, including 6 new advisory suppression/back-compat tests.
- Verified live: healthy / missing / update-pending / unknown-staleness states; `railway help up` and `railway up --help` stay clean; stdout-only pipe is parser-clean; advisory fires once then suppresses (session + 3-day window), state file inspected.
- fmt/clippy were unavailable in the local nix shell — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)