### PR TITLE
Add domain management commands to Railway CLI

### DIFF
--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -419,7 +419,7 @@ async fn retry_domain_certificate(
 
     post_graphql::<mutations::CustomDomainIssueCertificate, _>(
         &ctx.client,
-        ctx.configs.get_backboard_internal(),
+        ctx.configs.get_backboard(),
         mutations::custom_domain_issue_certificate::Variables {
             id: domain.summary.id.clone(),
         },

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -1,61 +1,384 @@
-use std::{cmp::max, time::Duration};
+use std::{cmp::max, fmt, time::Duration};
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
+use clap::Subcommand;
 use colored::Colorize;
 use is_terminal::IsTerminal;
 use queries::domains::DomainsDomains;
+use serde::Serialize;
 use serde_json::json;
 
-use crate::{consts::TICK_STRING, controllers::project::resolve_service_context};
+use crate::{
+    consts::TICK_STRING,
+    controllers::project::{ServiceContext, resolve_service_context},
+    util::prompt::prompt_confirm_with_default,
+};
 
 use super::*;
 
-/// Add a custom domain or generate a railway provided domain for a service.
+/// Add, list, inspect, update, or delete domains for a service.
 ///
-/// There is a maximum of 1 railway provided domain per service.
+/// Running without a subcommand preserves the original create behavior:
+/// - `railway domain` generates a Railway-provided service domain
+/// - `railway domain example.com` creates a custom domain
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway domain\n  railway domain example.com --port 3000\n  railway domain list --service api --json\n  railway domain status example.com\n  railway domain update example.com --port 8080\n  railway domain delete example.com --yes"
+)]
 pub struct Args {
-    /// The port to connect to the domain
-    #[clap(short, long)]
+    #[clap(subcommand)]
+    command: Option<Commands>,
+
+    /// The port to connect to the domain when creating a domain
+    #[clap(short, long, value_parser = parse_port)]
     port: Option<u16>,
 
-    /// The name of the service to generate the domain for
-    #[clap(short, long)]
+    /// The name of the service to manage domains for
+    #[clap(short, long, global = true)]
     service: Option<String>,
 
     /// Environment to use (defaults to linked environment)
-    #[clap(short, long)]
+    #[clap(short, long, global = true)]
     environment: Option<String>,
 
     /// Project ID to use (defaults to linked project)
-    #[clap(long, value_name = "PROJECT_ID")]
+    #[clap(long, value_name = "PROJECT_ID", global = true)]
     project: Option<String>,
 
     /// Optionally, specify a custom domain to use. If not specified, a domain will be generated.
     ///
     /// Specifying a custom domain will also return the required DNS records
-    /// to add to your DNS settings
+    /// to add to your DNS settings.
     domain: Option<String>,
 
     /// Output in JSON format
-    #[clap(long)]
+    #[clap(long, global = true)]
     json: bool,
 }
 
+#[derive(Subcommand)]
+enum Commands {
+    /// List domains for a service
+    #[clap(visible_alias = "ls")]
+    List,
+
+    /// Show status and DNS details for a domain
+    Status {
+        /// Domain name, URL, or domain ID
+        #[clap(value_name = "DOMAIN_OR_ID")]
+        domain: String,
+    },
+
+    /// Delete a custom or service domain
+    #[clap(visible_alias = "remove", visible_alias = "rm")]
+    Delete {
+        /// Domain name, URL, or domain ID
+        #[clap(value_name = "DOMAIN_OR_ID")]
+        domain: String,
+
+        /// Skip confirmation dialog
+        #[clap(short = 'y', long = "yes")]
+        yes: bool,
+    },
+
+    /// Update a domain
+    #[clap(visible_alias = "edit")]
+    Update {
+        /// Domain name, URL, or domain ID
+        #[clap(value_name = "DOMAIN_OR_ID")]
+        identifier: String,
+
+        /// The target port to route HTTP traffic to
+        #[clap(long, value_parser = parse_port)]
+        port: Option<u16>,
+
+        /// Rename a Railway-provided service domain. Accepts a full service domain or host label.
+        #[clap(long = "domain", value_name = "DOMAIN")]
+        new_domain: Option<String>,
+    },
+}
+
 pub async fn command(args: Args) -> Result<()> {
-    if let Some(domain) = args.domain {
-        create_custom_domain(
-            domain,
-            args.port,
-            args.project,
-            args.service,
-            args.environment,
-            args.json,
-        )
-        .await?;
-    } else {
-        create_service_domain(args.project, args.service, args.environment, args.json).await?;
+    let Args {
+        command,
+        port,
+        service,
+        environment,
+        project,
+        domain,
+        json,
+    } = args;
+
+    match command {
+        Some(Commands::List) => list_domains(project, service, environment, json).await?,
+        Some(Commands::Status { domain }) => {
+            show_domain_status(domain, project, service, environment, json).await?
+        }
+        Some(Commands::Delete { domain, yes }) => {
+            delete_domain(domain, project, service, environment, yes, json).await?
+        }
+        Some(Commands::Update {
+            identifier,
+            port,
+            new_domain,
+        }) => {
+            update_domain(
+                identifier,
+                port,
+                new_domain,
+                project,
+                service,
+                environment,
+                json,
+            )
+            .await?
+        }
+        None => {
+            if let Some(domain) = domain {
+                create_custom_domain(domain, port, project, service, environment, json).await?;
+            } else {
+                create_service_domain(project, service, environment, port, json).await?;
+            }
+        }
     }
+
+    Ok(())
+}
+
+fn parse_port(value: &str) -> std::result::Result<u16, String> {
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| "port must be a number from 1 to 65535".to_string())?;
+
+    if port == 0 {
+        return Err("port must be a number from 1 to 65535".to_string());
+    }
+
+    Ok(port)
+}
+
+async fn list_domains(
+    project: Option<String>,
+    service_name: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service_name, environment).await?;
+    let domains = fetch_domains(&ctx).await?;
+    let items = domain_items(&domains);
+    let summaries = summaries(&items);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&ListOutput { domains: summaries })?
+        );
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        println!(
+            "No domains found for service {} in environment {}.",
+            ctx.service_name.bold(),
+            ctx.environment_name.bold()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Domains for service {} in environment {}:",
+        ctx.service_name.bold(),
+        ctx.environment_name.bold()
+    );
+    print_domain_table(&items);
+
+    Ok(())
+}
+
+async fn show_domain_status(
+    identifier: String,
+    project: Option<String>,
+    service_name: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service_name, environment).await?;
+    let domain = resolve_domain(&ctx, &identifier).await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&DomainOutput { domain })?
+        );
+        return Ok(());
+    }
+
+    print_domain_details(&domain, "Domain status", false);
+
+    Ok(())
+}
+
+async fn delete_domain(
+    identifier: String,
+    project: Option<String>,
+    service_name: Option<String>,
+    environment: Option<String>,
+    yes: bool,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service_name, environment).await?;
+    let domain = resolve_domain(&ctx, &identifier).await?;
+
+    let confirmed = confirm_delete(yes, std::io::stdout().is_terminal(), || {
+        prompt_confirm_with_default(
+            &format!(
+                "Delete {} domain {}? This action cannot be undone.",
+                domain.summary.kind,
+                domain.summary.domain.red()
+            ),
+            false,
+        )
+    })?;
+
+    if !confirmed {
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&json!({
+                    "deleted": false,
+                    "domain": domain.summary,
+                }))?
+            );
+        } else {
+            println!("Deletion cancelled.");
+        }
+        return Ok(());
+    }
+
+    match domain.summary.kind {
+        DomainKind::Custom => {
+            post_graphql::<mutations::CustomDomainDelete, _>(
+                &ctx.client,
+                ctx.configs.get_backboard(),
+                mutations::custom_domain_delete::Variables {
+                    id: domain.summary.id.clone(),
+                },
+            )
+            .await?;
+        }
+        DomainKind::Service => {
+            post_graphql::<mutations::ServiceDomainDelete, _>(
+                &ctx.client,
+                ctx.configs.get_backboard(),
+                mutations::service_domain_delete::Variables {
+                    id: domain.summary.id.clone(),
+                },
+            )
+            .await?;
+        }
+    }
+
+    let domains = fetch_domains(&ctx).await?;
+    let remaining = domain_items(&domains);
+    if find_domain_details(&remaining, &domain.summary.id).is_some() {
+        bail!(
+            "Domain deletion was requested, but {} still exists after verification.",
+            domain.summary.id
+        );
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({
+                "deleted": true,
+                "domain": domain.summary,
+            }))?
+        );
+    } else {
+        println!(
+            "Deleted {} domain {}.",
+            domain.summary.kind,
+            domain.summary.domain.magenta().bold()
+        );
+    }
+
+    Ok(())
+}
+
+async fn update_domain(
+    identifier: String,
+    port: Option<u16>,
+    new_domain: Option<String>,
+    project: Option<String>,
+    service_name: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    if port.is_none() && new_domain.is_none() {
+        bail!("Specify --port, --domain, or both.");
+    }
+
+    let ctx = resolve_service_context(project, service_name, environment).await?;
+    let domain = resolve_domain(&ctx, &identifier).await?;
+    let target_port = port.map(|port| port as i64);
+
+    match domain.summary.kind {
+        DomainKind::Custom => {
+            if new_domain.is_some() {
+                bail!(
+                    "Custom domains cannot be renamed. Create the new custom domain, then delete the old one."
+                );
+            }
+
+            post_graphql::<mutations::CustomDomainUpdate, _>(
+                &ctx.client,
+                ctx.configs.get_backboard(),
+                mutations::custom_domain_update::Variables {
+                    environment_id: domain.summary.environment_id.clone(),
+                    id: domain.summary.id.clone(),
+                    target_port,
+                },
+            )
+            .await?;
+        }
+        DomainKind::Service => {
+            let service_domain = new_domain
+                .as_deref()
+                .map(|new_domain| service_domain_input(&domain, new_domain))
+                .transpose()?
+                .unwrap_or_else(|| domain.summary.domain.clone());
+
+            post_graphql::<mutations::ServiceDomainUpdate, _>(
+                &ctx.client,
+                ctx.configs.get_backboard(),
+                mutations::service_domain_update::Variables {
+                    input: mutations::service_domain_update::ServiceDomainUpdateInput {
+                        domain: service_domain,
+                        environment_id: domain.summary.environment_id.clone(),
+                        service_domain_id: domain.summary.id.clone(),
+                        service_id: domain.summary.service_id.clone(),
+                        target_port,
+                    },
+                },
+            )
+            .await?;
+        }
+    }
+
+    let updated = resolve_domain(&ctx, &domain.summary.id).await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&DomainOutput { domain: updated })?
+        );
+    } else {
+        let changes = update_change_summary(port, new_domain.as_deref());
+        println!("Updated {}.", changes);
+        print_domain_details(&updated, "Updated domain status", false);
+    }
+
     Ok(())
 }
 
