### PR TITLE
Add private networking CLI commands

### DIFF
--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1001,6 +1001,56 @@ impl RailwayMcp {
     }
 
     #[tool(
+        description = "List private networks for a Railway environment. Dashboard parity: mirrors privateNetworks(environmentId)."
+    )]
+    async fn list_private_networks(
+        &self,
+        Parameters(params): Parameters<EnvironmentParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_list_private_networks(params).await
+    }
+
+    #[tool(
+        description = "Show a service private network endpoint status. Dashboard parity: mirrors privateNetworkEndpoint(privateNetworkId, environmentId, serviceId)."
+    )]
+    async fn private_network_status(
+        &self,
+        Parameters(params): Parameters<PrivateNetworkStatusParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_private_network_status(params).await
+    }
+
+    #[tool(
+        description = "Enable private networking through Railway environment config. Dashboard parity: sets privateNetworkDisabled=false and optionally services.<serviceId>.networking.privateNetworkEndpoint; no direct endpoint mutations."
+    )]
+    async fn enable_private_network(
+        &self,
+        Parameters(params): Parameters<EnablePrivateNetworkParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_enable_private_network(params).await
+    }
+
+    #[tool(
+        description = "Set a service private endpoint DNS prefix through Railway environment config. Dashboard parity: uses the same config apply workflow as the dashboard endpoint edit."
+    )]
+    async fn set_private_network_endpoint(
+        &self,
+        Parameters(params): Parameters<SetPrivateNetworkEndpointParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_set_private_network_endpoint(params).await
+    }
+
+    #[tool(
+        description = "Check whether a private endpoint DNS prefix is available on a private network. Dashboard parity: mirrors privateNetworkEndpointNameAvailable."
+    )]
+    async fn check_private_network_endpoint_name(
+        &self,
+        Parameters(params): Parameters<CheckPrivateNetworkEndpointNameParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_check_private_network_endpoint_name(params).await
+    }
+
+    #[tool(
         description = "Set reference variables on a service. Each variable value must be a Railway reference expression starting with '${{' (e.g. '${{ Postgres.DATABASE_URL }}')."
     )]
     async fn add_reference_variable(
@@ -1224,6 +1274,27 @@ impl RailwayMcp {
             response.deployment_domain,
             response.deployment_id,
         ))]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_network_tools_are_registered() {
+        let router = RailwayMcp::tool_router();
+        let tools = router.list_all();
+        let names = tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"list_private_networks"));
+        assert!(names.contains(&"private_network_status"));
+        assert!(names.contains(&"enable_private_network"));
+        assert!(names.contains(&"set_private_network_endpoint"));
+        assert!(names.contains(&"check_private_network_endpoint_name"));
     }
 }
 

