### PR TITLE
Add TCP proxy command

### DIFF
--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1001,6 +1001,47 @@ impl RailwayMcp {
     }
 
     #[tool(
+        description = "List public TCP proxies for a Railway service. Returns endpoint, ID, proxy port, application port, and sync status."
+    )]
+    async fn list_tcp_proxies(
+        &self,
+        Parameters(params): Parameters<ServiceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_list_tcp_proxies(params).await
+    }
+
+    #[tool(
+        description = "Create a public TCP proxy for a Railway service application port. Only one TCP proxy is allowed per service instance."
+    )]
+    async fn create_tcp_proxy(
+        &self,
+        Parameters(params): Parameters<CreateTcpProxyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_create_tcp_proxy(params).await
+    }
+
+    #[tool(
+        description = "Get details for one public TCP proxy by ID, domain, endpoint, proxy port, or application port."
+    )]
+    async fn get_tcp_proxy(
+        &self,
+        Parameters(params): Parameters<TcpProxySelectorParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_get_tcp_proxy(params).await
+    }
+
+    #[tool(
+        description = "Remove a public TCP proxy by ID, domain, endpoint, proxy port, or application port. This is irreversible and returns a preview first.",
+        annotations(destructive_hint = true)
+    )]
+    async fn remove_tcp_proxy(
+        &self,
+        Parameters(params): Parameters<RemoveTcpProxyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_remove_tcp_proxy(params).await
+    }
+
+    #[tool(
         description = "Set reference variables on a service. Each variable value must be a Railway reference expression starting with '${{' (e.g. '${{ Postgres.DATABASE_URL }}')."
     )]
     async fn add_reference_variable(
@@ -1224,6 +1265,26 @@ impl RailwayMcp {
             response.deployment_domain,
             response.deployment_id,
         ))]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tcp_proxy_tools_are_registered() {
+        let router = RailwayMcp::tool_router();
+        let tools = router.list_all();
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"list_tcp_proxies"));
+        assert!(names.contains(&"create_tcp_proxy"));
+        assert!(names.contains(&"get_tcp_proxy"));
+        assert!(names.contains(&"remove_tcp_proxy"));
     }
 }
 

--- a/src/commands/mcp/params.rs
+++ b/src/commands/mcp/params.rs
@@ -23,6 +23,55 @@ pub struct ServiceParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreateTcpProxyParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Application port to expose through the TCP proxy.
+    pub application_port: i64,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct TcpProxySelectorParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// TCP proxy ID, domain, endpoint, proxy port, or application port.
+    pub proxy: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct RemoveTcpProxyParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// TCP proxy ID, domain, endpoint, proxy port, or application port.
+    pub proxy: String,
+    /// Must be set to true to confirm deletion. This action is irreversible.
+    #[serde(default)]
+    #[schemars(skip)]
+    pub confirm: bool,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ListDeploymentsParams {
     /// The project ID. If omitted, uses the currently linked project.
     #[serde(default)]

--- a/src/commands/mcp/tools/mod.rs
+++ b/src/commands/mcp/tools/mod.rs
@@ -3,3 +3,4 @@ pub mod observability;
 pub mod project;
 pub mod service;
 pub mod storage;
+pub mod tcp_proxy;

--- a/src/commands/mcp/tools/tcp_proxy.rs
+++ b/src/commands/mcp/tools/tcp_proxy.rs
@@ -235,7 +235,7 @@ fn format_tcp_proxy_create_for_service(
         output.push_str(&format!("\n{}", format_tcp_proxy_details(proxy)));
     } else {
         output.push_str(
-            "\nRedeploy the service for the TCP proxy to become active, then call list_tcp_proxies.",
+            "\nThe TCP proxy is configured but is not readable yet. Call list_tcp_proxies shortly; if it does not become active, redeploy the service.",
         );
     }
 
@@ -338,6 +338,6 @@ mod tests {
         let staged =
             format_tcp_proxy_create_for_service("redis", "svc_123", 5432, PatchMode::Stage, None);
         assert!(staged.contains("Change: staged"));
-        assert!(staged.contains("Redeploy the service"));
+        assert!(staged.contains("if it does not become active, redeploy the service"));
     }
 }