@@ -63,22 +386,12 @@ async fn create_service_domain(
     project: Option<String>,
     service_name: Option<String>,
     environment: Option<String>,
+    port: Option<u16>,
     json: bool,
 ) -> Result<()> {
-    let configs = Configs::new()?;
-
-    let client = GQLClient::new_authorized(&configs)?;
     let ctx = resolve_service_context(project, service_name, environment).await?;
 
-    let vars = queries::domains::Variables {
-        project_id: ctx.project_id.clone(),
-        environment_id: ctx.environment_id.clone(),
-        service_id: ctx.service_id.clone(),
-    };
-
-    let domains = post_graphql::<queries::Domains, _>(&client, configs.get_backboard(), vars)
-        .await?
-        .domains;
+    let domains = fetch_domains(&ctx).await?;
 
     let domain_count = domains.service_domains.len() + domains.custom_domains.len();
     if domain_count > 0 {
@@ -90,85 +403,55 @@ async fn create_service_domain(
         .and_then(|s| s.ok());
 
     let vars = mutations::service_domain_create::Variables {
-        service_id: ctx.service_id.clone(),
         environment_id: ctx.environment_id.clone(),
+        service_id: ctx.service_id.clone(),
+        target_port: port.map(|port| port as i64),
     };
-    let domain =
-        post_graphql::<mutations::ServiceDomainCreate, _>(&client, configs.get_backboard(), vars)
-            .await?
-            .service_domain_create
-            .domain;
+    let domain = post_graphql::<mutations::ServiceDomainCreate, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        vars,
+    )
+    .await?
+    .service_domain_create;
 
     if let Some(spinner) = spinner {
         spinner.finish_and_clear();
     }
 
-    let formatted_domain = format!("https://{domain}");
-    if json {
-        let out = json!({
-            "domain": formatted_domain
-        });
+    let details = details_from_created_service(&domain);
 
-        println!("{}", serde_json::to_string_pretty(&out)?);
-    } else {
+    if json {
         println!(
-            "Service Domain created:\n🚀 {}",
-            formatted_domain.magenta().bold()
+            "{}",
+            serde_json::to_string_pretty(&legacy_service_domain_output(&details))?
         );
+    } else {
+        print_domain_details(&details, "Service domain created", true);
     }
 
     Ok(())
 }
 
 fn print_existing_domains(domains: &DomainsDomains, json: bool) -> Result<()> {
+    let items = domain_items(domains);
+
     if json {
-        let all_domains: Vec<String> = domains
-            .service_domains
-            .iter()
-            .map(|d| format!("https://{}", d.domain))
-            .chain(
-                domains
-                    .custom_domains
-                    .iter()
-                    .map(|d| format!("https://{}", d.domain)),
-            )
-            .collect();
         println!(
             "{}",
-            serde_json::to_string_pretty(&json!({ "domains": all_domains }))?
+            serde_json::to_string_pretty(&legacy_domain_list_output(&items))?
         );
         return Ok(());
     }
 
     println!("Domains already exist on the service:");
-    let domain_count = domains.service_domains.len() + domains.custom_domains.len();
 
-    if domain_count == 1 {
-        let domain = domains
-            .service_domains
-            .first()
-            .map(|d| d.domain.clone())
-            .unwrap_or_else(|| {
-                domains
-                    .custom_domains
-                    .first()
-                    .map(|d| d.domain.clone())
-                    .unwrap_or_else(|| unreachable!())
-            });
-
-        let formatted_domain = format!("https://{domain}");
-        println!("🚀 {}", formatted_domain.magenta().bold());
+    if items.len() == 1 {
+        print_domain_details(&items[0], "Existing domain", false);
         return Ok(());
     }
 
-    for domain in &domains.custom_domains {
-        let formatted_domain = format!("https://{}", domain.domain);
-        println!("- {}", formatted_domain.magenta().bold());
-    }
-    for domain in &domains.service_domains {
-        let formatted_domain = format!("https://{}", domain.domain);
-        println!("- {}", formatted_domain.magenta().bold());
-    }
+    print_domain_table(&items);
 
     Ok(())
 }
@@ -194,9 +477,6 @@ async fn create_custom_domain(
     environment: Option<String>,
     json: bool,
 ) -> Result<()> {
-    let configs = Configs::new()?;
-
-    let client = GQLClient::new_authorized(&configs)?;
     let ctx = resolve_service_context(project, service_name, environment).await?;
 
     let spinner = (std::io::stdout().is_terminal() && !json)
@@ -209,21 +489,6 @@ async fn create_custom_domain(
         })
         .and_then(|s| s.ok());
 
-    let is_available = post_graphql::<queries::CustomDomainAvailable, _>(
-        &client,
-        configs.get_backboard(),
-        queries::custom_domain_available::Variables {
-            domain: domain.clone(),
-        },
-    )
-    .await?
-    .custom_domain_available
-    .available;
-
-    if !is_available {
-        bail!("Domain is not available:\n\t{}", domain);
-    }
-
     let vars = mutations::custom_domain_create::Variables {
         input: mutations::custom_domain_create::CustomDomainCreateInput {
             domain: domain.clone(),
@@ -234,9 +499,12 @@ async fn create_custom_domain(
         },
     };
 
-    let response =
-        post_graphql::<mutations::CustomDomainCreate, _>(&client, configs.get_backboard(), vars)
-            .await?;
+    let response = post_graphql::<mutations::CustomDomainCreate, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        vars,
+    )
+    .await?;
 
     if let Some(s) = spinner {
         s.finish_and_clear()
@@ -247,80 +515,428 @@ async fn create_custom_domain(
         return Ok(());
     }
 
-    println!("Domain created: {}", response.custom_domain_create.domain);
-
-    if response.custom_domain_create.status.dns_records.is_empty() {
-        // This case should be impossible, but added error handling for safety.
-        //
-        // It can only occur if the backend is not returning the correct data,
-        // and in that case, the post_graphql call should have already errored.
-        bail!("No DNS records found. Please check the Railway dashboard for more information.");
-    }
-
-    let zone = response.custom_domain_create.status.dns_records[0]
-        .zone
-        .clone();
-    println!(
-        "To finish setting up your custom domain, add the following DNS records to {}:\n",
-        &zone
-    );
-
-    print_dns(
-        response.custom_domain_create.status.dns_records,
-        &response.custom_domain_create.status.verification_dns_host,
-        &response.custom_domain_create.status.verification_token,
-        response.custom_domain_create.status.verified,
-        &zone,
-    );
-
-    println!(
-        "\nNote: if the Name is \"@\", the DNS record should be created for the root of the domain."
-    );
-    println!("DNS changes can take up to 72 hours to propagate worldwide.");
+    let details = details_from_created_custom(&response.custom_domain_create);
+    print_domain_details(&details, "Custom domain created", true);
 
     Ok(())
 }
 
-fn print_dns(
-    domains: Vec<
-        mutations::custom_domain_create::CustomDomainCreateCustomDomainCreateStatusDnsRecords,
-    >,
-    verification_dns_host: &Option<String>,
-    verification_token: &Option<String>,
-    verified: bool,
-    zone: &str,
-) {
-    // Build the TXT verification value if needed
-    let txt_verification = if !verified {
-        match (verification_dns_host, verification_token) {
+async fn fetch_domains(ctx: &ServiceContext) -> Result<DomainsDomains> {
+    let vars = queries::domains::Variables {
+        project_id: ctx.project_id.clone(),
+        environment_id: ctx.environment_id.clone(),
+        service_id: ctx.service_id.clone(),
+    };
+
+    Ok(
+        post_graphql::<queries::Domains, _>(&ctx.client, ctx.configs.get_backboard(), vars)
+            .await?
+            .domains,
+    )
+}
+
+async fn resolve_domain(ctx: &ServiceContext, identifier: &str) -> Result<DomainDetails> {
+    let domains = fetch_domains(ctx).await?;
+    let items = domain_items(&domains);
+
+    find_domain_details(&items, identifier)
+        .cloned()
+        .ok_or_else(|| anyhow!("Domain '{}' not found on the selected service", identifier))
+}
+
+fn domain_items(domains: &DomainsDomains) -> Vec<DomainDetails> {
+    domains
+        .service_domains
+        .iter()
+        .map(details_from_service)
+        .chain(domains.custom_domains.iter().map(details_from_custom))
+        .collect()
+}
+
+fn summaries(items: &[DomainDetails]) -> Vec<DomainSummary> {
+    items.iter().map(|domain| domain.summary.clone()).collect()
+}
+
+fn find_domain_details<'a>(
+    domains: &'a [DomainDetails],
+    identifier: &str,
+) -> Option<&'a DomainDetails> {
+    let normalized = normalize_domain_identifier(identifier);
+
+    domains.iter().find(|domain| {
+        domain.summary.id.eq_ignore_ascii_case(identifier)
+            || domain.summary.domain.eq_ignore_ascii_case(&normalized)
+    })
+}
+
+fn normalize_domain_identifier(identifier: &str) -> String {
+    let trimmed = identifier.trim();
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+
+    without_scheme
+        .split('/')
+        .next()
+        .unwrap_or(without_scheme)
+        .trim_end_matches('.')
+        .to_string()
+}
+
+fn details_from_service(domain: &queries::domains::DomainsDomainsServiceDomains) -> DomainDetails {
+    DomainDetails {
+        summary: DomainSummary {
+            id: domain.id.clone(),
+            domain: domain.domain.clone(),
+            kind: DomainKind::Service,
+            target_port: domain.target_port,
+            sync_status: enum_name(&domain.sync_status),
+            created_at: domain.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            updated_at: domain.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            environment_id: domain.environment_id.clone(),
+            service_id: domain.service_id.clone(),
+            service_domain_suffix: domain.suffix.clone(),
+        },
+        dns_records: Vec::new(),
+        verification: None,
+        certificate: None,
+        certificates: Vec::new(),
+    }
+}
+
+fn details_from_created_service(
+    domain: &mutations::service_domain_create::ServiceDomainCreateServiceDomainCreate,
+) -> DomainDetails {
+    DomainDetails {
+        summary: DomainSummary {
+            id: domain.id.clone(),
+            domain: domain.domain.clone(),
+            kind: DomainKind::Service,
+            target_port: domain.target_port,
+            sync_status: enum_name(&domain.sync_status),
+            created_at: domain.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            updated_at: domain.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            environment_id: domain.environment_id.clone(),
+            service_id: domain.service_id.clone(),
+            service_domain_suffix: domain.suffix.clone(),
+        },
+        dns_records: Vec::new(),
+        verification: None,
+        certificate: None,
+        certificates: Vec::new(),
+    }
+}
+
+fn details_from_custom(domain: &queries::domains::DomainsDomainsCustomDomains) -> DomainDetails {
+    DomainDetails {
+        summary: DomainSummary {
+            id: domain.id.clone(),
+            domain: domain.domain.clone(),
+            kind: DomainKind::Custom,
+            target_port: domain.target_port,
+            sync_status: enum_name(&domain.sync_status),
+            created_at: domain.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            updated_at: domain.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            environment_id: domain.environment_id.clone(),
+            service_id: domain.service_id.clone(),
+            service_domain_suffix: None,
+        },
+        dns_records: domain
+            .status
+            .dns_records
+            .iter()
+            .map(dns_from_query)
+            .collect(),
+        verification: Some(VerificationOutput {
+            verified: domain.status.verified,
+            dns_host: domain.status.verification_dns_host.clone(),
+            token: domain.status.verification_token.clone(),
+        }),
+        certificate: Some(CertificateStatusOutput {
+            status: enum_name(&domain.status.certificate_status),
+            detailed_status: enum_name_option(&domain.status.certificate_status_detailed),
+            error_message: domain.status.certificate_error_message.clone(),
+            error_type: enum_name_option(&domain.status.certificate_error_type),
+            retryable: domain.status.certificate_retryable,
+            cdn_provider: enum_name_option(&domain.status.cdn_provider),
+        }),
+        certificates: domain
+            .status
+            .certificates
+            .as_ref()
+            .map(|certificates| certificates.iter().map(certificate_from_query).collect())
+            .unwrap_or_default(),
+    }
+}
+
+fn details_from_created_custom(
+    domain: &mutations::custom_domain_create::CustomDomainCreateCustomDomainCreate,
+) -> DomainDetails {
+    DomainDetails {
+        summary: DomainSummary {
+            id: domain.id.clone(),
+            domain: domain.domain.clone(),
+            kind: DomainKind::Custom,
+            target_port: domain.target_port,
+            sync_status: enum_name(&domain.sync_status),
+            created_at: domain.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            updated_at: domain.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
+            environment_id: domain.environment_id.clone(),
+            service_id: domain.service_id.clone(),
+            service_domain_suffix: None,
+        },
+        dns_records: domain
+            .status
+            .dns_records
+            .iter()
+            .map(dns_from_create)
+            .collect(),
+        verification: Some(VerificationOutput {
+            verified: domain.status.verified,
+            dns_host: domain.status.verification_dns_host.clone(),
+            token: domain.status.verification_token.clone(),
+        }),
+        certificate: Some(CertificateStatusOutput {
+            status: enum_name(&domain.status.certificate_status),
+            detailed_status: enum_name_option(&domain.status.certificate_status_detailed),
+            error_message: domain.status.certificate_error_message.clone(),
+            error_type: enum_name_option(&domain.status.certificate_error_type),
+            retryable: domain.status.certificate_retryable,
+            cdn_provider: enum_name_option(&domain.status.cdn_provider),
+        }),
+        certificates: domain
+            .status
+            .certificates
+            .as_ref()
+            .map(|certificates| certificates.iter().map(certificate_from_create).collect())
+            .unwrap_or_default(),
+    }
+}
+
+fn dns_from_query(
+    record: &queries::domains::DomainsDomainsCustomDomainsStatusDnsRecords,
+) -> DnsRecordOutput {
+    DnsRecordOutput {
+        record_type: enum_name(&record.record_type),
+        name: if record.hostlabel.is_empty() {
+            "@".to_string()
+        } else {
+            record.hostlabel.clone()
+        },
+        fqdn: record.fqdn.clone(),
+        required_value: record.required_value.clone(),
+        current_value: record.current_value.clone(),
+        status: enum_name(&record.status),
+        zone: record.zone.clone(),
+        purpose: enum_name(&record.purpose),
+    }
+}
+
+fn dns_from_create(
+    record: &mutations::custom_domain_create::CustomDomainCreateCustomDomainCreateStatusDnsRecords,
+) -> DnsRecordOutput {
+    DnsRecordOutput {
+        record_type: enum_name(&record.record_type),
+        name: if record.hostlabel.is_empty() {
+            "@".to_string()
+        } else {
+            record.hostlabel.clone()
+        },
+        fqdn: record.fqdn.clone(),
+        required_value: record.required_value.clone(),
+        current_value: record.current_value.clone(),
+        status: enum_name(&record.status),
+        zone: record.zone.clone(),
+        purpose: enum_name(&record.purpose),
+    }
+}
+
+fn certificate_from_query(
+    certificate: &queries::domains::DomainsDomainsCustomDomainsStatusCertificates,
+) -> CertificateOutput {
+    CertificateOutput {
+        issued_at: certificate
+            .issued_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+        expires_at: certificate
+            .expires_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+        domain_names: certificate.domain_names.clone(),
+        fingerprint_sha256: certificate.fingerprint_sha256.clone(),
+        key_type: enum_name(&certificate.key_type),
+    }
+}
+
+fn certificate_from_create(
+    certificate: &mutations::custom_domain_create::CustomDomainCreateCustomDomainCreateStatusCertificates,
+) -> CertificateOutput {
+    CertificateOutput {
+        issued_at: certificate
+            .issued_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+        expires_at: certificate
+            .expires_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+        domain_names: certificate.domain_names.clone(),
+        fingerprint_sha256: certificate.fingerprint_sha256.clone(),
+        key_type: enum_name(&certificate.key_type),
+    }
+}
+
+fn print_domain_table(domains: &[DomainDetails]) {
+    let domain_width = domains
+        .iter()
+        .map(|domain| domain.summary.domain.len())
+        .max()
+        .unwrap_or("Domain".len())
+        .max("Domain".len())
+        + 3;
+    let type_width = "service".len() + 3;
+    let id_width = domains
+        .iter()
+        .map(|domain| domain.summary.id.len())
+        .max()
+        .unwrap_or("ID".len())
+        .max("ID".len())
+        + 3;
+    let port_width = domains
+        .iter()
+        .map(|domain| format_target_port(domain.summary.target_port).len())
+        .max()
+        .unwrap_or("Port".len())
+        .max("Port".len())
+        + 3;
+
+    println!(
+        "{:<domain_width$}{:<type_width$}{:<id_width$}{:<port_width$}Sync",
+        "Domain".bold(),
+        "Type".bold(),
+        "ID".bold(),
+        "Port".bold(),
+        domain_width = domain_width,
+        type_width = type_width,
+        id_width = id_width,
+        port_width = port_width,
+    );
+
+    for domain in domains {
+        println!(
+            "{:<domain_width$}{:<type_width$}{:<id_width$}{:<port_width$}{}",
+            domain.summary.domain,
+            domain.summary.kind,
+            domain.summary.id,
+            format_target_port(domain.summary.target_port),
+            domain.summary.sync_status,
+            domain_width = domain_width,
+            type_width = type_width,
+            id_width = id_width,
+            port_width = port_width,
+        );
+    }
+}
+
+fn print_domain_details(domain: &DomainDetails, title: &str, show_next_step: bool) {
+    println!("{}:", title.bold());
+    println!(
+        "  URL: {}",
+        format!("https://{}", domain.summary.domain)
+            .magenta()
+            .bold()
+    );
+    println!("  ID: {}", domain.summary.id);
+    println!("  Type: {}", domain.summary.kind);
+    println!(
+        "  Target port: {}",
+        format_target_port(domain.summary.target_port)
+    );
+    println!("  Sync status: {}", domain.summary.sync_status);
+
+    if let Some(created_at) = &domain.summary.created_at {
+        println!("  Created: {}", created_at);
+    }
+    if let Some(updated_at) = &domain.summary.updated_at {
+        println!("  Updated: {}", updated_at);
+    }
+
+    if let Some(verification) = &domain.verification {
+        println!(
+            "  Verified: {}",
+            if verification.verified { "yes" } else { "no" }
+        );
+    }
+
+    if let Some(certificate) = &domain.certificate {
+        println!("  Certificate status: {}", certificate.status);
+        if let Some(detailed_status) = &certificate.detailed_status {
+            println!("  Certificate detail: {}", detailed_status);
+        }
+        if let Some(error_message) = &certificate.error_message {
+            println!("  Certificate error: {}", error_message);
+        }
+        if let Some(error_type) = &certificate.error_type {
+            println!("  Certificate error type: {}", error_type);
+        }
+        if let Some(retryable) = certificate.retryable {
+            println!("  Certificate retryable: {}", retryable);
+        }
+    }
+
+    if !domain.dns_records.is_empty() {
+        println!("\nDNS records:");
+        print_dns(&domain.dns_records, domain.verification.as_ref());
+        println!(
+            "\nNote: if the Name is \"@\", the DNS record should be created for the root of the domain."
+        );
+        println!("DNS changes can take up to 72 hours to propagate worldwide.");
+    }
+
+    if show_next_step {
+        println!(
+            "\nNext: {}",
+            format!("railway domain status {}", domain.summary.id).bold()
+        );
+    }
+}
+
+fn print_dns(domains: &[DnsRecordOutput], verification: Option<&VerificationOutput>) {
+    let zone = domains.first().map(|record| record.zone.as_str());
+
+    let txt_verification = verification.and_then(|verification| {
+        if verification.verified {
+            return None;
+        }
+
+        match (&verification.dns_host, &verification.token) {
             (Some(host), Some(token)) => {
-                // Strip the zone suffix from the verification DNS host (e.g., "_railway-verify.example.com" -> "_railway-verify")
-                let host_label = host.strip_suffix(&format!(".{}", zone)).unwrap_or(host);
+                let host_label = zone
+                    .and_then(|zone| host.strip_suffix(&format!(".{}", zone)))
+                    .unwrap_or(host);
                 Some((host_label.to_string(), format!("railway-verify={}", token)))
             }
             _ => None,
         }
-    } else {
-        None
-    };
+    });
 
-    // I benchmarked this iter().fold() and it's faster than using 3x iter().map()
     let (padding_type, padding_hostlabel, padding_value) = domains
         .iter()
         // Minimum length should be 8, but we add 3 for extra padding so 8-3 = 5
         .fold((5, 5, 5), |(max_type, max_hostlabel, max_value), d| {
             (
-                max(max_type, d.record_type.to_string().len()),
-                max(max_hostlabel, d.hostlabel.len()),
+                max(max_type, d.record_type.len()),
+                max(max_hostlabel, d.name.len()),
                 max(max_value, d.required_value.len()),
             )
         });
 
-    // Include TXT verification record in padding calculation
     let (padding_type, padding_hostlabel, padding_value) =
         if let Some((host, value)) = &txt_verification {
             (
-                max(padding_type, 3), // "TXT".len()
+                max(padding_type, 3),
                 max(padding_hostlabel, host.len()),
                 max(padding_value, value.len()),
             )
@@ -328,11 +944,9 @@ fn print_dns(
             (padding_type, padding_hostlabel, padding_value)
         };
 
-    // Add extra minimum padding to each length
     let [padding_type, padding_hostlabel, padding_value] =
         [padding_type + 3, padding_hostlabel + 3, padding_value + 3];
 
-    // Print the header with consistent padding
     println!(
         "\t{:<width_type$}{:<width_host$}{:<width_value$}",
         "Type",
@@ -343,16 +957,11 @@ fn print_dns(
         width_value = padding_value
     );
 
-    // Print each domain entry with the same padding
-    for domain in &domains {
+    for domain in domains {
         println!(
             "\t{:<width_type$}{:<width_host$}{:<width_value$}",
-            domain.record_type.to_string(),
-            if domain.hostlabel.is_empty() {
-                "@"
-            } else {
-                &domain.hostlabel
-            },
+            domain.record_type,
+            domain.name,
             domain.required_value,
             width_type = padding_type,
             width_host = padding_hostlabel,
@@ -360,7 +969,6 @@ fn print_dns(
         );
     }
 
-    // Print TXT verification record if domain is not yet verified
     if let Some((host, value)) = txt_verification {
         println!(
             "\t{:<width_type$}{:<width_host$}{:<width_value$}",
@@ -370,6 +978,312 @@ fn print_dns(
             width_type = padding_type,
             width_host = padding_hostlabel,
             width_value = padding_value
+        );
+    }
+}
+
+fn format_target_port(port: Option<i64>) -> String {
+    port.map(|port| port.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn domain_url(domain: &str) -> String {
+    format!("https://{domain}")
+}
+
+fn legacy_service_domain_output(domain: &DomainDetails) -> serde_json::Value {
+    json!({
+        "domain": domain_url(&domain.summary.domain),
+    })
+}
+
+fn legacy_domain_list_output(domains: &[DomainDetails]) -> serde_json::Value {
+    json!({
+        "domains": domains
+            .iter()
+            .map(|domain| domain_url(&domain.summary.domain))
+            .collect::<Vec<_>>()
+    })
+}
+
+fn service_domain_input(domain: &DomainDetails, new_domain: &str) -> Result<String> {
+    let normalized = normalize_domain_identifier(new_domain);
+
+    if normalized.is_empty() {
+        bail!("--domain must not be empty.");
+    }
+
+    if normalized.contains('.') {
+        return Ok(normalized);
+    }
+
+    let Some(suffix) = &domain.summary.service_domain_suffix else {
+        bail!("Pass the full service domain because the current suffix could not be resolved.");
+    };
+
+    Ok(format!("{normalized}.{suffix}"))
+}
+
+fn update_change_summary(port: Option<u16>, new_domain: Option<&str>) -> String {
+    let mut changes = Vec::new();
+    if let Some(port) = port {
+        changes.push(format!("target port to {port}"));
+    }
+    if let Some(new_domain) = new_domain {
+        changes.push(format!(
+            "domain to {}",
+            normalize_domain_identifier(new_domain)
+        ));
+    }
+
+    changes.join(" and ")
+}
+
+fn enum_name<T: fmt::Debug>(value: &T) -> String {
+    format!("{value:?}")
+}
+
+fn enum_name_option<T: fmt::Debug>(value: &Option<T>) -> Option<String> {
+    value.as_ref().map(enum_name)
+}
+
+fn confirm_delete<F>(yes: bool, is_terminal: bool, prompt: F) -> Result<bool>
+where
+    F: FnOnce() -> Result<bool>,
+{
+    if yes {
+        Ok(true)
+    } else if is_terminal {
+        prompt()
+    } else {
+        bail!(
+            "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip confirmation."
+        );
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum DomainKind {
+    Custom,
+    Service,
+}
+
+impl fmt::Display for DomainKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DomainKind::Custom => write!(f, "custom"),
+            DomainKind::Service => write!(f, "service"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DomainSummary {
+    id: String,
+    domain: String,
+    #[serde(rename = "type")]
+    kind: DomainKind,
+    target_port: Option<i64>,
+    sync_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<String>,
+    #[serde(skip_serializing)]
+    environment_id: String,
+    #[serde(skip_serializing)]
+    service_id: String,
+    #[serde(skip_serializing)]
+    service_domain_suffix: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DomainDetails {
+    #[serde(flatten)]
+    summary: DomainSummary,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    dns_records: Vec<DnsRecordOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    verification: Option<VerificationOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    certificate: Option<CertificateStatusOutput>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    certificates: Vec<CertificateOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DnsRecordOutput {
+    record_type: String,
+    name: String,
+    fqdn: String,
+    required_value: String,
+    current_value: String,
+    status: String,
+    zone: String,
+    purpose: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct VerificationOutput {
+    verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dns_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CertificateStatusOutput {
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detailed_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    retryable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cdn_provider: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CertificateOutput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issued_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    domain_names: Vec<String>,
+    fingerprint_sha256: String,
+    key_type: String,
+}
+
+#[derive(Serialize)]
+struct ListOutput {
+    domains: Vec<DomainSummary>,
+}
+
+#[derive(Serialize)]
+struct DomainOutput {
+    domain: DomainDetails,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn sample_domain(id: &str, domain: &str) -> DomainDetails {
+        DomainDetails {
+            summary: DomainSummary {
+                id: id.to_string(),
+                domain: domain.to_string(),
+                kind: DomainKind::Custom,
+                target_port: Some(3000),
+                sync_status: "ACTIVE".to_string(),
+                created_at: None,
+                updated_at: None,
+                environment_id: "env_123".to_string(),
+                service_id: "svc_123".to_string(),
+                service_domain_suffix: None,
+            },
+            dns_records: Vec::new(),
+            verification: None,
+            certificate: None,
+            certificates: Vec::new(),
+        }
+    }
+
+    fn sample_service_domain(id: &str, domain: &str) -> DomainDetails {
+        let mut domain = sample_domain(id, domain);
+        domain.summary.kind = DomainKind::Service;
+        domain.summary.service_domain_suffix = Some("up.railway.app".to_string());
+        domain
+    }
+
+    #[test]
+    fn parses_legacy_create_and_subcommands() {
+        let args = Args::parse_from(["domain", "example.com", "--port", "3000"]);
+        assert!(args.command.is_none());
+        assert_eq!(args.domain.as_deref(), Some("example.com"));
+        assert_eq!(args.port, Some(3000));
+
+        let args = Args::parse_from(["domain", "list", "--service", "api", "--json"]);
+        assert!(matches!(args.command, Some(Commands::List)));
+        assert_eq!(args.service.as_deref(), Some("api"));
+        assert!(args.json);
+
+        let args = Args::parse_from([
+            "domain",
+            "update",
+            "example.com",
+            "--port",
+            "8080",
+            "--domain",
+            "api-new",
+        ]);
+        assert!(matches!(
+            args.command,
+            Some(Commands::Update {
+                identifier,
+                port: Some(8080),
+                new_domain: Some(new_domain),
+            }) if identifier == "example.com" && new_domain == "api-new"
+        ));
+    }
+
+    #[test]
+    fn validates_port_range() {
+        assert_eq!(parse_port("1").unwrap(), 1);
+        assert_eq!(parse_port("65535").unwrap(), 65535);
+        assert!(parse_port("0").is_err());
+        assert!(parse_port("65536").is_err());
+        assert!(Args::try_parse_from(["domain", "update", "example.com", "--port", "0"]).is_err());
+    }
+
+    #[test]
+    fn finds_domain_by_id_name_or_url() {
+        let domains = vec![sample_domain("dom_123", "api.example.com")];
+
+        assert!(find_domain_details(&domains, "dom_123").is_some());
+        assert!(find_domain_details(&domains, "API.EXAMPLE.COM").is_some());
+        assert!(find_domain_details(&domains, "https://api.example.com/").is_some());
+        assert!(find_domain_details(&domains, "missing.example.com").is_none());
+    }
+
+    #[test]
+    fn service_domain_input_accepts_full_domain_or_host_label() {
+        let domain = sample_service_domain("dom_123", "api.up.railway.app");
+
+        assert_eq!(
+            service_domain_input(&domain, "web.up.railway.app").unwrap(),
+            "web.up.railway.app"
+        );
+        assert_eq!(
+            service_domain_input(&domain, "web").unwrap(),
+            "web.up.railway.app"
+        );
+        assert!(service_domain_input(&domain, "").is_err());
+    }
+
+    #[test]
+    fn legacy_json_keeps_domain_string_contract() {
+        let domain = sample_domain("dom_123", "api.example.com");
+
+        assert_eq!(
+            legacy_service_domain_output(&domain),
+            serde_json::json!({ "domain": "https://api.example.com" })
+        );
+        assert_eq!(
+            legacy_domain_list_output(&[domain]),
+            serde_json::json!({ "domains": ["https://api.example.com"] })
         );
     }
 }

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -975,7 +975,7 @@ fn print_dns(domains: &[DnsRecordOutput], verification: Option<&VerificationOutp
                 let host_label = zone
                     .and_then(|zone| host.strip_suffix(&format!(".{}", zone)))
                     .unwrap_or(host);
-                Some((host_label.to_string(), format!("railway-verify={}", token)))
+                Some((host_label.to_string(), verification_txt_value(token)))
             }
             _ => None,
         }
@@ -1106,6 +1106,14 @@ fn enum_name_option<T: fmt::Debug>(value: &Option<T>) -> Option<String> {
     value.as_ref().map(enum_name)
 }
 
+fn verification_txt_value(token: &str) -> String {
+    let mut token = token;
+    while let Some(stripped) = token.strip_prefix("railway-verify=") {
+        token = stripped;
+    }
+    format!("railway-verify={token}")
+}
+
 fn confirm_delete<F>(yes: bool, is_terminal: bool, prompt: F) -> Result<bool>
 where
     F: FnOnce() -> Result<bool>,
@@ -1130,10 +1138,10 @@ enum DomainKind {
 
 impl fmt::Display for DomainKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DomainKind::Custom => write!(f, "custom"),
-            DomainKind::Service => write!(f, "service"),
-        }
+        f.pad(match self {
+            DomainKind::Custom => "custom",
+            DomainKind::Service => "service",
+        })
     }
 }
 
@@ -1313,6 +1321,25 @@ mod tests {
         assert!(parse_port("0").is_err());
         assert!(parse_port("65536").is_err());
         assert!(Args::try_parse_from(["domain", "update", "example.com", "--port", "0"]).is_err());
+    }
+
+    #[test]
+    fn domain_kind_display_respects_padding() {
+        assert_eq!(format!("{:<10}", DomainKind::Service), "service   ");
+        assert_eq!(format!("{:<9}", DomainKind::Custom), "custom   ");
+    }
+
+    #[test]
+    fn verification_txt_value_has_one_prefix() {
+        assert_eq!(verification_txt_value("abc123"), "railway-verify=abc123");
+        assert_eq!(
+            verification_txt_value("railway-verify=abc123"),
+            "railway-verify=abc123"
+        );
+        assert_eq!(
+            verification_txt_value("railway-verify=railway-verify=abc123"),
+            "railway-verify=abc123"
+        );
     }
 
     #[test]

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -23,7 +23,7 @@ use super::*;
 /// - `railway domain example.com` creates a custom domain
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway domain\n  railway domain example.com --port 3000\n  railway domain list --service api --json\n  railway domain status example.com\n  railway domain update example.com --port 8080\n  railway domain delete example.com --yes"
+    after_help = "Examples:\n\n  railway domain\n  railway domain example.com --port 3000\n  railway domain list --service api --json\n  railway domain status example.com\n  railway domain update example.com --port 8080\n  railway domain certificate retry example.com\n  railway domain delete example.com --yes"
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -96,6 +96,22 @@ enum Commands {
         #[clap(long = "domain", value_name = "DOMAIN")]
         new_domain: Option<String>,
     },
+
+    /// Manage custom domain certificates
+    Certificate {
+        #[clap(subcommand)]
+        command: CertificateCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum CertificateCommands {
+    /// Retry certificate issuance for a custom domain
+    Retry {
+        /// Domain name, URL, or domain ID
+        #[clap(value_name = "DOMAIN_OR_ID")]
+        domain: String,
+    },
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -133,6 +149,11 @@ pub async fn command(args: Args) -> Result<()> {
             )
             .await?
         }
+        Some(Commands::Certificate { command }) => match command {
+            CertificateCommands::Retry { domain } => {
+                retry_domain_certificate(domain, project, service, environment, json).await?
+            }
+        },
         None => {
             if let Some(domain) = domain {
                 create_custom_domain(domain, port, project, service, environment, json).await?;
@@ -376,6 +397,44 @@ async fn update_domain(
     } else {
         let changes = update_change_summary(port, new_domain.as_deref());
         println!("Updated {}.", changes);
+        print_domain_details(&updated, "Updated domain status", false);
+    }
+
+    Ok(())
+}
+
+async fn retry_domain_certificate(
+    identifier: String,
+    project: Option<String>,
+    service_name: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service_name, environment).await?;
+    let domain = resolve_domain(&ctx, &identifier).await?;
+
+    if domain.summary.kind != DomainKind::Custom {
+        bail!("Certificate retry is only supported for custom domains.");
+    }
+
+    post_graphql::<mutations::CustomDomainIssueCertificate, _>(
+        &ctx.client,
+        ctx.configs.get_backboard_internal(),
+        mutations::custom_domain_issue_certificate::Variables {
+            id: domain.summary.id.clone(),
+        },
+    )
+    .await?;
+
+    let updated = resolve_domain(&ctx, &domain.summary.id).await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&DomainOutput { domain: updated })?
+        );
+    } else {
+        println!("Certificate retry requested.");
         print_domain_details(&updated, "Updated domain status", false);
     }
 
@@ -1236,6 +1295,14 @@ mod tests {
                 port: Some(8080),
                 new_domain: Some(new_domain),
             }) if identifier == "example.com" && new_domain == "api-new"
+        ));
+
+        let args = Args::parse_from(["domain", "certificate", "retry", "example.com"]);
+        assert!(matches!(
+            args.command,
+            Some(Commands::Certificate {
+                command: CertificateCommands::Retry { domain },
+            }) if domain == "example.com"
         ));
     }
 

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -416,6 +416,9 @@ async fn retry_domain_certificate(
     if domain.summary.kind != DomainKind::Custom {
         bail!("Certificate retry is only supported for custom domains.");
     }
+    if let Some(reason) = certificate_retry_unavailable_reason(&domain) {
+        bail!("{reason}");
+    }
 
     post_graphql::<mutations::CustomDomainIssueCertificate, _>(
         &ctx.client,
@@ -1106,6 +1109,39 @@ fn enum_name_option<T: fmt::Debug>(value: &Option<T>) -> Option<String> {
     value.as_ref().map(enum_name)
 }
 
+const CERTIFICATE_STATUS_ISSUE_FAILED: &str = "CERTIFICATE_STATUS_TYPE_ISSUE_FAILED";
+
+fn certificate_retry_unavailable_reason(domain: &DomainDetails) -> Option<String> {
+    let Some(certificate) = &domain.certificate else {
+        return Some(
+            "Certificate retry is only available after certificate issuance fails. Current status is unknown."
+                .to_string(),
+        );
+    };
+
+    if certificate.status != CERTIFICATE_STATUS_ISSUE_FAILED {
+        return Some(format!(
+            "Certificate retry is only available after certificate issuance fails. Current status: {}.",
+            certificate.status
+        ));
+    }
+
+    if certificate.retryable == Some(false) {
+        return Some(
+            certificate
+                .error_message
+                .as_ref()
+                .map(|message| format!("Certificate retry is not available for this failure. {message}"))
+                .unwrap_or_else(|| {
+                    "Certificate retry is not available for this failure. Check your DNS configuration or contact support."
+                        .to_string()
+                }),
+        );
+    }
+
+    None
+}
+
 fn verification_txt_value(token: &str) -> String {
     let mut token = token;
     while let Some(stripped) = token.strip_prefix("railway-verify=") {
@@ -1275,6 +1311,17 @@ mod tests {
         domain
     }
 
+    fn sample_certificate(status: &str, retryable: Option<bool>) -> CertificateStatusOutput {
+        CertificateStatusOutput {
+            status: status.to_string(),
+            detailed_status: None,
+            error_message: Some("Certificate failed.".to_string()),
+            error_type: None,
+            retryable,
+            cdn_provider: None,
+        }
+    }
+
     #[test]
     fn parses_legacy_create_and_subcommands() {
         let args = Args::parse_from(["domain", "example.com", "--port", "3000"]);
@@ -1365,6 +1412,30 @@ mod tests {
             "web.up.railway.app"
         );
         assert!(service_domain_input(&domain, "").is_err());
+    }
+
+    #[test]
+    fn certificate_retry_matches_dashboard_gate() {
+        let mut domain = sample_domain("dom_123", "api.example.com");
+        assert!(certificate_retry_unavailable_reason(&domain).is_some());
+
+        domain.certificate = Some(sample_certificate(CERTIFICATE_STATUS_ISSUE_FAILED, None));
+        assert_eq!(certificate_retry_unavailable_reason(&domain), None);
+
+        domain.certificate = Some(sample_certificate(
+            CERTIFICATE_STATUS_ISSUE_FAILED,
+            Some(true),
+        ));
+        assert_eq!(certificate_retry_unavailable_reason(&domain), None);
+
+        domain.certificate = Some(sample_certificate(
+            CERTIFICATE_STATUS_ISSUE_FAILED,
+            Some(false),
+        ));
+        assert!(certificate_retry_unavailable_reason(&domain).is_some());
+
+        domain.certificate = Some(sample_certificate("CERTIFICATE_STATUS_TYPE_VALID", None));
+        assert!(certificate_retry_unavailable_reason(&domain).is_some());
     }
 
     #[test]

--- a/src/commands/functions/new.rs
+++ b/src/commands/functions/new.rs
@@ -184,6 +184,7 @@ async fn create_domain_if_requested(
         mutations::service_domain_create::Variables {
             service_id: service_id.to_string(),
             environment_id: environment.node.id.clone(),
+            target_port: None,
         },
     )
     .await?;

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -479,12 +479,21 @@ fn format_domain_details(domain: &McpDomainDetails) -> String {
                 .unwrap_or("");
             let host_label = host.strip_suffix(&format!(".{zone}")).unwrap_or(host);
             output.push_str(&format!(
-                "- TXT {host_label} -> railway-verify={token} (verification)\n"
+                "- TXT {host_label} -> {} (verification)\n",
+                verification_txt_value(token)
             ));
         }
     }
 
     output
+}
+
+fn verification_txt_value(token: &str) -> String {
+    let mut token = token;
+    while let Some(stripped) = token.strip_prefix("railway-verify=") {
+        token = stripped;
+    }
+    format!("railway-verify={token}")
 }
 
 fn format_target_port(port: Option<i64>) -> String {
@@ -1866,5 +1875,18 @@ mod tests {
             "web.up.railway.app"
         );
         assert!(mcp_service_domain_input(&domain, "").is_err());
+    }
+
+    #[test]
+    fn mcp_verification_txt_value_has_one_prefix() {
+        assert_eq!(verification_txt_value("abc123"), "railway-verify=abc123");
+        assert_eq!(
+            verification_txt_value("railway-verify=abc123"),
+            "railway-verify=abc123"
+        );
+        assert_eq!(
+            verification_txt_value("railway-verify=railway-verify=abc123"),
+            "railway-verify=abc123"
+        );
     }
 }

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1050,7 +1050,7 @@ impl RailwayMcp {
 
         post_graphql::<mutations::CustomDomainIssueCertificate, _>(
             &self.client,
-            self.configs.get_backboard_internal(),
+            self.configs.get_backboard(),
             mutations::custom_domain_issue_certificate::Variables {
                 id: domain.id.clone(),
             },

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -536,6 +536,39 @@ fn enum_name_option<T: fmt::Debug>(value: &Option<T>) -> Option<String> {
     value.as_ref().map(enum_name)
 }
 
+const CERTIFICATE_STATUS_ISSUE_FAILED: &str = "CERTIFICATE_STATUS_TYPE_ISSUE_FAILED";
+
+fn certificate_retry_unavailable_reason(domain: &McpDomainDetails) -> Option<String> {
+    let Some(certificate) = &domain.certificate else {
+        return Some(
+            "Certificate retry is only available after certificate issuance fails. Current status is unknown."
+                .to_string(),
+        );
+    };
+
+    if certificate.status != CERTIFICATE_STATUS_ISSUE_FAILED {
+        return Some(format!(
+            "Certificate retry is only available after certificate issuance fails. Current status: {}.",
+            certificate.status
+        ));
+    }
+
+    if certificate.retryable == Some(false) {
+        return Some(
+            certificate
+                .error_message
+                .as_ref()
+                .map(|message| format!("Certificate retry is not available for this failure. {message}"))
+                .unwrap_or_else(|| {
+                    "Certificate retry is not available for this failure. Check your DNS configuration or contact support."
+                        .to_string()
+                }),
+        );
+    }
+
+    None
+}
+
 fn validate_domain_port(port: i64) -> Result<i64, McpError> {
     if (1..=65535).contains(&port) {
         Ok(port)
@@ -1030,7 +1063,7 @@ impl RailwayMcp {
     }
 
     #[tool(
-        description = "Retry TLS certificate issuance for a custom domain by domain name, URL, or domain ID. Custom domains only. Returns updated status after readback."
+        description = "Retry failed TLS certificate issuance for a custom domain by domain name, URL, or domain ID. Custom domains only. Returns updated status after readback."
     )]
     async fn retry_domain_certificate(
         &self,
@@ -1046,6 +1079,9 @@ impl RailwayMcp {
                 "Certificate retry is only supported for custom domains.",
                 None,
             ));
+        }
+        if let Some(reason) = certificate_retry_unavailable_reason(&domain) {
+            return Err(McpError::invalid_params(reason, None));
         }
 
         post_graphql::<mutations::CustomDomainIssueCertificate, _>(
@@ -1852,6 +1888,17 @@ mod tests {
         domain
     }
 
+    fn sample_certificate(status: &str, retryable: Option<bool>) -> McpCertificateStatus {
+        McpCertificateStatus {
+            status: status.to_string(),
+            detailed_status: None,
+            error_message: Some("Certificate failed.".to_string()),
+            error_type: None,
+            retryable,
+            cdn_provider: None,
+        }
+    }
+
     #[test]
     fn mcp_domain_lookup_accepts_id_name_and_url() {
         let domains = vec![sample_domain()];
@@ -1875,6 +1922,30 @@ mod tests {
             "web.up.railway.app"
         );
         assert!(mcp_service_domain_input(&domain, "").is_err());
+    }
+
+    #[test]
+    fn mcp_certificate_retry_matches_dashboard_gate() {
+        let mut domain = sample_domain();
+        assert!(certificate_retry_unavailable_reason(&domain).is_some());
+
+        domain.certificate = Some(sample_certificate(CERTIFICATE_STATUS_ISSUE_FAILED, None));
+        assert_eq!(certificate_retry_unavailable_reason(&domain), None);
+
+        domain.certificate = Some(sample_certificate(
+            CERTIFICATE_STATUS_ISSUE_FAILED,
+            Some(true),
+        ));
+        assert_eq!(certificate_retry_unavailable_reason(&domain), None);
+
+        domain.certificate = Some(sample_certificate(
+            CERTIFICATE_STATUS_ISSUE_FAILED,
+            Some(false),
+        ));
+        assert!(certificate_retry_unavailable_reason(&domain).is_some());
+
+        domain.certificate = Some(sample_certificate("CERTIFICATE_STATUS_TYPE_VALID", None));
+        assert!(certificate_retry_unavailable_reason(&domain).is_some());
     }
 
     #[test]

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1021,6 +1021,44 @@ impl RailwayMcp {
     }
 
     #[tool(
+        description = "Retry TLS certificate issuance for a custom domain by domain name, URL, or domain ID. Custom domains only. Returns updated status after readback."
+    )]
+    async fn retry_domain_certificate(
+        &self,
+        Parameters(params): Parameters<DomainStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let domain = self.resolve_domain_details(&ctx, &params.domain).await?;
+
+        if domain.kind != McpDomainKind::Custom {
+            return Err(McpError::invalid_params(
+                "Certificate retry is only supported for custom domains.",
+                None,
+            ));
+        }
+
+        post_graphql::<mutations::CustomDomainIssueCertificate, _>(
+            &self.client,
+            self.configs.get_backboard_internal(),
+            mutations::custom_domain_issue_certificate::Variables {
+                id: domain.id.clone(),
+            },
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to retry domain certificate: {e}"), None)
+        })?;
+
+        let updated = self.resolve_domain_details(&ctx, &domain.id).await?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Certificate retry requested.\n\n{}",
+            format_domain_details(&updated)
+        ))]))
+    }
+
+    #[tool(
         description = "Delete a custom or service domain by domain name, URL, or domain ID. This is irreversible. Returns a preview first.",
         annotations(destructive_hint = true)
     )]

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{fmt, path::PathBuf, sync::Arc};
 
 use super::params::*;
 
@@ -186,6 +185,39 @@ impl RailwayMcp {
             context: ctx,
         })
     }
