### PR TITLE
feat(install): unify the --agents setup into one cohesive flow

### DIFF
--- a/agents.sh
+++ b/agents.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+#
+# Railway agent setup installer.
+#
+# Installs (or reuses) the Railway CLI and configures agent support in a
+# single step. This is a thin convenience wrapper so the published one-liner
+# can stay clean:
+#
+#     curl -fsSL railway.com/agents.sh | sh
+#
+# It is exactly equivalent to:
+#
+#     curl -fsSL railway.com/install.sh | sh -s -- --agents -y
+#
+# Any extra arguments are forwarded to install.sh, e.g. to opt into the
+# remote MCP server:
+#
+#     curl -fsSL railway.com/agents.sh | sh -s -- --remote
+#
+set -eu
+
+curl -fsSL https://railway.com/install.sh | sh -s -- --agents -y "$@"

--- a/install.sh
+++ b/install.sh
@@ -855,6 +855,9 @@ find_railway_bins() {
 }
 
 print_cli_conflicts() {
+  # In quiet mode (the agent setup flow) we only surface an actual conflict;
+  # the informational "on PATH" listing is noise when there's a single install.
+  local quiet="${1:-}"
   local bins_file
   local bin version
   local count=0
@@ -867,14 +870,14 @@ print_cli_conflicts() {
     return
   fi
 
-  info "Railway CLI on PATH:"
+  [ -z "$quiet" ] && info "Railway CLI on PATH:"
   while IFS= read -r bin; do
     count=$((count + 1))
     version="$("$bin" --version 2>/dev/null || echo unknown)"
-    info "  $bin ($version)"
+    [ -z "$quiet" ] && info "  $bin ($version)"
   done < "$bins_file"
   rm -f "$bins_file"
-  info "Shells use the first entry above."
+  [ -z "$quiet" ] && info "Shells use the first entry above."
 
   if [ "$count" -gt 1 ]; then
     warn "Multiple Railway CLI installs found. No PATH entries were reordered or removed."
@@ -926,11 +929,31 @@ run_agent_setup() {
     fi
   fi
 
-  "$railway_bin" setup agent $yes $remote
+  # Tell `setup agent` it's running inside the installer so it renders its
+  # skills/MCP steps as part of one unified flow (no duplicate header, footer,
+  # login prompt, or restart notices — the installer prints those once below).
+  RAILWAY_SETUP_EMBEDDED=1 "$railway_bin" setup agent $yes $remote
 
-  if ! "$railway_bin" whoami >/dev/null 2>&1; then
-    warn "Next: run '$railway_bin login' to finish setup (opens a browser)."
+  # Record login state for the consolidated next-steps block; don't warn here.
+  if "$railway_bin" whoami >/dev/null 2>&1; then
+    AGENT_LOGGED_IN=1
+  else
+    AGENT_LOGGED_IN=0
   fi
+}
+
+# Consolidated "what to do next" for the agent setup flow — a single block
+# instead of warnings scattered between the install, skills, and MCP steps.
+print_agent_next_steps() {
+  printf '\n%s\n' "${BOLD}Next steps${NO_COLOR}"
+  info "Restart your editor / agent to load the skills and MCP server."
+  if [ "${AGENT_LOGGED_IN:-0}" != "1" ]; then
+    info "Run ${BOLD}railway login${NO_COLOR} to connect your Railway account."
+  fi
+  if [ "$RAILWAY_UPGRADE_AGENT" != "1" ] && [ "$PATH_ACTIVATION_PRINTED" != "1" ] && activation="$(activation_command)"; then
+    info "New shells: run ${BOLD}$activation${NO_COLOR} (or add it to your shell profile)."
+  fi
+  printf '\n%s %s\n\n' "${GREEN}✓${NO_COLOR} Setup complete." "Learn more: ${UNDERLINE}https://docs.railway.com/ai${NO_COLOR}"
 }
 
 if [ "$UNINSTALL" = 1 ]; then
@@ -1103,6 +1126,10 @@ mkdir -p "${BIN_DIR}" || {
 }
 check_bin_dir "${BIN_DIR}"
 
+if [ "$AGENTS" = 1 ] && [ "$RAILWAY_UPGRADE_AGENT" != "1" ]; then
+  printf '\n%s\n' "${BOLD}Setting up Railway for agents${NO_COLOR}"
+fi
+
 install "${EXT}"
 
 completed "railway was installed successfully to $(tildify "$BIN_DIR/railway")"
@@ -1131,18 +1158,20 @@ if [ "$AGENTS" = 1 ]; then
     info "Upgraded Railway CLI to ${GREEN}${RAILWAY_VERSION}${NO_COLOR}."
   fi
 
-  print_cli_conflicts
+  print_cli_conflicts quiet
   run_agent_setup "$RAILWAY_BIN"
 
-  if [ "$RAILWAY_UPGRADE_AGENT" != "1" ] && [ "$PATH_ACTIVATION_PRINTED" != "1" ] && activation="$(activation_command)"; then
-    warn "IMPORTANT: Railway was installed to $BIN_DIR."
-    warn "Run '$activation' in new shells before calling railway, or add it to your shell startup file."
-  elif [ "$RAILWAY_UPGRADE_AGENT" != "1" ] && [ "$PATH_ACTIVATION_PRINTED" != "1" ]; then
-    warn "IMPORTANT: Railway was installed to $BIN_DIR."
-    warn "Add it to PATH before calling railway in new shells."
+  if [ "$RAILWAY_UPGRADE_AGENT" != "1" ] && [ "$PATH_ACTIVATION_PRINTED" != "1" ] && [ -z "$(activation_command)" ]; then
+    # No activation file was written; fall back to a plain PATH note.
+    warn "Railway was installed to $BIN_DIR. Add it to PATH before calling railway in new shells."
   fi
+
+  print_agent_next_steps
 fi
 
+# The "Poof" banner + telemetry notice are the standalone-CLI install ending;
+# the agent flow prints its own unified "Next steps" closer above instead.
+if [ "$AGENTS" != 1 ]; then
 printf "$MAGENTA"
   cat <<'EOF'
                    .
@@ -1165,3 +1194,4 @@ printf "$NO_COLOR"
 
 info "Railway collects anonymous CLI usage data to improve the developer experience."
 info "You can opt out anytime: ${BOLD}railway telemetry disable${NO_COLOR} or ${BOLD}RAILWAY_NO_TELEMETRY=1${NO_COLOR}"
+fi

--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -20,14 +20,20 @@ pub struct Args {
 }
 
 pub async fn command(args: Args) -> Result<()> {
-    install_mcp(&args.agent, args.remote).await
+    install_mcp(&args.agent, args.remote, false).await
 }
 
-pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool) -> Result<()> {
+// `quiet` suppresses the section header, the "Installing … to:" line, per-tool
+// success lines, and the footer/restart notice — used by the embedded
+// agent-setup flow, which prints its own collapsed one-line summary. Failures
+// are always surfaced so a silent error can't contradict that summary.
+pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool, quiet: bool) -> Result<()> {
     let home = dirs::home_dir().context("could not determine home directory")?;
     let tools = resolve_tools(&home, agent_filter)?;
 
-    println!("\n{}\n", "Railway MCP".bold());
+    if !quiet {
+        println!("\n{}\n", "Railway MCP".bold());
+    }
 
     let configurable: Vec<_> = tools
         .iter()
@@ -38,12 +44,14 @@ pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool) -> Result
     if configurable.is_empty() {
         // The skills command auto-includes "universal", which has no MCP target.
         // Tell the user nothing was configured rather than silently no-op.
-        println!("{}", "No MCP-capable tools selected or detected.".yellow());
-        if tools.iter().any(|t| t.slug == "universal") {
-            println!(
-                "{} The universal `.agents` directory has no MCP convention; pass --agent to target a specific tool.",
-                "!".yellow().bold()
-            );
+        if !quiet {
+            println!("{}", "No MCP-capable tools selected or detected.".yellow());
+            if tools.iter().any(|t| t.slug == "universal") {
+                println!(
+                    "{} The universal `.agents` directory has no MCP convention; pass --agent to target a specific tool.",
+                    "!".yellow().bold()
+                );
+            }
         }
         return Ok(());
     }
@@ -54,24 +62,28 @@ pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool) -> Result
     } else {
         "local stdio".cyan()
     };
