### PR TITLE
Add private networking command

### DIFF
--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1577,6 +1577,26 @@ impl RailwayMcp {
     }
 
     #[tool(
+        description = "Get private networking status for a service. Returns full hostname, short name, network name/ID, sync status, address family, and private IPs. If network is omitted, returns all private networks in the environment."
+    )]
+    async fn private_network_status(
+        &self,
+        Parameters(params): Parameters<PrivateNetworkParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_private_network_status(params).await
+    }
+
+    #[tool(
+        description = "Update the private networking endpoint name for a service. Name must be the short prefix without the .internal suffix. If network is omitted, uses the only private network or the network named railway."
+    )]
+    async fn private_network_update(
+        &self,
+        Parameters(params): Parameters<UpdatePrivateNetworkParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.do_private_network_update(params).await
+    }
+
+    #[tool(
         description = "Set reference variables on a service. Each variable value must be a Railway reference expression starting with '${{' (e.g. '${{ Postgres.DATABASE_URL }}')."
     )]
     async fn add_reference_variable(

--- a/src/commands/mcp/params.rs
+++ b/src/commands/mcp/params.rs
@@ -23,6 +23,40 @@ pub struct ServiceParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PrivateNetworkParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Private network name, ID, or DNS name. If omitted, status returns all networks.
+    #[serde(default)]
+    pub network: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct UpdatePrivateNetworkParams {
+    /// The project ID. If omitted, uses the currently linked project.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// The service ID or name. If omitted, uses the currently linked service.
+    #[serde(default)]
+    pub service_id: Option<String>,
+    /// The environment ID or name. If omitted, uses the currently linked environment.
+    #[serde(default)]
+    pub environment_id: Option<String>,
+    /// Private network name, ID, or DNS name. If omitted, uses the only network or the network named "railway".
+    #[serde(default)]
+    pub network: Option<String>,
+    /// Endpoint name prefix, without the .internal suffix.
+    pub name: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct CreateTcpProxyParams {
     /// The project ID. If omitted, uses the currently linked project.
     #[serde(default)]

--- a/src/commands/mcp/tools/mod.rs
+++ b/src/commands/mcp/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod docs;
 pub mod observability;
+pub mod private_network;
 pub mod project;
 pub mod service;
 pub mod storage;

--- a/src/commands/mcp/tools/private_network.rs
+++ b/src/commands/mcp/tools/private_network.rs
@@ -1,0 +1,202 @@
+use rmcp::{ErrorData as McpError, model::*};
+
+use crate::controllers::private_network::{self, PrivateNetworkState, PrivateNetworkStatus};
+
+use super::super::handler::{RailwayMcp, ResolvedServiceContext};
+use super::super::params::{PrivateNetworkParams, UpdatePrivateNetworkParams};
+
+impl RailwayMcp {
+    pub(crate) async fn do_private_network_status(
+        &self,
+        params: PrivateNetworkParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let statuses = private_network::fetch_private_network_statuses(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+            params.network.as_deref(),
+        )
+        .await
+        .map_err(mcp_private_network_error)?;
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_private_network_statuses(&ctx, &statuses),
+        )]))
+    }
+
+    pub(crate) async fn do_private_network_update(
+        &self,
+        params: UpdatePrivateNetworkParams,
+    ) -> Result<CallToolResult, McpError> {
+        let ctx = self
+            .resolve_service_context(params.project_id, params.service_id, params.environment_id)
+            .await?;
+        let status = private_network::update_private_network_endpoint_name(
+            &self.client,
+            &self.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+            params.network.as_deref(),
+            &params.name,
+        )
+        .await
+        .map_err(mcp_private_network_error)?;
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Private network endpoint updated.\n\n{}",
+            format_private_network_status(&status)
+        ))]))
+    }
+}
+
+fn format_private_network_statuses(
+    ctx: &ResolvedServiceContext,
+    statuses: &[PrivateNetworkStatus],
+) -> String {
+    if statuses.is_empty() {
+        return format!(
+            "No private networks found for service {} in environment {}.",
+            ctx.service_id, ctx.environment_id
+        );
+    }
+
+    let mut output = format!(
+        "Private networks for service {} in environment {}:\n\n",
+        ctx.service_id, ctx.environment_id
+    );
+
+    for (idx, status) in statuses.iter().enumerate() {
+        if idx > 0 {
+            output.push('\n');
+        }
+        output.push_str(&format_private_network_status(status));
+        output.push('\n');
+    }
+
+    output
+}
+
+fn format_private_network_status(status: &PrivateNetworkStatus) -> String {
+    let mut output = format!(
+        "Network: {} (id: {}, dns: {})\nAddress family: {}\nState: {}",
+        status.network.name,
+        status.network.id,
+        status.network.dns_name,
+        status.network.ip_family,
+        state_label(status.state)
+    );
+
+    if let Some(hostname) = &status.full_hostname {
+        output.push_str(&format!("\nHostname: {hostname}"));
+    }
+    if let Some(short_name) = &status.short_name {
+        output.push_str(&format!("\nShort name: {short_name}"));
+    }
+    if let Some(pending_hostname) = &status.pending_hostname {
+        output.push_str(&format!("\nPending hostname: {pending_hostname}"));
+    }
+    if let Some(endpoint) = &status.endpoint {
+        output.push_str(&format!(
+            "\nEndpoint ID: {}\nSync status: {}\nService instance ID: {}",
+            endpoint.id, endpoint.sync_status, endpoint.service_instance_id
+        ));
+        if !endpoint.private_ips.is_empty() {
+            output.push_str(&format!(
+                "\nPrivate IPs: {}",
+                endpoint.private_ips.join(", ")
+            ));
+        }
+    } else {
+        output.push_str(
+            "\nMessage: Private networking is initializing and will be ready once the deployment of this service is complete.",
+        );
+    }
+
+    output
+}
+
+fn state_label(state: PrivateNetworkState) -> &'static str {
+    match state {
+        PrivateNetworkState::Ready => "ready",
+        PrivateNetworkState::Creating => "creating",
+        PrivateNetworkState::Updating => "updating",
+        PrivateNetworkState::Deleting => "deleting",
+        PrivateNetworkState::Initializing => "initializing",
+        PrivateNetworkState::Unknown => "unknown",
+    }
+}
+
+fn mcp_private_network_error(error: anyhow::Error) -> McpError {
+    let message = error.to_string();
+    if message.contains("Malformed")
+        || message.contains("already used")
+        || message.contains("Multiple private networks")
+        || message.contains("Private network '")
+        || message.contains("Endpoint name must")
+        || message.contains("Enter your endpoint name")
+    {
+        McpError::invalid_params(message, None)
+    } else {
+        McpError::internal_error(
+            format!("Failed to manage private networking: {message}"),
+            None,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::controllers::private_network::{PrivateNetwork, PrivateNetworkEndpoint};
+
+    use super::*;
+
+    fn status() -> PrivateNetworkStatus {
+        private_network::private_network_status(
+            PrivateNetwork {
+                id: "pn_123".to_string(),
+                project_id: "project".to_string(),
+                environment_id: "environment".to_string(),
+                name: "railway".to_string(),
+                dns_name: "railway".to_string(),
+                ip_family: "IPv4 & IPv6".to_string(),
+                network_id: 1,
+                tags: vec!["SUPPORTS_IPV4_PRIVNETS".to_string()],
+                created_at: None,
+            },
+            Some(PrivateNetworkEndpoint {
+                id: "pne_123".to_string(),
+                service_instance_id: "si_123".to_string(),
+                dns_name: "api".to_string(),
+                new_dns_name: None,
+                private_ips: vec!["fd12::1".to_string()],
+                sync_status: "ACTIVE".to_string(),
+                tags: vec![],
+                created_at: None,
+            }),
+        )
+    }
+
+    #[test]
+    fn formats_private_network_status() {
+        let output = format_private_network_status(&status());
+
+        assert!(output.contains("Network: railway"));
+        assert!(output.contains("Hostname: api.railway.internal"));
+        assert!(output.contains("Address family: IPv4 & IPv6"));
+        assert!(output.contains("Private IPs: fd12::1"));
+    }
+
+    #[test]
+    fn validation_errors_are_invalid_params() {
+        let error =
+            private_network::validate_endpoint_name("api.railway.internal", "railway.internal")
+                .unwrap_err();
+        let mapped = mcp_private_network_error(error);
+
+        assert_eq!(mapped.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    }
+}

--- a/src/commands/mcp/tools/private_network.rs
+++ b/src/commands/mcp/tools/private_network.rs
@@ -134,8 +134,13 @@ fn mcp_private_network_error(error: anyhow::Error) -> McpError {
     let message = error.to_string();
     if message.contains("Malformed")
         || message.contains("already used")
+        || message.contains("reserved for internal use")
         || message.contains("Multiple private networks")
+        || message.contains("No private networks")
+        || message.contains("Cannot update private network endpoint")
+        || message.contains("Private networking is initializing")
         || message.contains("Private network '")
+        || message.contains("Private network selector")
         || message.contains("Endpoint name must")
         || message.contains("Enter your endpoint name")
     {
@@ -192,9 +197,7 @@ mod tests {
 
     #[test]
     fn validation_errors_are_invalid_params() {
-        let error =
-            private_network::validate_endpoint_name("api.railway.internal", "railway.internal")
-                .unwrap_err();
+        let error = private_network::validate_endpoint_name("api.railway.internal").unwrap_err();
         let mapped = mcp_private_network_error(error);
 
         assert_eq!(mapped.code, rmcp::model::ErrorCode::INVALID_PARAMS);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod mcp;
 pub mod metrics;
 pub mod open;
 mod output;
+pub mod private_network;
 pub mod project;
 pub mod redeploy;
 pub mod restart;

--- a/src/commands/private_network.rs
+++ b/src/commands/private_network.rs
@@ -2,7 +2,7 @@ use colored::ColoredString;
 use serde::Serialize;
 
 use crate::controllers::{
-    private_network::{self, PrivateNetworkState, PrivateNetworkStatus},
+    private_network::{self, PrivateNetworkState, PrivateNetworkStatus, endpoint_dns_suffix},
     project::resolve_service_context,
 };
 
@@ -96,7 +96,7 @@ async fn status(
         println!(
             "{}",
             serde_json::to_string_pretty(&StatusOutput {
-                private_networks: statuses,
+                private_networks: statuses.iter().map(PrivateNetworkOutput::from).collect(),
             })?
         );
         return Ok(());
@@ -142,7 +142,7 @@ async fn update(
         println!(
             "{}",
             serde_json::to_string_pretty(&UpdateOutput {
-                private_network: status,
+                private_network: PrivateNetworkOutput::from(&status),
             })?
         );
         return Ok(());
@@ -228,11 +228,137 @@ fn state_label(state: PrivateNetworkState) -> ColoredString {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct StatusOutput {
-    private_networks: Vec<PrivateNetworkStatus>,
+    private_networks: Vec<PrivateNetworkOutput>,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateOutput {
-    private_network: PrivateNetworkStatus,
+    private_network: PrivateNetworkOutput,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PrivateNetworkOutput {
+    network: NetworkOutput,
+    state: PrivateNetworkState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    endpoint: Option<EndpointOutput>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct NetworkOutput {
+    id: String,
+    name: String,
+    dns_name: String,
+    dns_suffix: String,
+    address_family: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EndpointOutput {
+    id: String,
+    short_name: String,
+    hostname: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pending_hostname: Option<String>,
+    sync_status: String,
+    private_ips: Vec<String>,
+}
+
+impl From<&PrivateNetworkStatus> for PrivateNetworkOutput {
+    fn from(status: &PrivateNetworkStatus) -> Self {
+        Self {
+            network: NetworkOutput {
+                id: status.network.id.clone(),
+                name: status.network.name.clone(),
+                dns_name: status.network.dns_name.clone(),
+                dns_suffix: endpoint_dns_suffix(&status.network),
+                address_family: status.network.ip_family.clone(),
+            },
+            state: status.state,
+            endpoint: status.endpoint.as_ref().map(|endpoint| EndpointOutput {
+                id: endpoint.id.clone(),
+                short_name: endpoint.dns_name.clone(),
+                hostname: private_network::full_hostname(&endpoint.dns_name, &status.network),
+                pending_hostname: status.pending_hostname.clone(),
+                sync_status: endpoint.sync_status.clone(),
+                private_ips: endpoint.private_ips.clone(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::controllers::private_network::{PrivateNetwork, PrivateNetworkEndpoint};
+
+    use super::*;
+
+    fn status() -> PrivateNetworkStatus {
+        private_network::private_network_status(
+            PrivateNetwork {
+                id: "pn_123".to_string(),
+                project_id: "project".to_string(),
+                environment_id: "environment".to_string(),
+                name: "railway".to_string(),
+                dns_name: "railway".to_string(),
+                ip_family: "IPv4 & IPv6".to_string(),
+                network_id: 1,
+                tags: vec!["SUPPORTS_IPV4_PRIVNETS".to_string()],
+                created_at: None,
+            },
+            Some(PrivateNetworkEndpoint {
+                id: "pne_123".to_string(),
+                service_instance_id: "si_123".to_string(),
+                dns_name: "api".to_string(),
+                new_dns_name: None,
+                private_ips: vec!["fd12::1".to_string()],
+                sync_status: "ACTIVE".to_string(),
+                tags: vec![],
+                created_at: None,
+            }),
+        )
+    }
+
+    #[test]
+    fn json_output_excludes_internal_fields() {
+        let output = StatusOutput {
+            private_networks: vec![PrivateNetworkOutput::from(&status())],
+        };
+        let value = serde_json::to_value(output).unwrap();
+
+        assert_eq!(
+            value["privateNetworks"][0]["network"],
+            serde_json::json!({
+                "id": "pn_123",
+                "name": "railway",
+                "dnsName": "railway",
+                "dnsSuffix": "railway.internal",
+                "addressFamily": "IPv4 & IPv6"
+            })
+        );
+        assert_eq!(
+            value["privateNetworks"][0]["endpoint"],
+            serde_json::json!({
+                "id": "pne_123",
+                "shortName": "api",
+                "hostname": "api.railway.internal",
+                "syncStatus": "ACTIVE",
+                "privateIps": ["fd12::1"]
+            })
+        );
+        assert_eq!(value["privateNetworks"][0]["state"], "ready");
+
+        let output = value.to_string();
+        assert!(!output.contains("networkId"));
+        assert!(!output.contains("tags"));
+        assert!(!output.contains("projectId"));
+        assert!(!output.contains("environmentId"));
+        assert!(!output.contains("serviceInstanceId"));
+        assert!(!output.contains("createdAt"));
+        assert!(!output.contains("pendingHostname"));
+    }
 }

--- a/src/commands/private_network.rs
+++ b/src/commands/private_network.rs
@@ -1,0 +1,238 @@
+use colored::ColoredString;
+use serde::Serialize;
+
+use crate::controllers::{
+    private_network::{self, PrivateNetworkState, PrivateNetworkStatus},
+    project::resolve_service_context,
+};
+
+use super::*;
+
+const FIELD_LABEL_WIDTH: usize = 16;
+
+/// Manage private networking for a service
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway private-network status --service api\n  railway private-network status --network railway --json\n  railway private-network update api-internal --service api\n\nAutomation notes:\n  Private networking uses the selected service and environment. When multiple private networks exist, status shows all of them and update defaults to the network named `railway` unless --network is provided."
+)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Service name or ID (defaults to linked service)
+    #[clap(short, long, global = true)]
+    service: Option<String>,
+
+    /// Environment to use (defaults to linked environment)
+    #[clap(short, long, global = true)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID", global = true)]
+    project: Option<String>,
+
+    /// Private network name, ID, or DNS name
+    #[clap(long, global = true)]
+    network: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long, global = true)]
+    json: bool,
+}
+
+#[derive(Parser)]
+enum Commands {
+    /// Show private networking status
+    Status,
+
+    /// Update the private networking endpoint name
+    Update {
+        /// Endpoint name prefix, without the .internal suffix
+        #[clap(value_name = "NAME")]
+        name: String,
+    },
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let Args {
+        command,
+        service,
+        environment,
+        project,
+        network,
+        json,
+    } = args;
+
+    crate::util::reporter::set_mode(json);
+
+    match command {
+        Commands::Status => status(project, service, environment, network, json).await?,
+        Commands::Update { name } => {
+            update(project, service, environment, network, name, json).await?
+        }
+    }
+
+    Ok(())
+}
+
+async fn status(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    network: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let statuses = private_network::fetch_private_network_statuses(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        network.as_deref(),
+    )
+    .await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&StatusOutput {
+                private_networks: statuses,
+            })?
+        );
+        return Ok(());
+    }
+
+    if statuses.is_empty() {
+        println!(
+            "No private networks found for service {} in environment {}.",
+            ctx.service_name.bold(),
+            ctx.environment_name.bold()
+        );
+        return Ok(());
+    }
+
+    println!("{}", "Private networking".bold());
+    println!();
+    print_context(&ctx.service_name, &ctx.environment_name);
+    print_statuses(&statuses);
+
+    Ok(())
+}
+
+async fn update(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    network: Option<String>,
+    name: String,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let status = private_network::update_private_network_endpoint_name(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        network.as_deref(),
+        &name,
+    )
+    .await?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&UpdateOutput {
+                private_network: status,
+            })?
+        );
+        return Ok(());
+    }
+
+    println!("{}", "Private networking".bold());
+    println!();
+    print_context(&ctx.service_name, &ctx.environment_name);
+    print_status(&status);
+
+    Ok(())
+}
+
+fn print_context(service_name: &str, environment_name: &str) {
+    print_field("Service:", &service_name.green().bold());
+    print_field("Environment:", &environment_name.blue().bold());
+}
+
+fn print_statuses(statuses: &[PrivateNetworkStatus]) {
+    for status in statuses {
+        print_status(status);
+    }
+}
+
+fn print_status(status: &PrivateNetworkStatus) {
+    println!();
+    print_divider();
+    print_field("Network:", &status.network.name.purple().bold());
+    print_field("Network ID:", &status.network.id.clone().dimmed());
+    print_field(
+        "DNS suffix:",
+        &format!("{}.internal", status.network.dns_name).dimmed(),
+    );
+    print_field(
+        "Address family:",
+        &status.network.ip_family.clone().magenta().bold(),
+    );
+    print_field("Status:", &state_label(status.state));
+
+    if let Some(hostname) = &status.full_hostname {
+        print_field("Hostname:", &hostname.clone().magenta().bold());
+    }
+    if let Some(short_name) = &status.short_name {
+        print_field("Short name:", &short_name.clone().magenta());
+    }
+    if let Some(pending_hostname) = &status.pending_hostname {
+        print_field("Pending:", &pending_hostname.clone().blue().bold());
+    }
+    if let Some(endpoint) = &status.endpoint {
+        print_field("Endpoint ID:", &endpoint.id.clone().dimmed());
+        if !endpoint.private_ips.is_empty() {
+            print_field("Private IPs:", &endpoint.private_ips.join(", "));
+        }
+    } else {
+        print_field(
+            "Message:",
+            &"Private networking is initializing and will be ready once the deployment of this service is complete."
+                .blue(),
+        );
+    }
+}
+
+fn print_field(label: &str, value: &dyn std::fmt::Display) {
+    let padded = format!("{label:<FIELD_LABEL_WIDTH$}");
+    println!("{} {value}", padded.dimmed());
+}
+
+fn print_divider() {
+    println!("{}", "─".repeat(48).dimmed());
+}
+
+fn state_label(state: PrivateNetworkState) -> ColoredString {
+    match state {
+        PrivateNetworkState::Ready => "ready".green().bold(),
+        PrivateNetworkState::Creating => "creating".blue().bold(),
+        PrivateNetworkState::Updating => "updating".blue().bold(),
+        PrivateNetworkState::Deleting => "deleting".yellow().bold(),
+        PrivateNetworkState::Initializing => "initializing".blue().bold(),
+        PrivateNetworkState::Unknown => "unknown".yellow().bold(),
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatusOutput {
+    private_networks: Vec<PrivateNetworkStatus>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateOutput {
+    private_network: PrivateNetworkStatus,
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -9,6 +9,7 @@ pub mod github;
 pub mod local_override;
 pub mod metrics;
 pub mod metrics_tui;
+pub mod private_network;
 pub mod project;
 pub mod regions;
 pub mod sandbox_exec;

--- a/src/controllers/private_network.rs
+++ b/src/controllers/private_network.rs
@@ -10,9 +10,10 @@ use crate::{
 
 const DEFAULT_PRIVATE_NETWORK_NAME: &str = "railway";
 const IPV4_PRIVATE_NETWORK_TAG: &str = "SUPPORTS_IPV4_PRIVNETS";
+const RESERVED_ENDPOINT_NAMES: &[&str] =
+    &["health", "internal", "internal-health", "railway", "up"];
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateNetwork {
     pub id: String,
     pub project_id: String,
@@ -22,36 +23,27 @@ pub struct PrivateNetwork {
     pub ip_family: String,
     pub network_id: i64,
     pub tags: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateNetworkEndpoint {
     pub id: String,
     pub service_instance_id: String,
     pub dns_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub new_dns_name: Option<String>,
     pub private_ips: Vec<String>,
     pub sync_status: String,
     pub tags: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateNetworkStatus {
     pub network: PrivateNetwork,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<PrivateNetworkEndpoint>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub full_hostname: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub short_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pending_hostname: Option<String>,
     pub state: PrivateNetworkState,
 }
@@ -147,9 +139,9 @@ pub async fn update_private_network_endpoint_name(
     network_selector: Option<&str>,
     name: &str,
 ) -> Result<PrivateNetworkStatus> {
+    let name = validate_endpoint_name(name)?;
     let networks = fetch_private_networks(client, configs, environment_id).await?;
     let network = resolve_network_for_update(&networks, network_selector)?.clone();
-    let name = validate_endpoint_name(name, &endpoint_dns_suffix(&network))?;
 
     let endpoint = fetch_private_network_endpoint(
         client,
@@ -165,7 +157,12 @@ pub async fn update_private_network_endpoint_name(
         )
     })?;
 
-    if endpoint.dns_name == name {
+    if endpoint.dns_name == name
+        || endpoint
+            .new_dns_name
+            .as_deref()
+            .is_some_and(|new_dns_name| new_dns_name.eq_ignore_ascii_case(&name))
+    {
         return Ok(private_network_status(network, Some(endpoint)));
     }
 
@@ -306,14 +303,13 @@ pub fn resolve_network<'a>(
     }
 }
 
-pub fn validate_endpoint_name(name: &str, dns_suffix: &str) -> Result<String> {
+pub fn validate_endpoint_name(name: &str) -> Result<String> {
     let name = name.trim();
     if name.is_empty() {
         bail!("Enter your endpoint name.");
     }
 
-    let suffix = dns_suffix.trim_start_matches('.');
-    if name.contains('.') || name.eq_ignore_ascii_case(suffix) {
+    if name.contains('.') {
         bail!("Endpoint name must be the short prefix, not a full .internal hostname.");
     }
 
@@ -332,7 +328,12 @@ pub fn validate_endpoint_name(name: &str, dns_suffix: &str) -> Result<String> {
         bail!("Malformed endpoint name.");
     }
 
-    Ok(name.to_ascii_lowercase())
+    let name = name.to_ascii_lowercase();
+    if is_reserved_endpoint_name(&name) {
+        bail!("Endpoint name is reserved for internal use: {name}");
+    }
+
+    Ok(name)
 }
 
 pub fn private_network_status(
@@ -349,7 +350,12 @@ pub fn private_network_status(
     let short_name = endpoint.as_ref().map(|endpoint| endpoint.dns_name.clone());
     let pending_hostname = endpoint
         .as_ref()
-        .and_then(|endpoint| endpoint.new_dns_name.as_ref())
+        .and_then(|endpoint| {
+            endpoint
+                .new_dns_name
+                .as_ref()
+                .filter(|new_name| !new_name.eq_ignore_ascii_case(&endpoint.dns_name))
+        })
         .map(|name| full_hostname(name, &network));
 
     PrivateNetworkStatus {
@@ -413,6 +419,10 @@ fn ip_family_label(tags: &[String]) -> String {
     } else {
         "IPv6".to_string()
     }
+}
+
+fn is_reserved_endpoint_name(name: &str) -> bool {
+    RESERVED_ENDPOINT_NAMES.contains(&name) || name.starts_with("railway-internal")
 }
 
 fn endpoint_state(endpoint: &PrivateNetworkEndpoint) -> PrivateNetworkState {
@@ -552,20 +562,17 @@ mod tests {
 
     #[test]
     fn validates_endpoint_name() {
-        assert_eq!(
-            validate_endpoint_name("api-1", "railway.internal").unwrap(),
-            "api-1"
-        );
-        assert_eq!(
-            validate_endpoint_name("API", "railway.internal").unwrap(),
-            "api"
-        );
-        assert!(validate_endpoint_name("", "railway.internal").is_err());
-        assert!(validate_endpoint_name("-api", "railway.internal").is_err());
-        assert!(validate_endpoint_name("api-", "railway.internal").is_err());
-        assert!(validate_endpoint_name("api.railway.internal", "railway.internal").is_err());
-        assert!(validate_endpoint_name("api.example", "railway.internal").is_err());
-        assert!(validate_endpoint_name("api_name", "railway.internal").is_err());
+        assert_eq!(validate_endpoint_name("api-1").unwrap(), "api-1");
+        assert_eq!(validate_endpoint_name("API").unwrap(), "api");
+        assert!(validate_endpoint_name("").is_err());
+        assert!(validate_endpoint_name("-api").is_err());
+        assert!(validate_endpoint_name("api-").is_err());
+        assert!(validate_endpoint_name("api.railway.internal").is_err());
+        assert!(validate_endpoint_name("api.example").is_err());
+        assert!(validate_endpoint_name("api_name").is_err());
+        assert!(validate_endpoint_name("railway").is_err());
+        assert!(validate_endpoint_name("railway-internal-1").is_err());
+        assert!(validate_endpoint_name("internal").is_err());
     }
 
     #[test]
@@ -591,6 +598,29 @@ mod tests {
         assert_eq!(status.short_name.as_deref(), Some("api"));
         assert_eq!(status.network.ip_family, "IPv4 & IPv6");
         assert_eq!(status.state, PrivateNetworkState::Ready);
+        assert!(status.pending_hostname.is_none());
+    }
+
+    #[test]
+    fn pending_hostname_only_shows_real_diff() {
+        let network = network("pn_1", "railway", "railway", vec![]);
+        let endpoint = PrivateNetworkEndpoint {
+            id: "pne_1".to_string(),
+            service_instance_id: "si_1".to_string(),
+            dns_name: "api".to_string(),
+            new_dns_name: Some("api-next".to_string()),
+            private_ips: vec![],
+            sync_status: "UPDATING".to_string(),
+            tags: vec![],
+            created_at: None,
+        };
+
+        let status = private_network_status(network, Some(endpoint));
+
+        assert_eq!(
+            status.pending_hostname.as_deref(),
+            Some("api-next.railway.internal")
+        );
     }
 
     #[test]

--- a/src/controllers/private_network.rs
+++ b/src/controllers/private_network.rs
@@ -1,0 +1,603 @@
+use anyhow::{Result, anyhow, bail};
+use reqwest::Client;
+use serde::Serialize;
+
+use crate::{
+    client::post_graphql,
+    config::Configs,
+    gql::{mutations, queries},
+};
+
+const DEFAULT_PRIVATE_NETWORK_NAME: &str = "railway";
+const IPV4_PRIVATE_NETWORK_TAG: &str = "SUPPORTS_IPV4_PRIVNETS";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateNetwork {
+    pub id: String,
+    pub project_id: String,
+    pub environment_id: String,
+    pub name: String,
+    pub dns_name: String,
+    pub ip_family: String,
+    pub network_id: i64,
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateNetworkEndpoint {
+    pub id: String,
+    pub service_instance_id: String,
+    pub dns_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_dns_name: Option<String>,
+    pub private_ips: Vec<String>,
+    pub sync_status: String,
+    pub tags: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateNetworkStatus {
+    pub network: PrivateNetwork,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<PrivateNetworkEndpoint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub short_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_hostname: Option<String>,
+    pub state: PrivateNetworkState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PrivateNetworkState {
+    Ready,
+    Creating,
+    Updating,
+    Deleting,
+    Initializing,
+    Unknown,
+}
+
+pub async fn fetch_private_networks(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+) -> Result<Vec<PrivateNetwork>> {
+    let networks = post_graphql::<queries::PrivateNetworks, _>(
+        client,
+        configs.get_backboard(),
+        queries::private_networks::Variables {
+            environment_id: environment_id.to_string(),
+        },
+    )
+    .await?
+    .private_networks;
+
+    Ok(networks
+        .iter()
+        .filter(|network| network.deleted_at.is_none())
+        .map(private_network_output)
+        .collect())
+}
+
+pub async fn fetch_private_network_endpoint(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    private_network_id: &str,
+) -> Result<Option<PrivateNetworkEndpoint>> {
+    let endpoint = post_graphql::<queries::PrivateNetworkEndpoint, _>(
+        client,
+        configs.get_backboard(),
+        queries::private_network_endpoint::Variables {
+            environment_id: environment_id.to_string(),
+            service_id: service_id.to_string(),
+            private_network_id: private_network_id.to_string(),
+        },
+    )
+    .await?
+    .private_network_endpoint;
+
+    Ok(endpoint
+        .filter(|endpoint| endpoint.deleted_at.is_none())
+        .map(|endpoint| private_network_endpoint_output(&endpoint)))
+}
+
+pub async fn fetch_private_network_statuses(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    network_selector: Option<&str>,
+) -> Result<Vec<PrivateNetworkStatus>> {
+    let networks = fetch_private_networks(client, configs, environment_id).await?;
+    let selected = resolve_networks_for_status(&networks, network_selector)?;
+    let mut statuses = Vec::with_capacity(selected.len());
+
+    for network in selected {
+        let endpoint = fetch_private_network_endpoint(
+            client,
+            configs,
+            environment_id,
+            service_id,
+            &network.id,
+        )
+        .await?;
+        statuses.push(private_network_status(network.clone(), endpoint));
+    }
+
+    Ok(statuses)
+}
+
+pub async fn update_private_network_endpoint_name(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    network_selector: Option<&str>,
+    name: &str,
+) -> Result<PrivateNetworkStatus> {
+    let networks = fetch_private_networks(client, configs, environment_id).await?;
+    let network = resolve_network_for_update(&networks, network_selector)?.clone();
+    let name = validate_endpoint_name(name, &endpoint_dns_suffix(&network))?;
+
+    let endpoint = fetch_private_network_endpoint(
+        client,
+        configs,
+        environment_id,
+        service_id,
+        &network.id,
+    )
+    .await?
+    .ok_or_else(|| {
+        anyhow!(
+            "Private networking is initializing for this service. Deploy or restart the service, then try again."
+        )
+    })?;
+
+    if endpoint.dns_name == name {
+        return Ok(private_network_status(network, Some(endpoint)));
+    }
+
+    if endpoint.sync_status != "ACTIVE" {
+        bail!(
+            "Cannot update private network endpoint while sync status is {}.",
+            endpoint.sync_status
+        );
+    }
+
+    let available =
+        endpoint_name_available(client, configs, environment_id, &network.id, &name).await?;
+    if !available {
+        bail!("Endpoint name already used: {name}");
+    }
+
+    let renamed = post_graphql::<mutations::PrivateNetworkEndpointRename, _>(
+        client,
+        configs.get_backboard(),
+        mutations::private_network_endpoint_rename::Variables {
+            id: endpoint.id.clone(),
+            dns_name: name,
+            private_network_id: network.id.clone(),
+        },
+    )
+    .await?
+    .private_network_endpoint_rename;
+
+    if !renamed {
+        bail!("Failed to update private network endpoint name.");
+    }
+
+    let endpoint =
+        fetch_private_network_endpoint(client, configs, environment_id, service_id, &network.id)
+            .await?
+            .unwrap_or(endpoint);
+
+    Ok(private_network_status(network, Some(endpoint)))
+}
+
+pub async fn endpoint_name_available(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    private_network_id: &str,
+    name: &str,
+) -> Result<bool> {
+    Ok(
+        post_graphql::<queries::PrivateNetworkEndpointNameAvailable, _>(
+            client,
+            configs.get_backboard(),
+            queries::private_network_endpoint_name_available::Variables {
+                environment_id: environment_id.to_string(),
+                private_network_id: private_network_id.to_string(),
+                prefix: name.to_string(),
+            },
+        )
+        .await?
+        .private_network_endpoint_name_available,
+    )
+}
+
+pub fn resolve_networks_for_status<'a>(
+    networks: &'a [PrivateNetwork],
+    selector: Option<&str>,
+) -> Result<Vec<&'a PrivateNetwork>> {
+    if let Some(selector) = selector {
+        return Ok(vec![resolve_network(networks, selector)?]);
+    }
+
+    Ok(networks.iter().collect())
+}
+
+pub fn resolve_network_for_update<'a>(
+    networks: &'a [PrivateNetwork],
+    selector: Option<&str>,
+) -> Result<&'a PrivateNetwork> {
+    if let Some(selector) = selector {
+        return resolve_network(networks, selector);
+    }
+
+    match networks.len() {
+        0 => bail!("No private networks found for this environment."),
+        1 => Ok(&networks[0]),
+        _ => {
+            let railway_matches = networks
+                .iter()
+                .filter(|network| {
+                    network
+                        .name
+                        .eq_ignore_ascii_case(DEFAULT_PRIVATE_NETWORK_NAME)
+                })
+                .collect::<Vec<_>>();
+
+            match railway_matches.len() {
+                1 => Ok(railway_matches[0]),
+                0 => bail!(
+                    "Multiple private networks found. Use --network to select one: {}",
+                    format_network_choices(networks)
+                ),
+                _ => bail!(
+                    "Multiple private networks named '{}'. Use --network with a private network ID: {}",
+                    DEFAULT_PRIVATE_NETWORK_NAME,
+                    format_network_choices(networks)
+                ),
+            }
+        }
+    }
+}
+
+pub fn resolve_network<'a>(
+    networks: &'a [PrivateNetwork],
+    selector: &str,
+) -> Result<&'a PrivateNetwork> {
+    if let Some(network) = networks
+        .iter()
+        .find(|network| network.id.eq_ignore_ascii_case(selector))
+    {
+        return Ok(network);
+    }
+
+    let matches = networks
+        .iter()
+        .filter(|network| {
+            network.name.eq_ignore_ascii_case(selector)
+                || network.dns_name.eq_ignore_ascii_case(selector)
+        })
+        .collect::<Vec<_>>();
+
+    match matches.len() {
+        0 => bail!("Private network '{selector}' not found."),
+        1 => Ok(matches[0]),
+        _ => bail!(
+            "Private network selector '{}' matched multiple networks. Use a private network ID: {}",
+            selector,
+            format_network_choices(networks)
+        ),
+    }
+}
+
+pub fn validate_endpoint_name(name: &str, dns_suffix: &str) -> Result<String> {
+    let name = name.trim();
+    if name.is_empty() {
+        bail!("Enter your endpoint name.");
+    }
+
+    let suffix = dns_suffix.trim_start_matches('.');
+    if name.contains('.') || name.eq_ignore_ascii_case(suffix) {
+        bail!("Endpoint name must be the short prefix, not a full .internal hostname.");
+    }
+
+    if name.starts_with('-') || name.ends_with('-') {
+        bail!("Malformed endpoint name: cannot start or end with '-'.");
+    }
+
+    if name.len() > 63 {
+        bail!("Malformed endpoint name: must be 63 characters or fewer.");
+    }
+
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-')
+    {
+        bail!("Malformed endpoint name.");
+    }
+
+    Ok(name.to_ascii_lowercase())
+}
+
+pub fn private_network_status(
+    network: PrivateNetwork,
+    endpoint: Option<PrivateNetworkEndpoint>,
+) -> PrivateNetworkStatus {
+    let state = endpoint
+        .as_ref()
+        .map(endpoint_state)
+        .unwrap_or(PrivateNetworkState::Initializing);
+    let hostname = endpoint
+        .as_ref()
+        .map(|endpoint| full_hostname(&endpoint.dns_name, &network));
+    let short_name = endpoint.as_ref().map(|endpoint| endpoint.dns_name.clone());
+    let pending_hostname = endpoint
+        .as_ref()
+        .and_then(|endpoint| endpoint.new_dns_name.as_ref())
+        .map(|name| full_hostname(name, &network));
+
+    PrivateNetworkStatus {
+        network,
+        endpoint,
+        full_hostname: hostname,
+        short_name,
+        pending_hostname,
+        state,
+    }
+}
+
+pub fn full_hostname(endpoint_name: &str, network: &PrivateNetwork) -> String {
+    format!("{}.{}", endpoint_name, endpoint_dns_suffix(network))
+}
+
+pub fn endpoint_dns_suffix(network: &PrivateNetwork) -> String {
+    format!("{}.internal", network.dns_name)
+}
+
+fn private_network_output(
+    network: &queries::private_networks::PrivateNetworksPrivateNetworks,
+) -> PrivateNetwork {
+    PrivateNetwork {
+        id: network.public_id.clone(),
+        project_id: network.project_id.clone(),
+        environment_id: network.environment_id.clone(),
+        name: network.name.clone(),
+        dns_name: network.dns_name.clone(),
+        ip_family: ip_family_label(&network.tags),
+        network_id: network.network_id,
+        tags: network.tags.clone(),
+        created_at: network
+            .created_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+    }
+}
+
+fn private_network_endpoint_output(
+    endpoint: &queries::private_network_endpoint::PrivateNetworkEndpointPrivateNetworkEndpoint,
+) -> PrivateNetworkEndpoint {
+    PrivateNetworkEndpoint {
+        id: endpoint.public_id.clone(),
+        service_instance_id: endpoint.service_instance_id.clone(),
+        dns_name: endpoint.dns_name.clone(),
+        new_dns_name: endpoint.new_dns_name.clone(),
+        private_ips: endpoint.private_ips.clone(),
+        sync_status: private_network_endpoint_sync_status(&endpoint.sync_status),
+        tags: endpoint.tags.clone(),
+        created_at: endpoint
+            .created_at
+            .as_ref()
+            .map(chrono::DateTime::to_rfc3339),
+    }
+}
+
+fn ip_family_label(tags: &[String]) -> String {
+    if tags.iter().any(|tag| tag == IPV4_PRIVATE_NETWORK_TAG) {
+        "IPv4 & IPv6".to_string()
+    } else {
+        "IPv6".to_string()
+    }
+}
+
+fn endpoint_state(endpoint: &PrivateNetworkEndpoint) -> PrivateNetworkState {
+    match endpoint.sync_status.as_str() {
+        "ACTIVE" => PrivateNetworkState::Ready,
+        "CREATING" => PrivateNetworkState::Creating,
+        "UPDATING" => PrivateNetworkState::Updating,
+        "DELETING" | "DELETED" => PrivateNetworkState::Deleting,
+        _ => PrivateNetworkState::Unknown,
+    }
+}
+
+fn private_network_endpoint_sync_status(
+    value: &queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus,
+) -> String {
+    match value {
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::ACTIVE => {
+            "ACTIVE".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::CREATING => {
+            "CREATING".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::DELETED => {
+            "DELETED".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::DELETING => {
+            "DELETING".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::UNSPECIFIED => {
+            "UNSPECIFIED".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::UPDATING => {
+            "UPDATING".to_string()
+        }
+        queries::private_network_endpoint::PrivateNetworkEndpointSyncStatus::Other(status) => {
+            status.clone()
+        }
+    }
+}
+
+fn format_network_choices(networks: &[PrivateNetwork]) -> String {
+    networks
+        .iter()
+        .map(|network| {
+            format!(
+                "{} (id: {}, dns: {})",
+                network.name, network.id, network.dns_name
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn network(id: &str, name: &str, dns_name: &str, tags: Vec<&str>) -> PrivateNetwork {
+        PrivateNetwork {
+            id: id.to_string(),
+            project_id: "project".to_string(),
+            environment_id: "environment".to_string(),
+            name: name.to_string(),
+            dns_name: dns_name.to_string(),
+            ip_family: ip_family_label(
+                &tags
+                    .into_iter()
+                    .map(std::string::ToString::to_string)
+                    .collect::<Vec<_>>(),
+            ),
+            network_id: 1,
+            tags: vec![],
+            created_at: None,
+        }
+    }
+
+    #[test]
+    fn resolves_network_for_update() {
+        let networks = vec![network("pn_1", "railway", "railway", vec![])];
+        assert_eq!(
+            resolve_network_for_update(&networks, None).unwrap().id,
+            "pn_1"
+        );
+
+        let networks = vec![
+            network("pn_1", "custom", "custom", vec![]),
+            network("pn_2", "railway", "railway", vec![]),
+        ];
+        assert_eq!(
+            resolve_network_for_update(&networks, None).unwrap().id,
+            "pn_2"
+        );
+        assert_eq!(
+            resolve_network_for_update(&networks, Some("custom"))
+                .unwrap()
+                .id,
+            "pn_1"
+        );
+        assert_eq!(
+            resolve_network_for_update(&networks, Some("pn_2"))
+                .unwrap()
+                .id,
+            "pn_2"
+        );
+        assert_eq!(
+            resolve_network_for_update(&networks, Some("railway"))
+                .unwrap()
+                .id,
+            "pn_2"
+        );
+    }
+
+    #[test]
+    fn update_errors_when_multiple_networks_have_no_default() {
+        let networks = vec![
+            network("pn_1", "alpha", "alpha", vec![]),
+            network("pn_2", "beta", "beta", vec![]),
+        ];
+
+        let err = resolve_network_for_update(&networks, None).unwrap_err();
+        assert!(err.to_string().contains("Multiple private networks found"));
+        assert!(err.to_string().contains("--network"));
+    }
+
+    #[test]
+    fn status_selects_all_networks_without_selector() {
+        let networks = vec![
+            network("pn_1", "alpha", "alpha", vec![]),
+            network("pn_2", "beta", "beta", vec![]),
+        ];
+        assert_eq!(
+            resolve_networks_for_status(&networks, None).unwrap().len(),
+            2
+        );
+        assert!(resolve_networks_for_status(&networks, Some("beta")).is_ok());
+    }
+
+    #[test]
+    fn validates_endpoint_name() {
+        assert_eq!(
+            validate_endpoint_name("api-1", "railway.internal").unwrap(),
+            "api-1"
+        );
+        assert_eq!(
+            validate_endpoint_name("API", "railway.internal").unwrap(),
+            "api"
+        );
+        assert!(validate_endpoint_name("", "railway.internal").is_err());
+        assert!(validate_endpoint_name("-api", "railway.internal").is_err());
+        assert!(validate_endpoint_name("api-", "railway.internal").is_err());
+        assert!(validate_endpoint_name("api.railway.internal", "railway.internal").is_err());
+        assert!(validate_endpoint_name("api.example", "railway.internal").is_err());
+        assert!(validate_endpoint_name("api_name", "railway.internal").is_err());
+    }
+
+    #[test]
+    fn shapes_status_data() {
+        let network = network("pn_1", "railway", "railway", vec![IPV4_PRIVATE_NETWORK_TAG]);
+        let endpoint = PrivateNetworkEndpoint {
+            id: "pne_1".to_string(),
+            service_instance_id: "si_1".to_string(),
+            dns_name: "api".to_string(),
+            new_dns_name: None,
+            private_ips: vec![],
+            sync_status: "ACTIVE".to_string(),
+            tags: vec![],
+            created_at: None,
+        };
+
+        let status = private_network_status(network, Some(endpoint));
+
+        assert_eq!(
+            status.full_hostname.as_deref(),
+            Some("api.railway.internal")
+        );
+        assert_eq!(status.short_name.as_deref(), Some("api"));
+        assert_eq!(status.network.ip_family, "IPv4 & IPv6");
+        assert_eq!(status.state, PrivateNetworkState::Ready);
+    }
+
+    #[test]
+    fn missing_endpoint_is_initializing() {
+        let status = private_network_status(network("pn_1", "railway", "railway", vec![]), None);
+
+        assert_eq!(status.state, PrivateNetworkState::Initializing);
+        assert!(status.full_hostname.is_none());
+    }
+}

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -280,6 +280,14 @@ pub struct TcpProxyDelete;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/PrivateNetworkEndpointRename.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct PrivateNetworkEndpointRename;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/EnvironmentCreate.graphql",
     response_derives = "Debug, Serialize, Clone",
     skip_serializing_none

--- a/src/gql/mutations/strings/PrivateNetworkEndpointRename.graphql
+++ b/src/gql/mutations/strings/PrivateNetworkEndpointRename.graphql
@@ -1,0 +1,3 @@
+mutation PrivateNetworkEndpointRename($id: String!, $dnsName: String!, $privateNetworkId: String!) {
+  privateNetworkEndpointRename(id: $id, dnsName: $dnsName, privateNetworkId: $privateNetworkId)
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -122,6 +122,30 @@ pub struct TcpProxies;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/PrivateNetworks.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq"
+)]
+pub struct PrivateNetworks;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/PrivateNetworkEndpoint.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq"
+)]
+pub struct PrivateNetworkEndpoint;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/PrivateNetworkEndpointNameAvailable.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct PrivateNetworkEndpointNameAvailable;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/ProjectToken.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/PrivateNetworkEndpoint.graphql
+++ b/src/gql/queries/strings/PrivateNetworkEndpoint.graphql
@@ -1,0 +1,13 @@
+query PrivateNetworkEndpoint($privateNetworkId: String!, $environmentId: String!, $serviceId: String!) {
+  privateNetworkEndpoint(privateNetworkId: $privateNetworkId, environmentId: $environmentId, serviceId: $serviceId) {
+    publicId
+    serviceInstanceId
+    dnsName
+    newDnsName
+    privateIps
+    createdAt
+    deletedAt
+    tags
+    syncStatus
+  }
+}

--- a/src/gql/queries/strings/PrivateNetworkEndpointNameAvailable.graphql
+++ b/src/gql/queries/strings/PrivateNetworkEndpointNameAvailable.graphql
@@ -1,0 +1,3 @@
+query PrivateNetworkEndpointNameAvailable($privateNetworkId: String!, $environmentId: String!, $prefix: String!) {
+  privateNetworkEndpointNameAvailable(privateNetworkId: $privateNetworkId, environmentId: $environmentId, prefix: $prefix)
+}

--- a/src/gql/queries/strings/PrivateNetworks.graphql
+++ b/src/gql/queries/strings/PrivateNetworks.graphql
@@ -1,0 +1,13 @@
+query PrivateNetworks($environmentId: String!) {
+  privateNetworks(environmentId: $environmentId) {
+    publicId
+    projectId
+    environmentId
+    name
+    dnsName
+    createdAt
+    deletedAt
+    tags
+    networkId
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ commands!(
     metrics,
     open,
     project,
+    private_network as "private-network",
     run(local),
     sandbox(sandboxes, sbx),
     service,
@@ -743,6 +744,22 @@ mod cli_tests {
             assert_parses(&["tcp-proxy", "create", "--port", "5432"]);
             assert_parses(&["tcp-proxy", "status", "proxy-id"]);
             assert_parses(&["tcp-proxy", "delete", "proxy-id", "--yes"]);
+        }
+
+        #[test]
+        fn private_network_subcommands() {
+            assert!(parse(&["private-network"]).is_err());
+            assert_parses(&["private-network", "status"]);
+            assert_parses(&["private-network", "status", "--service", "api", "--json"]);
+            assert_parses(&["private-network", "status", "--network", "railway"]);
+            assert_parses(&["private-network", "update", "api-internal"]);
+            assert_parses(&[
+                "private-network",
+                "update",
+                "api-internal",
+                "--network",
+                "railway",
+            ]);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Adds `railway private-network` support for inspecting and updating service private networking from the CLI, matching the Railway dashboard experience.

## What Changed

- Added `railway private-network status`
  - Shows private networking status for the selected project, environment, and service
  - Supports `--service`, `--environment`, `--project`, `--network`, and `--json`
  - Displays full hostname, short name, DNS suffix, address family, sync state, endpoint ID, and pending hostname when a rename is in flight

- Added `railway private-network update <name>`
  - Updates the private networking endpoint short name
  - Validates malformed and reserved names before mutation
  - Checks endpoint-name availability before renaming
  - Rejects full `.internal` hostnames and requires the short prefix only

- Tightened the JSON contract
  - Returns a CLI-focused shape instead of mirroring internal GraphQL fields
  - Omits internal fields like backend tags, numeric network IDs, service instance IDs, and timestamps

## Validation

Ran a live end-to-end test against Railway.

```sh
railway private-network status
```

```text
Private networking

Service:         pn-e2e-20260617-001
Environment:     production

────────────────────────────────────────────────
Network:         railway
Network ID:      62523e84-db7e-461e-b296-e621525ab09b
DNS suffix:      railway.internal
Address family:  IPv4 & IPv6
Status:          ready
Hostname:        pn-e2e-20260617-001.railway.internal
Short name:      pn-e2e-20260617-001
Endpoint ID:     ba62fa8e-25e5-4f86-928b-9da0b1add307
```

```sh
railway private-network status --network railway --json
```

```json
{
  "privateNetworks": [
    {
      "network": {
        "id": "62523e84-db7e-461e-b296-e621525ab09b",
        "name": "railway",
        "dnsName": "railway",
        "dnsSuffix": "railway.internal",
        "addressFamily": "IPv4 & IPv6"
      },
      "state": "ready",
      "endpoint": {
        "id": "ba62fa8e-25e5-4f86-928b-9da0b1add307",
        "shortName": "pn-e2e-20260617-001",
        "hostname": "pn-e2e-20260617-001.railway.internal",
        "syncStatus": "ACTIVE",
        "privateIps": []
      }
    }
  ]
}
```

```sh
railway private-network update pn-e2e-20260617-001.railway.internal --json
```

```json
{
  "code": "ERROR",
  "error": "Endpoint name must be the short prefix, not a full .internal hostname.",
  "hint": null
}
```

```sh
railway private-network update pn-e2e-20260617-alt --json
```

```json
{
  "privateNetwork": {
    "network": {
      "id": "62523e84-db7e-461e-b296-e621525ab09b",
      "name": "railway",
      "dnsName": "railway",
      "dnsSuffix": "railway.internal",
      "addressFamily": "IPv4 & IPv6"
    },
    "state": "ready",
    "endpoint": {
      "id": "ba62fa8e-25e5-4f86-928b-9da0b1add307",
      "shortName": "pn-e2e-20260617-alt",
      "hostname": "pn-e2e-20260617-alt.railway.internal",
      "syncStatus": "ACTIVE",
      "privateIps": []
    }
  }
}
```

The temp Railway project was deleted after the E2E run.

Also ran:

```sh
cargo test private_network
cargo test
```