+
+    pub(crate) async fn fetch_domains(
+        &self,
+        ctx: &ResolvedServiceContext,
+    ) -> Result<queries::domains::DomainsDomains, McpError> {
+        post_graphql::<queries::Domains, _>(
+            &self.client,
+            self.configs.get_backboard(),
+            queries::domains::Variables {
+                environment_id: ctx.environment_id.clone(),
+                project_id: ctx.project_id.clone(),
+                service_id: ctx.service_id.clone(),
+            },
+        )
+        .await
+        .map(|response| response.domains)
+        .map_err(|e| McpError::internal_error(format!("Failed to query domains: {e}"), None))
+    }
+
+    pub(crate) async fn resolve_domain_details(
+        &self,
+        ctx: &ResolvedServiceContext,
+        identifier: &str,
+    ) -> Result<McpDomainDetails, McpError> {
+        let domains = self.fetch_domains(ctx).await?;
+        let items = mcp_domain_items(&domains);
+        find_mcp_domain(&items, identifier).cloned().ok_or_else(|| {
+            McpError::invalid_params(
+                format!("Domain '{identifier}' not found on the selected service."),
+                None,
+            )
+        })
+    }
 }
 
 fn format_environments(project: &queries::RailwayProject) -> String {
@@ -206,6 +238,304 @@ fn format_services(project: &queries::RailwayProject) -> String {
         .map(|s| format!("- {} (id: {})", s.node.name, s.node.id))
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum McpDomainKind {
+    Custom,
+    Service,
+}
+
+impl fmt::Display for McpDomainKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            McpDomainKind::Custom => write!(f, "custom"),
+            McpDomainKind::Service => write!(f, "service"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct McpDomainDetails {
+    id: String,
+    domain: String,
+    kind: McpDomainKind,
+    target_port: Option<i64>,
+    sync_status: String,
+    service_domain_suffix: Option<String>,
+    environment_id: String,
+    service_id: String,
+    dns_records: Vec<McpDnsRecord>,
+    verification: Option<McpVerification>,
+    certificate: Option<McpCertificateStatus>,
+}
+
+#[derive(Debug, Clone)]
+struct McpDnsRecord {
+    record_type: String,
+    name: String,
+    required_value: String,
+    current_value: String,
+    status: String,
+    zone: String,
+}
+
+#[derive(Debug, Clone)]
+struct McpVerification {
+    verified: bool,
+    dns_host: Option<String>,
+    token: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct McpCertificateStatus {
+    status: String,
+    detailed_status: Option<String>,
+    error_message: Option<String>,
+    error_type: Option<String>,
+    retryable: Option<bool>,
+    cdn_provider: Option<String>,
+}
+
+fn mcp_domain_items(domains: &queries::domains::DomainsDomains) -> Vec<McpDomainDetails> {
+    domains
+        .service_domains
+        .iter()
+        .map(mcp_domain_from_service)
+        .chain(domains.custom_domains.iter().map(mcp_domain_from_custom))
+        .collect()
+}
+
+fn mcp_domain_from_service(
+    domain: &queries::domains::DomainsDomainsServiceDomains,
+) -> McpDomainDetails {
+    McpDomainDetails {
+        id: domain.id.clone(),
+        domain: domain.domain.clone(),
+        kind: McpDomainKind::Service,
+        target_port: domain.target_port,
+        sync_status: enum_name(&domain.sync_status),
+        service_domain_suffix: domain.suffix.clone(),
+        environment_id: domain.environment_id.clone(),
+        service_id: domain.service_id.clone(),
+        dns_records: Vec::new(),
+        verification: None,
+        certificate: None,
+    }
+}
+
+fn mcp_domain_from_custom(
+    domain: &queries::domains::DomainsDomainsCustomDomains,
+) -> McpDomainDetails {
+    McpDomainDetails {
+        id: domain.id.clone(),
+        domain: domain.domain.clone(),
+        kind: McpDomainKind::Custom,
+        target_port: domain.target_port,
+        sync_status: enum_name(&domain.sync_status),
+        service_domain_suffix: None,
+        environment_id: domain.environment_id.clone(),
+        service_id: domain.service_id.clone(),
+        dns_records: domain
+            .status
+            .dns_records
+            .iter()
+            .map(|record| McpDnsRecord {
+                record_type: enum_name(&record.record_type),
+                name: if record.hostlabel.is_empty() {
+                    "@".to_string()
+                } else {
+                    record.hostlabel.clone()
+                },
+                required_value: record.required_value.clone(),
+                current_value: record.current_value.clone(),
+                status: enum_name(&record.status),
+                zone: record.zone.clone(),
+            })
+            .collect(),
+        verification: Some(McpVerification {
+            verified: domain.status.verified,
+            dns_host: domain.status.verification_dns_host.clone(),
+            token: domain.status.verification_token.clone(),
+        }),
+        certificate: Some(McpCertificateStatus {
+            status: enum_name(&domain.status.certificate_status),
+            detailed_status: enum_name_option(&domain.status.certificate_status_detailed),
+            error_message: domain.status.certificate_error_message.clone(),
+            error_type: enum_name_option(&domain.status.certificate_error_type),
+            retryable: domain.status.certificate_retryable,
+            cdn_provider: enum_name_option(&domain.status.cdn_provider),
+        }),
+    }
+}
+
+fn find_mcp_domain<'a>(
+    domains: &'a [McpDomainDetails],
+    identifier: &str,
+) -> Option<&'a McpDomainDetails> {
+    let normalized = normalize_domain_identifier(identifier);
+
+    domains.iter().find(|domain| {
+        domain.id.eq_ignore_ascii_case(identifier)
+            || domain.domain.eq_ignore_ascii_case(&normalized)
+    })
+}
+
+fn normalize_domain_identifier(identifier: &str) -> String {
+    let trimmed = identifier.trim();
+    let without_scheme = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+
+    without_scheme
+        .split('/')
+        .next()
+        .unwrap_or(without_scheme)
+        .trim_end_matches('.')
+        .to_string()
+}
+
+fn format_domains(domains: &[McpDomainDetails]) -> String {
+    if domains.is_empty() {
+        return "No domains found.".to_string();
+    }
+
+    let mut output = String::from("## Domains\n");
+    for domain in domains {
+        output.push_str(&format!(
+            "- https://{} (type: {}, id: {}, target_port: {}, sync_status: {})\n",
+            domain.domain,
+            domain.kind,
+            domain.id,
+            format_target_port(domain.target_port),
+            domain.sync_status
+        ));
+    }
+    output
+}
+
+fn format_domain_details(domain: &McpDomainDetails) -> String {
+    let mut output = format!(
+        "## Domain status\nURL: https://{}\nID: {}\nType: {}\nTarget port: {}\nSync status: {}\n",
+        domain.domain,
+        domain.id,
+        domain.kind,
+        format_target_port(domain.target_port),
+        domain.sync_status
+    );
+
+    if let Some(verification) = &domain.verification {
+        output.push_str(&format!(
+            "Verified: {}\n",
+            if verification.verified { "yes" } else { "no" }
+        ));
+    }
+
+    if let Some(certificate) = &domain.certificate {
+        output.push_str(&format!("Certificate status: {}\n", certificate.status));
+        if let Some(detailed_status) = &certificate.detailed_status {
+            output.push_str(&format!("Certificate detail: {detailed_status}\n"));
+        }
+        if let Some(error_message) = &certificate.error_message {
+            output.push_str(&format!("Certificate error: {error_message}\n"));
+        }
+        if let Some(error_type) = &certificate.error_type {
+            output.push_str(&format!("Certificate error type: {error_type}\n"));
+        }
+        if let Some(retryable) = certificate.retryable {
+            output.push_str(&format!("Certificate retryable: {retryable}\n"));
+        }
+        if let Some(cdn_provider) = &certificate.cdn_provider {
+            output.push_str(&format!("CDN provider: {cdn_provider}\n"));
+        }
+    }
+
+    if !domain.dns_records.is_empty() {
+        output.push_str("\nDNS records:\n");
+        for record in &domain.dns_records {
+            output.push_str(&format!(
+                "- {} {} -> {} (status: {}, current: {})\n",
+                record.record_type,
+                record.name,
+                record.required_value,
+                record.status,
+                if record.current_value.is_empty() {
+                    "-"
+                } else {
+                    &record.current_value
+                }
+            ));
+        }
+
+        if let Some(verification) = &domain.verification
+            && !verification.verified
+            && let (Some(host), Some(token)) = (&verification.dns_host, &verification.token)
+        {
+            let zone = domain
+                .dns_records
+                .first()
+                .map(|record| record.zone.as_str())
+                .unwrap_or("");
+            let host_label = host.strip_suffix(&format!(".{zone}")).unwrap_or(host);
+            output.push_str(&format!(
+                "- TXT {host_label} -> railway-verify={token} (verification)\n"
+            ));
+        }
+    }
+
+    output
+}
+
+fn format_target_port(port: Option<i64>) -> String {
+    port.map(|port| port.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn mcp_service_domain_input(
+    domain: &McpDomainDetails,
+    new_domain: &str,
+) -> Result<String, McpError> {
+    let normalized = normalize_domain_identifier(new_domain);
+
+    if normalized.is_empty() {
+        return Err(McpError::invalid_params(
+            "new_domain must not be empty.",
+            None,
+        ));
+    }
+
+    if normalized.contains('.') {
+        return Ok(normalized);
+    }
+
+    let Some(suffix) = &domain.service_domain_suffix else {
+        return Err(McpError::invalid_params(
+            "Pass the full service domain because the current suffix could not be resolved.",
+            None,
+        ));
+    };
+
+    Ok(format!("{normalized}.{suffix}"))
+}
+
+fn enum_name<T: fmt::Debug>(value: &T) -> String {
+    format!("{value:?}")
+}
+
+fn enum_name_option<T: fmt::Debug>(value: &Option<T>) -> Option<String> {
+    value.as_ref().map(enum_name)
+}
+
+fn validate_domain_port(port: i64) -> Result<i64, McpError> {
+    if (1..=65535).contains(&port) {
+        Ok(port)
+    } else {
+        Err(McpError::invalid_params(
+            "port must be a number from 1 to 65535",
+            None,
+        ))
+    }
 }
 
 #[tool_router]
@@ -589,36 +919,17 @@ impl RailwayMcp {
         let ctx = self
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
+        let target_port = params.port.map(validate_domain_port).transpose()?;
 
         if let Some(custom_domain) = &params.domain {
-            // Custom domain flow: check availability then create
-            let avail_vars = queries::custom_domain_available::Variables {
-                domain: custom_domain.clone(),
-            };
-            let avail = post_graphql::<queries::CustomDomainAvailable, _>(
-                &self.client,
-                self.configs.get_backboard(),
-                avail_vars,
-            )
-            .await
-            .map_err(|e| {
-                McpError::internal_error(format!("Failed to check domain availability: {e}"), None)
-            })?;
-
-            if !avail.custom_domain_available.available {
-                let msg = &avail.custom_domain_available.message;
-                return Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Domain '{custom_domain}' is not available: {msg}"
-                ))]));
-            }
-
+            // Custom domain creation performs availability checks server-side.
             let create_vars = mutations::custom_domain_create::Variables {
                 input: mutations::custom_domain_create::CustomDomainCreateInput {
                     domain: custom_domain.clone(),
-                    environment_id: ctx.environment_id,
-                    project_id: ctx.project_id,
-                    service_id: ctx.service_id,
-                    target_port: params.port,
+                    environment_id: ctx.environment_id.clone(),
+                    project_id: ctx.project_id.clone(),
+                    service_id: ctx.service_id.clone(),
+                    target_port,
                 },
             };
             let result = post_graphql::<mutations::CustomDomainCreate, _>(
@@ -631,69 +942,31 @@ impl RailwayMcp {
                 McpError::internal_error(format!("Failed to create custom domain: {e}"), None)
             })?;
 
-            let domain_data = &result.custom_domain_create;
-            let mut output = format!(
-                "Custom domain created: {}\n\nDNS Records to configure:\n",
-                domain_data.domain
-            );
-            for record in &domain_data.status.dns_records {
-                output.push_str(&format!(
-                    "  {} {} -> {}\n",
-                    record.record_type, record.hostlabel, record.required_value
-                ));
-            }
-
-            // Include TXT verification record if the domain is not yet verified
-            if !domain_data.status.verified {
-                if let (Some(host), Some(token)) = (
-                    &domain_data.status.verification_dns_host,
-                    &domain_data.status.verification_token,
-                ) {
-                    let zone = domain_data
-                        .status
-                        .dns_records
-                        .first()
-                        .map(|r| r.zone.as_str())
-                        .unwrap_or("");
-                    let host_label = host.strip_suffix(&format!(".{zone}")).unwrap_or(host);
-                    output.push_str(&format!(
-                        "\nVerification TXT record (required):\n  TXT {host_label} -> railway-verify={token}\n"
-                    ));
-                }
-            }
-
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            let domain = self
+                .resolve_domain_details(&ctx, &result.custom_domain_create.id)
+                .await?;
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "Custom domain created.\n\n{}",
+                format_domain_details(&domain)
+            ))]))
         } else {
             // Service domain flow: return existing or create new
-            let domain_vars = queries::domains::Variables {
-                environment_id: ctx.environment_id.clone(),
-                project_id: ctx.project_id.clone(),
-                service_id: ctx.service_id.clone(),
-            };
-            let existing = post_graphql::<queries::Domains, _>(
-                &self.client,
-                self.configs.get_backboard(),
-                domain_vars,
-            )
-            .await
-            .map_err(|e| McpError::internal_error(format!("Failed to query domains: {e}"), None))?;
+            let existing = self.fetch_domains(&ctx).await?;
 
-            let domains = &existing.domains;
+            let domains = &existing;
             if !domains.service_domains.is_empty() || !domains.custom_domains.is_empty() {
-                let mut output = String::from("Existing domains:\n");
-                for sd in &domains.service_domains {
-                    output.push_str(&format!("  Service domain: https://{}\n", sd.domain));
-                }
-                for cd in &domains.custom_domains {
-                    output.push_str(&format!("  Custom domain: https://{}\n", cd.domain));
-                }
+                let output = format!(
+                    "Existing domains:\n{}",
+                    format_domains(&mcp_domain_items(domains))
+                );
                 return Ok(CallToolResult::success(vec![Content::text(output)]));
             }
 
             // No domains exist — create a service domain
             let create_vars = mutations::service_domain_create::Variables {
-                environment_id: ctx.environment_id,
-                service_id: ctx.service_id,
+                environment_id: ctx.environment_id.clone(),
+                service_id: ctx.service_id.clone(),
+                target_port,
             };
             let result = post_graphql::<mutations::ServiceDomainCreate, _>(
                 &self.client,
@@ -705,11 +978,190 @@ impl RailwayMcp {
                 McpError::internal_error(format!("Failed to create service domain: {e}"), None)
             })?;
 
+            let domain = self
+                .resolve_domain_details(&ctx, &result.service_domain_create.id)
+                .await?;
             Ok(CallToolResult::success(vec![Content::text(format!(
-                "Service domain created: https://{}",
-                result.service_domain_create.domain
+                "Service domain created.\n\n{}",
+                format_domain_details(&domain)
             ))]))
         }
