### PR TITLE
Harden Railway config apply safety

### DIFF
--- a/assets/railway-config/README.md
+++ b/assets/railway-config/README.md
@@ -42,4 +42,4 @@ railway config apply
 - Services already managed by `railway.json` / `railway.toml` must be migrated before `.railway/railway.ts` can manage them.
 - Use `replicas` for scaling; advanced placement can still specify region names.
 - Use `group("Name", [resources])` to keep large projects organized on the Railway canvas.
-- Secrets imported from Railway may be omitted or represented with `preserve()` so they are not overwritten.
+- Secrets imported from Railway are rendered as `preserve()` so existing values are retained without writing secret values to source. Use `railway config pull --omit-preserved-variables` for a smaller import.

--- a/assets/railway-config/README.md
+++ b/assets/railway-config/README.md
@@ -34,19 +34,11 @@ Apply the planned changes:
 railway config apply
 ```
 
-Deploy this directory:
-
-```bash
-railway up
-```
-
-If `.railway/railway.ts` has pending project changes, `railway up` previews them and asks before applying them.
-
 ## Notes
 
 - `railway config plan` is safe and does not change Railway.
-- `railway config apply` asks before applying unless you pass `--yes`.
-- `railway up` deploys this directory when the service has no GitHub or image source.
+- `railway config apply` previews changes and asks before applying unless you pass `--yes`.
+- Destructive changes in non-interactive or agent sessions require `railway config apply --confirm-destructive` after reviewing the plan.
 - Services already managed by `railway.json` / `railway.toml` must be migrated before `.railway/railway.ts` can manage them.
 - Use `replicas` for scaling; advanced placement can still specify region names.
 - Use `group("Name", [resources])` to keep large projects organized on the Railway canvas.

--- a/assets/railway-config/SKILL.md
+++ b/assets/railway-config/SKILL.md
@@ -20,7 +20,7 @@ The source of desired Railway project state is:
 3. Do not write `EnvironmentConfigPatch`, `ServiceInstance`, Backboard internals, or generated Railway domains into source.
 4. Prefer Railway configuration helpers like `service()`, `postgres()`, `redis()`, `mysql()`, `mongo()`, `bucket()`, `group()`, `github()`, and `image()`.
 5. Use `service.env.VARIABLE` and `database.env.VARIABLE` for references.
-6. Keep secrets out of source. Prefer omitting unknown imported secrets; use `preserve()` when an existing Railway-managed value must be explicitly retained.
+6. Keep secrets out of source. Imported unknown secret values should use `preserve()` or be omitted when the user wants a smaller import.
 7. Prefer product DSL names such as `domains`, `replicas`, and `group`; avoid internal names like `customDomains` and `multiRegionConfig`.
 8. Do not add platform defaults unless the user explicitly wants them.
 9. Do not manage a service from both `.railway/railway.ts` and `railway.json` / `railway.toml`; migrate the repo config first.
@@ -40,6 +40,12 @@ Import current Railway state:
 
 ```bash
 railway config pull
+```
+
+Import current Railway state with a smaller generated file that omits unknown variable values:
+
+```bash
+railway config pull --omit-preserved-variables
 ```
 
 Preview changes:

--- a/assets/railway-config/SKILL.md
+++ b/assets/railway-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: railway-config
-description: Edit this project's Railway infrastructure-as-code configuration. Use this skill whenever the user asks to create, change, import, review, deploy, or troubleshoot Railway project infrastructure for the current repository, including services, databases, buckets, custom domains, replicas/regions, groups, environment variables, `railway config *`, `.railway/railway.ts`, or `railway up` behavior.
+description: Edit this project's Railway infrastructure-as-code configuration. Use this skill whenever the user asks to create, change, import, review, or troubleshoot Railway project infrastructure for the current repository, including services, databases, buckets, custom domains, replicas/regions, groups, environment variables, `railway config *`, or `.railway/railway.ts`.
 ---
 
 # Railway configuration skill
@@ -25,7 +25,8 @@ The source of desired Railway project state is:
 8. Do not add platform defaults unless the user explicitly wants them.
 9. Do not manage a service from both `.railway/railway.ts` and `railway.json` / `railway.toml`; migrate the repo config first.
 10. After editing `.railway/railway.ts`, run `railway config plan`.
-11. Do not run `railway config apply` unless the user asks.
+11. Do not run `railway config apply` unless the user explicitly asks.
+12. Never use `railway config apply --yes` or `railway config apply --confirm-destructive` from an agent session without explicit user approval for the exact plan.
 
 ## Commands
 
@@ -51,12 +52,6 @@ Apply changes:
 
 ```bash
 railway config apply
