### PR TITLE
feat(install): two-section agent setup output + /agents docs link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -724,6 +724,7 @@ configure_shell_startup() {
 }
 
 configure_shell_path() {
+  local quiet="${1:-}"
   local quoted_bin_dir
   local quoted_railway_home
   local fish_bin_dir
@@ -770,6 +771,17 @@ $fish_line"
   if activation="$(activation_command)"; then
     path_commands="$activation"
     startup_contents="$activation"
+  fi
+
+  # Agent flow: still write the startup file, but collapse to one clean line.
+  # The "source in this shell" reminder is deferred to the next-steps block, so
+  # leave PATH_ACTIVATION_PRINTED unset to signal next-steps should show it.
+  if [ -n "$quiet" ]; then
+    if configure_shell_startup "$startup_contents"; then
+      completed "Shell PATH — $(tildify "$SHELL_STARTUP_FILE") updated"
+    fi
+    RAILWAY_ACTIVATION_CMD="$path_commands"
+    return
   fi
 
   warn "Railway was installed to $(tildify "$BIN_DIR"), but this shell does not resolve 'railway' from there yet."
@@ -942,18 +954,27 @@ run_agent_setup() {
   fi
 }
 
-# Consolidated "what to do next" for the agent setup flow — a single block
-# instead of warnings scattered between the install, skills, and MCP steps.
+# Section 2 of the agent setup flow: a visually distinct "completion +
+# verification" block, separated from the installation steps by a rule.
 print_agent_next_steps() {
+  local rule="────────────────────────────────────────────"
+  local n=1
+  printf '\n%s\n\n' "$rule"
+  printf '%s %s\n' "${GREEN}✓${NO_COLOR}" "${BOLD}Setup complete${NO_COLOR}"
+
   printf '\n%s\n' "${BOLD}Next steps${NO_COLOR}"
-  info "Restart your editor / agent to load the skills and MCP server."
+  printf '  %s  %s\n' "$n" "Restart your editor / agent to load the skills and MCP server."
+  n=$((n + 1))
   if [ "${AGENT_LOGGED_IN:-0}" != "1" ]; then
-    info "Run ${BOLD}railway login${NO_COLOR} to connect your Railway account."
+    printf '  %s  Run %s to connect your Railway account.\n' "$n" "${BOLD}railway login${NO_COLOR}"
+    n=$((n + 1))
   fi
-  if [ "$RAILWAY_UPGRADE_AGENT" != "1" ] && [ "$PATH_ACTIVATION_PRINTED" != "1" ] && activation="$(activation_command)"; then
-    info "New shells: run ${BOLD}$activation${NO_COLOR} (or add it to your shell profile)."
+  if [ -n "${RAILWAY_ACTIVATION_CMD:-}" ]; then
+    printf '  %s  Run %s to use railway in this shell.\n' "$n" "${BOLD}${RAILWAY_ACTIVATION_CMD}${NO_COLOR}"
+    n=$((n + 1))
   fi
-  printf '\n%s %s\n\n' "${GREEN}✓${NO_COLOR} Setup complete." "Learn more: ${UNDERLINE}https://docs.railway.com/ai${NO_COLOR}"
+
+  printf '\n%s\n\n' "Docs · ${UNDERLINE}https://docs.railway.com/agents${NO_COLOR}"
 }
 
 if [ "$UNINSTALL" = 1 ]; then
@@ -1132,13 +1153,21 @@ fi
 
 install "${EXT}"
 
-completed "railway was installed successfully to $(tildify "$BIN_DIR/railway")"
+if [ "$AGENTS" = 1 ]; then
+  completed "CLI — v${RAILWAY_VERSION} · $(tildify "$BIN_DIR")"
+else
+  completed "railway was installed successfully to $(tildify "$BIN_DIR/railway")"
+fi
 if [ "$RAILWAY_UPGRADE_AGENT" != "1" ]; then
   write_env_files
 fi
 
 if ! installed_railway_is_on_path; then
-  configure_shell_path
+  if [ "$AGENTS" = 1 ]; then
+    configure_shell_path quiet
+  else
+    configure_shell_path
+  fi
 fi
 
 if [ "$AGENTS" != 1 ]; then

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -13,7 +13,7 @@ use crate::{
     telemetry::{self, SetupAgentPhase, SetupAgentTrackEvent},
 };
 
-const DOCS_URL: &str = "https://docs.railway.com/ai";
+const DOCS_URL: &str = "https://docs.railway.com/agents";
 
 /// Set up your editor for Railway agent functionality (skills, MCP, login)
 #[derive(Parser)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,11 @@ async fn main() -> Result<()> {
     // to cautious interactive users who want release visibility. Suppress it
     // when disabled via env var or CI, where extra output is noise.
     let env_or_ci_suppressed = telemetry::is_auto_update_disabled_by_env() || Configs::env_is_ci();
-    if is_tty && !env_or_ci_suppressed {
+    // The installer's embedded agent setup renders one cohesive flow; the
+    // version/skills update banners are noise mid-install (the user just
+    // configured skills), so suppress them in that context.
+    let embedded_setup = std::env::var("RAILWAY_SETUP_EMBEDDED").is_ok();
+    if is_tty && !env_or_ci_suppressed && !embedded_setup {
         if let Some(ref latest_version) = known_pending {
             let is_skipped = skipped_version.as_deref() == Some(latest_version.as_str());
             if !is_skipped
@@ -341,7 +345,7 @@ async fn main() -> Result<()> {
                 "--force".cyan(),
             );
         }
-    } else if !env_or_ci_suppressed && !is_help_or_error {
+    } else if !env_or_ci_suppressed && !is_help_or_error && !embedded_setup {
         // Non-TTY counterpart of the banner above, for agent callers only.
         // Staged-binary apply is TTY-gated (see auto_applied_version), so a
         // machine whose railway usage is entirely agent-driven would


### PR DESCRIPTION
## Summary

Follow-up to cli#973. Refines the embedded agent install flow (`curl -fsSL agents.railway.com | sh`) into **two visually distinct sections** — installation, then completion / next-steps — for a cleaner, developer-friendly experience, and points the docs link at `/agents`.

### Before (current 5.13.1)
The PATH setup printed a 4-line block interleaved between the install and skills lines, the "Unmanaged Railway skills found…" nag printed mid-flow, and there was no separation between "what got set up" and "what to do next."

### After
```
Setting up Railway for agents
> Installing railway, please wait…
✓ CLI — v5.13.2 · ~/.railway/bin
✓ Shell PATH — ~/.zshrc updated
✓ Agent skills — Universal (.agents), Claude Code, OpenAI Codex, OpenCode, GitHub Copilot, Factory Droid, Cursor
✓ Railway MCP (local) — Claude Code, OpenAI Codex, OpenCode, GitHub Copilot, Factory Droid, Cursor

────────────────────────────────────────────

✓ Setup complete

Next steps
  1  Restart your editor / agent to load the skills and MCP server.
  2  Run railway login to connect your Railway account.
  3  Run source "$HOME/.railway/env" to use railway in this shell.

Docs · https://docs.railway.com/agents
```

## Changes
- **`install.sh`**: collapse the verbose shell-PATH output to one `✓ Shell PATH` line (still writes the startup file; the `source` reminder moves to Next steps); clean `✓ CLI — vX · path` line; a rule separating the install rows from a `✓ Setup complete` + numbered **Next steps** block.
- **`main.rs`**: suppress the version / "skills update available" / "unmanaged skills" banners during embedded setup (`RAILWAY_SETUP_EMBEDDED`) — noise mid-install.
- **Docs link → `https://docs.railway.com/agents`** (was `/ai`), in both the embedded next-steps and the standalone `setup agent` footer.

## Safety
All new behavior is gated behind `RAILWAY_SETUP_EMBEDDED` / `AGENTS=1`. Standalone install, direct `railway setup agent`, and direct `railway skills/mcp install` run the original paths verbatim. `cargo check` clean; `install.sh` syntax-checked.

Labeled `release/patch` to auto-cut `5.13.2` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)