+    }
+
+    #[tool(
+        description = "List service and custom domains for a service. Returns domain, type, ID, target port, and sync status."
+    )]
+    async fn list_domains(
+        &self,
+        Parameters(params): Parameters<ServiceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let domains = self.fetch_domains(&ctx).await?;
+        Ok(CallToolResult::success(vec![Content::text(
+            format_domains(&mcp_domain_items(&domains)),
+        )]))
+    }
+
+    #[tool(
+        description = "Show status for a service or custom domain by domain name, URL, or domain ID. Includes DNS records, verification status, certificate status/errors, sync status, and target port."
+    )]
+    async fn domain_status(
+        &self,
+        Parameters(params): Parameters<DomainStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let domain = self.resolve_domain_details(&ctx, &params.domain).await?;
+        Ok(CallToolResult::success(vec![Content::text(
+            format_domain_details(&domain),
+        )]))
+    }
+
+    #[tool(
+        description = "Delete a custom or service domain by domain name, URL, or domain ID. This is irreversible. Returns a preview first.",
+        annotations(destructive_hint = true)
+    )]
+    async fn delete_domain(
+        &self,
+        Parameters(params): Parameters<DeleteDomainParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let domain = self.resolve_domain_details(&ctx, &params.domain).await?;
+
+        if !params.confirm {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "⚠️ This will permanently delete {} domain https://{} (id: {}). Call again with confirm: true to proceed.",
+                domain.kind, domain.domain, domain.id
+            ))]));
+        }
+
+        match domain.kind {
+            McpDomainKind::Custom => {
+                post_graphql::<mutations::CustomDomainDelete, _>(
+                    &self.client,
+                    self.configs.get_backboard(),
+                    mutations::custom_domain_delete::Variables {
+                        id: domain.id.clone(),
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to delete custom domain: {e}"), None)
+                })?;
+            }
+            McpDomainKind::Service => {
+                post_graphql::<mutations::ServiceDomainDelete, _>(
+                    &self.client,
+                    self.configs.get_backboard(),
+                    mutations::service_domain_delete::Variables {
+                        id: domain.id.clone(),
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to delete service domain: {e}"), None)
+                })?;
+            }
+        }
+
+        let domains = self.fetch_domains(&ctx).await?;
+        let remaining = mcp_domain_items(&domains);
+        if find_mcp_domain(&remaining, &domain.id).is_some() {
+            return Err(McpError::internal_error(
+                format!(
+                    "Domain deletion was requested, but {} still exists after verification.",
+                    domain.id
+                ),
+                None,
+            ));
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Deleted {} domain https://{} (id: {}).",
+            domain.kind, domain.domain, domain.id
+        ))]))
+    }
+
+    #[tool(
+        description = "Update a custom or service domain by domain name, URL, or domain ID. Supports target port changes for both domain types and Railway service-domain renames via new_domain. Port must be from 1 to 65535. Returns updated status after readback."
+    )]
+    async fn update_domain(
+        &self,
+        Parameters(params): Parameters<UpdateDomainParams>,
+    ) -> Result<CallToolResult, McpError> {
+        if params.port.is_none() && params.new_domain.is_none() {
+            return Err(McpError::invalid_params(
+                "Provide port, new_domain, or both.",
+                None,
+            ));
+        }
+
+        let port = params.port.map(validate_domain_port).transpose()?;
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let domain = self.resolve_domain_details(&ctx, &params.domain).await?;
+
+        match domain.kind {
+            McpDomainKind::Custom => {
+                if params.new_domain.is_some() {
+                    return Err(McpError::invalid_params(
+                        "Custom domains cannot be renamed. Create the new custom domain, then delete the old one.",
+                        None,
+                    ));
+                }
+
+                post_graphql::<mutations::CustomDomainUpdate, _>(
+                    &self.client,
+                    self.configs.get_backboard(),
+                    mutations::custom_domain_update::Variables {
+                        environment_id: domain.environment_id.clone(),
+                        id: domain.id.clone(),
+                        target_port: port,
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to update custom domain: {e}"), None)
+                })?;
+            }
+            McpDomainKind::Service => {
+                post_graphql::<mutations::ServiceDomainUpdate, _>(
+                    &self.client,
+                    self.configs.get_backboard(),
+                    mutations::service_domain_update::Variables {
+                        input: mutations::service_domain_update::ServiceDomainUpdateInput {
+                            domain: params
+                                .new_domain
+                                .as_deref()
+                                .map(|new_domain| mcp_service_domain_input(&domain, new_domain))
+                                .transpose()?
+                                .unwrap_or_else(|| domain.domain.clone()),
+                            environment_id: domain.environment_id.clone(),
+                            service_domain_id: domain.id.clone(),
+                            service_id: domain.service_id.clone(),
+                            target_port: port,
+                        },
+                    },
+                )
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("Failed to update service domain: {e}"), None)
+                })?;
+            }
+        }
+
+        let updated = self.resolve_domain_details(&ctx, &domain.id).await?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Updated domain https://{}.\n\n{}",
+            domain.domain,
+            format_domain_details(&updated)
+        ))]))
     }
 
     #[tool(
