### PR TITLE
Add support for passing `--project <PROJECT>` to  `deployment list`

### DIFF
--- a/src/commands/deployment.rs
+++ b/src/commands/deployment.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::client::post_graphql;
-use crate::controllers::environment::get_matched_environment;
-use crate::controllers::project::{ensure_project_and_environment_exist, get_project};
+use crate::controllers::project::resolve_service_context;
 use crate::gql::queries::deployments::{DeploymentStatus, ResponseData, Variables};
 use chrono::{DateTime, Local, Utc};
 use serde::Serialize;
@@ -40,6 +39,10 @@ struct ListArgs {
     #[clap(short, long)]
     environment: Option<String>,
 
+    /// Project ID or name to list deployments from (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT")]
+    project: Option<String>,
+
     /// Maximum number of deployments to show (default: 20, max: 1000)
     #[clap(long, default_value = "20")]
     limit: i64,
@@ -62,6 +65,7 @@ pub async fn command(args: Args) -> Result<()> {
     match args.command {
         Commands::List(list_args) => {
             list_deployments(
+                list_args.project,
                 list_args.service,
                 list_args.environment,
                 list_args.limit,
@@ -81,17 +85,12 @@ pub async fn command(args: Args) -> Result<()> {
 }
 
 async fn list_deployments(
+    project: Option<String>,
     service: Option<String>,
     environment: Option<String>,
     limit: i64,
     json: bool,
 ) -> Result<()> {
-    let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
-
     let limit = if limit > 1000 {
         eprintln!(
             "{}",
@@ -108,37 +107,18 @@ async fn list_deployments(
         limit
     };
 
-    let project = get_project(&client, &configs, linked_project.project.clone()).await?;
-    let environment = match environment {
-        Some(env) => env,
-        None => linked_project.environment_id()?.to_string(),
-    };
-    let environment_id = get_matched_environment(&project, environment)?.id;
-
-    let service_id = if let Some(service_name_or_id) = service {
-        let service = project
-            .services
-            .edges
-            .iter()
-            .find(|s| {
-                s.node.name.to_lowercase() == service_name_or_id.to_lowercase()
-                    || s.node.id == service_name_or_id
-            })
-            .ok_or_else(|| anyhow::anyhow!("Service '{}' not found", service_name_or_id))?;
-        service.node.id.clone()
-    } else if let Some(linked_service_id) = linked_project.service {
-        linked_service_id
-    } else {
-        bail!(
-            "No service specified and no service linked. Use 'railway link' to link a service or specify one with the service argument."
-        );
-    };
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let client = ctx.client;
+    let configs = ctx.configs;
+    let project_id = ctx.project_id;
+    let environment_id = ctx.environment_id;
+    let service_id = ctx.service_id;
 
     let variables = Variables {
         input: crate::gql::queries::deployments::DeploymentListInput {
             service_id: Some(service_id.clone()),
             environment_id: Some(environment_id),
-            project_id: None,
+            project_id: Some(project_id),
             status: None,
             include_deleted: None,
         },

--- a/src/controllers/project.rs
+++ b/src/controllers/project.rs
@@ -20,6 +20,7 @@ use crate::{
         },
     },
     errors::RailwayError,
+    workspace::workspaces_with_client,
 };
 
 use super::environment::get_matched_environment;
@@ -58,6 +59,86 @@ pub async fn get_project(
         .project;
 
     Ok(project)
+}
+
+#[derive(Debug, Clone)]
+struct ProjectChoice {
+    id: String,
+    name: String,
+    workspace_name: String,
+}
+
+pub async fn resolve_project_id_or_name(
+    client: &Client,
+    configs: &Configs,
+    project: &str,
+) -> Result<String> {
+    match get_project(client, configs, project.to_string()).await {
+        Ok(project) => return Ok(project.id),
+        Err(RailwayError::ProjectNotFound) => {}
+        Err(RailwayError::GraphQLError(message)) if message.contains("Project not found") => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    let choices = project_choices(client, configs).await?;
+    let id_matches = choices
+        .iter()
+        .filter(|choice| choice.id.eq_ignore_ascii_case(project))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if let Some(choice) = single_project_match(id_matches, project, "project ID")? {
+        return Ok(choice.id);
+    }
+
+    let name_matches = choices
+        .into_iter()
+        .filter(|choice| choice.name.eq_ignore_ascii_case(project))
+        .collect::<Vec<_>>();
+
+    if let Some(choice) = single_project_match(name_matches, project, "project name")? {
+        return Ok(choice.id);
+    }
+
+    bail!("Project \"{}\" not found", project)
+}
+
+async fn project_choices(client: &Client, configs: &Configs) -> Result<Vec<ProjectChoice>> {
+    let mut choices = Vec::new();
+    for workspace in workspaces_with_client(client, configs).await? {
+        let workspace_name = workspace.name().to_string();
+        choices.extend(
+            workspace
+                .projects()
+                .into_iter()
+                .filter(|project| project.deleted_at().is_none())
+                .map(|project| ProjectChoice {
+                    id: project.id().to_string(),
+                    name: project.name().to_string(),
+                    workspace_name: workspace_name.clone(),
+                }),
+        );
+    }
+    Ok(choices)
+}
+
+fn single_project_match(
+    matches: Vec<ProjectChoice>,
+    input: &str,
+    kind: &str,
+) -> Result<Option<ProjectChoice>> {
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.into_iter().next()),
+        _ => {
+            let available = matches
+                .iter()
+                .map(|choice| format!("{} ({})", choice.id, choice.workspace_name))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("Ambiguous {kind} \"{input}\". Use one of these project IDs: {available}");
+        }
+    }
 }
 
 pub fn get_service(
@@ -263,11 +344,16 @@ pub async fn resolve_service_context(
         ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
     }
 
-    let project_id = project_arg
-        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
-        .ok_or_else(|| {
-            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
-        })?;
+    let project_id = if let Some(project_arg) = project_arg {
+        resolve_project_id_or_name(&client, &configs, &project_arg).await?
+    } else {
+        linked_project
+            .as_ref()
+            .map(|lp| lp.project.clone())
+            .ok_or_else(|| {
+                anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+            })?
+    };
 
     let project = get_project(&client, &configs, project_id.clone()).await?;
 
@@ -293,7 +379,9 @@ pub async fn resolve_service_context(
         (Some(service_arg), _) => {
             let service = services
                 .iter()
-                .find(|s| s.node.name == service_arg || s.node.id == service_arg)
+                .find(|s| {
+                    s.node.name.eq_ignore_ascii_case(&service_arg) || s.node.id == service_arg
+                })
                 .with_context(|| format!("Service '{service_arg}' not found"))?;
             (service.node.id.clone(), service.node.name.clone())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -562,6 +562,20 @@ mod cli_tests {
         }
 
         #[test]
+        fn deployment_list_project_flag_parses() {
+            assert_parses(&[
+                "deployment",
+                "list",
+                "--project",
+                "project-id",
+                "--environment",
+                "production",
+                "--service",
+                "api",
+            ]);
+        }
+
+        #[test]
         fn logs_http_examples_parse() {
             assert_parses(&["logs", "--http", "--lines", "50"]);
             assert_parses(&[


### PR DESCRIPTION
## Summary

Adds project selection support to `railway deployment list` via `--project <PROJECT>`, matching the service-scoped command pattern used elsewhere in the CLI.

## Why

`deployment list` previously only worked from the linked project, even though related commands such as logs/restart/redeploy can target another project through `--project` plus `--environment`.

## Changes

- Adds `-p, --project <PROJECT>` to `railway deployment list`.
- Routes deployment listing through `resolve_service_context` so project, environment, and service resolution stay consistent.
- Adds exact project ID/name resolution for shared service context commands, with ambiguity errors for duplicate project names.
- Preserves the previous case-insensitive service-name behavior when resolving explicit services.
- Adds a CLI parser regression test for `deployment list --project ... --environment ... --service ...`.

## Validation

- `cargo test cli_tests`
- `cargo test --no-run`
- `cargo run -- deployment list --help`

## Release

Minor: exposes a new CLI flag for an existing command.