--- a/src/commands/mcp/tools/tcp_proxy.rs
+++ b/src/commands/mcp/tools/tcp_proxy.rs
@@ -1,0 +1,343 @@
+use rmcp::{ErrorData as McpError, model::*};
+
+use crate::controllers::tcp_proxy::{self, PatchMode, TcpProxy};
+
+use super::super::handler::{RailwayMcp, ResolvedServiceContext};
+use super::super::params::{
+    CreateTcpProxyParams, RemoveTcpProxyParams, ServiceParams, TcpProxySelectorParams,
+};
+
+impl RailwayMcp {
+    pub(crate) async fn do_list_tcp_proxies(
+        &self,
+        params: ServiceParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let proxies = tcp_proxy::fetch_tcp_proxies(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch TCP proxies: {e}"), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_tcp_proxy_list(&ctx, &proxies),
+        )]))
+    }
+
+    pub(crate) async fn do_create_tcp_proxy(
+        &self,
+        params: CreateTcpProxyParams,
+    ) -> Result<CallToolResult, McpError> {
+        let port = tcp_proxy::validate_application_port(params.application_port)
+            .map_err(|e| McpError::invalid_params(e, None))?;
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let proxies = tcp_proxy::fetch_tcp_proxies(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch TCP proxies: {e}"), None))?;
+
+        if let Some(proxy) = tcp_proxy::existing_proxy_for_create(&proxies, port)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?
+        {
+            return Ok(CallToolResult::success(vec![Content::text(format!(
+                "TCP proxy already exists for application port {}.\n{}",
+                port,
+                format_tcp_proxy_details(proxy)
+            ))]));
+        }
+
+        let service_name = service_name(&ctx);
+        let mode = tcp_proxy::apply_tcp_proxy_patch(
+            &self.client,
+            &self.configs,
+            &ctx.context.project,
+            &ctx.environment_id,
+            &ctx.service_id,
+            &service_name,
+            port,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to configure TCP proxy: {e}"), None)
+        })?;
+
+        if mode == PatchMode::Commit {
+            tcp_proxy::verify_tcp_proxy_configured(
+                &self.client,
+                &self.configs,
+                &ctx.environment_id,
+                &ctx.service_id,
+                port,
+            )
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Failed to verify TCP proxy config: {e}"), None)
+            })?;
+        }
+
+        let active_proxy = tcp_proxy::fetch_tcp_proxies(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch TCP proxies: {e}"), None))?
+        .into_iter()
+        .find(|proxy| proxy.application_port == i64::from(port));
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_tcp_proxy_create(&ctx, port, mode, active_proxy.as_ref()),
+        )]))
+    }
+
+    pub(crate) async fn do_get_tcp_proxy(
+        &self,
+        params: TcpProxySelectorParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let proxies = tcp_proxy::fetch_tcp_proxies(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch TCP proxies: {e}"), None))?;
+        let proxy = resolve_tcp_proxy_from_list(&proxies, &params.proxy)?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_tcp_proxy_details(proxy),
+        )]))
+    }
+
+    pub(crate) async fn do_remove_tcp_proxy(
+        &self,
+        params: RemoveTcpProxyParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let proxies = tcp_proxy::fetch_tcp_proxies(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to fetch TCP proxies: {e}"), None))?;
+        let proxy = resolve_tcp_proxy_from_list(&proxies, &params.proxy)?;
+
+        if !params.confirm {
+            return Ok(CallToolResult::success(vec![Content::text(
+                format_tcp_proxy_remove_preview(proxy),
+            )]));
+        }
+
+        tcp_proxy::delete_tcp_proxy(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+            proxy,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to remove TCP proxy: {e}"), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "TCP proxy removed: {} (id: {}, application port: {}, committed: true)",
+            proxy.endpoint, proxy.id, proxy.application_port
+        ))]))
+    }
+}
+
+fn resolve_tcp_proxy_from_list<'a>(
+    proxies: &'a [TcpProxy],
+    identifier: &str,
+) -> Result<&'a TcpProxy, McpError> {
+    tcp_proxy::find_tcp_proxy(proxies, identifier)
+        .map_err(|e| McpError::invalid_params(e.to_string(), None))?
+        .ok_or_else(|| {
+            McpError::invalid_params(
+                format!(
+                    "TCP proxy '{}' not found on the selected service",
+                    identifier
+                ),
+                None,
+            )
+        })
+}
+
+fn format_tcp_proxy_list(ctx: &ResolvedServiceContext, proxies: &[TcpProxy]) -> String {
+    let service_name = service_name(ctx);
+    if proxies.is_empty() {
+        return format!(
+            "No TCP proxies found for service {service_name} (id: {}) in environment {}.",
+            ctx.service_id, ctx.environment_id
+        );
+    }
+
+    let mut output = format!(
+        "TCP proxies for service {service_name} (id: {}) in environment {}:\n",
+        ctx.service_id, ctx.environment_id
+    );
+    for proxy in proxies {
+        output.push_str(&format!(
+            "- {} (id: {}, application port: {}, proxy port: {}, sync: {})\n",
+            proxy.endpoint, proxy.id, proxy.application_port, proxy.proxy_port, proxy.sync_status
+        ));
+    }
+    output
+}
+
+fn format_tcp_proxy_create(
+    ctx: &ResolvedServiceContext,
+    port: u16,
+    mode: PatchMode,
+    active_proxy: Option<&TcpProxy>,
+) -> String {
+    let service_name = service_name(ctx);
+    format_tcp_proxy_create_for_service(&service_name, &ctx.service_id, port, mode, active_proxy)
+}
+
+fn format_tcp_proxy_create_for_service(
+    service_name: &str,
+    service_id: &str,
+    port: u16,
+    mode: PatchMode,
+    active_proxy: Option<&TcpProxy>,
+) -> String {
+    let change = match mode {
+        PatchMode::Commit => "committed",
+        PatchMode::Stage => {
+            "staged (environment has pending changes; use `railway environment edit` to commit)"
+        }
+    };
+    let mut output = format!(
+        "TCP proxy configured for service {service_name} (id: {}) on application port {port}.\nChange: {change}",
+        service_id
+    );
+
+    if let Some(proxy) = active_proxy {
+        output.push_str(&format!("\n{}", format_tcp_proxy_details(proxy)));
+    } else {
+        output.push_str(
+            "\nRedeploy the service for the TCP proxy to become active, then call list_tcp_proxies.",
+        );
+    }
+
+    output
+}
+
+fn format_tcp_proxy_details(proxy: &TcpProxy) -> String {
+    let mut output = format!(
+        "TCP proxy:\nEndpoint: {}\nID: {}\nDomain: {}\nProxy port: {}\nApplication port: {}\nSync status: {}\nService ID: {}\nEnvironment ID: {}",
+        proxy.endpoint,
+        proxy.id,
+        proxy.domain,
+        proxy.proxy_port,
+        proxy.application_port,
+        proxy.sync_status,
+        proxy.service_id,
+        proxy.environment_id
+    );
+
+    if let Some(created_at) = &proxy.created_at {
+        output.push_str(&format!("\nCreated: {created_at}"));
+    }
+    if let Some(updated_at) = &proxy.updated_at {
+        output.push_str(&format!("\nUpdated: {updated_at}"));
+    }
+
+    output
+}
+
+fn format_tcp_proxy_remove_preview(proxy: &TcpProxy) -> String {
+    format!(
+        "This will permanently remove TCP proxy {} (id: {}, application port: {}). Call again with confirm: true to proceed.",
+        proxy.endpoint, proxy.id, proxy.application_port
+    )
+}
+
+fn service_name(ctx: &ResolvedServiceContext) -> String {
+    ctx.context
+        .project
+        .services
+        .edges
+        .iter()
+        .find(|service| service.node.id == ctx.service_id)
+        .map(|service| service.node.name.clone())
+        .unwrap_or_else(|| ctx.service_id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_proxy() -> TcpProxy {
+        TcpProxy {
+            id: "tcp_123".to_string(),
+            domain: "containers-us-west.railway.app".to_string(),
+            proxy_port: 15432,
+            application_port: 5432,
+            endpoint: "containers-us-west.railway.app:15432".to_string(),
+            sync_status: "ACTIVE".to_string(),
+            service_id: "svc_123".to_string(),
+            environment_id: "env_123".to_string(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn tcp_proxy_details_include_agent_selectors() {
+        let output = format_tcp_proxy_details(&sample_proxy());
+
+        assert!(output.contains("Endpoint: containers-us-west.railway.app:15432"));
+        assert!(output.contains("ID: tcp_123"));
+        assert!(output.contains("Application port: 5432"));
+        assert!(output.contains("Sync status: ACTIVE"));
+    }
+
+    #[test]
+    fn tcp_proxy_remove_preview_requires_confirmation() {
+        let output = format_tcp_proxy_remove_preview(&sample_proxy());
+
+        assert!(output.contains("confirm: true"));
+        assert!(output.contains("tcp_123"));
+        assert!(output.contains("5432"));
+    }
+
+    #[test]
+    fn tcp_proxy_create_output_reports_staged_or_committed() {
+        let proxy = sample_proxy();
+
+        let committed = format_tcp_proxy_create_for_service(
+            "redis",
+            "svc_123",
+            5432,
+            PatchMode::Commit,
+            Some(&proxy),
+        );
+        assert!(committed.contains("Change: committed"));
+        assert!(committed.contains("Endpoint: containers-us-west.railway.app:15432"));
+
+        let staged =
+            format_tcp_proxy_create_for_service("redis", "svc_123", 5432, PatchMode::Stage, None);
+        assert!(staged.contains("Change: staged"));
+        assert!(staged.contains("Redeploy the service"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -46,6 +46,7 @@ pub mod skills;
 pub mod ssh;
 pub mod starship;
 pub mod status;
+pub mod tcp_proxy;
 pub mod telemetry_cmd;
 pub mod templates;
 pub mod unlink;

--- a/src/commands/tcp_proxy.rs
+++ b/src/commands/tcp_proxy.rs
@@ -1,17 +1,12 @@
-use std::collections::BTreeMap;
-
-use anyhow::{anyhow, bail};
+use anyhow::bail;
 use colored::Colorize;
 use is_terminal::IsTerminal;
 use serde::Serialize;
 
 use crate::{
     controllers::{
-        config::{
-            EnvironmentConfig, ServiceInstance, ServiceNetworking, TcpProxyConfig,
-            environment::fetch_environment_config,
-        },
-        project::{ServiceContext, resolve_service_context},
+        project::resolve_service_context,
+        tcp_proxy::{self, PatchMode, TcpProxy, parse_port},
     },
     util::{progress::create_spinner_if, prompt::prompt_confirm_with_default},
 };
@@ -101,18 +96,6 @@ pub async fn command(args: Args) -> Result<()> {
     Ok(())
 }
 
-fn parse_port(value: &str) -> std::result::Result<u16, String> {
-    let port = value
-        .parse::<u16>()
-        .map_err(|_| "port must be a number from 1 to 65535".to_string())?;
-
-    if port == 0 {
-        return Err("port must be a number from 1 to 65535".to_string());
-    }
-
-    Ok(port)
-}
-
 async fn list(
     project: Option<String>,
     service: Option<String>,
@@ -120,8 +103,13 @@ async fn list(
     json: bool,
 ) -> Result<()> {
     let ctx = resolve_service_context(project, service, environment).await?;
-    let proxies = fetch_tcp_proxies(&ctx).await?;
-    let outputs = proxy_outputs(&proxies);
+    let outputs = tcp_proxy::fetch_tcp_proxies(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
 
     if json {
         println!(
@@ -158,7 +146,14 @@ async fn status(
     json: bool,
 ) -> Result<()> {
     let ctx = resolve_service_context(project, service, environment).await?;
-    let proxy = resolve_proxy(&ctx, &proxy).await?;
+    let proxy = tcp_proxy::resolve_tcp_proxy(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        &proxy,
+    )
+    .await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&ProxyOutput { proxy })?);
@@ -178,9 +173,14 @@ async fn create(
     json: bool,
 ) -> Result<()> {
     let ctx = resolve_service_context(project, service, environment).await?;
-    let existing = fetch_tcp_proxies(&ctx).await?;
-    let existing_outputs = proxy_outputs(&existing);
-    if let Some(proxy) = existing_proxy_for_create(&existing_outputs, port)? {
+    let existing = tcp_proxy::fetch_tcp_proxies(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    if let Some(proxy) = tcp_proxy::existing_proxy_for_create(&existing, port)? {
         let proxy = proxy.clone();
         if json {
             println!(
@@ -203,15 +203,35 @@ async fn create(
     }
 
     let spinner = create_spinner_if(!json, "Configuring TCP proxy...".into());
-    let patch_mode = apply_tcp_proxy_patch(&ctx, port).await?;
+    let patch_mode = tcp_proxy::apply_tcp_proxy_patch(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.project,
+        &ctx.environment_id,
+        &ctx.service_id,
+        &ctx.service_name,
+        port,
+    )
+    .await?;
     if patch_mode == PatchMode::Commit {
-        verify_tcp_proxy_configured(&ctx, port).await?;
+        tcp_proxy::verify_tcp_proxy_configured(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+            port,
+        )
+        .await?;
     }
-    let active_proxy = fetch_tcp_proxies(&ctx)
-        .await?
-        .iter()
-        .find(|proxy| proxy.application_port == i64::from(port) && proxy.deleted_at.is_none())
-        .map(proxy_output);
+    let active_proxy = tcp_proxy::fetch_tcp_proxies(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?
+    .into_iter()
+    .find(|proxy| proxy.application_port == i64::from(port));
 
     if json {
         println!(
@@ -268,7 +288,14 @@ async fn delete(
     json: bool,
 ) -> Result<()> {
     let ctx = resolve_service_context(project, service, environment).await?;
-    let proxy = resolve_proxy(&ctx, &proxy).await?;
+    let proxy = tcp_proxy::resolve_tcp_proxy(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        &proxy,
+    )
+    .await?;
 
     let confirmed = if yes {
         true
@@ -302,30 +329,14 @@ async fn delete(
     }
 
     let spinner = create_spinner_if(!json, "Deleting TCP proxy...".into());
-    let deleted = post_graphql::<mutations::TcpProxyDelete, _>(
+    tcp_proxy::delete_tcp_proxy(
         &ctx.client,
-        ctx.configs.get_backboard(),
-        mutations::tcp_proxy_delete::Variables {
-            id: proxy.id.clone(),
-        },
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        &proxy,
     )
-    .await?
-    .tcp_proxy_delete;
-
-    if !deleted {
-        bail!("Failed to delete TCP proxy {}", proxy.id);
-    }
-
-    let remaining = fetch_tcp_proxies(&ctx).await?;
-    if remaining
-        .iter()
-        .any(|item| item.id == proxy.id && item.deleted_at.is_none())
-    {
-        bail!(
-            "TCP proxy deletion was requested, but {} still exists after verification.",
-            proxy.id
-        );
-    }
+    .await?;
 
     if json {
         println!(
@@ -347,269 +358,7 @@ async fn delete(
     Ok(())
 }
 
-async fn fetch_tcp_proxies(
-    ctx: &ServiceContext,
-) -> Result<Vec<queries::tcp_proxies::TcpProxiesTcpProxies>> {
-    Ok(post_graphql::<queries::TcpProxies, _>(
-        &ctx.client,
-        ctx.configs.get_backboard(),
-        queries::tcp_proxies::Variables {
-            environment_id: ctx.environment_id.clone(),
-            service_id: ctx.service_id.clone(),
-        },
-    )
-    .await?
-    .tcp_proxies)
-}
-
-fn existing_proxy_for_create(
-    proxies: &[TcpProxyOutput],
-    port: u16,
-) -> Result<Option<&TcpProxyOutput>> {
-    let Some(proxy) = proxies.first() else {
-        return Ok(None);
-    };
-
-    if proxy.application_port == i64::from(port) {
-        return Ok(Some(proxy));
-    }
-
-    bail!(
-        "A TCP proxy already exists for application port {} ({}). Only one TCP proxy is allowed per service instance. Delete it before creating a TCP proxy for application port {}.",
-        proxy.application_port,
-        proxy.endpoint,
-        port
-    );
-}
-
-async fn resolve_proxy(ctx: &ServiceContext, identifier: &str) -> Result<TcpProxyOutput> {
-    let proxies = fetch_tcp_proxies(ctx).await?;
-    let outputs = proxy_outputs(&proxies);
-
-    find_proxy(&outputs, identifier)?.cloned().ok_or_else(|| {
-        anyhow!(
-            "TCP proxy '{}' not found on the selected service",
-            identifier
-        )
-    })
-}
-
-fn proxy_outputs(proxies: &[queries::tcp_proxies::TcpProxiesTcpProxies]) -> Vec<TcpProxyOutput> {
-    proxies
-        .iter()
-        .filter(|proxy| proxy.deleted_at.is_none())
-        .map(proxy_output)
-        .collect()
-}
-
-fn proxy_output(proxy: &queries::tcp_proxies::TcpProxiesTcpProxies) -> TcpProxyOutput {
-    TcpProxyOutput {
-        id: proxy.id.clone(),
-        domain: proxy.domain.clone(),
-        proxy_port: proxy.proxy_port,
-        application_port: proxy.application_port,
-        endpoint: format!("{}:{}", proxy.domain, proxy.proxy_port),
-        sync_status: tcp_proxy_sync_status(&proxy.sync_status),
-        service_id: proxy.service_id.clone(),
-        environment_id: proxy.environment_id.clone(),
-        created_at: proxy.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
-        updated_at: proxy.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
-    }
-}
-
-fn find_proxy<'a>(
-    proxies: &'a [TcpProxyOutput],
-    identifier: &str,
-) -> Result<Option<&'a TcpProxyOutput>> {
-    if let Some(proxy) = proxies
-        .iter()
-        .find(|proxy| proxy.id.eq_ignore_ascii_case(identifier))
-    {
-        return Ok(Some(proxy));
-    }
-
-    let normalized = normalize_proxy_identifier(identifier);
-    let matches = matching_proxies(proxies, &normalized);
-
-    match matches.len() {
-        0 => Ok(None),
-        1 => Ok(Some(matches[0])),
-        _ => bail!(
-            "TCP proxy selector '{}' matched multiple proxies: {}. Use a TCP proxy ID or full endpoint.",
-            identifier,
-            format_proxy_choices(&matches)
-        ),
-    }
-}
-
-fn matching_proxies<'a>(
-    proxies: &'a [TcpProxyOutput],
-    normalized: &NormalizedProxyIdentifier,
-) -> Vec<&'a TcpProxyOutput> {
-    if let Some(port) = normalized.port {
-        return proxies
-            .iter()
-            .filter(|proxy| {
-                proxy.domain.eq_ignore_ascii_case(&normalized.host) && proxy.proxy_port == port
-            })
-            .collect();
-    }
-
-    if let Ok(numeric) = normalized.host.parse::<i64>() {
-        return proxies
-            .iter()
-            .filter(|proxy| proxy.proxy_port == numeric || proxy.application_port == numeric)
-            .collect();
-    }
-
-    proxies
-        .iter()
-        .filter(|proxy| proxy.domain.eq_ignore_ascii_case(&normalized.host))
-        .collect()
-}
-
-fn format_proxy_choices(proxies: &[&TcpProxyOutput]) -> String {
-    proxies
-        .iter()
-        .map(|proxy| {
-            format!(
-                "{} (id: {}, app port: {})",
-                proxy.endpoint, proxy.id, proxy.application_port
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct NormalizedProxyIdentifier {
-    host: String,
-    port: Option<i64>,
-}
-
-fn normalize_proxy_identifier(identifier: &str) -> NormalizedProxyIdentifier {
-    let trimmed = identifier.trim();
-    let without_scheme = trimmed
-        .strip_prefix("tcp://")
-        .or_else(|| trimmed.strip_prefix("https://"))
-        .or_else(|| trimmed.strip_prefix("http://"))
-        .unwrap_or(trimmed);
-    let endpoint = without_scheme
-        .split('/')
-        .next()
-        .unwrap_or(without_scheme)
-        .trim_end_matches('.');
-
-    if let Some((host, port)) = endpoint.rsplit_once(':') {
-        if let Ok(port) = port.parse::<i64>() {
-            return NormalizedProxyIdentifier {
-                host: host.trim_end_matches('.').to_string(),
-                port: Some(port),
-            };
-        }
-    }
-
-    NormalizedProxyIdentifier {
-        host: endpoint.to_string(),
-        port: None,
-    }
-}
-
-async fn apply_tcp_proxy_patch(ctx: &ServiceContext, port: u16) -> Result<PatchMode> {
-    let patch = tcp_proxy_patch(&ctx.service_id, port);
-    let mode = patch_mode(ctx);
-
-    match mode {
-        PatchMode::Commit => {
-            post_graphql::<mutations::EnvironmentPatchCommit, _>(
-                &ctx.client,
-                ctx.configs.get_backboard(),
-                mutations::environment_patch_commit::Variables {
-                    environment_id: ctx.environment_id.clone(),
-                    patch,
-                    commit_message: Some(format!(
-                        "Create TCP proxy for {} on port {}",
-                        ctx.service_name, port
-                    )),
-                },
-            )
-            .await?;
-        }
-        PatchMode::Stage => {
-            post_graphql::<mutations::EnvironmentStageChanges, _>(
-                &ctx.client,
-                ctx.configs.get_backboard(),
-                mutations::environment_stage_changes::Variables {
-                    environment_id: ctx.environment_id.clone(),
-                    input: patch,
-                    merge: Some(true),
-                },
-            )
-            .await?;
-        }
-    }
-
-    Ok(mode)
-}
-
-fn tcp_proxy_patch(service_id: &str, port: u16) -> EnvironmentConfig {
-    EnvironmentConfig {
-        services: BTreeMap::from([(
-            service_id.to_string(),
-            ServiceInstance {
-                networking: Some(ServiceNetworking {
-                    tcp_proxies: BTreeMap::from([(
-                        port.to_string(),
-                        Some(TcpProxyConfig::default()),
-                    )]),
-                    ..ServiceNetworking::default()
-                }),
-                ..ServiceInstance::default()
-            },
-        )]),
-        ..EnvironmentConfig::default()
-    }
-}
-
-fn patch_mode(ctx: &ServiceContext) -> PatchMode {
-    let unmerged_changes = ctx
-        .project
-        .environments
-        .edges
-        .iter()
-        .find(|env| env.node.id == ctx.environment_id)
-        .and_then(|env| env.node.unmerged_changes_count)
-        .unwrap_or_default();
-
-    if unmerged_changes > 0 {
-        PatchMode::Stage
-    } else {
-        PatchMode::Commit
-    }
-}
-
-async fn verify_tcp_proxy_configured(ctx: &ServiceContext, port: u16) -> Result<()> {
-    let response = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, false)
-        .await?
-        .config;
-
-    let configured = response
-        .services
-        .get(&ctx.service_id)
-        .and_then(|service| service.networking.as_ref())
-        .is_some_and(|networking| networking.tcp_proxies.contains_key(&port.to_string()));
-
-    if !configured {
-        bail!(
-            "TCP proxy configuration was requested, but port {} was not present after verification.",
-            port
-        );
-    }
-
-    Ok(())
-}
-
-fn print_proxy_table(proxies: &[TcpProxyOutput]) {
+fn print_proxy_table(proxies: &[TcpProxy]) {
     let endpoint_width = proxies
         .iter()
         .map(|proxy| proxy.endpoint.len())
@@ -656,7 +405,7 @@ fn print_proxy_table(proxies: &[TcpProxyOutput]) {
     }
 }
 
-fn print_proxy_details(proxy: &TcpProxyOutput, title: &str) {
+fn print_proxy_details(proxy: &TcpProxy, title: &str) {
     println!("{}:", title.bold());
     println!("  Endpoint: {}", proxy.endpoint.magenta().bold());
     println!("  ID: {}", proxy.id);
@@ -673,52 +422,14 @@ fn print_proxy_details(proxy: &TcpProxyOutput, title: &str) {
     }
 }
 
-fn tcp_proxy_sync_status(value: &queries::tcp_proxies::TCPProxySyncStatus) -> String {
-    match value {
-        queries::tcp_proxies::TCPProxySyncStatus::ACTIVE => "ACTIVE".to_string(),
-        queries::tcp_proxies::TCPProxySyncStatus::CREATING => "CREATING".to_string(),
-        queries::tcp_proxies::TCPProxySyncStatus::DELETED => "DELETED".to_string(),
-        queries::tcp_proxies::TCPProxySyncStatus::DELETING => "DELETING".to_string(),
-        queries::tcp_proxies::TCPProxySyncStatus::UNSPECIFIED => "UNSPECIFIED".to_string(),
-        queries::tcp_proxies::TCPProxySyncStatus::UPDATING => "UPDATING".to_string(),
-        queries::tcp_proxies::TCPProxySyncStatus::Other(status) => status.clone(),
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
-enum PatchMode {
-    Commit,
-    Stage,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TcpProxyOutput {
-    id: String,
-    domain: String,
-    proxy_port: i64,
-    application_port: i64,
-    endpoint: String,
-    sync_status: String,
-    #[serde(skip_serializing)]
-    service_id: String,
-    #[serde(skip_serializing)]
-    environment_id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    created_at: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    updated_at: Option<String>,
-}
-
 #[derive(Serialize)]
 struct ListOutput {
-    proxies: Vec<TcpProxyOutput>,
+    proxies: Vec<TcpProxy>,
 }
 
 #[derive(Serialize)]
 struct ProxyOutput {
-    proxy: TcpProxyOutput,
+    proxy: TcpProxy,
 }
 
 #[derive(Serialize)]
@@ -727,7 +438,7 @@ struct CreateOutput {
     application_port: u16,
     staged: bool,
     committed: bool,
-    proxy: Option<TcpProxyOutput>,
+    proxy: Option<TcpProxy>,
 }
 
 #[derive(Serialize)]
@@ -745,28 +456,13 @@ mod tests {
     use super::*;
     use clap::Parser;
 
-    fn sample_proxy() -> TcpProxyOutput {
-        TcpProxyOutput {
+    fn sample_proxy() -> TcpProxy {
+        TcpProxy {
             id: "tcp_123".to_string(),
             domain: "containers-us-west.railway.app".to_string(),
             proxy_port: 15432,
             application_port: 5432,
             endpoint: "containers-us-west.railway.app:15432".to_string(),
-            sync_status: "ACTIVE".to_string(),
-            service_id: "svc_123".to_string(),
-            environment_id: "env_123".to_string(),
-            created_at: None,
-            updated_at: None,
-        }
-    }
-
-    fn sample_proxy_with_ports(id: &str, proxy_port: i64, application_port: i64) -> TcpProxyOutput {
-        TcpProxyOutput {
-            id: id.to_string(),
-            domain: "containers-us-west.railway.app".to_string(),
-            proxy_port,
-            application_port,
-            endpoint: format!("containers-us-west.railway.app:{proxy_port}"),
             sync_status: "ACTIVE".to_string(),
             service_id: "svc_123".to_string(),
             environment_id: "env_123".to_string(),
@@ -801,95 +497,6 @@ mod tests {
         assert_eq!(parse_port("65535").unwrap(), 65535);
         assert!(parse_port("0").is_err());
         assert!(parse_port("65536").is_err());
-    }
-
-    #[test]
-    fn normalizes_proxy_identifier() {
-        assert_eq!(
-            normalize_proxy_identifier("tcp://containers-us-west.railway.app:15432/path"),
-            NormalizedProxyIdentifier {
-                host: "containers-us-west.railway.app".to_string(),
-                port: Some(15432),
-            }
-        );
-        assert_eq!(
-            normalize_proxy_identifier("containers-us-west.railway.app."),
-            NormalizedProxyIdentifier {
-                host: "containers-us-west.railway.app".to_string(),
-                port: None,
-            }
-        );
-    }
-
-    #[test]
-    fn finds_proxy_by_id_endpoint_domain_or_port() {
-        let proxy = sample_proxy();
-        let proxies = vec![proxy];
-
-        assert!(find_proxy(&proxies, "tcp_123").unwrap().is_some());
-        assert!(
-            find_proxy(&proxies, "containers-us-west.railway.app:15432")
-                .unwrap()
-                .is_some()
-        );
-        assert!(
-            find_proxy(&proxies, "containers-us-west.railway.app")
-                .unwrap()
-                .is_some()
-        );
-        assert!(find_proxy(&proxies, "15432").unwrap().is_some());
-        assert!(find_proxy(&proxies, "5432").unwrap().is_some());
-        assert!(find_proxy(&proxies, "missing").unwrap().is_none());
-    }
-
-    #[test]
-    fn create_allows_existing_proxy_only_for_same_application_port() {
-        let proxy = sample_proxy();
-        let proxies = vec![proxy];
-
-        let existing = existing_proxy_for_create(&proxies, 5432).unwrap().unwrap();
-        assert_eq!(existing.id, "tcp_123");
-
-        let err = existing_proxy_for_create(&proxies, 6380).unwrap_err();
-        assert!(err.to_string().contains("Only one TCP proxy is allowed"));
-        assert!(err.to_string().contains("application port 5432"));
-        assert!(err.to_string().contains("application port 6380"));
-    }
-
-    #[test]
-    fn id_lookup_wins_even_when_numeric_selector_would_be_ambiguous() {
-        let proxies = vec![
-            sample_proxy_with_ports("15432", 15432, 5432),
-            sample_proxy_with_ports("tcp_456", 15433, 15432),
-        ];
-
-        let proxy = find_proxy(&proxies, "15432").unwrap().unwrap();
-
-        assert_eq!(proxy.id, "15432");
-    }
-
-    #[test]
-    fn ambiguous_domain_or_port_selector_errors() {
-        let proxies = vec![
-            sample_proxy_with_ports("tcp_123", 15432, 5432),
-            sample_proxy_with_ports("tcp_456", 15433, 5432),
-        ];
-
-        let domain_err = find_proxy(&proxies, "containers-us-west.railway.app").unwrap_err();
-        assert!(domain_err.to_string().contains("matched multiple proxies"));
-
-        let port_err = find_proxy(&proxies, "5432").unwrap_err();
-        assert!(
-            port_err
-                .to_string()
-                .contains("Use a TCP proxy ID or full endpoint")
-        );
-
-        assert!(
-            find_proxy(&proxies, "containers-us-west.railway.app:15433")
-                .unwrap()
-                .is_some()
-        );
     }
 
     #[test]
@@ -932,16 +539,12 @@ mod tests {
     }
 
     #[test]
-    fn tcp_proxy_sync_status_outputs_clean_strings() {
-        assert_eq!(
-            tcp_proxy_sync_status(&queries::tcp_proxies::TCPProxySyncStatus::ACTIVE),
-            "ACTIVE"
-        );
-        assert_eq!(
-            tcp_proxy_sync_status(&queries::tcp_proxies::TCPProxySyncStatus::Other(
-                "NEW_STATUS".to_string()
-            )),
-            "NEW_STATUS"
-        );
+    fn proxy_output_omits_internal_context_fields() {
+        let value = serde_json::to_value(sample_proxy()).unwrap();
+
+        assert_eq!(value["id"], "tcp_123");
+        assert_eq!(value["endpoint"], "containers-us-west.railway.app:15432");
+        assert!(value.get("serviceId").is_none());
+        assert!(value.get("environmentId").is_none());
     }
 }

--- a/src/commands/tcp_proxy.rs
+++ b/src/commands/tcp_proxy.rs
@@ -1,0 +1,947 @@
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, bail};
+use colored::Colorize;
+use is_terminal::IsTerminal;
+use serde::Serialize;
+
+use crate::{
+    controllers::{
+        config::{
+            EnvironmentConfig, ServiceInstance, ServiceNetworking, TcpProxyConfig,
+            environment::fetch_environment_config,
+        },
+        project::{ServiceContext, resolve_service_context},
+    },
+    util::{progress::create_spinner_if, prompt::prompt_confirm_with_default},
+};
+
+use super::*;
+
+/// Manage public TCP proxies for a service
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway tcp-proxy list --service postgres --json\n  railway tcp-proxy create --port 5432 --service postgres\n  railway tcp-proxy status tcp-proxy-id\n  railway tcp-proxy delete tcp-proxy-id --yes\n\nAutomation notes:\n  Only one TCP proxy is allowed per service instance.\n  TCP proxy creation updates service networking config. Redeploy the service after committing the change for the proxy to become active."
+)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Service name or ID (defaults to linked service)
+    #[clap(short, long, global = true)]
+    service: Option<String>,
+
+    /// Environment to use (defaults to linked environment)
+    #[clap(short, long, global = true)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID", global = true)]
+    project: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long, global = true)]
+    json: bool,
+}
+
+#[derive(Parser)]
+enum Commands {
+    /// List TCP proxies for a service
+    #[clap(visible_alias = "ls")]
+    List,
+
+    /// Create a TCP proxy for an application port
+    #[clap(visible_alias = "add", visible_alias = "new")]
+    Create {
+        /// Application port to expose through the TCP proxy
+        #[clap(long, value_parser = parse_port)]
+        port: u16,
+    },
+
+    /// Show status for a TCP proxy
+    Status {
+        /// TCP proxy ID, domain, endpoint, proxy port, or application port
+        #[clap(value_name = "PROXY")]
+        proxy: String,
+    },
+
+    /// Delete a TCP proxy
+    #[clap(visible_alias = "remove", visible_alias = "rm")]
+    Delete {
+        /// TCP proxy ID, domain, endpoint, proxy port, or application port
+        #[clap(value_name = "PROXY")]
+        proxy: String,
+
+        /// Skip confirmation dialog
+        #[clap(short = 'y', long = "yes")]
+        yes: bool,
+    },
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let Args {
+        command,
+        service,
+        environment,
+        project,
+        json,
+    } = args;
+
+    crate::util::reporter::set_mode(json);
+
+    match command {
+        Commands::List => list(project, service, environment, json).await?,
+        Commands::Create { port } => create(project, service, environment, port, json).await?,
+        Commands::Status { proxy } => status(project, service, environment, proxy, json).await?,
+        Commands::Delete { proxy, yes } => {
+            delete(project, service, environment, proxy, yes, json).await?
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_port(value: &str) -> std::result::Result<u16, String> {
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| "port must be a number from 1 to 65535".to_string())?;
+
+    if port == 0 {
+        return Err("port must be a number from 1 to 65535".to_string());
+    }
+
+    Ok(port)
+}
+
+async fn list(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let proxies = fetch_tcp_proxies(&ctx).await?;
+    let outputs = proxy_outputs(&proxies);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&ListOutput { proxies: outputs })?
+        );
+        return Ok(());
+    }
+
+    if outputs.is_empty() {
+        println!(
+            "No TCP proxies found for service {} in environment {}.",
+            ctx.service_name.bold(),
+            ctx.environment_name.bold()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "TCP proxies for service {} in environment {}:",
+        ctx.service_name.bold(),
+        ctx.environment_name.bold()
+    );
+    print_proxy_table(&outputs);
+
+    Ok(())
+}
+
+async fn status(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    proxy: String,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let proxy = resolve_proxy(&ctx, &proxy).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&ProxyOutput { proxy })?);
+        return Ok(());
+    }
+
+    print_proxy_details(&proxy, "TCP proxy status");
+
+    Ok(())
+}
+
+async fn create(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    port: u16,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let existing = fetch_tcp_proxies(&ctx).await?;
+    let existing_outputs = proxy_outputs(&existing);
+    if let Some(proxy) = existing_proxy_for_create(&existing_outputs, port)? {
+        let proxy = proxy.clone();
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&CreateOutput {
+                    application_port: port,
+                    staged: false,
+                    committed: false,
+                    proxy: Some(proxy),
+                })?
+            );
+        } else {
+            println!(
+                "TCP proxy already exists for application port {}:",
+                port.to_string().cyan()
+            );
+            print_proxy_details(&proxy, "Existing TCP proxy");
+        }
+        return Ok(());
+    }
+
+    let spinner = create_spinner_if(!json, "Configuring TCP proxy...".into());
+    let patch_mode = apply_tcp_proxy_patch(&ctx, port).await?;
+    if patch_mode == PatchMode::Commit {
+        verify_tcp_proxy_configured(&ctx, port).await?;
+    }
+    let active_proxy = fetch_tcp_proxies(&ctx)
+        .await?
+        .iter()
+        .find(|proxy| proxy.application_port == i64::from(port) && proxy.deleted_at.is_none())
+        .map(proxy_output);
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&CreateOutput {
+                application_port: port,
+                staged: patch_mode == PatchMode::Stage,
+                committed: patch_mode == PatchMode::Commit,
+                proxy: active_proxy,
+            })?
+        );
+        return Ok(());
+    }
+
+    let msg = match patch_mode {
+        PatchMode::Commit => format!(
+            "Configured TCP proxy for service {} on application port {}.",
+            ctx.service_name.blue(),
+            port.to_string().cyan()
+        ),
+        PatchMode::Stage => format!(
+            "Staged TCP proxy for service {} on application port {} in {} {}",
+            ctx.service_name.blue(),
+            port.to_string().cyan(),
+            ctx.environment_name.magenta().bold(),
+            "(use 'railway environment edit' to commit)".dimmed()
+        ),
+    };
+
+    if let Some(spinner) = spinner {
+        spinner.finish_with_message(msg);
+    } else {
+        println!("{msg}");
+    }
+
+    if let Some(proxy) = active_proxy {
+        print_proxy_details(&proxy, "Active TCP proxy");
+    } else {
+        println!(
+            "Redeploy the service for the TCP proxy to become active, then run {}.",
+            format!("railway tcp-proxy list --service {}", ctx.service_name).bold()
+        );
+    }
+
+    Ok(())
+}
+
+async fn delete(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    proxy: String,
+    yes: bool,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let proxy = resolve_proxy(&ctx, &proxy).await?;
+
+    let confirmed = if yes {
+        true
+    } else if std::io::stdout().is_terminal() {
+        prompt_confirm_with_default(
+            &format!(
+                "Delete TCP proxy {}? This action cannot be undone.",
+                proxy.endpoint.red()
+            ),
+            false,
+        )?
+    } else {
+        bail!(
+            "Cannot prompt for confirmation in non-interactive mode. Use --yes to skip confirmation."
+        );
+    };
+
+    if !confirmed {
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "deleted": false,
+                    "proxy": proxy,
+                }))?
+            );
+        } else {
+            println!("Deletion cancelled.");
+        }
+        return Ok(());
+    }
+
+    let spinner = create_spinner_if(!json, "Deleting TCP proxy...".into());
+    let deleted = post_graphql::<mutations::TcpProxyDelete, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        mutations::tcp_proxy_delete::Variables {
+            id: proxy.id.clone(),
+        },
+    )
+    .await?
+    .tcp_proxy_delete;
+
+    if !deleted {
+        bail!("Failed to delete TCP proxy {}", proxy.id);
+    }
+
+    let remaining = fetch_tcp_proxies(&ctx).await?;
+    if remaining
+        .iter()
+        .any(|item| item.id == proxy.id && item.deleted_at.is_none())
+    {
+        bail!(
+            "TCP proxy deletion was requested, but {} still exists after verification.",
+            proxy.id
+        );
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&DeleteOutput {
+                id: proxy.id,
+                endpoint: proxy.endpoint,
+                application_port: proxy.application_port,
+                staged: false,
+                committed: true,
+            })?
+        );
+    } else if let Some(spinner) = spinner {
+        spinner.finish_with_message(format!("Deleted TCP proxy {}", proxy.endpoint.blue()));
+    } else {
+        println!("Deleted TCP proxy {}.", proxy.endpoint.blue());
+    }
+
+    Ok(())
+}
+
+async fn fetch_tcp_proxies(
+    ctx: &ServiceContext,
+) -> Result<Vec<queries::tcp_proxies::TcpProxiesTcpProxies>> {
+    Ok(post_graphql::<queries::TcpProxies, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        queries::tcp_proxies::Variables {
+            environment_id: ctx.environment_id.clone(),
+            service_id: ctx.service_id.clone(),
+        },
+    )
+    .await?
+    .tcp_proxies)
+}
+
+fn existing_proxy_for_create(
+    proxies: &[TcpProxyOutput],
+    port: u16,
+) -> Result<Option<&TcpProxyOutput>> {
+    let Some(proxy) = proxies.first() else {
+        return Ok(None);
+    };
+
+    if proxy.application_port == i64::from(port) {
+        return Ok(Some(proxy));
+    }
+
+    bail!(
+        "A TCP proxy already exists for application port {} ({}). Only one TCP proxy is allowed per service instance. Delete it before creating a TCP proxy for application port {}.",
+        proxy.application_port,
+        proxy.endpoint,
+        port
+    );
+}
+
+async fn resolve_proxy(ctx: &ServiceContext, identifier: &str) -> Result<TcpProxyOutput> {
+    let proxies = fetch_tcp_proxies(ctx).await?;
+    let outputs = proxy_outputs(&proxies);
+
+    find_proxy(&outputs, identifier)?.cloned().ok_or_else(|| {
+        anyhow!(
+            "TCP proxy '{}' not found on the selected service",
+            identifier
+        )
+    })
+}
+
+fn proxy_outputs(proxies: &[queries::tcp_proxies::TcpProxiesTcpProxies]) -> Vec<TcpProxyOutput> {
+    proxies
+        .iter()
+        .filter(|proxy| proxy.deleted_at.is_none())
+        .map(proxy_output)
+        .collect()
+}
+
+fn proxy_output(proxy: &queries::tcp_proxies::TcpProxiesTcpProxies) -> TcpProxyOutput {
+    TcpProxyOutput {
+        id: proxy.id.clone(),
+        domain: proxy.domain.clone(),
+        proxy_port: proxy.proxy_port,
+        application_port: proxy.application_port,
+        endpoint: format!("{}:{}", proxy.domain, proxy.proxy_port),
+        sync_status: tcp_proxy_sync_status(&proxy.sync_status),
+        service_id: proxy.service_id.clone(),
+        environment_id: proxy.environment_id.clone(),
+        created_at: proxy.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
+        updated_at: proxy.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
+    }
+}
+
+fn find_proxy<'a>(
+    proxies: &'a [TcpProxyOutput],
+    identifier: &str,
+) -> Result<Option<&'a TcpProxyOutput>> {
+    if let Some(proxy) = proxies
+        .iter()
+        .find(|proxy| proxy.id.eq_ignore_ascii_case(identifier))
+    {
+        return Ok(Some(proxy));
+    }
+
+    let normalized = normalize_proxy_identifier(identifier);
+    let matches = matching_proxies(proxies, &normalized);
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(Some(matches[0])),
+        _ => bail!(
+            "TCP proxy selector '{}' matched multiple proxies: {}. Use a TCP proxy ID or full endpoint.",
+            identifier,
+            format_proxy_choices(&matches)
+        ),
+    }
+}
+
+fn matching_proxies<'a>(
+    proxies: &'a [TcpProxyOutput],
+    normalized: &NormalizedProxyIdentifier,
+) -> Vec<&'a TcpProxyOutput> {
+    if let Some(port) = normalized.port {
+        return proxies
+            .iter()
+            .filter(|proxy| {
+                proxy.domain.eq_ignore_ascii_case(&normalized.host) && proxy.proxy_port == port
+            })
+            .collect();
+    }
+
+    if let Ok(numeric) = normalized.host.parse::<i64>() {
+        return proxies
+            .iter()
+            .filter(|proxy| proxy.proxy_port == numeric || proxy.application_port == numeric)
+            .collect();
+    }
+
+    proxies
+        .iter()
+        .filter(|proxy| proxy.domain.eq_ignore_ascii_case(&normalized.host))
+        .collect()
+}
+
+fn format_proxy_choices(proxies: &[&TcpProxyOutput]) -> String {
+    proxies
+        .iter()
+        .map(|proxy| {
+            format!(
+                "{} (id: {}, app port: {})",
+                proxy.endpoint, proxy.id, proxy.application_port
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedProxyIdentifier {
+    host: String,
+    port: Option<i64>,
+}
+
+fn normalize_proxy_identifier(identifier: &str) -> NormalizedProxyIdentifier {
+    let trimmed = identifier.trim();
+    let without_scheme = trimmed
+        .strip_prefix("tcp://")
+        .or_else(|| trimmed.strip_prefix("https://"))
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let endpoint = without_scheme
+        .split('/')
+        .next()
+        .unwrap_or(without_scheme)
+        .trim_end_matches('.');
+
+    if let Some((host, port)) = endpoint.rsplit_once(':') {
+        if let Ok(port) = port.parse::<i64>() {
+            return NormalizedProxyIdentifier {
+                host: host.trim_end_matches('.').to_string(),
+                port: Some(port),
+            };
+        }
+    }
+
+    NormalizedProxyIdentifier {
+        host: endpoint.to_string(),
+        port: None,
+    }
+}
+
+async fn apply_tcp_proxy_patch(ctx: &ServiceContext, port: u16) -> Result<PatchMode> {
+    let patch = tcp_proxy_patch(&ctx.service_id, port);
+    let mode = patch_mode(ctx);
+
+    match mode {
+        PatchMode::Commit => {
+            post_graphql::<mutations::EnvironmentPatchCommit, _>(
+                &ctx.client,
+                ctx.configs.get_backboard(),
+                mutations::environment_patch_commit::Variables {
+                    environment_id: ctx.environment_id.clone(),
+                    patch,
+                    commit_message: Some(format!(
+                        "Create TCP proxy for {} on port {}",
+                        ctx.service_name, port
+                    )),
+                },
+            )
+            .await?;
+        }
+        PatchMode::Stage => {
+            post_graphql::<mutations::EnvironmentStageChanges, _>(
+                &ctx.client,
+                ctx.configs.get_backboard(),
+                mutations::environment_stage_changes::Variables {
+                    environment_id: ctx.environment_id.clone(),
+                    input: patch,
+                    merge: Some(true),
+                },
+            )
+            .await?;
+        }
+    }
+
+    Ok(mode)
+}
+
+fn tcp_proxy_patch(service_id: &str, port: u16) -> EnvironmentConfig {
+    EnvironmentConfig {
+        services: BTreeMap::from([(
+            service_id.to_string(),
+            ServiceInstance {
+                networking: Some(ServiceNetworking {
+                    tcp_proxies: BTreeMap::from([(
+                        port.to_string(),
+                        Some(TcpProxyConfig::default()),
+                    )]),
+                    ..ServiceNetworking::default()
+                }),
+                ..ServiceInstance::default()
+            },
+        )]),
+        ..EnvironmentConfig::default()
+    }
+}
+
+fn patch_mode(ctx: &ServiceContext) -> PatchMode {
+    let unmerged_changes = ctx
+        .project
+        .environments
+        .edges
+        .iter()
+        .find(|env| env.node.id == ctx.environment_id)
+        .and_then(|env| env.node.unmerged_changes_count)
+        .unwrap_or_default();
+
+    if unmerged_changes > 0 {
+        PatchMode::Stage
+    } else {
+        PatchMode::Commit
+    }
+}
+
+async fn verify_tcp_proxy_configured(ctx: &ServiceContext, port: u16) -> Result<()> {
+    let response = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, false)
+        .await?
+        .config;
+
+    let configured = response
+        .services
+        .get(&ctx.service_id)
+        .and_then(|service| service.networking.as_ref())
+        .is_some_and(|networking| networking.tcp_proxies.contains_key(&port.to_string()));
+
+    if !configured {
+        bail!(
+            "TCP proxy configuration was requested, but port {} was not present after verification.",
+            port
+        );
+    }
+
+    Ok(())
+}
+
+fn print_proxy_table(proxies: &[TcpProxyOutput]) {
+    let endpoint_width = proxies
+        .iter()
+        .map(|proxy| proxy.endpoint.len())
+        .max()
+        .unwrap_or("Endpoint".len())
+        .max("Endpoint".len())
+        + 3;
+    let app_width = proxies
+        .iter()
+        .map(|proxy| proxy.application_port.to_string().len())
+        .max()
+        .unwrap_or("App Port".len())
+        .max("App Port".len())
+        + 3;
+    let id_width = proxies
+        .iter()
+        .map(|proxy| proxy.id.len())
+        .max()
+        .unwrap_or("ID".len())
+        .max("ID".len())
+        + 3;
+
+    println!(
+        "{:<endpoint_width$}{:<app_width$}{:<id_width$}Sync",
+        "Endpoint".bold(),
+        "App Port".bold(),
+        "ID".bold(),
+        endpoint_width = endpoint_width,
+        app_width = app_width,
+        id_width = id_width,
+    );
+
+    for proxy in proxies {
+        println!(
+            "{:<endpoint_width$}{:<app_width$}{:<id_width$}{}",
+            proxy.endpoint,
+            proxy.application_port,
+            proxy.id,
+            proxy.sync_status,
+            endpoint_width = endpoint_width,
+            app_width = app_width,
+            id_width = id_width,
+        );
+    }
+}
+
+fn print_proxy_details(proxy: &TcpProxyOutput, title: &str) {
+    println!("{}:", title.bold());
+    println!("  Endpoint: {}", proxy.endpoint.magenta().bold());
+    println!("  ID: {}", proxy.id);
+    println!("  Domain: {}", proxy.domain);
+    println!("  Proxy port: {}", proxy.proxy_port);
+    println!("  Application port: {}", proxy.application_port);
+    println!("  Sync status: {}", proxy.sync_status);
+
+    if let Some(created_at) = &proxy.created_at {
+        println!("  Created: {}", created_at);
+    }
+    if let Some(updated_at) = &proxy.updated_at {
+        println!("  Updated: {}", updated_at);
+    }
+}
+
+fn tcp_proxy_sync_status(value: &queries::tcp_proxies::TCPProxySyncStatus) -> String {
+    match value {
+        queries::tcp_proxies::TCPProxySyncStatus::ACTIVE => "ACTIVE".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::CREATING => "CREATING".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::DELETED => "DELETED".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::DELETING => "DELETING".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::UNSPECIFIED => "UNSPECIFIED".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::UPDATING => "UPDATING".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::Other(status) => status.clone(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum PatchMode {
+    Commit,
+    Stage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TcpProxyOutput {
+    id: String,
+    domain: String,
+    proxy_port: i64,
+    application_port: i64,
+    endpoint: String,
+    sync_status: String,
+    #[serde(skip_serializing)]
+    service_id: String,
+    #[serde(skip_serializing)]
+    environment_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ListOutput {
+    proxies: Vec<TcpProxyOutput>,
+}
+
+#[derive(Serialize)]
+struct ProxyOutput {
+    proxy: TcpProxyOutput,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateOutput {
+    application_port: u16,
+    staged: bool,
+    committed: bool,
+    proxy: Option<TcpProxyOutput>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DeleteOutput {
+    id: String,
+    endpoint: String,
+    application_port: i64,
+    staged: bool,
+    committed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn sample_proxy() -> TcpProxyOutput {
+        TcpProxyOutput {
+            id: "tcp_123".to_string(),
+            domain: "containers-us-west.railway.app".to_string(),
+            proxy_port: 15432,
+            application_port: 5432,
+            endpoint: "containers-us-west.railway.app:15432".to_string(),
+            sync_status: "ACTIVE".to_string(),
+            service_id: "svc_123".to_string(),
+            environment_id: "env_123".to_string(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn sample_proxy_with_ports(id: &str, proxy_port: i64, application_port: i64) -> TcpProxyOutput {
+        TcpProxyOutput {
+            id: id.to_string(),
+            domain: "containers-us-west.railway.app".to_string(),
+            proxy_port,
+            application_port,
+            endpoint: format!("containers-us-west.railway.app:{proxy_port}"),
+            sync_status: "ACTIVE".to_string(),
+            service_id: "svc_123".to_string(),
+            environment_id: "env_123".to_string(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn parses_subcommands() {
+        assert!(matches!(
+            Args::parse_from(["tcp-proxy", "list"]).command,
+            Commands::List
+        ));
+        assert!(matches!(
+            Args::parse_from(["tcp-proxy", "create", "--port", "5432"]).command,
+            Commands::Create { port: 5432 }
+        ));
+        assert!(matches!(
+            Args::parse_from(["tcp-proxy", "status", "tcp_123"]).command,
+            Commands::Status { proxy } if proxy == "tcp_123"
+        ));
+        assert!(matches!(
+            Args::parse_from(["tcp-proxy", "delete", "tcp_123", "--yes"]).command,
+            Commands::Delete { proxy, yes: true } if proxy == "tcp_123"
+        ));
+    }
+
+    #[test]
+    fn validates_port_range() {
+        assert_eq!(parse_port("1").unwrap(), 1);
+        assert_eq!(parse_port("65535").unwrap(), 65535);
+        assert!(parse_port("0").is_err());
+        assert!(parse_port("65536").is_err());
+    }
+
+    #[test]
+    fn normalizes_proxy_identifier() {
+        assert_eq!(
+            normalize_proxy_identifier("tcp://containers-us-west.railway.app:15432/path"),
+            NormalizedProxyIdentifier {
+                host: "containers-us-west.railway.app".to_string(),
+                port: Some(15432),
+            }
+        );
+        assert_eq!(
+            normalize_proxy_identifier("containers-us-west.railway.app."),
+            NormalizedProxyIdentifier {
+                host: "containers-us-west.railway.app".to_string(),
+                port: None,
+            }
+        );
+    }
+
+    #[test]
+    fn finds_proxy_by_id_endpoint_domain_or_port() {
+        let proxy = sample_proxy();
+        let proxies = vec![proxy];
+
+        assert!(find_proxy(&proxies, "tcp_123").unwrap().is_some());
+        assert!(
+            find_proxy(&proxies, "containers-us-west.railway.app:15432")
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            find_proxy(&proxies, "containers-us-west.railway.app")
+                .unwrap()
+                .is_some()
+        );
+        assert!(find_proxy(&proxies, "15432").unwrap().is_some());
+        assert!(find_proxy(&proxies, "5432").unwrap().is_some());
+        assert!(find_proxy(&proxies, "missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn create_allows_existing_proxy_only_for_same_application_port() {
+        let proxy = sample_proxy();
+        let proxies = vec![proxy];
+
+        let existing = existing_proxy_for_create(&proxies, 5432).unwrap().unwrap();
+        assert_eq!(existing.id, "tcp_123");
+
+        let err = existing_proxy_for_create(&proxies, 6380).unwrap_err();
+        assert!(err.to_string().contains("Only one TCP proxy is allowed"));
+        assert!(err.to_string().contains("application port 5432"));
+        assert!(err.to_string().contains("application port 6380"));
+    }
+
+    #[test]
+    fn id_lookup_wins_even_when_numeric_selector_would_be_ambiguous() {
+        let proxies = vec![
+            sample_proxy_with_ports("15432", 15432, 5432),
+            sample_proxy_with_ports("tcp_456", 15433, 15432),
+        ];
+
+        let proxy = find_proxy(&proxies, "15432").unwrap().unwrap();
+
+        assert_eq!(proxy.id, "15432");
+    }
+
+    #[test]
+    fn ambiguous_domain_or_port_selector_errors() {
+        let proxies = vec![
+            sample_proxy_with_ports("tcp_123", 15432, 5432),
+            sample_proxy_with_ports("tcp_456", 15433, 5432),
+        ];
+
+        let domain_err = find_proxy(&proxies, "containers-us-west.railway.app").unwrap_err();
+        assert!(domain_err.to_string().contains("matched multiple proxies"));
+
+        let port_err = find_proxy(&proxies, "5432").unwrap_err();
+        assert!(
+            port_err
+                .to_string()
+                .contains("Use a TCP proxy ID or full endpoint")
+        );
+
+        assert!(
+            find_proxy(&proxies, "containers-us-west.railway.app:15433")
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn create_output_keeps_proxy_key_when_proxy_is_unavailable() {
+        let output = CreateOutput {
+            application_port: 5432,
+            staged: false,
+            committed: true,
+            proxy: None,
+        };
+
+        let value = serde_json::to_value(output).unwrap();
+
+        assert_eq!(value["applicationPort"], 5432);
+        assert_eq!(value["staged"], false);
+        assert_eq!(value["committed"], true);
+        assert!(value.get("proxy").is_some());
+        assert!(value["proxy"].is_null());
+    }
+
+    #[test]
+    fn delete_output_is_compact_and_not_a_stale_proxy_snapshot() {
+        let output = DeleteOutput {
+            id: "tcp_123".to_string(),
+            endpoint: "containers-us-west.railway.app:15432".to_string(),
+            application_port: 5432,
+            staged: false,
+            committed: true,
+        };
+
+        let value = serde_json::to_value(output).unwrap();
+
+        assert_eq!(value["id"], "tcp_123");
+        assert_eq!(value["endpoint"], "containers-us-west.railway.app:15432");
+        assert_eq!(value["applicationPort"], 5432);
+        assert_eq!(value["staged"], false);
+        assert_eq!(value["committed"], true);
+        assert!(value.get("proxy").is_none());
+        assert!(value.get("syncStatus").is_none());
+    }
+
+    #[test]
+    fn tcp_proxy_sync_status_outputs_clean_strings() {
+        assert_eq!(
+            tcp_proxy_sync_status(&queries::tcp_proxies::TCPProxySyncStatus::ACTIVE),
+            "ACTIVE"
+        );
+        assert_eq!(
+            tcp_proxy_sync_status(&queries::tcp_proxies::TCPProxySyncStatus::Other(
+                "NEW_STATUS".to_string()
+            )),
+            "NEW_STATUS"
+        );
+    }
+}

--- a/src/commands/tcp_proxy.rs
+++ b/src/commands/tcp_proxy.rs
@@ -16,7 +16,7 @@ use super::*;
 /// Manage public TCP proxies for a service
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway tcp-proxy list --service postgres --json\n  railway tcp-proxy create --port 5432 --service postgres\n  railway tcp-proxy status tcp-proxy-id\n  railway tcp-proxy delete tcp-proxy-id --yes\n\nAutomation notes:\n  Only one TCP proxy is allowed per service instance.\n  TCP proxy creation updates service networking config. Redeploy the service after committing the change for the proxy to become active."
+    after_help = "Examples:\n\n  railway tcp-proxy list --service postgres --json\n  railway tcp-proxy create --port 5432 --service postgres\n  railway tcp-proxy status tcp-proxy-id\n  railway tcp-proxy delete tcp-proxy-id --yes\n\nAutomation notes:\n  Only one TCP proxy is allowed per service instance.\n  TCP proxy creation updates service networking config. If the proxy does not become active, redeploy the service and check its status."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -271,7 +271,7 @@ async fn create(
         print_proxy_details(&proxy, "Active TCP proxy");
     } else {
         println!(
-            "Redeploy the service for the TCP proxy to become active, then run {}.",
+            "The TCP proxy is configured but is not readable yet. Run {} shortly; if it does not become active, redeploy the service.",
             format!("railway tcp-proxy list --service {}", ctx.service_name).bold()
         );
     }
@@ -342,6 +342,7 @@ async fn delete(
         println!(
             "{}",
             serde_json::to_string_pretty(&DeleteOutput {
+                deleted: true,
                 id: proxy.id,
                 endpoint: proxy.endpoint,
                 application_port: proxy.application_port,
@@ -444,6 +445,7 @@ struct CreateOutput {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DeleteOutput {
+    deleted: bool,
     id: String,
     endpoint: String,
     application_port: i64,
@@ -520,6 +522,7 @@ mod tests {
     #[test]
     fn delete_output_is_compact_and_not_a_stale_proxy_snapshot() {
         let output = DeleteOutput {
+            deleted: true,
             id: "tcp_123".to_string(),
             endpoint: "containers-us-west.railway.app:15432".to_string(),
             application_port: 5432,
@@ -529,6 +532,7 @@ mod tests {
 
         let value = serde_json::to_value(output).unwrap();
 
+        assert_eq!(value["deleted"], true);
         assert_eq!(value["id"], "tcp_123");
         assert_eq!(value["endpoint"], "containers-us-west.railway.app:15432");
         assert_eq!(value["applicationPort"], 5432);

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -15,6 +15,7 @@ pub mod sandbox_exec;
 pub mod scale_tui;
 pub mod service;
 pub mod ssh;
+pub mod tcp_proxy;
 pub mod upload;
 pub mod user;
 pub mod variables;

--- a/src/controllers/tcp_proxy.rs
+++ b/src/controllers/tcp_proxy.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use anyhow::{Result, anyhow, bail};
 use reqwest::Client;
@@ -7,12 +8,12 @@ use serde::Serialize;
 use crate::{
     client::post_graphql,
     config::Configs,
-    controllers::config::{
-        EnvironmentConfig, ServiceInstance, ServiceNetworking, TcpProxyConfig,
-        environment::fetch_environment_config,
-    },
+    controllers::config::{EnvironmentConfig, ServiceInstance, ServiceNetworking, TcpProxyConfig},
     gql::{mutations, queries},
 };
+
+const VERIFY_ATTEMPTS: usize = 8;
+const VERIFY_DELAY_MS: u64 = 250;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -89,9 +90,18 @@ pub async fn fetch_tcp_proxies(
 pub fn active_tcp_proxies(proxies: &[queries::tcp_proxies::TcpProxiesTcpProxies]) -> Vec<TcpProxy> {
     proxies
         .iter()
-        .filter(|proxy| proxy.deleted_at.is_none())
+        .filter(|proxy| is_live_tcp_proxy(proxy))
         .map(tcp_proxy_output)
         .collect()
+}
+
+fn is_live_tcp_proxy(proxy: &queries::tcp_proxies::TcpProxiesTcpProxies) -> bool {
+    proxy.deleted_at.is_none()
+        && !matches!(
+            proxy.sync_status,
+            queries::tcp_proxies::TCPProxySyncStatus::DELETED
+                | queries::tcp_proxies::TCPProxySyncStatus::DELETING
+        )
 }
 
 pub fn tcp_proxy_output(proxy: &queries::tcp_proxies::TcpProxiesTcpProxies) -> TcpProxy {
@@ -110,13 +120,16 @@ pub fn tcp_proxy_output(proxy: &queries::tcp_proxies::TcpProxiesTcpProxies) -> T
 }
 
 pub fn existing_proxy_for_create(proxies: &[TcpProxy], port: u16) -> Result<Option<&TcpProxy>> {
+    if let Some(proxy) = proxies
+        .iter()
+        .find(|proxy| proxy.application_port == i64::from(port))
+    {
+        return Ok(Some(proxy));
+    }
+
     let Some(proxy) = proxies.first() else {
         return Ok(None);
     };
-
-    if proxy.application_port == i64::from(port) {
-        return Ok(Some(proxy));
-    }
 
     bail!(
         "A TCP proxy already exists for application port {} ({}). Only one TCP proxy is allowed per service instance. Delete it before creating a TCP proxy for application port {}.",
@@ -285,24 +298,24 @@ pub async fn verify_tcp_proxy_configured(
     service_id: &str,
     port: u16,
 ) -> Result<()> {
-    let response = fetch_environment_config(client, configs, environment_id, false)
-        .await?
-        .config;
+    for attempt in 0..VERIFY_ATTEMPTS {
+        let proxies = fetch_tcp_proxies(client, configs, environment_id, service_id).await?;
+        if proxies
+            .iter()
+            .any(|proxy| proxy.application_port == i64::from(port))
+        {
+            return Ok(());
+        }
 
-    let configured = response
-        .services
-        .get(service_id)
-        .and_then(|service| service.networking.as_ref())
-        .is_some_and(|networking| networking.tcp_proxies.contains_key(&port.to_string()));
-
-    if !configured {
-        bail!(
-            "TCP proxy configuration was requested, but port {} was not present after verification.",
-            port
-        );
+        if attempt + 1 < VERIFY_ATTEMPTS {
+            tokio::time::sleep(Duration::from_millis(VERIFY_DELAY_MS)).await;
+        }
     }
 
-    Ok(())
+    bail!(
+        "TCP proxy configuration was requested, but port {} was not present after verification.",
+        port
+    );
 }
 
 pub async fn delete_tcp_proxy(
@@ -422,6 +435,24 @@ mod tests {
         }
     }
 
+    fn sample_raw_proxy(
+        id: &str,
+        sync_status: queries::tcp_proxies::TCPProxySyncStatus,
+    ) -> queries::tcp_proxies::TcpProxiesTcpProxies {
+        queries::tcp_proxies::TcpProxiesTcpProxies {
+            id: id.to_string(),
+            domain: "containers-us-west.railway.app".to_string(),
+            proxy_port: 15432,
+            application_port: 5432,
+            service_id: "svc_123".to_string(),
+            environment_id: "env_123".to_string(),
+            sync_status,
+            created_at: None,
+            updated_at: None,
+            deleted_at: None,
+        }
+    }
+
     #[test]
     fn validates_port_range() {
         assert_eq!(parse_port("1").unwrap(), 1);
@@ -488,6 +519,18 @@ mod tests {
     }
 
     #[test]
+    fn create_idempotency_is_not_dependent_on_proxy_order() {
+        let proxies = vec![
+            sample_proxy_with_ports("tcp_6379", 16379, 6379),
+            sample_proxy_with_ports("tcp_5432", 15432, 5432),
+        ];
+
+        let existing = existing_proxy_for_create(&proxies, 5432).unwrap().unwrap();
+
+        assert_eq!(existing.id, "tcp_5432");
+    }
+
+    #[test]
     fn id_lookup_wins_even_when_numeric_selector_would_be_ambiguous() {
         let proxies = vec![
             sample_proxy_with_ports("15432", 15432, 5432),
@@ -521,6 +564,29 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
+    }
+
+    #[test]
+    fn active_tcp_proxies_ignores_deleted_and_deleting_sync_status() {
+        let proxies = vec![
+            sample_raw_proxy(
+                "tcp_active",
+                queries::tcp_proxies::TCPProxySyncStatus::ACTIVE,
+            ),
+            sample_raw_proxy(
+                "tcp_deleting",
+                queries::tcp_proxies::TCPProxySyncStatus::DELETING,
+            ),
+            sample_raw_proxy(
+                "tcp_deleted",
+                queries::tcp_proxies::TCPProxySyncStatus::DELETED,
+            ),
+        ];
+
+        let active = active_tcp_proxies(&proxies);
+
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, "tcp_active");
     }
 
     #[test]

--- a/src/controllers/tcp_proxy.rs
+++ b/src/controllers/tcp_proxy.rs
@@ -1,0 +1,551 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Result, anyhow, bail};
+use reqwest::Client;
+use serde::Serialize;
+
+use crate::{
+    client::post_graphql,
+    config::Configs,
+    controllers::config::{
+        EnvironmentConfig, ServiceInstance, ServiceNetworking, TcpProxyConfig,
+        environment::fetch_environment_config,
+    },
+    gql::{mutations, queries},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PatchMode {
+    Commit,
+    Stage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TcpProxy {
+    pub id: String,
+    pub domain: String,
+    pub proxy_port: i64,
+    pub application_port: i64,
+    pub endpoint: String,
+    pub sync_status: String,
+    #[serde(skip_serializing)]
+    pub service_id: String,
+    #[serde(skip_serializing)]
+    pub environment_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedProxyIdentifier {
+    pub host: String,
+    pub port: Option<i64>,
+}
+
+pub fn parse_port(value: &str) -> std::result::Result<u16, String> {
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| "port must be a number from 1 to 65535".to_string())?;
+
+    if port == 0 {
+        return Err("port must be a number from 1 to 65535".to_string());
+    }
+
+    Ok(port)
+}
+
+pub fn validate_application_port(port: i64) -> std::result::Result<u16, String> {
+    if !(1..=65535).contains(&port) {
+        return Err("application_port must be a number from 1 to 65535".to_string());
+    }
+
+    Ok(port as u16)
+}
+
+pub async fn fetch_tcp_proxies(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<Vec<TcpProxy>> {
+    let proxies = post_graphql::<queries::TcpProxies, _>(
+        client,
+        configs.get_backboard(),
+        queries::tcp_proxies::Variables {
+            environment_id: environment_id.to_string(),
+            service_id: service_id.to_string(),
+        },
+    )
+    .await?
+    .tcp_proxies;
+
+    Ok(active_tcp_proxies(&proxies))
+}
+
+pub fn active_tcp_proxies(proxies: &[queries::tcp_proxies::TcpProxiesTcpProxies]) -> Vec<TcpProxy> {
+    proxies
+        .iter()
+        .filter(|proxy| proxy.deleted_at.is_none())
+        .map(tcp_proxy_output)
+        .collect()
+}
+
+pub fn tcp_proxy_output(proxy: &queries::tcp_proxies::TcpProxiesTcpProxies) -> TcpProxy {
+    TcpProxy {
+        id: proxy.id.clone(),
+        domain: proxy.domain.clone(),
+        proxy_port: proxy.proxy_port,
+        application_port: proxy.application_port,
+        endpoint: format!("{}:{}", proxy.domain, proxy.proxy_port),
+        sync_status: tcp_proxy_sync_status(&proxy.sync_status),
+        service_id: proxy.service_id.clone(),
+        environment_id: proxy.environment_id.clone(),
+        created_at: proxy.created_at.as_ref().map(chrono::DateTime::to_rfc3339),
+        updated_at: proxy.updated_at.as_ref().map(chrono::DateTime::to_rfc3339),
+    }
+}
+
+pub fn existing_proxy_for_create(proxies: &[TcpProxy], port: u16) -> Result<Option<&TcpProxy>> {
+    let Some(proxy) = proxies.first() else {
+        return Ok(None);
+    };
+
+    if proxy.application_port == i64::from(port) {
+        return Ok(Some(proxy));
+    }
+
+    bail!(
+        "A TCP proxy already exists for application port {} ({}). Only one TCP proxy is allowed per service instance. Delete it before creating a TCP proxy for application port {}.",
+        proxy.application_port,
+        proxy.endpoint,
+        port
+    );
+}
+
+pub async fn resolve_tcp_proxy(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    identifier: &str,
+) -> Result<TcpProxy> {
+    let proxies = fetch_tcp_proxies(client, configs, environment_id, service_id).await?;
+
+    find_tcp_proxy(&proxies, identifier)?
+        .cloned()
+        .ok_or_else(|| {
+            anyhow!(
+                "TCP proxy '{}' not found on the selected service",
+                identifier
+            )
+        })
+}
+
+pub fn find_tcp_proxy<'a>(
+    proxies: &'a [TcpProxy],
+    identifier: &str,
+) -> Result<Option<&'a TcpProxy>> {
+    if let Some(proxy) = proxies
+        .iter()
+        .find(|proxy| proxy.id.eq_ignore_ascii_case(identifier))
+    {
+        return Ok(Some(proxy));
+    }
+
+    let normalized = normalize_proxy_identifier(identifier);
+    let matches = matching_proxies(proxies, &normalized);
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(Some(matches[0])),
+        _ => bail!(
+            "TCP proxy selector '{}' matched multiple proxies: {}. Use a TCP proxy ID or full endpoint.",
+            identifier,
+            format_proxy_choices(&matches)
+        ),
+    }
+}
+
+pub fn normalize_proxy_identifier(identifier: &str) -> NormalizedProxyIdentifier {
+    let trimmed = identifier.trim();
+    let without_scheme = trimmed
+        .strip_prefix("tcp://")
+        .or_else(|| trimmed.strip_prefix("https://"))
+        .or_else(|| trimmed.strip_prefix("http://"))
+        .unwrap_or(trimmed);
+    let endpoint = without_scheme
+        .split('/')
+        .next()
+        .unwrap_or(without_scheme)
+        .trim_end_matches('.');
+
+    if let Some((host, port)) = endpoint.rsplit_once(':') {
+        if let Ok(port) = port.parse::<i64>() {
+            return NormalizedProxyIdentifier {
+                host: host.trim_end_matches('.').to_string(),
+                port: Some(port),
+            };
+        }
+    }
+
+    NormalizedProxyIdentifier {
+        host: endpoint.to_string(),
+        port: None,
+    }
+}
+
+pub async fn apply_tcp_proxy_patch(
+    client: &Client,
+    configs: &Configs,
+    project: &queries::RailwayProject,
+    environment_id: &str,
+    service_id: &str,
+    service_name: &str,
+    port: u16,
+) -> Result<PatchMode> {
+    let patch = tcp_proxy_patch(service_id, port);
+    let mode = patch_mode(project, environment_id);
+
+    match mode {
+        PatchMode::Commit => {
+            post_graphql::<mutations::EnvironmentPatchCommit, _>(
+                client,
+                configs.get_backboard(),
+                mutations::environment_patch_commit::Variables {
+                    environment_id: environment_id.to_string(),
+                    patch,
+                    commit_message: Some(format!(
+                        "Create TCP proxy for {} on port {}",
+                        service_name, port
+                    )),
+                },
+            )
+            .await?;
+        }
+        PatchMode::Stage => {
+            post_graphql::<mutations::EnvironmentStageChanges, _>(
+                client,
+                configs.get_backboard(),
+                mutations::environment_stage_changes::Variables {
+                    environment_id: environment_id.to_string(),
+                    input: patch,
+                    merge: Some(true),
+                },
+            )
+            .await?;
+        }
+    }
+
+    Ok(mode)
+}
+
+pub fn tcp_proxy_patch(service_id: &str, port: u16) -> EnvironmentConfig {
+    EnvironmentConfig {
+        services: BTreeMap::from([(
+            service_id.to_string(),
+            ServiceInstance {
+                networking: Some(ServiceNetworking {
+                    tcp_proxies: BTreeMap::from([(
+                        port.to_string(),
+                        Some(TcpProxyConfig::default()),
+                    )]),
+                    ..ServiceNetworking::default()
+                }),
+                ..ServiceInstance::default()
+            },
+        )]),
+        ..EnvironmentConfig::default()
+    }
+}
+
+pub fn patch_mode(project: &queries::RailwayProject, environment_id: &str) -> PatchMode {
+    let unmerged_changes = project
+        .environments
+        .edges
+        .iter()
+        .find(|env| env.node.id == environment_id)
+        .and_then(|env| env.node.unmerged_changes_count)
+        .unwrap_or_default();
+
+    if unmerged_changes > 0 {
+        PatchMode::Stage
+    } else {
+        PatchMode::Commit
+    }
+}
+
+pub async fn verify_tcp_proxy_configured(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    port: u16,
+) -> Result<()> {
+    let response = fetch_environment_config(client, configs, environment_id, false)
+        .await?
+        .config;
+
+    let configured = response
+        .services
+        .get(service_id)
+        .and_then(|service| service.networking.as_ref())
+        .is_some_and(|networking| networking.tcp_proxies.contains_key(&port.to_string()));
+
+    if !configured {
+        bail!(
+            "TCP proxy configuration was requested, but port {} was not present after verification.",
+            port
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn delete_tcp_proxy(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    proxy: &TcpProxy,
+) -> Result<()> {
+    let deleted = post_graphql::<mutations::TcpProxyDelete, _>(
+        client,
+        configs.get_backboard(),
+        mutations::tcp_proxy_delete::Variables {
+            id: proxy.id.clone(),
+        },
+    )
+    .await?
+    .tcp_proxy_delete;
+
+    if !deleted {
+        bail!("Failed to delete TCP proxy {}", proxy.id);
+    }
+
+    let remaining = fetch_tcp_proxies(client, configs, environment_id, service_id).await?;
+    if remaining.iter().any(|item| item.id == proxy.id) {
+        bail!(
+            "TCP proxy deletion was requested, but {} still exists after verification.",
+            proxy.id
+        );
+    }
+
+    Ok(())
+}
+
+pub fn tcp_proxy_sync_status(value: &queries::tcp_proxies::TCPProxySyncStatus) -> String {
+    match value {
+        queries::tcp_proxies::TCPProxySyncStatus::ACTIVE => "ACTIVE".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::CREATING => "CREATING".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::DELETED => "DELETED".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::DELETING => "DELETING".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::UNSPECIFIED => "UNSPECIFIED".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::UPDATING => "UPDATING".to_string(),
+        queries::tcp_proxies::TCPProxySyncStatus::Other(status) => status.clone(),
+    }
+}
+
+fn matching_proxies<'a>(
+    proxies: &'a [TcpProxy],
+    normalized: &NormalizedProxyIdentifier,
+) -> Vec<&'a TcpProxy> {
+    if let Some(port) = normalized.port {
+        return proxies
+            .iter()
+            .filter(|proxy| {
+                proxy.domain.eq_ignore_ascii_case(&normalized.host) && proxy.proxy_port == port
+            })
+            .collect();
+    }
+
+    if let Ok(numeric) = normalized.host.parse::<i64>() {
+        return proxies
+            .iter()
+            .filter(|proxy| proxy.proxy_port == numeric || proxy.application_port == numeric)
+            .collect();
+    }
+
+    proxies
+        .iter()
+        .filter(|proxy| proxy.domain.eq_ignore_ascii_case(&normalized.host))
+        .collect()
+}
+
+fn format_proxy_choices(proxies: &[&TcpProxy]) -> String {
+    proxies
+        .iter()
+        .map(|proxy| {
+            format!(
+                "{} (id: {}, app port: {})",
+                proxy.endpoint, proxy.id, proxy.application_port
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_proxy() -> TcpProxy {
+        TcpProxy {
+            id: "tcp_123".to_string(),
+            domain: "containers-us-west.railway.app".to_string(),
+            proxy_port: 15432,
+            application_port: 5432,
+            endpoint: "containers-us-west.railway.app:15432".to_string(),
+            sync_status: "ACTIVE".to_string(),
+            service_id: "svc_123".to_string(),
+            environment_id: "env_123".to_string(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn sample_proxy_with_ports(id: &str, proxy_port: i64, application_port: i64) -> TcpProxy {
+        TcpProxy {
+            id: id.to_string(),
+            domain: "containers-us-west.railway.app".to_string(),
+            proxy_port,
+            application_port,
+            endpoint: format!("containers-us-west.railway.app:{proxy_port}"),
+            sync_status: "ACTIVE".to_string(),
+            service_id: "svc_123".to_string(),
+            environment_id: "env_123".to_string(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn validates_port_range() {
+        assert_eq!(parse_port("1").unwrap(), 1);
+        assert_eq!(parse_port("65535").unwrap(), 65535);
+        assert_eq!(validate_application_port(1).unwrap(), 1);
+        assert_eq!(validate_application_port(65535).unwrap(), 65535);
+        assert!(parse_port("0").is_err());
+        assert!(parse_port("65536").is_err());
+        assert!(validate_application_port(0).is_err());
+        assert!(validate_application_port(65536).is_err());
+    }
+
+    #[test]
+    fn normalizes_proxy_identifier() {
+        assert_eq!(
+            normalize_proxy_identifier("tcp://containers-us-west.railway.app:15432/path"),
+            NormalizedProxyIdentifier {
+                host: "containers-us-west.railway.app".to_string(),
+                port: Some(15432),
+            }
+        );
+        assert_eq!(
+            normalize_proxy_identifier("containers-us-west.railway.app."),
+            NormalizedProxyIdentifier {
+                host: "containers-us-west.railway.app".to_string(),
+                port: None,
+            }
+        );
+    }
+
+    #[test]
+    fn finds_proxy_by_id_endpoint_domain_or_port() {
+        let proxy = sample_proxy();
+        let proxies = vec![proxy];
+
+        assert!(find_tcp_proxy(&proxies, "tcp_123").unwrap().is_some());
+        assert!(
+            find_tcp_proxy(&proxies, "containers-us-west.railway.app:15432")
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            find_tcp_proxy(&proxies, "containers-us-west.railway.app")
+                .unwrap()
+                .is_some()
+        );
+        assert!(find_tcp_proxy(&proxies, "15432").unwrap().is_some());
+        assert!(find_tcp_proxy(&proxies, "5432").unwrap().is_some());
+        assert!(find_tcp_proxy(&proxies, "missing").unwrap().is_none());
+    }
+
+    #[test]
+    fn create_allows_existing_proxy_only_for_same_application_port() {
+        let proxy = sample_proxy();
+        let proxies = vec![proxy];
+
+        let existing = existing_proxy_for_create(&proxies, 5432).unwrap().unwrap();
+        assert_eq!(existing.id, "tcp_123");
+
+        let err = existing_proxy_for_create(&proxies, 6380).unwrap_err();
+        assert!(err.to_string().contains("Only one TCP proxy is allowed"));
+        assert!(err.to_string().contains("application port 5432"));
+        assert!(err.to_string().contains("application port 6380"));
+    }
+
+    #[test]
+    fn id_lookup_wins_even_when_numeric_selector_would_be_ambiguous() {
+        let proxies = vec![
+            sample_proxy_with_ports("15432", 15432, 5432),
+            sample_proxy_with_ports("tcp_456", 15433, 15432),
+        ];
+
+        let proxy = find_tcp_proxy(&proxies, "15432").unwrap().unwrap();
+
+        assert_eq!(proxy.id, "15432");
+    }
+
+    #[test]
+    fn ambiguous_domain_or_port_selector_errors() {
+        let proxies = vec![
+            sample_proxy_with_ports("tcp_123", 15432, 5432),
+            sample_proxy_with_ports("tcp_456", 15433, 5432),
+        ];
+
+        let domain_err = find_tcp_proxy(&proxies, "containers-us-west.railway.app").unwrap_err();
+        assert!(domain_err.to_string().contains("matched multiple proxies"));
+
+        let port_err = find_tcp_proxy(&proxies, "5432").unwrap_err();
+        assert!(
+            port_err
+                .to_string()
+                .contains("Use a TCP proxy ID or full endpoint")
+        );
+
+        assert!(
+            find_tcp_proxy(&proxies, "containers-us-west.railway.app:15433")
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn tcp_proxy_patch_sets_networking_config_for_service_port() {
+        let patch = tcp_proxy_patch("svc_123", 6379);
+        let networking = patch
+            .services
+            .get("svc_123")
+            .and_then(|service| service.networking.as_ref())
+            .unwrap();
+
+        assert!(networking.tcp_proxies.contains_key("6379"));
+    }
+
+    #[test]
+    fn tcp_proxy_sync_status_outputs_clean_strings() {
+        assert_eq!(
+            tcp_proxy_sync_status(&queries::tcp_proxies::TCPProxySyncStatus::ACTIVE),
+            "ACTIVE"
+        );
+        assert_eq!(
+            tcp_proxy_sync_status(&queries::tcp_proxies::TCPProxySyncStatus::Other(
+                "NEW_STATUS".to_string()
+            )),
+            "NEW_STATUS"
+        );
+    }
+}

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -230,6 +230,14 @@ pub struct CustomDomainCreate;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/TcpProxyDelete.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct TcpProxyDelete;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/EnvironmentCreate.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/strings/TcpProxyDelete.graphql
+++ b/src/gql/mutations/strings/TcpProxyDelete.graphql
@@ -1,0 +1,3 @@
+mutation TcpProxyDelete($id: String!) {
+  tcpProxyDelete(id: $id)
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -114,6 +114,14 @@ pub struct Domains;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/TcpProxies.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct TcpProxies;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/ProjectToken.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/TcpProxies.graphql
+++ b/src/gql/queries/strings/TcpProxies.graphql
@@ -1,0 +1,14 @@
+query TcpProxies($environmentId: String!, $serviceId: String!) {
+  tcpProxies(environmentId: $environmentId, serviceId: $serviceId) {
+    id
+    domain
+    proxyPort
+    applicationPort
+    serviceId
+    environmentId
+    syncStatus
+    createdAt
+    updatedAt
+    deletedAt
+  }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,12 @@
 #[macro_export]
 macro_rules! commands {
-    ($($module:ident $(($($alias:ident),*))?),*) => {
+    (@command_name $module:ident) => {
+        stringify!($module)
+    };
+    (@command_name $module:ident as $name:literal) => {
+        $name
+    };
+    ($($module:ident $(as $name:literal)? $(($($alias:ident),*))?),*) => {
         pastey::paste! {
             /// Build the global CLI (root command) and attach module subcommands.
             pub fn build_args() -> clap::Command {
@@ -17,6 +23,7 @@ macro_rules! commands {
                     .version(clap::crate_version!());
                 $(
                     {
+                        let command_name = $crate::commands!(@command_name $module $(as $name)?);
                         // Get the subcommand as defined by the module.
                         let sub = <$crate::commands::$module::Args as ::clap::CommandFactory>::command();
                         // Allow the module to add dynamic arguments (if needed) and add any aliases.
@@ -37,10 +44,9 @@ macro_rules! commands {
                                     s = get_dynamic_args(s);
                                 }
                             }
-                            s = s.name(stringify!($module));
+                            s = s.name(command_name);
                             s
                         };
-                        let command_name = stringify!($module);
                         // Add this subcommand into the global CLI.
                         cmd = cmd.subcommand(sub.name(command_name));
                     }
@@ -63,7 +69,8 @@ macro_rules! commands {
             pub async fn exec_cli(matches: clap::ArgMatches) -> anyhow::Result<()> {
                 match matches.subcommand() {
                     $(
-                        Some((stringify!([<$module:snake>]), sub_matches)) => {
+                        Some((matched_command_name, sub_matches))
+                            if matched_command_name == $crate::commands!(@command_name [<$module:snake>] $(as $name)?) => {
                             // Walk nested subcommand levels so telemetry can
                             // distinguish e.g. `sandbox template build` from
                             // `sandbox template status` ("template:build").

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ commands!(
     status,
     telemetry_cmd(telemetry),
     templates,
+    tcp_proxy as "tcp-proxy",
     unlink,
     up,
     upgrade,
@@ -544,6 +545,7 @@ mod cli_tests {
             assert_subcommand(&["link"], "link");
             assert_subcommand(&["up"], "up");
             assert_subcommand(&["redeploy"], "redeploy");
+            assert_subcommand(&["tcp-proxy", "list"], "tcp-proxy");
         }
 
         #[test]
@@ -714,6 +716,15 @@ mod cli_tests {
                 "eu-west=2",
                 "us-east=1",
             ]);
+        }
+
+        #[test]
+        fn tcp_proxy_subcommands() {
+            assert_parses(&["tcp-proxy", "list"]);
+            assert_parses(&["tcp-proxy", "list", "--service", "api", "--json"]);
+            assert_parses(&["tcp-proxy", "create", "--port", "5432"]);
+            assert_parses(&["tcp-proxy", "status", "proxy-id"]);
+            assert_parses(&["tcp-proxy", "delete", "proxy-id", "--yes"]);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Adds TCP proxy management to both the Railway CLI and the local CLI MCP server.

- Adds a top-level `railway tcp-proxy` command for public TCP proxies on a Railway service.
- Adds local MCP tools for agents: `list_tcp_proxies`, `create_tcp_proxy`, `get_tcp_proxy`, and `remove_tcp_proxy`.
- Creates TCP proxies through service networking config and deletes them through `tcpProxyDelete`.
- Adds agent-friendly CLI JSON success and runtime error output.
- Enforces Railway's one-TCP-proxy-per-service-instance constraint before attempting mutation.
- Shares TCP proxy selector, patch, delete, and sync-status logic between CLI and MCP to avoid drift.
- Verifies committed creates through the TCP proxy query with a short retry loop to tolerate read-after-write lag.

## Command documentation

### `railway tcp-proxy list`

Aliases: `ls`

Lists TCP proxies for the selected service.

```sh
railway tcp-proxy list \
  --project <project> \
  --environment <environment> \
  --service <service>
```

JSON output:

```sh
railway tcp-proxy list --json
```

Returns an object with a `proxies` array. Each proxy includes stable fields such as `id`, `domain`, `proxyPort`, `endpoint`, `applicationPort`, and `syncStatus`.

### `railway tcp-proxy create --port <PORT>`

Aliases: `add`, `new`

Creates a public TCP proxy for the selected service application port.

```sh
railway tcp-proxy create --port 6379 \
  --project <project> \
  --environment <environment> \
  --service <service>
```

Behavior:

- Validates the application port is in range.
- If an active TCP proxy already exists for the same application port, the command is idempotent and returns the existing proxy.
- If a TCP proxy already exists for another application port, the command fails before mutation because only one TCP proxy is allowed per service instance.
- If the selected environment has pending changes, the networking config patch is staged.
- If there are no pending changes, the networking config patch is committed.
- After a committed create, the command verifies the requested application port through the TCP proxy query with short retries.
- If the proxy is configured but not yet readable, check `railway tcp-proxy list` shortly; redeploy only if it does not become active.

JSON output:

```sh
railway tcp-proxy create --port 6379 --json
```

Returns metadata about the requested patch plus a stable `proxy` field. `proxy` is always present:

```json
{
  "applicationPort": 6379,
  "staged": false,
  "committed": true,
  "proxy": null
}
```

When an existing/active proxy is readable, `proxy` is the proxy object instead of `null`.

### `railway tcp-proxy status <PROXY>`

Shows details for a single TCP proxy.

```sh
railway tcp-proxy status <PROXY> \
  --project <project> \
  --environment <environment> \
  --service <service>
```

`<PROXY>` can be:

- TCP proxy ID
- Full endpoint, for example `host.proxy.rlwy.net:12345`
- Domain
- Proxy port
- Application port

For automation, prefer resolving via `railway tcp-proxy list --json` and then using the proxy ID. Ambiguous selectors fail with a structured error under `--json`.

### `railway tcp-proxy delete <PROXY> --yes`

Aliases: `remove`, `rm`

Deletes a TCP proxy.

```sh
railway tcp-proxy delete <PROXY> --yes \
  --project <project> \
  --environment <environment> \
  --service <service>
```

Behavior:

- Resolves `<PROXY>` using the same selectors as `status`.
- Requires confirmation unless `--yes` is provided.
- Deletes by resolved proxy ID via `tcpProxyDelete`.
- Verifies the proxy is no longer present after mutation.

JSON output:

```sh
railway tcp-proxy delete <PROXY> --yes --json
```

Returns compact env-patch-style metadata and does not include a stale nested proxy snapshot:

```json
{
  "deleted": true,
  "id": "...",
  "endpoint": "host.proxy.rlwy.net:12345",
  "applicationPort": 6379,
  "staged": false,
  "committed": true
}
```

If an interactive deletion is cancelled under `--json`, the output includes `"deleted": false` and the resolved proxy snapshot.

## Local MCP tools

The local `railway mcp` server now exposes readable text tools for the same TCP proxy workflow:

- `list_tcp_proxies`: lists endpoint, ID, proxy port, application port, and sync status for the selected service.
- `create_tcp_proxy`: creates a public TCP proxy for `application_port`; idempotent for the existing port and rejected when a different TCP proxy already exists.
- `get_tcp_proxy`: shows details for a proxy by ID, endpoint, domain, proxy port, or application port.
- `remove_tcp_proxy`: previews the deletion first, then requires `confirm: true`; deletes by resolved proxy ID.

These tools use the same project/environment/service resolution as existing MCP service tools. Remote MCP changes are intentionally out of scope.

## JSON contract notes

- `syncStatus` values serialize as clean schema strings such as `ACTIVE`, `CREATING`, `DELETED`, `DELETING`, `UNSPECIFIED`, and `UPDATING`.
- Future unknown `syncStatus` values serialize as the raw value rather than Rust debug output.
- `create --json` always includes `proxy`, with `null` when config is committed/staged but the proxy is not yet readable.
- `delete --json` success includes `deleted: true`, returns compact mutation metadata, and intentionally omits stale `syncStatus`/nested `proxy` data.
- Runtime command errors run through the shared JSON reporter mode when `--json` is set; clap argument parsing errors still use clap's standard error format.

## Validation

Local validation:

- `cargo fmt -- --check`
- `cargo test tcp_proxy -- --nocapture`
- `cargo test mcp -- --nocapture`
- `cargo test`

Live Railway smoke test:

- Created temp project `tcp-proxy-smoke-20260614-codex`.
- Created a fresh service `redis-smoke-2` from `redis:7-alpine`.
- Deployed successfully.
- Created a TCP proxy on application port `6379`.
- Verified list/status selectors by ID, endpoint, domain, proxy port, and application port.
- Verified same-port create is idempotent.
- Verified different-port create fails with a structured one-proxy-limit JSON error.
- Verified data plane connectivity through the public TCP endpoint with Redis `PING` returning `+PONG`.
- Deleted the TCP proxy and verified list/config cleanup.

The temp Railway project/service were intentionally left in place for inspection.