@@ -1322,5 +1774,59 @@ impl ServerHandler for RailwayMcp {
                 "Railway MCP server. Manage your Railway projects, services, deployments, and more.".to_string(),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_domain() -> McpDomainDetails {
+        McpDomainDetails {
+            id: "dom_123".to_string(),
+            domain: "api.example.com".to_string(),
+            kind: McpDomainKind::Custom,
+            target_port: Some(3000),
+            sync_status: "ACTIVE".to_string(),
+            service_domain_suffix: None,
+            environment_id: "env_123".to_string(),
+            service_id: "svc_123".to_string(),
+            dns_records: Vec::new(),
+            verification: None,
+            certificate: None,
+        }
+    }
+
+    fn sample_service_domain() -> McpDomainDetails {
+        let mut domain = sample_domain();
+        domain.kind = McpDomainKind::Service;
+        domain.domain = "api.up.railway.app".to_string();
+        domain.service_domain_suffix = Some("up.railway.app".to_string());
+        domain
+    }
+
+    #[test]
+    fn mcp_domain_lookup_accepts_id_name_and_url() {
+        let domains = vec![sample_domain()];
+
+        assert!(find_mcp_domain(&domains, "dom_123").is_some());
+        assert!(find_mcp_domain(&domains, "API.EXAMPLE.COM").is_some());
+        assert!(find_mcp_domain(&domains, "https://api.example.com/").is_some());
+        assert!(find_mcp_domain(&domains, "missing.example.com").is_none());
+    }
+
+    #[test]
+    fn mcp_service_domain_input_accepts_full_domain_or_host_label() {
+        let domain = sample_service_domain();
+
+        assert_eq!(
+            mcp_service_domain_input(&domain, "web.up.railway.app").unwrap(),
+            "web.up.railway.app"
+        );
+        assert_eq!(
+            mcp_service_domain_input(&domain, "web").unwrap(),
+            "web.up.railway.app"
+        );
+        assert!(mcp_service_domain_input(&domain, "").is_err());
     }
 }

