### PR TITLE
feat(install): rework agent setup Next steps for first-run guidance

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ set -eu
 printf '\n'
 
 BOLD="$(tput bold 2>/dev/null || printf '')"
+DIM="$(tput dim 2>/dev/null || printf '')"
 GREY="$(tput setaf 0 2>/dev/null || printf '')"
 UNDERLINE="$(tput smul 2>/dev/null || printf '')"
 RED="$(tput setaf 1 2>/dev/null || printf '')"
@@ -946,8 +947,11 @@ run_agent_setup() {
   # login prompt, or restart notices — the installer prints those once below).
   RAILWAY_SETUP_EMBEDDED=1 "$railway_bin" setup agent $yes $remote
 
-  # Record login state for the consolidated next-steps block; don't warn here.
-  if "$railway_bin" whoami >/dev/null 2>&1; then
+  # Record login state (and the "Logged in as …" line) for the next-steps
+  # block; don't warn here. whoami exits non-zero and prints nothing when
+  # unauthenticated.
+  AGENT_WHOAMI="$("$railway_bin" whoami 2>/dev/null)"
+  if [ $? -eq 0 ] && [ -n "$AGENT_WHOAMI" ]; then
     AGENT_LOGGED_IN=1
   else
     AGENT_LOGGED_IN=0
@@ -958,21 +962,29 @@ run_agent_setup() {
 # verification" block, separated from the installation steps by a rule.
 print_agent_next_steps() {
   local rule="────────────────────────────────────────────"
-  local n=1
   printf '\n%s\n\n' "$rule"
   printf '%s %s\n' "${GREEN}✓${NO_COLOR}" "${BOLD}Setup complete${NO_COLOR}"
 
   printf '\n%s\n' "${BOLD}Next steps${NO_COLOR}"
-  printf '  %s  %s\n' "$n" "Restart your editor / agent to load the skills and MCP server."
-  n=$((n + 1))
-  if [ "${AGENT_LOGGED_IN:-0}" != "1" ]; then
-    printf '  %s  Run %s to connect your Railway account.\n' "$n" "${BOLD}railway login${NO_COLOR}"
-    n=$((n + 1))
+
+  # 1. Account — green check when already authenticated, otherwise the action.
+  if [ "${AGENT_LOGGED_IN:-0}" = "1" ]; then
+    printf '  1  %s\n' "${GREEN}✓ ${AGENT_WHOAMI:-Logged in to Railway}${NO_COLOR}"
+  else
+    printf '  1  Run %s to connect your Railway account\n' "${BOLD}railway login${NO_COLOR}"
   fi
+
+  # 2. Shell PATH — green check when railway already resolves, otherwise activate.
   if [ -n "${RAILWAY_ACTIVATION_CMD:-}" ]; then
-    printf '  %s  Run %s to use railway in this shell.\n' "$n" "${BOLD}${RAILWAY_ACTIVATION_CMD}${NO_COLOR}"
-    n=$((n + 1))
+    printf '  2  Run %s to use railway in this shell\n' "${BOLD}${RAILWAY_ACTIVATION_CMD}${NO_COLOR}"
+  else
+    printf '  2  %s\n' "${GREEN}✓ railway is on your PATH${NO_COLOR}"
   fi
+
+  # 3. Kick the tires — guide the user (or agent) into actually using it.
+  printf '  3  %s\n' "Run your agent (Claude Code, Codex, OpenCode, etc.) and ask it to ${BOLD}'Show the status of your projects'${NO_COLOR} or ${BOLD}'Deploy this application'${NO_COLOR}"
+
+  printf '\n%s\n' "${DIM}Note: if running in an agent session, you may need to restart the agent to access the new Skills or MCP resources.${NO_COLOR}"
 
   printf '\n%s\n\n' "Docs · ${UNDERLINE}https://docs.railway.com/agents${NO_COLOR}"
 }


### PR DESCRIPTION
## Summary

Follow-up to cli#974 (`v5.13.2`). Reworks the **Next steps** block of the agent install flow so it guides a first-time user (or agent) through getting started, and reflects already-done state with green ✓ confirmations instead of hiding completed steps.

### First-time user (not logged in, fresh PATH)
```
Next steps
  1  Run railway login to connect your Railway account
  2  Run source "$HOME/.railway/env" to use railway in this shell
  3  Run your agent (Claude Code, Codex, OpenCode, etc.) and ask it to 'Show the status of your projects' or 'Deploy this application'

Note: if running in an agent session, you may need to restart the agent to access the new Skills or MCP resources.

Docs · https://docs.railway.com/agents
```

### Returning user (logged in, already on PATH)
```
Next steps
  1  ✓ Logged in as Cody (cody@railway.com) 👋
  2  ✓ railway is on your PATH
  3  Run your agent (Claude Code, Codex, OpenCode, etc.) and ask it to 'Show the status of your projects' or 'Deploy this application'
  ...
```

## Changes (install.sh only)
- **Always show all 3 steps.** Login & PATH flip to a **green ✓** line when satisfied, otherwise show the action.
- **Step 1 shows the logged-in identity** — captures `railway whoami` (`Logged in as <name> (<email>) 👋`); falls back to "Logged in to Railway".
- **Step 3 is the getting-started CTA** — run your agent and ask it to *"Show the status of your projects"* or *"Deploy this application"* (both bold).
- **Restart moved to a dimmed Note** (the user may be in a plain shell, not an editor).

## Safety
`install.sh`-only, all within the `AGENTS=1` agent flow. Standalone install and direct `setup agent`/`skills`/`mcp` are untouched. Syntax-checked (`sh -n`). Labeled `release/patch` to auto-cut `5.13.3` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)