### PR TITLE
feat: add agents.sh install wrapper

### DIFF
--- a/agents.sh
+++ b/agents.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+#
+# Railway agent setup installer.
+#
+# Installs (or reuses) the Railway CLI and configures agent support in a
+# single step. This is a thin convenience wrapper so the published one-liner
+# can stay clean:
+#
+#     curl -fsSL railway.com/agents.sh | sh
+#
+# It is exactly equivalent to:
+#
+#     curl -fsSL railway.com/install.sh | sh -s -- --agents -y
+#
+# Any extra arguments are forwarded to install.sh, e.g. to opt into the
+# remote MCP server:
+#
+#     curl -fsSL railway.com/agents.sh | sh -s -- --remote
+#
+set -eu
+
+curl -fsSL https://railway.com/install.sh | sh -s -- --agents -y "$@"


### PR DESCRIPTION
## What

Adds `agents.sh` — a thin convenience wrapper so the agent-setup install one-liner can stay clean:

```bash
curl -fsSL agents.railway.com | sh
```

It is exactly equivalent to the documented agent install:

```bash
curl -fsSL railway.com/install.sh | sh -s -- --agents -y
```

Extra args are forwarded to `install.sh`, e.g. to opt into the remote MCP server:

```bash
curl -fsSL agents.railway.com | sh -s -- --remote
```

## Why

This is the redirect target for the new agent entrypoints:
- `agents.railway.com` (backboard content-negotiates: browsers → `railway.com/agents`, `curl`/`sh` → this script)
- `railway.com/agents.sh` (frontend redirect)

Both point at `https://raw.githubusercontent.com/railwayapp/cli/master/agents.sh`, so this needs to land on `master` for those entrypoints to resolve.

## Notes

- POSIX `sh`; relies on `install.sh` reading its prompt from `/dev/tty` (so the pipe form works), plus `-y` to skip confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)