--- a/src/commands/mcp/params.rs
+++ b/src/commands/mcp/params.rs
@@ -131,6 +131,61 @@ pub struct GenerateDomainParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DomainStatusParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Domain name, URL, or domain ID.
+    pub domain: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct DeleteDomainParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Domain name, URL, or domain ID.
+    pub domain: String,
+    /// Must be set to true to confirm deletion. This action is irreversible.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub confirm: bool,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct UpdateDomainParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Domain name, URL, or domain ID.
+    pub domain: String,
+    /// Target port for the domain. Must be from 1 to 65535.
+    #[serde(default)]
+    pub port: Option<i64>,
+    /// Rename a Railway-provided service domain. Accepts a full service domain or host label.
+    #[serde(default)]
+    pub new_domain: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct LinkServiceParams {
     /// The project ID. If omitted, uses the currently linked project.
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -291,10 +291,6 @@ impl Configs {
         format!("https://backboard.{}/graphql/v2", self.get_host())
     }
 
-    pub fn get_backboard_internal(&self) -> String {
-        format!("https://backboard.{}/graphql/internal", self.get_host())
-    }
-
     /// SSH relay host and non-default port for the current environment.
     /// Mirrors backboard's `controllers/ssh` mapping: only the develop relay
     /// is separate (and listens on 2222); staging falls through to the

--- a/src/config.rs
+++ b/src/config.rs
@@ -291,6 +291,10 @@ impl Configs {
         format!("https://backboard.{}/graphql/v2", self.get_host())
     }
 
+    pub fn get_backboard_internal(&self) -> String {
+        format!("https://backboard.{}/graphql/internal", self.get_host())
+    }
+
     /// SSH relay host and non-default port for the current environment.
     /// Mirrors backboard's `controllers/ssh` mapping: only the develop relay
     /// is separate (and listens on 2222); staging falls through to the

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -264,6 +264,14 @@ pub struct CustomDomainDelete;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/CustomDomainIssueCertificate.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct CustomDomainIssueCertificate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/EnvironmentCreate.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -53,6 +53,23 @@ pub struct ServiceDomainCreate;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/ServiceDomainUpdate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct ServiceDomainUpdate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/ServiceDomainDelete.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ServiceDomainDelete;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/ValidateTwoFactor.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]
@@ -226,6 +243,23 @@ pub struct ServiceDisconnect;
     skip_serializing_none
 )]
 pub struct CustomDomainCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/CustomDomainUpdate.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct CustomDomainUpdate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/CustomDomainDelete.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct CustomDomainDelete;
 
 #[derive(GraphQLQuery)]
 #[graphql(