--- a/src/commands/mcp/params.rs
+++ b/src/commands/mcp/params.rs
@@ -23,6 +23,90 @@ pub struct ServiceParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct EnvironmentParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PrivateNetworkStatusParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Private network ID, name, DNS suffix, or numeric network ID. Defaults to the network named "railway", then the first network.
+    #[serde(default)]
+    pub network: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct EnablePrivateNetworkParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. Required only when endpoint is provided, unless a service is linked.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Optional service private endpoint DNS prefix to configure in the same environment config patch.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Stage the environment config change instead of committing it immediately.
+    #[serde(default)]
+    pub stage: bool,
+    /// Commit message to use when applying immediately.
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SetPrivateNetworkEndpointParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Service private endpoint DNS prefix to set through environment config.
+    pub endpoint: String,
+    /// Stage the environment config change instead of committing it immediately.
+    #[serde(default)]
+    pub stage: bool,
+    /// Commit message to use when applying immediately.
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CheckPrivateNetworkEndpointNameParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Private endpoint DNS prefix to validate and check.
+    pub endpoint: String,
+    /// Private network ID, name, DNS suffix, or numeric network ID. Defaults to the network named "railway", then the first network.
+    #[serde(default)]
+    pub network: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ListDeploymentsParams {
     /// The project ID. If omitted, uses the currently linked project.
     #[serde(default)]

--- a/src/commands/mcp/tools/mod.rs
+++ b/src/commands/mcp/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod docs;
 pub mod observability;
+pub mod private_network;
 pub mod project;
 pub mod service;
 pub mod storage;

--- a/src/commands/mcp/tools/private_network.rs
+++ b/src/commands/mcp/tools/private_network.rs
@@ -1,0 +1,484 @@
+use rmcp::{ErrorData as McpError, model::*};
+
+use crate::controllers::private_network::{
+    self, PatchMode, PrivateNetwork, PrivateNetworkEndpoint,
+};
+
+use super::super::handler::{RailwayMcp, ResolvedServiceContext};
+use super::super::params::{
+    CheckPrivateNetworkEndpointNameParams, EnablePrivateNetworkParams, EnvironmentParams,
+    PrivateNetworkStatusParams, SetPrivateNetworkEndpointParams,
+};
+
+impl RailwayMcp {
+    pub(crate) async fn do_list_private_networks(
+        &self,
+        params: EnvironmentParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_context(params.project_id, params.environment_id)
+            .await?;
+        let networks = private_network::fetch_private_networks(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to fetch private networks: {e}"), None)
+        })?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_private_network_list(&ctx.environment_id, &networks),
+        )]))
+    }
+
+    pub(crate) async fn do_private_network_status(
+        &self,
+        params: PrivateNetworkStatusParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let networks = private_network::fetch_private_networks(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to fetch private networks: {e}"), None)
+        })?;
+        let network = resolve_private_network_from_list(&networks, params.network.as_deref())?;
+
+        let endpoint = private_network::fetch_private_network_endpoint(
+            &self.client,
+            &self.configs,
+            &network.public_id,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to fetch private network endpoint: {e}"),
+                None,
+            )
+        })?;
+        let internal_url = if let Some(endpoint) = endpoint.as_ref() {
+            let configured_endpoint_name = private_network::fetch_configured_endpoint_name(
+                &self.client,
+                &self.configs,
+                &ctx.environment_id,
+                &ctx.service_id,
+            )
+            .await
+            .map_err(|e| {
+                McpError::internal_error(
+                    format!("Failed to fetch private endpoint config: {e}"),
+                    None,
+                )
+            })?;
+
+            Some(private_network::internal_url_for_dns_name(
+                network,
+                configured_endpoint_name
+                    .as_deref()
+                    .unwrap_or(&endpoint.dns_name),
+            ))
+        } else {
+            None
+        };
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_private_network_status(
+                &ctx,
+                network,
+                endpoint.as_ref(),
+                internal_url.as_deref(),
+            ),
+        )]))
+    }
+
+    pub(crate) async fn do_enable_private_network(
+        &self,
+        params: EnablePrivateNetworkParams,
+    ) -> Result<CallToolResult, McpError> {
+        let endpoint = params
+            .endpoint
+            .as_deref()
+            .map(private_network::validate_endpoint_prefix)
+            .transpose()
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+
+        if let Some(endpoint) = endpoint {
+            let ctx = self
+                .resolve_service_context(
+                    params.project_id,
+                    params.service_id,
+                    params.environment_id,
+                )
+                .await?;
+            let service_name = service_name(&ctx);
+            let mode = private_network::apply_enable_patch(
+                &self.client,
+                &self.configs,
+                &ctx.environment_id,
+                Some(&ctx.service_id),
+                Some(&endpoint),
+                params.stage,
+                Some(params.message.unwrap_or_else(|| {
+                    format!(
+                        "Enable private networking for {} with endpoint {}",
+                        service_name, endpoint
+                    )
+                })),
+            )
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Failed to enable private networking: {e}"), None)
+            })?;
+
+            if mode == PatchMode::Commit {
+                verify_private_network_commit(
+                    &self.client,
+                    &self.configs,
+                    &ctx.environment_id,
+                    Some((&ctx.service_id, &endpoint)),
+                )
+                .await?;
+            }
+
+            return Ok(CallToolResult::success(vec![Content::text(
+                format_private_network_change(
+                    &ctx.environment_id,
+                    Some((&service_name, &ctx.service_id)),
+                    Some(&endpoint),
+                    mode,
+                ),
+            )]));
+        }
+
+        let ctx = self
+            .resolve_context(params.project_id, params.environment_id)
+            .await?;
+        let mode = private_network::apply_enable_patch(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            None,
+            None,
+            params.stage,
+            Some(
+                params
+                    .message
+                    .unwrap_or_else(|| "Enable private networking".to_string()),
+            ),
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to enable private networking: {e}"), None)
+        })?;
+
+        if mode == PatchMode::Commit {
+            verify_private_network_commit(&self.client, &self.configs, &ctx.environment_id, None)
+                .await?;
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_private_network_change(&ctx.environment_id, None, None, mode),
+        )]))
+    }
+
+    pub(crate) async fn do_set_private_network_endpoint(
+        &self,
+        params: SetPrivateNetworkEndpointParams,
+    ) -> Result<CallToolResult, McpError> {
+        let endpoint = private_network::validate_endpoint_prefix(&params.endpoint)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let service_name = service_name(&ctx);
+        let mode = private_network::apply_set_endpoint_patch(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+            &endpoint,
+            params.stage,
+            Some(params.message.unwrap_or_else(|| {
+                format!(
+                    "Set private network endpoint for {} to {}",
+                    service_name, endpoint
+                )
+            })),
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to set private network endpoint: {e}"), None)
+        })?;
+
+        if mode == PatchMode::Commit {
+            verify_private_network_commit(
+                &self.client,
+                &self.configs,
+                &ctx.environment_id,
+                Some((&ctx.service_id, &endpoint)),
+            )
+            .await?;
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_private_network_change(
+                &ctx.environment_id,
+                Some((&service_name, &ctx.service_id)),
+                Some(&endpoint),
+                mode,
+            ),
+        )]))
+    }
+
+    pub(crate) async fn do_check_private_network_endpoint_name(
+        &self,
+        params: CheckPrivateNetworkEndpointNameParams,
+    ) -> Result<CallToolResult, McpError> {
+        let endpoint = private_network::validate_endpoint_prefix(&params.endpoint)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        let ctx = self
+            .resolve_context(params.project_id, params.environment_id)
+            .await?;
+        let networks = private_network::fetch_private_networks(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to fetch private networks: {e}"), None)
+        })?;
+        let network = resolve_private_network_from_list(&networks, params.network.as_deref())?;
+        let available = private_network::private_network_endpoint_name_available(
+            &self.client,
+            &self.configs,
+            &network.public_id,
+            &ctx.environment_id,
+            &endpoint,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to check endpoint name: {e}"), None)
+        })?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Endpoint name '{}' is {} on private network {} (id: {}).",
+            endpoint,
+            if available {
+                "available"
+            } else {
+                "already used"
+            },
+            network.name,
+            network.public_id
+        ))]))
+    }
+}
+
+async fn verify_private_network_commit(
+    client: &reqwest::Client,
+    configs: &crate::config::Configs,
+    environment_id: &str,
+    endpoint: Option<(&str, &str)>,
+) -> Result<(), McpError> {
+    private_network::verify_private_network_enabled(client, configs, environment_id)
+        .await
+        .map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to verify private networking config: {e}"),
+                None,
+            )
+        })?;
+
+    if let Some((service_id, endpoint)) = endpoint {
+        private_network::verify_endpoint_configured(
+            client,
+            configs,
+            environment_id,
+            service_id,
+            endpoint,
+        )
+        .await
+        .map_err(|e| {
+            McpError::internal_error(
+                format!("Failed to verify private endpoint config: {e}"),
+                None,
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn resolve_private_network_from_list<'a>(
+    networks: &'a [PrivateNetwork],
+    identifier: Option<&str>,
+) -> Result<&'a PrivateNetwork, McpError> {
+    private_network::resolve_private_network(networks, identifier)
+        .map_err(|e| McpError::invalid_params(e.to_string(), None))?
+        .ok_or_else(|| {
+            McpError::invalid_params(
+                "No private network found in the selected environment.",
+                None,
+            )
+        })
+}
+
+fn format_private_network_list(environment_id: &str, networks: &[PrivateNetwork]) -> String {
+    if networks.is_empty() {
+        return format!("No private networks found in environment {environment_id}.");
+    }
+
+    let mut output = format!("Private networks for environment {environment_id}:\n");
+    for network in networks {
+        output.push_str(&format!(
+            "- {} (id: {}, dns: {}.internal, networkId: {}, address: {})\n",
+            network.name,
+            network.public_id,
+            network.dns_name,
+            network.network_id,
+            if network.supports_ipv4 {
+                "IPv4 & IPv6"
+            } else {
+                "IPv6"
+            }
+        ));
+    }
+    output
+}
+
+fn format_private_network_status(
+    ctx: &ResolvedServiceContext,
+    network: &PrivateNetwork,
+    endpoint: Option<&PrivateNetworkEndpoint>,
+    internal_url: Option<&str>,
+) -> String {
+    let service_name = service_name(ctx);
+    let mut output = format!(
+        "Private network endpoint for service {service_name} (id: {}) in environment {}:\nNetwork: {} (id: {}, dns: {}.internal, networkId: {})\nAddress family: {}",
+        ctx.service_id,
+        ctx.environment_id,
+        network.name,
+        network.public_id,
+        network.dns_name,
+        network.network_id,
+        if network.supports_ipv4 {
+            "IPv4 & IPv6"
+        } else {
+            "IPv6"
+        }
+    );
+
+    let Some(endpoint) = endpoint else {
+        output.push_str(
+            "\nEndpoint: initializing; deploy or apply pending config changes to create it.",
+        );
+        return output;
+    };
+
+    output.push_str(&format!(
+        "\nEndpoint ID: {}\nEndpoint name: {}\nSync status: {}",
+        endpoint.public_id, endpoint.dns_name, endpoint.sync_status
+    ));
+    if let Some(internal_url) = internal_url {
+        output.push_str(&format!("\nInternal URL: {internal_url}"));
+    }
+    if let Some(new_dns_name) = &endpoint.new_dns_name {
+        output.push_str(&format!("\nPending name: {new_dns_name}"));
+    }
+    if !endpoint.private_ips.is_empty() {
+        output.push_str(&format!(
+            "\nPrivate IPs: {}",
+            endpoint.private_ips.join(", ")
+        ));
+    }
+    output
+}
+
+fn format_private_network_change(
+    environment_id: &str,
+    service: Option<(&str, &str)>,
+    endpoint: Option<&str>,
+    mode: PatchMode,
+) -> String {
+    let change = match mode {
+        PatchMode::Commit => "committed",
+        PatchMode::Stage => {
+            "staged (environment has pending changes; use `railway environment edit` to commit)"
+        }
+    };
+    let mut output = format!(
+        "Private networking config {change} in environment {environment_id}. Dashboard parity: this used the environment config workflow, not direct endpoint mutations."
+    );
+
+    if let Some((service_name, service_id)) = service {
+        output.push_str(&format!("\nService: {service_name} (id: {service_id})"));
+    }
+    if let Some(endpoint) = endpoint {
+        output.push_str(&format!("\nEndpoint: {endpoint}"));
+    }
+
+    output
+}
+
+fn service_name(ctx: &ResolvedServiceContext) -> String {
+    ctx.context
+        .project
+        .services
+        .edges
+        .iter()
+        .find(|service| service.node.id == ctx.service_id)
+        .map(|service| service.node.name.clone())
+        .unwrap_or_else(|| ctx.service_id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_network(name: &str) -> PrivateNetwork {
+        PrivateNetwork {
+            public_id: format!("pn_{name}"),
+            project_id: "project_123".to_string(),
+            environment_id: "env_123".to_string(),
+            name: name.to_string(),
+            dns_name: name.to_string(),
+            network_id: 42,
+            tags: vec![],
+            supports_ipv4: false,
+            created_at: None,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn private_network_change_output_reports_config_workflow() {
+        let output = format_private_network_change(
+            "env_123",
+            Some(("api", "svc_123")),
+            Some("api-internal"),
+            PatchMode::Stage,
+        );
+
+        assert!(output.contains("staged"));
+        assert!(output.contains("environment config workflow"));
+        assert!(output.contains("api-internal"));
+    }
+
+    #[test]
+    fn private_network_list_includes_internal_suffix() {
+        let output = format_private_network_list("env_123", &[sample_network("railway")]);
+
+        assert!(output.contains("railway.internal"));
+        assert!(output.contains("pn_railway"));
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod mcp;
 pub mod metrics;
 pub mod open;
 mod output;
+pub mod private_network;
 pub mod project;
 pub mod redeploy;
 pub mod restart;

--- a/src/commands/private_network.rs
+++ b/src/commands/private_network.rs
@@ -1,0 +1,699 @@
+use colored::Colorize;
+use serde::Serialize;
+
+use crate::{
+    controllers::{
+        private_network::{
+            self, PatchMode, PrivateNetwork, PrivateNetworkEndpoint, parse_endpoint_prefix,
+        },
+        project::{resolve_environment_context, resolve_service_context},
+    },
+    util::progress::create_spinner_if,
+};
+
+use super::*;
+
+/// Manage private networking using the same config workflow as the dashboard
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway private-network list --json\n  railway private-network status --service api --json\n  railway private-network enable --json\n  railway private-network enable --service api --endpoint api-internal --json\n  railway private-network enable --stage\n  railway private-network set-endpoint api-internal --service api --json\n  railway private-network name-available api-internal --json\n\nAliases:\n  list: ls\n\nDashboard parity notes:\n  This command mirrors the Railway dashboard private networking settings.\n  `enable` and `set-endpoint` update environment config; they do not call low-level endpoint create or rename mutations directly.\n  The dashboard does not expose durable private-network disable or endpoint delete actions, so this command does not either.\n\nAutomation notes:\n  Passing --project requires --environment. By default, changes are committed immediately. Use --stage to stage config changes without committing."
+)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Environment to use (defaults to linked environment)
+    #[clap(short, long, global = true)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID", global = true)]
+    project: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long, global = true)]
+    json: bool,
+}
+
+#[derive(Parser)]
+enum Commands {
+    /// List private networks for an environment
+    #[clap(
+        visible_alias = "ls",
+        after_help = "Examples:\n\n  railway private-network list\n  railway private-network list --environment production --json\n\nDashboard parity:\n  Mirrors the dashboard privateNetworks(environmentId) query."
+    )]
+    List,
+
+    /// Show the selected service's private network endpoint status
+    #[clap(
+        after_help = "Examples:\n\n  railway private-network status --service api\n  railway private-network status --service api --network railway --json\n\nDashboard parity:\n  Mirrors the dashboard privateNetworkEndpoint(privateNetworkId, environmentId, serviceId) query.\n  If --network is omitted, the CLI uses the environment network named `railway`, falling back to the first network."
+    )]
+    Status {
+        /// Service name or ID (defaults to linked service, or the only service in the project)
+        #[clap(short, long)]
+        service: Option<String>,
+
+        /// Private network ID, name, DNS suffix, or numeric network ID
+        #[clap(long)]
+        network: Option<String>,
+    },
+
+    /// Enable private networking through environment config
+    #[clap(
+        after_help = "Examples:\n\n  railway private-network enable\n  railway private-network enable --stage\n  railway private-network enable --service api --endpoint api-internal --message \"Enable private networking\"\n\nDashboard parity:\n  Mirrors the dashboard Enable Private Networking action by setting privateNetworkDisabled=false in environment config.\n  When --endpoint is passed, the same config patch also sets the selected service's networking.privateNetworkEndpoint.\n  The backend apply workflow creates or updates endpoints; this command does not call direct endpoint create or rename mutations."
+    )]
+    Enable {
+        /// Service name or ID, required only when --endpoint is passed unless a service is linked
+        #[clap(short, long)]
+        service: Option<String>,
+
+        /// Optional endpoint DNS prefix to set on the selected service
+        #[clap(long, value_parser = parse_endpoint_prefix)]
+        endpoint: Option<String>,
+
+        /// Stage the config change instead of committing it immediately
+        #[clap(long)]
+        stage: bool,
+
+        /// Commit message to use when applying immediately
+        #[clap(short, long)]
+        message: Option<String>,
+    },
+
+    /// Set a service's private network endpoint name through config
+    #[clap(
+        after_help = "Examples:\n\n  railway private-network set-endpoint api-internal --service api\n  railway private-network set-endpoint api-renamed --stage\n  railway private-network set-endpoint api-internal --message \"Update private endpoint\" --json\n\nDashboard parity:\n  Mirrors editing the private endpoint field in the dashboard by staging or committing services.<serviceId>.networking.privateNetworkEndpoint.\n  The backend apply workflow performs the endpoint rename; this command does not call the direct rename mutation."
+    )]
+    SetEndpoint {
+        /// Endpoint DNS prefix
+        #[clap(value_name = "DNS_PREFIX", value_parser = parse_endpoint_prefix)]
+        endpoint: String,
+
+        /// Service name or ID (defaults to linked service, or the only service in the project)
+        #[clap(short, long)]
+        service: Option<String>,
+
+        /// Stage the config change instead of committing it immediately
+        #[clap(long)]
+        stage: bool,
+
+        /// Commit message to use when applying immediately
+        #[clap(short, long)]
+        message: Option<String>,
+    },
+
+    /// Check whether a private endpoint name is available
+    #[clap(
+        after_help = "Examples:\n\n  railway private-network name-available api-internal\n  railway private-network name-available api-internal --network railway --json\n\nDashboard parity:\n  Mirrors the dashboard privateNetworkEndpointNameAvailable query and validates the same simple DNS-prefix shape before querying."
+    )]
+    NameAvailable {
+        /// Endpoint DNS prefix
+        #[clap(value_name = "DNS_PREFIX", value_parser = parse_endpoint_prefix)]
+        endpoint: String,
+
+        /// Private network ID, name, DNS suffix, or numeric network ID
+        #[clap(long)]
+        network: Option<String>,
+    },
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let Args {
+        command,
+        environment,
+        project,
+        json,
+    } = args;
+
+    crate::util::reporter::set_mode(json);
+
+    match command {
+        Commands::List => list(project, environment, json).await?,
+        Commands::Status { service, network } => {
+            status(project, service, environment, network, json).await?
+        }
+        Commands::Enable {
+            service,
+            endpoint,
+            stage,
+            message,
+        } => {
+            enable(
+                project,
+                service,
+                environment,
+                endpoint,
+                stage,
+                message,
+                json,
+            )
+            .await?
+        }
+        Commands::SetEndpoint {
+            endpoint,
+            service,
+            stage,
+            message,
+        } => {
+            set_endpoint(
+                project,
+                service,
+                environment,
+                endpoint,
+                stage,
+                message,
+                json,
+            )
+            .await?
+        }
+        Commands::NameAvailable { endpoint, network } => {
+            name_available(project, environment, endpoint, network, json).await?
+        }
+    }
+
+    Ok(())
+}
+
+async fn list(project: Option<String>, environment: Option<String>, json: bool) -> Result<()> {
+    let ctx = resolve_environment_context(project, environment).await?;
+    let networks =
+        private_network::fetch_private_networks(&ctx.client, &ctx.configs, &ctx.environment_id)
+            .await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&ListOutput { networks })?
+        );
+        return Ok(());
+    }
+
+    if networks.is_empty() {
+        println!(
+            "No private networks found in environment {}.",
+            ctx.environment_name.bold()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "Private networks for environment {}:",
+        ctx.environment_name.bold()
+    );
+    print_network_table(&networks);
+
+    Ok(())
+}
+
+async fn status(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    network: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let networks =
+        private_network::fetch_private_networks(&ctx.client, &ctx.configs, &ctx.environment_id)
+            .await?;
+    let network = private_network::resolve_private_network(&networks, network.as_deref())?.cloned();
+
+    let endpoint = match &network {
+        Some(network) => {
+            private_network::fetch_private_network_endpoint(
+                &ctx.client,
+                &ctx.configs,
+                &network.public_id,
+                &ctx.environment_id,
+                &ctx.service_id,
+            )
+            .await?
+        }
+        None => None,
+    };
+    let configured_endpoint_name = if network.is_some() && endpoint.is_some() {
+        private_network::fetch_configured_endpoint_name(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+        .await?
+    } else {
+        None
+    };
+    let internal_url = network
+        .as_ref()
+        .zip(endpoint.as_ref())
+        .map(|(network, endpoint)| {
+            private_network::internal_url_for_dns_name(
+                network,
+                configured_endpoint_name
+                    .as_deref()
+                    .unwrap_or(&endpoint.dns_name),
+            )
+        });
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&StatusOutput {
+                network,
+                endpoint,
+                internal_url,
+            })?
+        );
+        return Ok(());
+    }
+
+    print_status(
+        &ctx.service_name,
+        network.as_ref(),
+        endpoint.as_ref(),
+        internal_url.as_deref(),
+    );
+
+    Ok(())
+}
+
+async fn enable(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    endpoint: Option<String>,
+    stage: bool,
+    message: Option<String>,
+    json: bool,
+) -> Result<()> {
+    if let Some(endpoint) = endpoint {
+        let ctx = resolve_service_context(project, service, environment).await?;
+        let spinner = create_spinner_if(!json, "Updating private networking config...".into());
+        let mode = private_network::apply_enable_patch(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+            Some(&ctx.service_id),
+            Some(&endpoint),
+            stage,
+            Some(message.unwrap_or_else(|| {
+                format!(
+                    "Enable private networking for {} with endpoint {}",
+                    ctx.service_name, endpoint
+                )
+            })),
+        )
+        .await?;
+
+        if mode == PatchMode::Commit {
+            private_network::verify_private_network_enabled(
+                &ctx.client,
+                &ctx.configs,
+                &ctx.environment_id,
+            )
+            .await?;
+            private_network::verify_endpoint_configured(
+                &ctx.client,
+                &ctx.configs,
+                &ctx.environment_id,
+                &ctx.service_id,
+                &endpoint,
+            )
+            .await?;
+        }
+
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&MutationOutput {
+                    staged: mode == PatchMode::Stage,
+                    committed: mode == PatchMode::Commit,
+                    environment_id: ctx.environment_id,
+                    service_id: Some(ctx.service_id),
+                })?
+            );
+            return Ok(());
+        }
+
+        finish_private_network_change(spinner, mode, &ctx.environment_name, Some(&endpoint));
+        return Ok(());
+    }
+
+    let ctx = resolve_environment_context(project, environment).await?;
+    let spinner = create_spinner_if(!json, "Updating private networking config...".into());
+    let mode = private_network::apply_enable_patch(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        None,
+        None,
+        stage,
+        Some(message.unwrap_or_else(|| "Enable private networking".to_string())),
+    )
+    .await?;
+
+    if mode == PatchMode::Commit {
+        private_network::verify_private_network_enabled(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+        )
+        .await?;
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&MutationOutput {
+                staged: mode == PatchMode::Stage,
+                committed: mode == PatchMode::Commit,
+                environment_id: ctx.environment_id,
+                service_id: None,
+            })?
+        );
+        return Ok(());
+    }
+
+    finish_private_network_change(spinner, mode, &ctx.environment_name, None);
+
+    Ok(())
+}
+
+async fn set_endpoint(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    endpoint: String,
+    stage: bool,
+    message: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let spinner = create_spinner_if(!json, "Updating private endpoint config...".into());
+    let mode = private_network::apply_set_endpoint_patch(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        &endpoint,
+        stage,
+        Some(message.unwrap_or_else(|| {
+            format!(
+                "Set private network endpoint for {} to {}",
+                ctx.service_name, endpoint
+            )
+        })),
+    )
+    .await?;
+
+    if mode == PatchMode::Commit {
+        private_network::verify_endpoint_configured(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+            &endpoint,
+        )
+        .await?;
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&MutationOutput {
+                staged: mode == PatchMode::Stage,
+                committed: mode == PatchMode::Commit,
+                environment_id: ctx.environment_id,
+                service_id: Some(ctx.service_id),
+            })?
+        );
+        return Ok(());
+    }
+
+    finish_private_network_change(spinner, mode, &ctx.environment_name, Some(&endpoint));
+
+    Ok(())
+}
+
+async fn name_available(
+    project: Option<String>,
+    environment: Option<String>,
+    endpoint: String,
+    network: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_environment_context(project, environment).await?;
+    let networks =
+        private_network::fetch_private_networks(&ctx.client, &ctx.configs, &ctx.environment_id)
+            .await?;
+    let network = private_network::resolve_private_network(&networks, network.as_deref())?
+        .cloned()
+        .context("No private network found in the selected environment")?;
+    let available = private_network::private_network_endpoint_name_available(
+        &ctx.client,
+        &ctx.configs,
+        &network.public_id,
+        &ctx.environment_id,
+        &endpoint,
+    )
+    .await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&NameAvailableOutput {
+                endpoint,
+                available,
+                network,
+            })?
+        );
+        return Ok(());
+    }
+
+    if available {
+        println!("Endpoint name {} is available.", endpoint.green());
+    } else {
+        println!("Endpoint name {} is already used.", endpoint.red());
+    }
+
+    Ok(())
+}
+
+fn finish_private_network_change(
+    spinner: Option<indicatif::ProgressBar>,
+    mode: PatchMode,
+    environment_name: &str,
+    endpoint: Option<&str>,
+) {
+    let suffix = endpoint
+        .map(|endpoint| format!(" Endpoint: {}.", endpoint.cyan()))
+        .unwrap_or_default();
+    let msg = match mode {
+        PatchMode::Commit => format!(
+            "Committed private networking config in environment {}.{}",
+            environment_name.magenta().bold(),
+            suffix
+        ),
+        PatchMode::Stage => format!(
+            "Staged private networking config in environment {}.{} {}",
+            environment_name.magenta().bold(),
+            suffix,
+            "(use 'railway environment edit' to commit)".dimmed()
+        ),
+    };
+
+    if let Some(spinner) = spinner {
+        spinner.finish_with_message(msg);
+    } else {
+        println!("{msg}");
+    }
+}
+
+fn print_network_table(networks: &[PrivateNetwork]) {
+    for network in networks {
+        let family = if network.supports_ipv4 {
+            "IPv4 & IPv6"
+        } else {
+            "IPv6"
+        };
+        println!(
+            "- {} (id: {}, dns: {}.internal, networkId: {}, {})",
+            network.name.bold(),
+            network.public_id,
+            network.dns_name,
+            network.network_id,
+            family
+        );
+    }
+}
+
+fn print_status(
+    service_name: &str,
+    network: Option<&PrivateNetwork>,
+    endpoint: Option<&PrivateNetworkEndpoint>,
+    internal_url: Option<&str>,
+) {
+    let Some(network) = network else {
+        println!("No private network found for the selected environment.");
+        return;
+    };
+
+    println!(
+        "Private network endpoint for service {}:",
+        service_name.bold()
+    );
+    println!("  {} {}", "network:".dimmed(), network.name);
+    println!("  {} {}", "network id:".dimmed(), network.public_id);
+    println!("  {} {}.internal", "dns suffix:".dimmed(), network.dns_name);
+    println!(
+        "  {} {}",
+        "address family:".dimmed(),
+        if network.supports_ipv4 {
+            "IPv4 & IPv6"
+        } else {
+            "IPv6"
+        }
+    );
+
+    let Some(endpoint) = endpoint else {
+        println!(
+            "  {} {}",
+            "endpoint:".dimmed(),
+            "initializing; deploy or apply pending config changes to create it".yellow()
+        );
+        return;
+    };
+
+    println!("  {} {}", "endpoint id:".dimmed(), endpoint.public_id);
+    println!("  {} {}", "endpoint name:".dimmed(), endpoint.dns_name);
+    if let Some(internal_url) = internal_url {
+        println!("  {} {}", "internal url:".dimmed(), internal_url.cyan());
+    }
+    println!("  {} {}", "sync status:".dimmed(), endpoint.sync_status);
+    if let Some(new_dns_name) = &endpoint.new_dns_name {
+        println!("  {} {}", "pending name:".dimmed(), new_dns_name);
+    }
+    if !endpoint.private_ips.is_empty() {
+        println!(
+            "  {} {}",
+            "private ips:".dimmed(),
+            endpoint.private_ips.join(", ")
+        );
+    }
+}
+
+#[derive(Serialize)]
+struct ListOutput {
+    networks: Vec<PrivateNetwork>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusOutput {
+    network: Option<PrivateNetwork>,
+    endpoint: Option<PrivateNetworkEndpoint>,
+    internal_url: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MutationOutput {
+    staged: bool,
+    committed: bool,
+    environment_id: String,
+    service_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct NameAvailableOutput {
+    endpoint: String,
+    available: bool,
+    network: PrivateNetwork,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_network() -> PrivateNetwork {
+        PrivateNetwork {
+            public_id: "pn_123".to_string(),
+            project_id: "project_123".to_string(),
+            environment_id: "env_123".to_string(),
+            name: "railway".to_string(),
+            dns_name: "railway".to_string(),
+            network_id: 42,
+            tags: vec![],
+            supports_ipv4: false,
+            created_at: None,
+            deleted_at: None,
+        }
+    }
+
+    fn sample_endpoint() -> PrivateNetworkEndpoint {
+        PrivateNetworkEndpoint {
+            public_id: "pne_123".to_string(),
+            service_instance_id: "si_123".to_string(),
+            dns_name: "api-internal".to_string(),
+            new_dns_name: None,
+            private_ips: vec!["fd12::1".to_string()],
+            tags: vec![],
+            sync_status: "ACTIVE".to_string(),
+            created_at: None,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn json_outputs_use_documented_shapes() {
+        let list = serde_json::to_value(ListOutput {
+            networks: vec![sample_network()],
+        })
+        .unwrap();
+        assert!(list.get("networks").is_some());
+
+        let status = serde_json::to_value(StatusOutput {
+            network: Some(sample_network()),
+            endpoint: Some(sample_endpoint()),
+            internal_url: Some("api-internal.railway.internal".to_string()),
+        })
+        .unwrap();
+        assert!(status.get("network").is_some());
+        assert!(status.get("endpoint").is_some());
+        assert_eq!(
+            status
+                .get("internalUrl")
+                .and_then(serde_json::Value::as_str),
+            Some("api-internal.railway.internal")
+        );
+
+        let mutation = serde_json::to_value(MutationOutput {
+            staged: true,
+            committed: false,
+            environment_id: "env_123".to_string(),
+            service_id: Some("svc_123".to_string()),
+        })
+        .unwrap();
+        assert_eq!(
+            mutation.get("staged").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            mutation
+                .get("committed")
+                .and_then(serde_json::Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            mutation
+                .get("environmentId")
+                .and_then(serde_json::Value::as_str),
+            Some("env_123")
+        );
+        assert_eq!(
+            mutation
+                .get("serviceId")
+                .and_then(serde_json::Value::as_str),
+            Some("svc_123")
+        );
+    }
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -9,6 +9,7 @@ pub mod github;
 pub mod local_override;
 pub mod metrics;
 pub mod metrics_tui;
+pub mod private_network;
 pub mod project;
 pub mod regions;
 pub mod sandbox_exec;

--- a/src/controllers/private_network.rs
+++ b/src/controllers/private_network.rs
@@ -1,0 +1,565 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Result, anyhow, bail};
+use reqwest::Client;
+use serde::Serialize;
+
+use crate::{
+    client::post_graphql,
+    config::Configs,
+    controllers::config::{
+        EnvironmentConfig, ServiceInstance, ServiceNetworking,
+        environment::fetch_environment_config,
+    },
+    gql::{mutations, queries},
+    util::retry::{RetryConfig, retry_with_backoff},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PatchMode {
+    Commit,
+    Stage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateNetwork {
+    pub public_id: String,
+    pub project_id: String,
+    pub environment_id: String,
+    pub name: String,
+    pub dns_name: String,
+    pub network_id: i64,
+    pub tags: Vec<String>,
+    pub supports_ipv4: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateNetworkEndpoint {
+    pub public_id: String,
+    pub service_instance_id: String,
+    pub dns_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_dns_name: Option<String>,
+    pub private_ips: Vec<String>,
+    pub tags: Vec<String>,
+    pub sync_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
+}
+
+pub fn parse_endpoint_prefix(value: &str) -> std::result::Result<String, String> {
+    validate_endpoint_prefix(value).map_err(|error| error.to_string())
+}
+
+pub fn validate_endpoint_prefix(value: &str) -> Result<String> {
+    let prefix = value.trim();
+
+    if prefix.is_empty() {
+        bail!("endpoint name cannot be empty");
+    }
+    if prefix.len() > 63 {
+        bail!("endpoint name must be 63 characters or fewer");
+    }
+    if prefix.starts_with('-') || prefix.ends_with('-') {
+        bail!("endpoint name cannot start or end with a hyphen");
+    }
+    if !prefix
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+    {
+        bail!("endpoint name must use only lowercase letters, numbers, and hyphens");
+    }
+
+    Ok(prefix.to_string())
+}
+
+pub async fn fetch_private_networks(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+) -> Result<Vec<PrivateNetwork>> {
+    let networks = post_graphql::<queries::PrivateNetworks, _>(
+        client,
+        configs.get_backboard(),
+        queries::private_networks::Variables {
+            environment_id: environment_id.to_string(),
+        },
+    )
+    .await?
+    .private_networks;
+
+    Ok(networks.iter().map(private_network_output).collect())
+}
+
+pub fn private_network_output(
+    network: &queries::private_networks::PrivateNetworksPrivateNetworks,
+) -> PrivateNetwork {
+    PrivateNetwork {
+        public_id: network.public_id.clone(),
+        project_id: network.project_id.clone(),
+        environment_id: network.environment_id.clone(),
+        name: network.name.clone(),
+        dns_name: network.dns_name.clone(),
+        network_id: network.network_id,
+        supports_ipv4: supports_ipv4(&network.tags),
+        tags: network.tags.clone(),
+        created_at: network
+            .created_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+        deleted_at: network
+            .deleted_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+    }
+}
+
+pub fn supports_ipv4(tags: &[String]) -> bool {
+    tags.iter().any(|tag| tag == "SUPPORTS_IPV4_PRIVNETS")
+}
+
+pub fn resolve_default_network(networks: &[PrivateNetwork]) -> Option<&PrivateNetwork> {
+    networks
+        .iter()
+        .find(|network| network.deleted_at.is_none() && network.name == "railway")
+        .or_else(|| networks.iter().find(|network| network.deleted_at.is_none()))
+        .or_else(|| networks.first())
+}
+
+pub fn find_private_network<'a>(
+    networks: &'a [PrivateNetwork],
+    identifier: &str,
+) -> Result<Option<&'a PrivateNetwork>> {
+    let identifier = identifier.trim();
+
+    if let Some(network) = networks.iter().find(|network| {
+        network.public_id.eq_ignore_ascii_case(identifier)
+            || network.name.eq_ignore_ascii_case(identifier)
+            || network.dns_name.eq_ignore_ascii_case(identifier)
+            || network.network_id.to_string() == identifier
+    }) {
+        return Ok(Some(network));
+    }
+
+    Ok(None)
+}
+
+pub fn resolve_private_network<'a>(
+    networks: &'a [PrivateNetwork],
+    identifier: Option<&str>,
+) -> Result<Option<&'a PrivateNetwork>> {
+    if let Some(identifier) = identifier {
+        return find_private_network(networks, identifier)?
+            .map(Some)
+            .ok_or_else(|| {
+                anyhow!(
+                    "Private network '{}' not found in the selected environment",
+                    identifier
+                )
+            });
+    }
+
+    Ok(resolve_default_network(networks))
+}
+
+pub async fn fetch_private_network_endpoint(
+    client: &Client,
+    configs: &Configs,
+    private_network_id: &str,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<Option<PrivateNetworkEndpoint>> {
+    let endpoint = post_graphql::<queries::PrivateNetworkEndpoint, _>(
+        client,
+        configs.get_backboard(),
+        queries::private_network_endpoint::Variables {
+            private_network_id: private_network_id.to_string(),
+            environment_id: environment_id.to_string(),
+            service_id: service_id.to_string(),
+        },
+    )
+    .await?
+    .private_network_endpoint;
+
+    Ok(endpoint.as_ref().map(private_network_endpoint_output))
+}
+
+pub fn private_network_endpoint_output(
+    endpoint: &queries::private_network_endpoint::PrivateNetworkEndpointPrivateNetworkEndpoint,
+) -> PrivateNetworkEndpoint {
+    PrivateNetworkEndpoint {
+        public_id: endpoint.public_id.clone(),
+        service_instance_id: endpoint.service_instance_id.clone(),
+        dns_name: endpoint.dns_name.clone(),
+        new_dns_name: endpoint.new_dns_name.clone(),
+        private_ips: endpoint.private_ips.clone(),
+        tags: endpoint.tags.clone(),
+        sync_status: endpoint_sync_status(&endpoint.sync_status),
+        created_at: endpoint
+            .created_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+        deleted_at: endpoint
+            .deleted_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+    }
+}
+
+pub fn endpoint_sync_status(
+    value: &queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus,
+) -> String {
+    match value {
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::ACTIVE => {
+            "ACTIVE".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::CREATING => {
+            "CREATING".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::DELETED => {
+            "DELETED".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::DELETING => {
+            "DELETING".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::UNSPECIFIED => {
+            "UNSPECIFIED".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::UPDATING => {
+            "UPDATING".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::Other(status) => {
+            status.clone()
+        }
+    }
+}
+
+pub async fn private_network_endpoint_name_available(
+    client: &Client,
+    configs: &Configs,
+    private_network_id: &str,
+    environment_id: &str,
+    prefix: &str,
+) -> Result<bool> {
+    Ok(
+        post_graphql::<queries::PrivateNetworkEndpointNameAvailable, _>(
+            client,
+            configs.get_backboard(),
+            queries::private_network_endpoint_name_available::Variables {
+                private_network_id: private_network_id.to_string(),
+                environment_id: environment_id.to_string(),
+                prefix: prefix.to_string(),
+            },
+        )
+        .await?
+        .private_network_endpoint_name_available,
+    )
+}
+
+pub async fn fetch_configured_endpoint_name(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<Option<String>> {
+    let config = fetch_environment_config(client, configs, environment_id, false)
+        .await?
+        .config;
+
+    Ok(config
+        .services
+        .get(service_id)
+        .and_then(|service| service.networking.as_ref())
+        .and_then(|networking| networking.private_network_endpoint.clone()))
+}
+
+pub async fn apply_enable_patch(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: Option<&str>,
+    endpoint: Option<&str>,
+    stage: bool,
+    commit_message: Option<String>,
+) -> Result<PatchMode> {
+    let patch = enable_private_network_patch(service_id, endpoint);
+    apply_private_network_patch(
+        client,
+        configs,
+        environment_id,
+        patch,
+        stage,
+        commit_message,
+    )
+    .await
+}
+
+pub async fn apply_set_endpoint_patch(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    endpoint: &str,
+    stage: bool,
+    commit_message: Option<String>,
+) -> Result<PatchMode> {
+    let patch = endpoint_patch(service_id, endpoint);
+    apply_private_network_patch(
+        client,
+        configs,
+        environment_id,
+        patch,
+        stage,
+        commit_message,
+    )
+    .await
+}
+
+async fn apply_private_network_patch(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    patch: EnvironmentConfig,
+    stage: bool,
+    commit_message: Option<String>,
+) -> Result<PatchMode> {
+    if stage {
+        post_graphql::<mutations::EnvironmentStageChanges, _>(
+            client,
+            configs.get_backboard(),
+            mutations::environment_stage_changes::Variables {
+                environment_id: environment_id.to_string(),
+                input: patch,
+                merge: Some(true),
+            },
+        )
+        .await?;
+        return Ok(PatchMode::Stage);
+    }
+
+    post_graphql::<mutations::EnvironmentPatchCommit, _>(
+        client,
+        configs.get_backboard(),
+        mutations::environment_patch_commit::Variables {
+            environment_id: environment_id.to_string(),
+            patch,
+            commit_message,
+        },
+    )
+    .await?;
+    Ok(PatchMode::Commit)
+}
+
+pub fn enable_private_network_patch(
+    service_id: Option<&str>,
+    endpoint: Option<&str>,
+) -> EnvironmentConfig {
+    EnvironmentConfig {
+        private_network_disabled: Some(false),
+        services: service_id
+            .zip(endpoint)
+            .map(|(service_id, endpoint)| {
+                BTreeMap::from([(
+                    service_id.to_string(),
+                    ServiceInstance {
+                        networking: Some(ServiceNetworking {
+                            private_network_endpoint: Some(endpoint.to_string()),
+                            ..ServiceNetworking::default()
+                        }),
+                        ..ServiceInstance::default()
+                    },
+                )])
+            })
+            .unwrap_or_default(),
+        ..EnvironmentConfig::default()
+    }
+}
+
+pub fn endpoint_patch(service_id: &str, endpoint: &str) -> EnvironmentConfig {
+    EnvironmentConfig {
+        services: BTreeMap::from([(
+            service_id.to_string(),
+            ServiceInstance {
+                networking: Some(ServiceNetworking {
+                    private_network_endpoint: Some(endpoint.to_string()),
+                    ..ServiceNetworking::default()
+                }),
+                ..ServiceInstance::default()
+            },
+        )]),
+        ..EnvironmentConfig::default()
+    }
+}
+
+pub async fn verify_private_network_enabled(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+) -> Result<()> {
+    retry_with_backoff(verify_retry_config(), || async {
+        let config = fetch_environment_config(client, configs, environment_id, false)
+            .await?
+            .config;
+
+        if config.private_network_disabled == Some(true) {
+            bail!(
+                "Private networking was requested, but environment config still reports it disabled."
+            );
+        }
+
+        Ok(())
+    })
+    .await
+}
+
+pub async fn verify_endpoint_configured(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    endpoint: &str,
+) -> Result<()> {
+    retry_with_backoff(verify_retry_config(), || async {
+        let config = fetch_environment_config(client, configs, environment_id, false)
+            .await?
+            .config;
+
+        let configured = config
+            .services
+            .get(service_id)
+            .and_then(|service| service.networking.as_ref())
+            .and_then(|networking| networking.private_network_endpoint.as_ref())
+            .is_some_and(|configured| configured == endpoint);
+
+        if !configured {
+            bail!(
+                "Private network endpoint '{}' was requested, but it was not present after verification.",
+                endpoint
+            );
+        }
+
+        Ok(())
+    })
+    .await
+}
+
+pub fn internal_url_for_dns_name(network: &PrivateNetwork, dns_name: &str) -> String {
+    format!("{}.{}.internal", dns_name, network.dns_name)
+}
+
+fn verify_retry_config() -> RetryConfig {
+    RetryConfig {
+        max_attempts: 6,
+        initial_delay_ms: 500,
+        max_delay_ms: 3_000,
+        backoff_multiplier: 1.8,
+        on_retry: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn network(public_id: &str, name: &str, dns_name: &str, tags: Vec<&str>) -> PrivateNetwork {
+        PrivateNetwork {
+            public_id: public_id.to_string(),
+            project_id: "project_123".to_string(),
+            environment_id: "env_123".to_string(),
+            name: name.to_string(),
+            dns_name: dns_name.to_string(),
+            network_id: 42,
+            tags: tags.into_iter().map(ToString::to_string).collect(),
+            supports_ipv4: false,
+            created_at: None,
+            deleted_at: None,
+        }
+    }
+
+    #[test]
+    fn default_network_prefers_railway() {
+        let fallback = network("pn_fallback", "custom", "custom", vec![]);
+        let railway = network("pn_railway", "railway", "railway", vec![]);
+
+        assert_eq!(
+            resolve_default_network(&[fallback, railway])
+                .unwrap()
+                .public_id,
+            "pn_railway"
+        );
+    }
+
+    #[test]
+    fn endpoint_prefix_validation_matches_dashboard_label_rules() {
+        assert!(validate_endpoint_prefix("api-internal").is_ok());
+        assert!(validate_endpoint_prefix("-api").is_err());
+        assert!(validate_endpoint_prefix("api-").is_err());
+        assert!(validate_endpoint_prefix("API").is_err());
+        assert!(validate_endpoint_prefix("api_internal").is_err());
+        assert!(validate_endpoint_prefix("").is_err());
+    }
+
+    #[test]
+    fn supports_ipv4_uses_dashboard_tag() {
+        assert!(supports_ipv4(&["SUPPORTS_IPV4_PRIVNETS".to_string()]));
+        assert!(!supports_ipv4(&["OTHER".to_string()]));
+    }
+
+    #[test]
+    fn internal_url_uses_network_dns_suffix() {
+        let network = network("pn_railway", "railway", "railway", vec![]);
+        let endpoint = PrivateNetworkEndpoint {
+            public_id: "pne_123".to_string(),
+            service_instance_id: "si_123".to_string(),
+            dns_name: "api".to_string(),
+            new_dns_name: None,
+            private_ips: vec![],
+            tags: vec![],
+            sync_status: "ACTIVE".to_string(),
+            created_at: None,
+            deleted_at: None,
+        };
+
+        assert_eq!(
+            internal_url_for_dns_name(&network, &endpoint.dns_name),
+            "api.railway.internal"
+        );
+        assert_eq!(
+            internal_url_for_dns_name(&network, "api-renamed"),
+            "api-renamed.railway.internal"
+        );
+    }
+
+    #[test]
+    fn patches_set_dashboard_config_fields() {
+        let enable = enable_private_network_patch(Some("svc_123"), Some("api-internal"));
+        assert_eq!(enable.private_network_disabled, Some(false));
+        assert_eq!(
+            enable
+                .services
+                .get("svc_123")
+                .and_then(|service| service.networking.as_ref())
+                .and_then(|networking| networking.private_network_endpoint.as_ref()),
+            Some(&"api-internal".to_string())
+        );
+
+        let endpoint = endpoint_patch("svc_123", "api-renamed");
+        assert_eq!(
+            endpoint
+                .services
+                .get("svc_123")
+                .and_then(|service| service.networking.as_ref())
+                .and_then(|networking| networking.private_network_endpoint.as_ref()),
+            Some(&"api-renamed".to_string())
+        );
+    }
+}

--- a/src/controllers/project.rs
+++ b/src/controllers/project.rs
@@ -239,6 +239,65 @@ pub struct ServiceContext {
     pub service_name: String,
 }
 
+/// Resolved context for environment-scoped operations.
+pub struct EnvironmentContext {
+    pub client: Client,
+    pub configs: Configs,
+    pub environment_id: String,
+    pub environment_name: String,
+}
+
+/// Resolves project and environment from args and linked project.
+/// When project_arg is provided, environment_arg must also be provided.
+pub async fn resolve_environment_context(
+    project_arg: Option<String>,
+    environment_arg: Option<String>,
+) -> Result<EnvironmentContext> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+
+    if project_arg.is_some() && environment_arg.is_none() {
+        bail!("--environment is required when using --project");
+    }
+
+    let linked_project = if project_arg.is_none() {
+        Some(configs.get_linked_project().await?)
+    } else {
+        None
+    };
+
+    if let Some(ref linked_project) = linked_project {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    }
+
+    let project_id = project_arg
+        .or_else(|| linked_project.as_ref().map(|lp| lp.project.clone()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project specified. Use --project or run `railway link` first")
+        })?;
+
+    let project = get_project(&client, &configs, project_id.clone()).await?;
+
+    let env = match environment_arg {
+        Some(env) => env,
+        None => linked_project
+            .as_ref()
+            .context("No environment linked. Use --environment when using --project")?
+            .environment_id()?
+            .to_string(),
+    };
+    let environment = get_matched_environment(&project, env)?;
+    let environment_id = environment.id;
+    let environment_name = environment.name;
+
+    Ok(EnvironmentContext {
+        client,
+        configs,
+        environment_id,
+        environment_name,
+    })
+}
+
 /// Resolves project, environment, and service from args and linked project.
 /// When project_arg is provided, environment_arg must also be provided.
 pub async fn resolve_service_context(

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -114,6 +114,30 @@ pub struct Domains;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/PrivateNetworks.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct PrivateNetworks;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/PrivateNetworkEndpoint.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct PrivateNetworkEndpoint;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/PrivateNetworkEndpointNameAvailable.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct PrivateNetworkEndpointNameAvailable;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/ProjectToken.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/PrivateNetworkEndpoint.graphql
+++ b/src/gql/queries/strings/PrivateNetworkEndpoint.graphql
@@ -1,0 +1,13 @@
+query PrivateNetworkEndpoint($privateNetworkId: String!, $environmentId: String!, $serviceId: String!) {
+  privateNetworkEndpoint(privateNetworkId: $privateNetworkId, environmentId: $environmentId, serviceId: $serviceId) {
+    publicId
+    serviceInstanceId
+    dnsName
+    newDnsName
+    privateIps
+    tags
+    syncStatus
+    createdAt
+    deletedAt
+  }
+}

--- a/src/gql/queries/strings/PrivateNetworkEndpointNameAvailable.graphql
+++ b/src/gql/queries/strings/PrivateNetworkEndpointNameAvailable.graphql
@@ -1,0 +1,3 @@
+query PrivateNetworkEndpointNameAvailable($privateNetworkId: String!, $environmentId: String!, $prefix: String!) {
+  privateNetworkEndpointNameAvailable(privateNetworkId: $privateNetworkId, environmentId: $environmentId, prefix: $prefix)
+}

--- a/src/gql/queries/strings/PrivateNetworks.graphql
+++ b/src/gql/queries/strings/PrivateNetworks.graphql
@@ -1,0 +1,13 @@
+query PrivateNetworks($environmentId: String!) {
+  privateNetworks(environmentId: $environmentId) {
+    publicId
+    projectId
+    environmentId
+    name
+    dnsName
+    networkId
+    tags
+    createdAt
+    deletedAt
+  }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,12 @@
 #[macro_export]
 macro_rules! commands {
-    ($($module:ident $(($($alias:ident),*))?),*) => {
+    (@name $module:ident as $name:literal) => {
+        $name
+    };
+    (@name $module:ident) => {
+        stringify!($module)
+    };
+    ($($module:ident $(as $name:literal)? $(($($alias:ident),*))?),*) => {
         pastey::paste! {
             /// Build the global CLI (root command) and attach module subcommands.
             pub fn build_args() -> clap::Command {
@@ -17,6 +23,7 @@ macro_rules! commands {
                     .version(clap::crate_version!());
                 $(
                     {
+                        let command_name = commands!(@name $module $(as $name)?);
                         // Get the subcommand as defined by the module.
                         let sub = <$crate::commands::$module::Args as ::clap::CommandFactory>::command();
                         // Allow the module to add dynamic arguments (if needed) and add any aliases.
@@ -37,10 +44,9 @@ macro_rules! commands {
                                     s = get_dynamic_args(s);
                                 }
                             }
-                            s = s.name(stringify!($module));
+                            s = s.name(command_name);
                             s
                         };
-                        let command_name = stringify!($module);
                         // Add this subcommand into the global CLI.
                         cmd = cmd.subcommand(sub.name(command_name));
                     }
@@ -63,7 +69,7 @@ macro_rules! commands {
             pub async fn exec_cli(matches: clap::ArgMatches) -> anyhow::Result<()> {
                 match matches.subcommand() {
                     $(
-                        Some((stringify!([<$module:snake>]), sub_matches)) => {
+                        Some((commands!(@name $module $(as $name)?), sub_matches)) => {
                             // Walk nested subcommand levels so telemetry can
                             // distinguish e.g. `sandbox template build` from
                             // `sandbox template status` ("template:build").
@@ -76,7 +82,7 @@ macro_rules! commands {
                                 }
                                 if parts.is_empty() { None } else { Some(parts.join(":")) }
                             };
-                            let command_name = stringify!([<$module:snake>]);
+                            let command_name = commands!(@name $module $(as $name)?);
                             let args = <$crate::commands::$module::Args as ::clap::FromArgMatches>::from_arg_matches(sub_matches)
                                 .map_err(anyhow::Error::from)?;
                             let start = ::std::time::Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ commands!(
     mcp,
     metrics,
     open,
+    private_network as "private-network",
     project,
     run(local),
     sandbox(sandboxes, sbx),
@@ -713,6 +714,55 @@ mod cli_tests {
                 "worker",
                 "eu-west=2",
                 "us-east=1",
+            ]);
+        }
+
+        #[test]
+        fn private_network_subcommands() {
+            assert_parses(&["private-network", "list"]);
+            assert_parses(&[
+                "private-network",
+                "list",
+                "--environment",
+                "production",
+                "--json",
+            ]);
+            assert_parses(&[
+                "private-network",
+                "status",
+                "--service",
+                "api",
+                "--network",
+                "railway",
+            ]);
+            assert_parses(&["private-network", "enable"]);
+            assert_parses(&["private-network", "enable", "--stage"]);
+            assert_parses(&[
+                "private-network",
+                "enable",
+                "--service",
+                "api",
+                "--endpoint",
+                "api-internal",
+                "--message",
+                "Enable private networking",
+            ]);
+            assert_parses(&[
+                "private-network",
+                "set-endpoint",
+                "api-internal",
+                "--service",
+                "api",
+            ]);
+            assert_parses(&["private-network", "set-endpoint", "api-renamed", "--stage"]);
+            assert_parses(&["private-network", "name-available", "api-internal"]);
+            assert_parses(&[
+                "private-network",
+                "name-available",
+                "api-internal",
+                "--network",
+                "railway",
+                "--json",
             ]);
         }
 


### PR DESCRIPTION
## Summary

Adds `railway private-network` with dashboard-parity behavior for Railway private networking:

- `list` mirrors `privateNetworks(environmentId)`.
- `status` mirrors `privateNetworkEndpoint(privateNetworkId, environmentId, serviceId)`.
- `enable` uses the environment config apply workflow to set `privateNetworkDisabled=false`.
- `set-endpoint` uses the same config path as the dashboard endpoint edit flow.
- `name-available` mirrors dashboard endpoint-name validation.
- MCP support is limited to dashboard-equivalent operations.

The implementation intentionally does not add private-network disable, endpoint delete, or direct endpoint create/rename commands because the dashboard service settings flow does not expose those as user actions.

## Checks

- `cargo check`
- `cargo fmt -- --check`
- `cargo test`
- `git diff --check`
- Live smoke test against a kept Railway project. Public transcript below is redacted for IDs, account details, and URLs.

## Command Surface

```console
$ railway private-network --help
Manage private networking using the same config workflow as the dashboard

Usage: railway private-network [OPTIONS] <COMMAND>

Commands:
  list            List private networks for an environment [aliases: ls]
  status          Show the selected service's private network endpoint status
  enable          Enable private networking through environment config
  set-endpoint    Set a service's private network endpoint name through config
  name-available  Check whether a private endpoint name is available
  help            Print this message or the help of the given subcommand(s)

Options:
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
  -p, --project <PROJECT_ID>       Project ID to use (defaults to linked project)
      --json                       Output in JSON format
  -h, --help                       Print help
  -V, --version                    Print version

Examples:

  railway private-network list --json
  railway private-network status --service api --json
  railway private-network enable --json
  railway private-network enable --service api --endpoint api-internal --json
  railway private-network enable --stage
  railway private-network set-endpoint api-internal --service api --json
  railway private-network name-available api-internal --json

Aliases:
  list: ls

Dashboard parity notes:
  This command mirrors the Railway dashboard private networking settings.
  `enable` and `set-endpoint` update environment config; they do not call low-level endpoint create or rename mutations directly.
  The dashboard does not expose durable private-network disable or endpoint delete actions, so this command does not either.

Automation notes:
  Passing --project requires --environment. By default, changes are committed immediately. Use --stage to stage config changes without committing.
```

```console
$ railway private-network list --help
List private networks for an environment

Usage: railway private-network list [OPTIONS]

Options:
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
  -p, --project <PROJECT_ID>       Project ID to use (defaults to linked project)
      --json                       Output in JSON format
  -h, --help                       Print help
  -V, --version                    Print version

Examples:

  railway private-network list
  railway private-network list --environment production --json

Dashboard parity:
  Mirrors the dashboard privateNetworks(environmentId) query.
```

```console
$ railway private-network status --help
Show the selected service's private network endpoint status

Usage: railway private-network status [OPTIONS]

Options:
  -s, --service <SERVICE>          Service name or ID (defaults to linked service, or the only service in the project)
      --network <NETWORK>          Private network ID, name, DNS suffix, or numeric network ID
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
  -p, --project <PROJECT_ID>       Project ID to use (defaults to linked project)
      --json                       Output in JSON format
  -h, --help                       Print help
  -V, --version                    Print version

Examples:

  railway private-network status --service api
  railway private-network status --service api --network railway --json

Dashboard parity:
  Mirrors the dashboard privateNetworkEndpoint(privateNetworkId, environmentId, serviceId) query.
  If --network is omitted, the CLI uses the environment network named `railway`, falling back to the first network.
```

```console
$ railway private-network enable --help
Enable private networking through environment config

Usage: railway private-network enable [OPTIONS]

Options:
  -s, --service <SERVICE>          Service name or ID, required only when --endpoint is passed unless a service is linked
      --endpoint <ENDPOINT>        Optional endpoint DNS prefix to set on the selected service
      --stage                      Stage the config change instead of committing it immediately
  -m, --message <MESSAGE>          Commit message to use when applying immediately
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
  -p, --project <PROJECT_ID>       Project ID to use (defaults to linked project)
      --json                       Output in JSON format
  -h, --help                       Print help
  -V, --version                    Print version

Examples:

  railway private-network enable
  railway private-network enable --stage
  railway private-network enable --service api --endpoint api-internal --message "Enable private networking"

Dashboard parity:
  Mirrors the dashboard Enable Private Networking action by setting privateNetworkDisabled=false in environment config.
  When --endpoint is passed, the same config patch also sets the selected service's networking.privateNetworkEndpoint.
  The backend apply workflow creates or updates endpoints; this command does not call direct endpoint create or rename mutations.
```

```console
$ railway private-network set-endpoint --help
Set a service's private network endpoint name through config

Usage: railway private-network set-endpoint [OPTIONS] <DNS_PREFIX>

Arguments:
  <DNS_PREFIX>  Endpoint DNS prefix

Options:
  -s, --service <SERVICE>          Service name or ID (defaults to linked service, or the only service in the project)
      --stage                      Stage the config change instead of committing it immediately
  -m, --message <MESSAGE>          Commit message to use when applying immediately
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
  -p, --project <PROJECT_ID>       Project ID to use (defaults to linked project)
      --json                       Output in JSON format
  -h, --help                       Print help
  -V, --version                    Print version

Examples:

  railway private-network set-endpoint api-internal --service api
  railway private-network set-endpoint api-renamed --stage
  railway private-network set-endpoint api-internal --message "Update private endpoint" --json

Dashboard parity:
  Mirrors editing the private endpoint field in the dashboard by staging or committing services.<serviceId>.networking.privateNetworkEndpoint.
  The backend apply workflow performs the endpoint rename; this command does not call the direct rename mutation.
```

```console
$ railway private-network name-available --help
Check whether a private endpoint name is available

Usage: railway private-network name-available [OPTIONS] <DNS_PREFIX>

Arguments:
  <DNS_PREFIX>  Endpoint DNS prefix

Options:
      --network <NETWORK>          Private network ID, name, DNS suffix, or numeric network ID
  -e, --environment <ENVIRONMENT>  Environment to use (defaults to linked environment)
  -p, --project <PROJECT_ID>       Project ID to use (defaults to linked project)
      --json                       Output in JSON format
  -h, --help                       Print help
  -V, --version                    Print version

Examples:

  railway private-network name-available api-internal
  railway private-network name-available api-internal --network railway --json

Dashboard parity:
  Mirrors the dashboard privateNetworkEndpointNameAvailable query and validates the same simple DNS-prefix shape before querying.
```

## Live Smoke Test

Date: 2026-06-15

Railway project was intentionally kept for inspection. Identifiers and URLs are redacted in this public PR body.

- Project name: `<smoke-project>`
- Project ID: `<project-id>`
- Environment: `production`
- Environment ID: `<environment-id>`
- Service ID: `<service-id>`
- Service instance ID from endpoint status: `<service-instance-id>`
- Deployment ID: `<deployment-id>`
- Private network ID: `<private-network-id>`
- Endpoint ID: `<endpoint-id>`

### Auth

```console
$ RAILWAY_CALLER=skill:use-railway@1.3.0 RAILWAY_AGENT_SESSION=private-network-cli-smoke-20260615 railway whoami
Logged in as <account>
```

### Create And Deploy Temp Service

Initial project-name attempt:

```console
$ railway up --new --name private-network-smoke-20260615-codex --detach --yes --json --message "private-network cli smoke deploy"
> Select a workspace <workspace>
{"code":"GRAPHQL_ERROR","error":"Invalid project name","hint":null}
```

Immediate retry hit workspace rate limiting:

```console
$ railway up --new --name "<smoke-project>" --detach --yes --json --message "private-network cli smoke deploy"
> Select a workspace <workspace>
{"code":"GRAPHQL_ERROR","error":"You are creating projects too quickly. This workspace allows 1 project per 30 seconds. Try again shortly.","hint":null}
```

Successful retry:

```console
$ railway up --new --name "<smoke-project>" --detach --yes --json --message "private-network cli smoke deploy"
> Select a workspace <workspace>
{"dashboardUrl":"<dashboard-url>","deploymentId":"<deployment-id>","detectedServices":[],"environmentId":"<environment-id>","logsUrl":"<logs-url>","projectId":"<project-id>","projectName":"<smoke-project>","serviceId":"<service-id>","status":"queued","url":null}
```

Deployment status:

```console
$ railway deployment list --environment <environment-id> --service <service-id> --limit 5 --json
[
  {
    "id": "<deployment-id>",
    "status": "SUCCESS",
    "createdAt": "2026-06-15T15:00:13.391Z"
  }
]
```

### Private Network Commands

```console
$ railway private-network list --project <project-id> --environment <environment-id> --json
{
  "networks": [
    {
      "publicId": "<private-network-id>",
      "projectId": "<project-id>",
      "environmentId": "<environment-id>",
      "name": "railway",
      "dnsName": "railway",
      "networkId": 2028487189,
      "tags": [
        "SUPPORTS_IPV4_PRIVNETS"
      ],
      "supportsIpv4": true,
      "createdAt": "2026-06-15T15:00:12.467+00:00"
    }
  ]
}
```

```console
$ railway private-network status --project <project-id> --environment <environment-id> --service <service-id> --json
{
  "network": {
    "publicId": "<private-network-id>",
    "projectId": "<project-id>",
    "environmentId": "<environment-id>",
    "name": "railway",
    "dnsName": "railway",
    "networkId": 2028487189,
    "tags": [
      "SUPPORTS_IPV4_PRIVNETS"
    ],
    "supportsIpv4": true,
    "createdAt": "2026-06-15T15:00:12.467+00:00"
  },
  "endpoint": {
    "publicId": "<endpoint-id>",
    "serviceInstanceId": "<service-instance-id>",
    "dnsName": "private-network-smoke-20260615",
    "newDnsName": "private-network-smoke-20260615",
    "privateIps": [],
    "tags": [],
    "syncStatus": "ACTIVE",
    "createdAt": "2026-06-15T15:01:11.551+00:00"
  },
  "internalUrl": "private-network-smoke-20260615.railway.internal"
}
```

```console
$ railway private-network name-available api-internal --project <project-id> --environment <environment-id> --network railway --json
{
  "endpoint": "api-internal",
  "available": true,
  "network": {
    "publicId": "<private-network-id>",
    "projectId": "<project-id>",
    "environmentId": "<environment-id>",
    "name": "railway",
    "dnsName": "railway",
    "networkId": 2028487189,
    "tags": [
      "SUPPORTS_IPV4_PRIVNETS"
    ],
    "supportsIpv4": true,
    "createdAt": "2026-06-15T15:00:12.467+00:00"
  }
}
```

```console
$ railway private-network enable --project <project-id> --environment <environment-id> --stage --json
{
  "staged": true,
  "committed": false,
  "environmentId": "<environment-id>",
  "serviceId": null
}
```

First commit attempt exposed immediate verification lag:

```console
$ railway private-network enable --project <project-id> --environment <environment-id> --service <service-id> --endpoint api-internal --message "Smoke enable private networking endpoint" --json
{"code":"ERROR","error":"Private network endpoint 'api-internal' was requested, but it was not present after verification.","hint":null}
```

After adding retry-based verification, the same commit path succeeded:

```console
$ railway private-network enable --project <project-id> --environment <environment-id> --service <service-id> --endpoint api-internal --message "Smoke enable private networking endpoint" --json
{
  "staged": false,
  "committed": true,
  "environmentId": "<environment-id>",
  "serviceId": "<service-id>"
}
```

```console
$ railway private-network set-endpoint api-renamed --project <project-id> --environment <environment-id> --service <service-id> --message "Smoke rename private endpoint" --json
{
  "staged": false,
  "committed": true,
  "environmentId": "<environment-id>",
  "serviceId": "<service-id>"
}
```

```console
$ railway private-network status --project <project-id> --environment <environment-id> --service <service-id> --network railway --json
{
  "network": {
    "publicId": "<private-network-id>",
    "projectId": "<project-id>",
    "environmentId": "<environment-id>",
    "name": "railway",
    "dnsName": "railway",
    "networkId": 2028487189,
    "tags": [
      "SUPPORTS_IPV4_PRIVNETS"
    ],
    "supportsIpv4": true,
    "createdAt": "2026-06-15T15:00:12.467+00:00"
  },
  "endpoint": {
    "publicId": "<endpoint-id>",
    "serviceInstanceId": "<service-instance-id>",
    "dnsName": "api-renamed",
    "newDnsName": "api-renamed",
    "privateIps": [],
    "tags": [],
    "syncStatus": "ACTIVE",
    "createdAt": "2026-06-15T15:01:11.551+00:00"
  },
  "internalUrl": "api-renamed.railway.internal"
}
```

```console
$ railway private-network name-available api-renamed --project <project-id> --environment <environment-id> --network railway --json
{
  "endpoint": "api-renamed",
  "available": false,
  "network": {
    "publicId": "<private-network-id>",
    "projectId": "<project-id>",
    "environmentId": "<environment-id>",
    "name": "railway",
    "dnsName": "railway",
    "networkId": 2028487189,
    "tags": [
      "SUPPORTS_IPV4_PRIVNETS"
    ],
    "supportsIpv4": true,
    "createdAt": "2026-06-15T15:00:12.467+00:00"
  }
}
```

## Smoke Findings

- Hyphenated project display name `private-network-smoke-20260615-codex` was rejected by the API. The smoke used a title-cased project name.
- The workspace rate limit is one project per 30 seconds; immediate retry returned a GraphQL rate-limit error.
- New services can already have an active private endpoint before explicitly editing the endpoint. In this smoke it started as `private-network-smoke-20260615.railway.internal`.
- Environment config verification can lag the commit mutation by a few seconds. The CLI now retries post-commit verification before returning an error.
- `name-available` correctly returned `true` before setting `api-internal` and `false` after renaming the endpoint to `api-renamed`.
