### PR TITLE
fix(sandbox): rename template status query to sandboxTemplateBuild

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -789,8 +789,9 @@ async fn create(
                     )
                 })?;
             Some(mutations::sandbox_create::SandboxTemplateInput {
-                instructions: stored.instructions,
+                instructions: Some(stored.instructions),
                 base_image_digest: stored.base_image_digest,
+                name: None,
             })
         }
         None => None,
@@ -854,8 +855,9 @@ async fn template_build(
         mutations::sandbox_template_build::Variables {
             environment_id: environment_id.clone(),
             input: mutations::sandbox_template_build::SandboxTemplateInput {
-                instructions: args.commands.clone(),
+                instructions: Some(args.commands.clone()),
                 base_image_digest: args.base_image_digest.clone(),
+                name: None,
             },
         },
     )
@@ -876,7 +878,7 @@ async fn template_build(
 
     let already_ready = matches!(
         built.status,
-        mutations::sandbox_template_build::SandboxTemplateStatus::READY
+        mutations::sandbox_template_build::SandboxTemplateBuildStatus::READY
     );
     let status = if args.wait && !already_ready {
         wait_for_template(client, configs, &environment_id, &built.id).await?
@@ -929,13 +931,13 @@ async fn template_status(
         }
     };
 
-    let res = post_graphql::<queries::SandboxTemplate, _>(
+    let res = post_graphql::<queries::SandboxTemplateBuild, _>(
         client,
         configs.get_backboard(),
-        queries::sandbox_template::Variables { environment_id, id },
+        queries::sandbox_template_build::Variables { environment_id, id },
     )
     .await?;
-    let tpl = res.sandbox_template;
+    let tpl = res.sandbox_template_build;
 
     if args.json {
         println!("{}", serde_json::to_string_pretty(&tpl)?);
@@ -974,16 +976,16 @@ async fn template_list(
 
     let mut rows = Vec::new();
     for t in &templates {
-        let status = post_graphql::<queries::SandboxTemplate, _>(
+        let status = post_graphql::<queries::SandboxTemplateBuild, _>(
             client,
             configs.get_backboard(),
-            queries::sandbox_template::Variables {
+            queries::sandbox_template_build::Variables {
                 environment_id: environment_id.clone(),
                 id: t.id.clone(),
             },
         )
         .await
-        .map(|r| format!("{:?}", r.sandbox_template.status))
+        .map(|r| format!("{:?}", r.sandbox_template_build.status))
         .unwrap_or_else(|_| "UNKNOWN".to_string());
         rows.push((t, status));
     }
@@ -1035,21 +1037,21 @@ async fn wait_for_template(
     let deadline = std::time::Instant::now() + Duration::from_secs(45 * 60);
     loop {
         tokio::time::sleep(Duration::from_secs(5)).await;
-        let res = post_graphql::<queries::SandboxTemplate, _>(
+        let res = post_graphql::<queries::SandboxTemplateBuild, _>(
             client,
             configs.get_backboard(),
-            queries::sandbox_template::Variables {
+            queries::sandbox_template_build::Variables {
                 environment_id: environment_id.to_string(),
                 id: id.to_string(),
             },
         )
         .await?;
-        match res.sandbox_template.status {
-            queries::sandbox_template::SandboxTemplateStatus::READY => {
+        match res.sandbox_template_build.status {
+            queries::sandbox_template_build::SandboxTemplateBuildStatus::READY => {
                 spinner.finish_and_clear();
                 return Ok("READY".to_string());
             }
-            queries::sandbox_template::SandboxTemplateStatus::FAILED => {
+            queries::sandbox_template_build::SandboxTemplateBuildStatus::FAILED => {
                 fail_spinner(&mut spinner, "Template build failed".to_string());
                 bail!(
                     "Template build failed. Each instruction must exit 0 within 10 minutes; fix the failing step and rebuild."

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -282,11 +282,11 @@ pub struct Sandboxes;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
-    query_path = "src/gql/queries/strings/SandboxTemplate.graphql",
+    query_path = "src/gql/queries/strings/SandboxTemplateBuild.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none
 )]
-pub struct SandboxTemplate;
+pub struct SandboxTemplateBuild;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/src/gql/queries/strings/SandboxTemplate.graphql
+++ b/src/gql/queries/strings/SandboxTemplate.graphql
@@ -1,7 +1,0 @@
-query SandboxTemplate($environmentId: String!, $id: ID!) {
-  sandboxTemplate(environmentId: $environmentId, id: $id) {
-    id
-    status
-    environmentId
-  }
-}

--- a/src/gql/queries/strings/SandboxTemplateBuild.graphql
+++ b/src/gql/queries/strings/SandboxTemplateBuild.graphql
@@ -1,0 +1,7 @@
+query SandboxTemplateBuild($environmentId: String!, $id: ID!) {
+  sandboxTemplateBuild(environmentId: $environmentId, id: $id) {
+    id
+    status
+    environmentId
+  }
+}

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -17591,7 +17591,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "SandboxTemplate",
+                  "name": "SandboxTemplateBuild",
                   "ofType": null
                 }
               }
@@ -33181,13 +33181,13 @@
               "deprecationReason": null,
               "description": "Get the status of a sandbox template.",
               "isDeprecated": false,
-              "name": "sandboxTemplate",
+              "name": "sandboxTemplateBuild",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "SandboxTemplate",
+                  "name": "SandboxTemplateBuild",
                   "ofType": null
                 }
               }
@@ -38663,7 +38663,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "SandboxTemplateStatus",
+                  "name": "SandboxTemplateBuildStatus",
                   "ofType": null
                 }
               }
@@ -38672,7 +38672,7 @@
           "inputFields": null,
           "interfaces": [],
           "kind": "OBJECT",
-          "name": "SandboxTemplate",
+          "name": "SandboxTemplateBuild",
           "possibleTypes": null
         },
         {
@@ -38695,21 +38695,27 @@
               "description": null,
               "name": "instructions",
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   }
                 }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               }
             }
           ],
@@ -38750,7 +38756,7 @@
           "inputFields": null,
           "interfaces": null,
           "kind": "ENUM",
-          "name": "SandboxTemplateStatus",
+          "name": "SandboxTemplateBuildStatus",
           "possibleTypes": null
         },
         {


### PR DESCRIPTION
Compat for railwayapp/mono#31063, which renames `Query.sandboxTemplate` to `sandboxTemplateBuild` and `SandboxTemplateStatus` to `SandboxTemplateBuildStatus`. No behavior change: same poll cadence, statuses, and output.

- Rename the poll query and generated struct; update call sites in `template status`, `template list`, and the `--wait` build loop
- Hand-patch `schema.json` sandbox entries to the new schema (backend not deployed yet, so introspection still returns the old shape)
- `SandboxTemplateInput.instructions` is now optional with a new `name` field; pass `Some(...)`/`name: None`, wire payload unchanged via `skip_serializing_none`

Note on sequencing: this must release after the backend deploys — the new query does not exist on prod yet, and older CLI releases will break on `template status`/`--wait` once it does. E2E verification (build/status/list/create from template) pending backend deploy.