--- a/src/gql/mutations/strings/CustomDomainCreate.graphql
+++ b/src/gql/mutations/strings/CustomDomainCreate.graphql
@@ -8,6 +8,7 @@ mutation CustomDomainCreate($input: CustomDomainCreateInput!) {
     environmentId
     projectId
     targetPort
+    syncStatus
     status {
       dnsRecords {
         hostlabel
@@ -28,6 +29,10 @@ mutation CustomDomainCreate($input: CustomDomainCreateInput!) {
         keyType
       }
       certificateStatus
+      certificateStatusDetailed
+      certificateErrorMessage
+      certificateErrorType
+      certificateRetryable
       verificationToken
       verificationDnsHost
       verified

--- a/src/gql/mutations/strings/CustomDomainDelete.graphql
+++ b/src/gql/mutations/strings/CustomDomainDelete.graphql
@@ -1,0 +1,3 @@
+mutation CustomDomainDelete($id: String!) {
+  customDomainDelete(id: $id)
+}

--- a/src/gql/mutations/strings/CustomDomainIssueCertificate.graphql
+++ b/src/gql/mutations/strings/CustomDomainIssueCertificate.graphql
@@ -1,0 +1,3 @@
+mutation CustomDomainIssueCertificate($id: String!) {
+  customDomainIssueCertificate(id: $id)
+}

--- a/src/gql/mutations/strings/CustomDomainUpdate.graphql
+++ b/src/gql/mutations/strings/CustomDomainUpdate.graphql
@@ -1,0 +1,3 @@
+mutation CustomDomainUpdate($environmentId: String!, $id: String!, $targetPort: Int) {
+  customDomainUpdate(environmentId: $environmentId, id: $id, targetPort: $targetPort)
+}

--- a/src/gql/mutations/strings/ServiceDomainCreate.graphql
+++ b/src/gql/mutations/strings/ServiceDomainCreate.graphql
@@ -1,8 +1,23 @@
-mutation ServiceDomainCreate($environmentId: String!, $serviceId: String!) {
+mutation ServiceDomainCreate(
+  $environmentId: String!
+  $serviceId: String!
+  $targetPort: Int
+) {
   serviceDomainCreate(
-    input: { environmentId: $environmentId, serviceId: $serviceId }
+    input: {
+      environmentId: $environmentId
+      serviceId: $serviceId
+      targetPort: $targetPort
+    }
   ) {
     id
     domain
+    suffix
+    environmentId
+    serviceId
+    targetPort
+    syncStatus
+    createdAt
+    updatedAt
   }
 }

--- a/src/gql/mutations/strings/ServiceDomainDelete.graphql
+++ b/src/gql/mutations/strings/ServiceDomainDelete.graphql
@@ -1,0 +1,3 @@
+mutation ServiceDomainDelete($id: String!) {
+  serviceDomainDelete(id: $id)
+}

--- a/src/gql/mutations/strings/ServiceDomainUpdate.graphql
+++ b/src/gql/mutations/strings/ServiceDomainUpdate.graphql
@@ -1,0 +1,3 @@
+mutation ServiceDomainUpdate($input: ServiceDomainUpdateInput!) {
+  serviceDomainUpdate(input: $input)
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -173,14 +173,6 @@ pub struct GitHubRepos;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
-    query_path = "src/gql/queries/strings/CustomDomainAvailable.graphql",
-    response_derives = "Debug, Serialize, Clone"
-)]
-pub struct CustomDomainAvailable;
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/Regions.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/CustomDomainAvailable.graphql
+++ b/src/gql/queries/strings/CustomDomainAvailable.graphql
@@ -1,7 +1,0 @@
-query CustomDomainAvailable($domain: String!) {
-  customDomainAvailable(domain: $domain) {
-    __typename
-    available
-    message
-  }
-}

--- a/src/gql/queries/strings/Domains.graphql
+++ b/src/gql/queries/strings/Domains.graphql
@@ -11,10 +11,52 @@ query Domains(
     serviceDomains {
       id
       domain
+      suffix
+      environmentId
+      serviceId
+      targetPort
+      syncStatus
+      createdAt
+      updatedAt
     }
     customDomains {
       id
       domain
+      environmentId
+      projectId
+      serviceId
+      targetPort
+      syncStatus
+      createdAt
+      updatedAt
+      status {
+        dnsRecords {
+          hostlabel
+          fqdn
+          recordType
+          requiredValue
+          currentValue
+          status
+          zone
+          purpose
+        }
+        cdnProvider
+        certificateStatus
+        certificateStatusDetailed
+        certificateErrorMessage
+        certificateErrorType
+        certificateRetryable
+        certificates {
+          issuedAt
+          expiresAt
+          domainNames
+          fingerprintSha256
+          keyType
+        }
+        verificationToken
+        verificationDnsHost
+        verified
+      }
     }
   }
 }

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -13782,6 +13782,37 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Issues a new certificate",
+              "isDeprecated": false,
+              "name": "customDomainIssueCertificate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "environmentId",
                   "type": {
                     "kind": "NON_NULL",


### PR DESCRIPTION
## Summary

Adds a Domain Management MVP to the Railway CLI and local MCP server. Users and agents can now create, list, inspect, update, retry certificates for, and delete Railway service domains and custom domains from the CLI.

## What Changed

- Added domain subcommands:
  - `railway domain list` / `ls`
  - `railway domain status <domain-or-id>`
  - `railway domain update <domain-or-id>`
  - `railway domain certificate retry <domain-or-id>`
  - `railway domain delete <domain-or-id>` / `remove` / `rm`
- Extended existing `railway domain [DOMAIN]` create behavior with `--port`.
- Added service-domain target port updates and service-domain rename support.
- Added custom-domain target port updates.
- Added custom-domain certificate retry support.
- Added local MCP parity for create/list/status/update/certificate retry/delete domain workflows.
- Preserved legacy `railway domain --json` output shapes.
- Fixed custom-domain creation with CLI OAuth by removing the standalone `customDomainAvailable` preflight and relying on `customDomainCreate`, matching dashboard behavior.

## CLI Commands

```bash
railway domain [DOMAIN] [--port <PORT>] [--service <SERVICE>] [--environment <ENVIRONMENT>] [--project <PROJECT_ID>] [--json]
railway domain list [--service <SERVICE>] [--environment <ENVIRONMENT>] [--project <PROJECT_ID>] [--json]
railway domain status <DOMAIN_OR_ID> [--service <SERVICE>] [--environment <ENVIRONMENT>] [--project <PROJECT_ID>] [--json]
railway domain update <DOMAIN_OR_ID> [--port <PORT>] [--domain <DOMAIN_OR_LABEL>] [--service <SERVICE>] [--environment <ENVIRONMENT>] [--project <PROJECT_ID>] [--json]
railway domain certificate retry <DOMAIN_OR_ID> [--service <SERVICE>] [--environment <ENVIRONMENT>] [--project <PROJECT_ID>] [--json]
railway domain delete <DOMAIN_OR_ID> [--yes] [--service <SERVICE>] [--environment <ENVIRONMENT>] [--project <PROJECT_ID>] [--json]
```

Notes:

- `<DOMAIN_OR_ID>` accepts a domain ID, domain name, or full URL.
- `--port` must be in the range `1-65535`.
- `--domain` renames Railway-provided service domains only. Custom domains cannot be renamed.
- `domain certificate retry` supports custom domains only.
- `--yes` makes deletion non-interactive.

## JSON Output Contracts

Legacy create/list behavior remains compatible:

```json
{ "domain": "https://example.up.railway.app" }
```

```json
{ "domains": ["https://example.up.railway.app"] }
```

`railway domain list --json`:

```json
{
  "domains": [
    {
      "id": "0240ae9b-453b-4885-abcc-30c79ecdaab1",
      "domain": "example.up.railway.app",
      "type": "service",
      "targetPort": 8080,
      "syncStatus": "ACTIVE",
      "createdAt": "2026-06-14T13:01:36.312+00:00",
      "updatedAt": "2026-06-14T13:01:36.866+00:00"
    }
  ]
}
```

`railway domain status --json`, `railway domain update --json`, and `railway domain certificate retry --json`:

```json
{
  "domain": {
    "id": "c310f34c-0276-4eba-a6fa-9c85e07fe518",
    "domain": "custom.example.com",
    "type": "custom",
    "targetPort": 8080,
    "syncStatus": "ACTIVE",
    "createdAt": "2026-06-14T13:00:14.183+00:00",
    "updatedAt": "2026-06-14T13:00:49.926+00:00",
    "dnsRecords": [
      {
        "recordType": "DNS_RECORD_TYPE_CNAME",
        "name": "custom",
        "fqdn": "custom.example.com",
        "requiredValue": "example.up.railway.app",
        "currentValue": "",
        "status": "DNS_RECORD_STATUS_REQUIRES_UPDATE",
        "zone": "example.com",
        "purpose": "DNS_RECORD_PURPOSE_TRAFFIC_ROUTE"
      }
    ],
    "verification": {
      "verified": false,
      "dnsHost": "_railway-verify.custom",
      "token": "railway-verify=..."
    },
    "certificate": {
      "status": "CERTIFICATE_STATUS_TYPE_VALIDATING_OWNERSHIP"
    }
  }
}
```

`railway domain delete --json`:

```json
{
  "deleted": true,
  "domain": {
    "id": "c310f34c-0276-4eba-a6fa-9c85e07fe518",
    "domain": "custom.example.com",
    "type": "custom",
    "targetPort": 8080,
    "syncStatus": "ACTIVE",
    "createdAt": "2026-06-14T13:00:14.183+00:00",
    "updatedAt": "2026-06-14T13:00:49.926+00:00"
  }
}
```

Custom-domain creation keeps the existing mutation-shaped output:

```json
{
  "customDomainCreate": {
    "id": "c310f34c-0276-4eba-a6fa-9c85e07fe518",
    "domain": "custom.example.com",
    "targetPort": 3000,
    "syncStatus": "CREATING",
    "status": {
      "dnsRecords": [],
      "certificateStatus": "CERTIFICATE_STATUS_TYPE_VALIDATING_OWNERSHIP",
      "verified": false
    }
  }
}
```

## MCP Tools

- `generate_domain`
- `list_domains`
- `domain_status`
- `update_domain`
- `retry_domain_certificate`
- `delete_domain`

## Notes

- Dashboard domain management uses direct domain mutations, not the environment patch flow. This PR matches that API flow.
- TCP proxies still use the environment patch flow in the dashboard; domains do not.
- Certificate retry uses the dashboard/internal `customDomainIssueCertificate` mutation with token auth.
- Service-domain creation now passes `targetPort` directly to `serviceDomainCreate`, avoiding create-then-update sync races.
- Custom-domain creation now matches the dashboard mutation path, which avoids the CLI OAuth failure caused by calling the standalone availability query.

## Testing

- `cargo build --quiet`
- `cargo test --quiet`
  - `322 passed`
- `git diff --check`

## Live Smoke Test

Ran a full end-to-end smoke test against a new Railway project:

- Created and deployed a Node service.
- Verified deployment reached `SUCCESS`.
- Created/listed/inspected/updated/renamed/deleted a service domain.
- Verified service-domain live routing moved from port `3000` to `8080`.
- Created/listed/inspected/updated/deleted a custom domain.
- Verified custom-domain DNS, certificate, and verification output.
- Created a disposable custom domain, retried certificate issuance by ID, verified service-domain retry is rejected, then deleted the disposable custom domain.
- Recreated a final service domain and verified legacy JSON output remains compatible.

Final smoke project was intentionally left running for inspection.