-```
-
-Deploy this directory:
-
-```bash
-railway up
 ```
 
 Machine-readable preview:
@@ -204,6 +199,7 @@ export default defineRailway(() => {
 
 Before applying changes, confirm:
 
+- The user has reviewed the latest `railway config plan` output.
 - `railway config plan` shows only expected changes.
 - Secrets are not replaced with literal placeholder values.
 - Existing Railway-managed variables are omitted or use `preserve()` when the value should remain untouched.

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -368,7 +368,9 @@ async fn write_pulled_config(
 }
 
 async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGraph> {
-    let temp_dir = std::env::temp_dir().join(format!("railway-config-pull-{}", std::process::id()));
+    let temp_dir = std::env::current_dir()
+        .context("Unable to get current directory")?
+        .join(format!(".railway-config-pull-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).context("Failed to create temporary Railway config directory")?;
     let temp_file = temp_dir.join("railway.ts");
     fs::write(&temp_file, railway_ts("import-placeholder"))
@@ -391,7 +393,22 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
     let _ = fs::remove_dir(temp_dir);
 
     if !response.ok {
-        bail!("Could not import Railway configuration because planning returned diagnostics.");
+        let diagnostics = response
+            .diagnostics
+            .iter()
+            .map(|diagnostic| {
+                if diagnostic.path.is_empty() {
+                    diagnostic.message.clone()
+                } else {
+                    format!("{}: {}", diagnostic.path, diagnostic.message)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if diagnostics.is_empty() {
+            bail!("Could not import Railway configuration because planning returned diagnostics.");
+        }
+        bail!("Could not import Railway configuration:\n{diagnostics}");
     }
 
     response

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -52,6 +52,10 @@ struct SharedArgs {
     #[clap(long)]
     yes: bool,
 
+    /// Allow destructive applies in non-interactive or agent sessions.
+    #[clap(long)]
+    confirm_destructive: bool,
+
     /// Ask Railway to decrypt variables while planning, when authorized.
     #[clap(long)]
     decrypt_variables: bool,
@@ -116,7 +120,15 @@ struct PullArgs {
 
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
-        Command::Plan(args) => run_sync(args, false, false).await,
+        Command::Plan(args) => {
+            if args.yes {
+                bail!("--yes is only valid with `railway config apply`.");
+            }
+            if args.confirm_destructive {
+                bail!("--confirm-destructive is only valid with `railway config apply`.");
+            }
+            run_sync(args, false, false).await
+        }
         Command::Stage(_args) => bail!(
             "Staged Railway configuration changes are not available yet. Run `railway config plan` to preview changes or `railway config apply` to apply them."
         ),
@@ -346,6 +358,7 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         stage: false,
         json: true,
         yes: false,
+        confirm_destructive: false,
         apply: false,
         decrypt_variables: false,
         include_types: false,
@@ -1034,6 +1047,7 @@ async fn run_sync(args: SharedArgs, stage: bool, apply: bool) -> Result<()> {
         stage,
         json: args.json,
         yes: args.yes,
+        confirm_destructive: args.confirm_destructive,
         apply,
         decrypt_variables: args.decrypt_variables,
         include_types: args.include_types,

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -113,6 +113,10 @@ struct PullArgs {
     #[clap(long)]
     runner: Option<String>,
 
+    /// Omit unknown imported variables instead of rendering them as preserve().
+    #[clap(long)]
+    omit_preserved_variables: bool,
+
     /// Ask an agent to turn imported state into idiomatic railway.ts code.
     #[clap(long)]
     agent: bool,
@@ -184,7 +188,9 @@ async fn init_config(args: InitArgs) -> Result<()> {
             &railway_ts_from_repo(&cwd, &project_name),
             args.force,
         )?,
-        InitMode::ImportFromRailway => write_pulled_config(&railway_file, args.force, None).await?,
+        InitMode::ImportFromRailway => {
+            write_pulled_config(&railway_file, args.force, None, true).await?
+        }
         InitMode::MinimalFile => write_new(&railway_file, &railway_ts(&project_name), args.force)?,
     }
     write_new(
@@ -289,7 +295,13 @@ async fn pull_config(args: PullArgs) -> Result<()> {
 
     create_parent(&railway_file)?;
     create_parent(&skill_file)?;
-    write_pulled_config(&railway_file, args.force, args.runner).await?;
+    write_pulled_config(
+        &railway_file,
+        args.force,
+        args.runner,
+        !args.omit_preserved_variables,
+    )
+    .await?;
     let wrote_readme = write_asset_if_missing(
         &readme_file,
         include_str!("../../../assets/railway-config/README.md"),
@@ -341,9 +353,18 @@ async fn pull_config(args: PullArgs) -> Result<()> {
     Ok(())
 }
 
-async fn write_pulled_config(path: &Path, force: bool, runner: Option<String>) -> Result<()> {
+async fn write_pulled_config(
+    path: &Path,
+    force: bool,
+    runner: Option<String>,
+    preserve_variables: bool,
+) -> Result<()> {
     let graph = load_current_graph(runner).await?;
-    write_new(path, &render_graph_as_railway_ts(&graph), force)
+    write_new(
+        path,
+        &render_graph_as_railway_ts(&graph, preserve_variables),
+        force,
+    )
 }
 
 async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGraph> {
@@ -378,7 +399,7 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         .context("Railway did not return current project state")
 }
 
-fn render_graph_as_railway_ts(graph: &runner::DesiredGraph) -> String {
+fn render_graph_as_railway_ts(graph: &runner::DesiredGraph, preserve_variables: bool) -> String {
     let mut imports = vec!["defineRailway", "project", "service"];
     if graph
         .resources
@@ -406,7 +427,9 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph) -> String {
     }) {
         imports.push("image");
     }
-    // Imported unknown secrets are preserved by default and omitted from generated source.
+    if preserve_variables && graph.resources.iter().any(has_preserved_variables) {
+        imports.push("preserve");
+    }
     if graph.resources.iter().any(|resource| {
         resource.r#type == "database" && resource.engine.as_deref() == Some("postgres")
     }) {
@@ -476,7 +499,7 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph) -> String {
                     "  const {var_name} = service(\"{}\"",
                     resource.name
                 ));
-                let body = render_service_body(resource, &source_aliases);
+                let body = render_service_body(resource, &source_aliases, preserve_variables);
                 if body.is_empty() {
                     out.push_str(");\n");
                 } else {
@@ -513,6 +536,18 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph) -> String {
     out.push_str("  });\n");
     out.push_str("});\n");
     out
+}
+
+fn has_preserved_variables(resource: &runner::DesiredResource) -> bool {
+    resource
+        .variables
+        .as_ref()
+        .map(|variables| {
+            variables
+                .values()
+                .any(|value| value.get("type").and_then(|value| value.as_str()) == Some("preserve"))
+        })
+        .unwrap_or(false)
 }
 
 fn shared_github_sources(
@@ -557,6 +592,7 @@ fn shared_github_sources(
 fn render_service_body(
     resource: &runner::DesiredResource,
     source_aliases: &std::collections::BTreeMap<String, String>,
+    preserve_variables: bool,
 ) -> String {
     let mut lines = Vec::new();
     if let Some(source) = &resource.source {
@@ -599,7 +635,7 @@ fn render_service_body(
     render_build(resource.build.as_ref(), &mut lines);
     render_deploy(resource.deploy.as_ref(), &mut lines);
     render_networking(resource.networking.as_ref(), &mut lines);
-    render_variables(resource.variables.as_ref(), &mut lines);
+    render_variables(resource.variables.as_ref(), &mut lines, preserve_variables);
     if lines.is_empty() {
         return String::new();
     }
@@ -609,6 +645,7 @@ fn render_service_body(
 fn render_variables(
     vars: Option<&serde_json::Map<String, serde_json::Value>>,
     lines: &mut Vec<String>,
+    preserve_variables: bool,
 ) {
     let Some(vars) = vars else {
         return;
@@ -619,7 +656,7 @@ fn render_variables(
         .into_iter()
         .filter_map(|(key, value)| {
             if value.get("type").and_then(|value| value.as_str()) == Some("preserve") {
-                return None;
+                return preserve_variables.then(|| format!("      {}: preserve(),", ts_key(key)));
             }
             if let Some(literal) = value.get("value").and_then(|value| value.as_str()) {
                 return Some(format!("      {}: {:?},", ts_key(key), literal));

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -65,7 +65,7 @@ pub(super) struct RunnerResponse {
     current_environment: Option<CurrentEnvironment>,
     pub(super) change_set: Option<ChangeSet>,
     diff: Option<String>,
-    diagnostics: Vec<Diagnostic>,
+    pub(super) diagnostics: Vec<Diagnostic>,
     pub(super) current_graph: Option<DesiredGraph>,
     pub(super) desired_graph: Option<DesiredGraph>,
     staged_patch: Option<StagedPatch>,
@@ -96,10 +96,10 @@ pub(super) struct Change {
 }
 
 #[derive(Deserialize, serde::Serialize)]
-struct Diagnostic {
+pub(super) struct Diagnostic {
     severity: String,
-    path: String,
-    message: String,
+    pub(super) path: String,
+    pub(super) message: String,
 }
 
 #[derive(Deserialize, serde::Serialize)]

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -32,6 +32,10 @@ pub struct Args {
     #[clap(long)]
     pub(super) yes: bool,
 
+    /// Allow destructive applies in non-interactive or agent sessions.
+    #[clap(long)]
+    pub(super) confirm_destructive: bool,
+
     #[clap(skip)]
     pub(super) apply: bool,
 
@@ -162,7 +166,7 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
     let (configs, linked_project, token, auth_type) = ensure_config_context().await?;
     let command = if args.stage {
         "stage"
-    } else if args.apply || args.yes {
+    } else if args.apply {
         "apply"
     } else {
         "plan"
@@ -190,46 +194,37 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
         }
     }
 
-    if command == "apply" && !args.yes && !args.json {
-        if !std::io::stdout().is_terminal() {
-            bail!("Run `railway config apply --yes` to apply changes non-interactively.");
-        }
-
-        let mut spinner = create_spinner_if(true, "Checking Railway configuration".into());
+    if command == "apply" {
         let preview =
-            invoke_runner(&args, &configs, &linked_project, &token, auth_type, "plan").await?;
-        if let Some(spinner) = &mut spinner {
-            if preview.ok {
-                success_spinner(spinner, "Checked Railway configuration".into());
-            } else {
-                fail_spinner(spinner, "Could not read Railway configuration".into());
-            }
-        }
-
-        print_response_with_options_and_next(&preview, args.verbose, false);
-        if !preview.ok {
-            bail!("IaC runner returned diagnostics");
-        }
+            preview_before_apply(&args, &configs, &linked_project, &token, auth_type).await?;
         let changes = preview
             .change_set
             .as_ref()
             .map(|change_set| change_set.changes.len())
             .unwrap_or(0);
         if changes == 0 {
+            if !args.json {
+                print_response_with_options(&preview, args.verbose);
+            }
             return Ok(());
         }
 
         let destructive = has_destructive_changes(&preview);
-        println!();
-        let prompt = if destructive {
-            "Apply these changes? This will remove Railway resources or variables."
-        } else {
-            "Apply these changes to Railway?"
-        };
-        if !prompt_confirm_with_default(prompt, false)? {
-            bail!("No changes applied.");
+        guard_destructive_apply(&args, destructive)?;
+
+        if !args.yes && !args.json {
+            print_response_with_options_and_next(&preview, args.verbose, false);
+            println!();
+            let prompt = if destructive {
+                "Apply these changes? This will remove Railway resources or variables."
+            } else {
+                "Apply these changes to Railway?"
+            };
+            if !prompt_confirm_with_default(prompt, false)? {
+                bail!("No changes applied.");
+            }
+            println!();
         }
-        println!();
     }
 
     let mut spinner = create_spinner_if(
@@ -257,6 +252,54 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
     print_response_with_options(&output, args.verbose);
     if !output.ok {
         bail!("IaC runner returned diagnostics");
+    }
+
+    Ok(())
+}
+
+async fn preview_before_apply(
+    args: &Args,
+    configs: &Configs,
+    linked_project: &LinkedProject,
+    token: &str,
+    auth_type: &str,
+) -> Result<RunnerResponse> {
+    if !args.yes && !args.json && !std::io::stdout().is_terminal() {
+        bail!("Run `railway config apply --yes` to apply changes non-interactively.");
+    }
+
+    let mut spinner = create_spinner_if(
+        !args.json && std::io::stdout().is_terminal(),
+        "Checking Railway configuration".into(),
+    );
+    let preview = invoke_runner(args, configs, linked_project, token, auth_type, "plan").await?;
+    if let Some(spinner) = &mut spinner {
+        if preview.ok {
+            success_spinner(spinner, "Checked Railway configuration".into());
+        } else {
+            fail_spinner(spinner, "Could not read Railway configuration".into());
+        }
+    }
+
+    if !preview.ok {
+        if !args.json {
+            print_response_with_options_and_next(&preview, args.verbose, false);
+        }
+        bail!("IaC runner returned diagnostics");
+    }
+
+    Ok(preview)
+}
+
+fn guard_destructive_apply(args: &Args, destructive: bool) -> Result<()> {
+    if !destructive || args.confirm_destructive {
+        return Ok(());
+    }
+
+    if args.yes || args.json || crate::telemetry::is_agent() {
+        bail!(
+            "Destructive Railway configuration changes require explicit confirmation. Review `railway config plan`, then re-run with `railway config apply --confirm-destructive` if the removals are expected."
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Hardens `railway config` after beta feedback around agent safety, destructive applies, and imported variables.

## What changed

- Rejects `railway config plan --yes` instead of allowing `--yes` to affect command selection.
- Keeps `--yes` scoped to `railway config apply` only.
- Requires `railway config apply --confirm-destructive` for destructive changes in non-interactive / agent-style flows.
- Ensures `config apply` previews before applying, including `--yes` flows.
- Improves `config pull` diagnostics so runner errors are surfaced instead of only saying planning returned diagnostics.
- Fixes `config pull` temporary file evaluation by creating the temp config inside the current project, so project-local SDK resolution works.
- Changes `config pull` to render unknown imported variables as `preserve()` by default.
- Adds `railway config pull --omit-preserved-variables` for smaller imports when users do not want explicit preserved variable entries.
- Updates generated Railway config README/SKILL guidance for agents and destructive applies.

## Validation

Tested with the local CLI against a throwaway Railway project in `~/Railway/iac-walkthroughs/w-5`, using published `railway@3.1.2` from the project install.

Verified:

- `config pull` works through `node_modules/.bin/railway-iac-ts`.
- default pull renders `preserve()` for unknown variables.
- `--omit-preserved-variables` omits preserved variable entries.
- `config plan --yes` fails safely.
- destructive `config apply --yes` fails without `--confirm-destructive`.
- final restored config plans as no-op.

Also ran:

```bash
cargo fmt
cargo build
cargo test config --no-fail-fast
cargo package --allow-dirty
```