-    println!(
-        "{} {} {} {}\n",
-        "Installing".bold(),
-        transport,
-        "to:".bold(),
-        names.join(", ")
-    );
+    if !quiet {
+        println!(
+            "{} {} {} {}\n",
+            "Installing".bold(),
+            transport,
+            "to:".bold(),
+            names.join(", ")
+        );
+    }
 
     for tool in &configurable {
         let path = config_path(tool.slug, &home);
         match install_for(tool.slug, &path, remote) {
             Ok(()) => {
-                println!(
-                    "{} {}: configured \u{2192} {}",
-                    "\u{2713}".green(),
-                    tool.name.bold(),
-                    path.display().to_string().cyan()
-                );
+                if !quiet {
+                    println!(
+                        "{} {}: configured \u{2192} {}",
+                        "\u{2713}".green(),
+                        tool.name.bold(),
+                        path.display().to_string().cyan()
+                    );
+                }
             }
             Err(e) => {
                 println!(
@@ -84,11 +96,13 @@ pub(crate) async fn install_mcp(agent_filter: &[String], remote: bool) -> Result
         }
     }
 
-    println!("\n{}", "MCP server installed successfully!".green().bold());
-    println!(
-        "{} You may need to restart your tool(s) for the MCP server to register.\n",
-        "!".yellow().bold()
-    );
+    if !quiet {
+        println!("\n{}", "MCP server installed successfully!".green().bold());
+        println!(
+            "{} You may need to restart your tool(s) for the MCP server to register.\n",
+            "!".yellow().bold()
+        );
+    }
 
     Ok(())
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -146,8 +146,14 @@ async fn agent_setup_inner(args: AgentArgs) -> Result<Vec<String>> {
     // isn't a TTY (piped, CI, agent-driven). Matches the convention used by
     // `interact_or!` elsewhere in this CLI.
     let non_interactive = args.yes || !is_stdout_terminal();
+    // When launched by the installer (`… | sh --agents`, which sets
+    // RAILWAY_SETUP_EMBEDDED), render only the skills/MCP steps as part of one
+    // unified flow — the installer prints the banner, next steps, and closer.
+    let embedded = std::env::var("RAILWAY_SETUP_EMBEDDED").is_ok();
 
-    println!("\n{}\n", "Railway Agent Setup".bold().cyan());
+    if !embedded {
+        println!("\n{}\n", "Railway Agent Setup".bold().cyan());
+    }
 
     let choices: Vec<ToolChoice> = coding_tools(&home)
         .into_iter()
@@ -166,7 +172,9 @@ async fn agent_setup_inner(args: AgentArgs) -> Result<Vec<String>> {
             .filter(|c| c.detected)
             .map(|c| c.slug.to_string())
             .collect();
-        println!("{} {}\n", "Detected:".bold(), detected.join(", ").cyan());
+        if !embedded {
+            println!("{} {}\n", "Detected:".bold(), detected.join(", ").cyan());
+        }
         detected
     } else {
         let default_indices: Vec<usize> = choices
@@ -206,44 +214,95 @@ async fn agent_setup_inner(args: AgentArgs) -> Result<Vec<String>> {
         .cloned()
         .collect();
     if missing_skills.is_empty() {
-        println!(
-            "\n{} {}",
-            "-".dimmed(),
-            "Railway skills already configured; skipping install.".dimmed()
-        );
+        if !embedded {
+            println!(
+                "\n{} {}",
+                "-".dimmed(),
+                "Railway skills already configured; skipping install.".dimmed()
+            );
+        }
     } else {
-        skills::install_skills(&missing_skills, false).await?;
+        skills::install_skills(&missing_skills, false, embedded).await?;
+    }
+    if embedded {
+        let names: Vec<&str> = choices
+            .iter()
+            .filter(|c| selected_slugs.iter().any(|s| s.as_str() == c.slug))
+            .map(|c| c.name)
+            .collect();
+        println!(
+            "{} {} \u{2014} {}",
+            "\u{2713}".green(),
+            "Agent skills".bold(),
+            names.join(", ")
+        );
     }
 
     // Step 2: MCP install (skips universal internally — no MCP convention).
     // `--remote` short-circuits the prompt; `-y`/non-TTY defaults to local.
     let mcp_choice = pick_mcp_choice(args.remote, non_interactive)?;
-    match mcp_choice {
-        McpChoice::Local => install_missing_mcp(&home, &selected_slugs, false).await?,
-        McpChoice::Remote => install_missing_mcp(&home, &selected_slugs, true).await?,
+    let mcp_transport = match mcp_choice {
+        McpChoice::Local => {
+            install_missing_mcp(&home, &selected_slugs, false, embedded).await?;
+            Some("local")
+        }
+        McpChoice::Remote => {
+            install_missing_mcp(&home, &selected_slugs, true, embedded).await?;
+            Some("remote")
+        }
         McpChoice::Skip => {
-            println!(
-                "\n{} {}",
-                "-".dimmed(),
-                "Skipping MCP install. Run `railway mcp install` later to configure.".dimmed()
-            );
+            if !embedded {
+                println!(
+                    "\n{} {}",
+                    "-".dimmed(),
+                    "Skipping MCP install. Run `railway mcp install` later to configure.".dimmed()
+                );
+            }
+            None
+        }
+    };
+    if embedded {
+        if let Some(transport) = mcp_transport {
+            let names: Vec<&str> = choices
+                .iter()
+                .filter(|c| {
+                    selected_slugs.iter().any(|s| s.as_str() == c.slug)
+                        && mcp_install::supports_mcp(c.slug)
+                })
+                .map(|c| c.name)
+                .collect();
+            if !names.is_empty() {
+                println!(
+                    "{} {} ({}) \u{2014} {}",
+                    "\u{2713}".green(),
+                    "Railway MCP".bold(),
+                    transport,
+                    names.join(", ")
+                );
+            }
         }
     }
 
-    // Step 3: login
-    if non_interactive {
-        warn_if_not_logged_in().await;
-    } else {
-        ensure_logged_in_interactive().await?;
+    // Step 3: login — skipped when embedded; the installer owns login (it logs
+    // in interactively before this runs, and shows `railway login` in its
+    // consolidated next-steps when not logged in).
+    if !embedded {
+        if non_interactive {
+            warn_if_not_logged_in().await;
+        } else {
+            ensure_logged_in_interactive().await?;
+        }
     }
 
-    // Step 4: docs link
-    println!(
-        "\n{} {} {}\n",
-        "\u{2713}".green().bold(),
-        "Setup complete. Learn more:".bold(),
-        DOCS_URL.purple()
-    );
+    // Step 4: docs link — the installer prints the unified closer when embedded.
+    if !embedded {
+        println!(
+            "\n{} {} {}\n",
+            "\u{2713}".green().bold(),
+            "Setup complete. Learn more:".bold(),
+            DOCS_URL.purple()
+        );
+    }
 
     if let Err(e) = crate::util::agent_advisory::record_setup_complete() {
         eprintln!("{}: {e}", "Warning: failed to record agent setup".yellow());
@@ -362,6 +421,7 @@ async fn install_missing_mcp(
     home: &std::path::Path,
     selected_slugs: &[String],
     remote: bool,
+    quiet: bool,
 ) -> Result<()> {
     let missing_mcp: Vec<String> = selected_slugs
         .iter()
@@ -371,15 +431,17 @@ async fn install_missing_mcp(
         .collect();
 
     if missing_mcp.is_empty() {
-        println!(
-            "\n{} {}",
-            "-".dimmed(),
-            "Railway MCP already configured; skipping install.".dimmed()
-        );
+        if !quiet {
+            println!(
+                "\n{} {}",
+                "-".dimmed(),
+                "Railway MCP already configured; skipping install.".dimmed()
+            );
+        }
         return Ok(());
     }
 
-    mcp_install::install_mcp(&missing_mcp, remote).await
+    mcp_install::install_mcp(&missing_mcp, remote, quiet).await
 }
 
 /// Mirrors the logic at the top of `login::command` without invoking the

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -392,7 +392,7 @@ pub(crate) async fn refresh_skill_update_state() {
 
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
-        None | Some(Commands::Install) => install_skills(&args.agent, args.force).await,
+        None | Some(Commands::Install) => install_skills(&args.agent, args.force, false).await,
         Some(Commands::Remove) => remove_skills(&args.agent).await,
     }
 }
@@ -676,8 +676,12 @@ fn extract_skill_files(tarball_bytes: &[u8]) -> Result<SkillFiles> {
     Ok(skills)
 }
 
-pub(super) async fn install_skills(agent_filter: &[String], force: bool) -> Result<()> {
-    run_install(agent_filter, force, false).await
+pub(super) async fn install_skills(
+    agent_filter: &[String],
+    force: bool,
+    quiet: bool,
+) -> Result<()> {
+    run_install(agent_filter, force, quiet).await
 }
 
 /// Headless skills refresh, spawned as a detached process (mirrors the binary's


### PR DESCRIPTION
## Problem

`curl -fsSL agents.railway.com | sh` stitched two programs' output into a disconnected wall of text:
- `install.sh`'s standalone-CLI epilogue (the `Railway CLI on PATH:` listing, the **"Poof! Railway is now installed"** ASCII banner, the telemetry notice) printed *after* `railway setup agent` already said **"Setup complete,"**
- two separate "restart your tool(s)" notices, two "installed" claims, scattered PATH/login nudges,
- and two different visual styles (install.sh `>`/`✓` vs the Rust section headers).

## Change

Make `install.sh` the orchestrator of the agent flow; have `setup agent` render only its steps when embedded.

**`install.sh`** (all gated on `AGENTS=1`):
- Prints a `Setting up Railway for agents` banner.
- Sets `RAILWAY_SETUP_EMBEDDED=1` around `setup agent`.
- Quiets the `Railway CLI on PATH:` listing unless there's a real conflict.
- Prints one consolidated **Next steps** block (restart · `railway login` if needed · `source …/env` if needed) and a single closer.
- **Suppresses the Poof banner + telemetry** for the agent flow.

**`setup agent`** (when `RAILWAY_SETUP_EMBEDDED` is set): skips its header, `Detected`, login step, and `Setup complete` footer; collapses skills + MCP to one line each.

**`skills::install_skills` / `mcp::install_mcp`**: gain a `quiet` param (suppresses headers / per-tool lines / footer; **failures still surface**).

### Before → After (agent flow)

The middle/footer wall (`Railway Agent Setup` → per-tool ✓ lists → 2× restart notes → `Setup complete` → `Poof!` ASCII → telemetry) becomes:

```
Setting up Railway for agents

> Installing railway, please wait…
✓ railway was installed successfully to ~/.railway/bin/railway
✓ Agent skills — Universal (.agents), Claude Code, OpenAI Codex, OpenCode, GitHub Copilot, Factory Droid, Cursor
✓ Railway MCP (local) — Claude Code, OpenAI Codex, OpenCode, GitHub Copilot, Factory Droid, Cursor

Next steps
> Restart your editor / agent to load the skills and MCP server.
> Run railway login to connect your Railway account.
> New shells: run source "$HOME/.railway/env" (or add it to your shell profile).

✓ Setup complete. Learn more: https://docs.railway.com/ai
```

## Safety — existing flows untouched

Every change sits behind `if !embedded` / `if !quiet` / `AGENTS=1`, so the **unset path runs the original code verbatim**:

| Flow | Result |
|---|---|
| Standalone install (`… install.sh \| sh`, no `--agents`) | unchanged (banner/quiet/next-steps all `AGENTS=1`-gated; Poof + telemetry still print) |
| `railway setup agent` (direct) | unchanged — verified the header/`Detected`/skills/MCP/login/`Setup complete` output is byte-identical |
| `railway skills install` / `railway mcp install` (direct) | unchanged (`quiet=false`) |
| brew / npm installs | never touch install.sh; `setup agent` runs without the env var |

Verified: `cargo check`/`build` clean; ran `setup agent` with and without `RAILWAY_SETUP_EMBEDDED` — embedded shows the collapsed lines, non-embedded shows the original output intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)