### PR TITLE
Add network flow logs command

### DIFF
--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -6,17 +6,21 @@ use is_terminal::IsTerminal;
 use crate::{
     controllers::{
         deployment::{
-            FetchLogsParams, fetch_build_logs, fetch_deploy_logs, fetch_http_logs,
-            stream_build_logs, stream_deploy_logs, stream_http_logs,
+            FetchLogsParams, FetchNetworkFlowLogsParams, fetch_build_logs, fetch_deploy_logs,
+            fetch_http_logs, fetch_network_flow_logs, stream_build_logs, stream_deploy_logs,
+            stream_http_logs, stream_network_flow_logs,
         },
         project::resolve_service_context,
     },
     util::{
-        logs::{LogFormat, print_http_log, print_log},
+        logs::{
+            LogFormat, format_network_flow_log_header, print_http_log, print_log,
+            print_network_flow_log,
+        },
         time::parse_time,
     },
 };
-use anyhow::bail;
+use anyhow::{Context, bail};
 
 use super::{
     queries::deployments::{DeploymentListInput, DeploymentStatus},
@@ -110,14 +114,189 @@ impl FromStr for StatusFilter {
     }
 }
 
-fn build_http_filter(args: &Args) -> Option<String> {
-    compose_http_filter(
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum NetworkFlowProtocol {
+    Tcp,
+    Udp,
+    Icmp,
+    Icmpv6,
+    Unknown,
+}
+
+impl fmt::Display for NetworkFlowProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tcp => write!(f, "tcp"),
+            Self::Udp => write!(f, "udp"),
+            Self::Icmp => write!(f, "icmp"),
+            Self::Icmpv6 => write!(f, "icmpv6"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum NetworkFlowDirection {
+    Ingress,
+    Egress,
+}
+
+impl fmt::Display for NetworkFlowDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ingress => write!(f, "ingress"),
+            Self::Egress => write!(f, "egress"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum NetworkFlowPeerKind {
+    Service,
+    Internet,
+    #[value(name = "edge_proxy", alias = "edge-proxy")]
+    EdgeProxy,
+    #[value(name = "local_dns", alias = "dns")]
+    LocalDns,
+    Unknown,
+}
+
+impl fmt::Display for NetworkFlowPeerKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Service => write!(f, "service"),
+            Self::Internet => write!(f, "internet"),
+            Self::EdgeProxy => write!(f, "edge_proxy"),
+            Self::LocalDns => write!(f, "local_dns"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+fn build_http_filter(args: &Args) -> Result<Option<String>> {
+    let status = args
+        .status
+        .as_deref()
+        .map(StatusFilter::from_str)
+        .transpose()
+        .map_err(anyhow::Error::msg)?;
+
+    Ok(compose_http_filter(
         args.method.as_ref(),
-        args.status.as_ref(),
+        status.as_ref(),
         args.path.as_deref(),
         args.request_id.as_deref(),
         args.filter.as_deref(),
-    )
+    ))
+}
+
+fn build_network_flow_filter(args: &Args) -> Result<Option<String>> {
+    if args.method.is_some() || args.path.is_some() || args.request_id.is_some() {
+        bail!("--method, --path, and --request-id can only be used with --http");
+    }
+
+    compose_network_flow_filter(NetworkFlowFilterParts {
+        protocol: args.protocol.as_ref(),
+        direction: args.direction.as_ref(),
+        peer: args.peer.as_deref(),
+        peer_kind: args.peer_kind.as_ref(),
+        status: args.status.as_deref(),
+        dropped: args.dropped,
+        port: args.port,
+        src: args.src.as_deref(),
+        dst: args.dst.as_deref(),
+        host: args.host.as_deref(),
+        drop_cause: args.drop_cause.as_deref(),
+        raw_filter: args.filter.as_deref(),
+    })
+}
+
+pub struct NetworkFlowFilterParts<'a> {
+    pub protocol: Option<&'a NetworkFlowProtocol>,
+    pub direction: Option<&'a NetworkFlowDirection>,
+    pub peer: Option<&'a str>,
+    pub peer_kind: Option<&'a NetworkFlowPeerKind>,
+    pub status: Option<&'a str>,
+    pub dropped: Option<bool>,
+    pub port: Option<u16>,
+    pub src: Option<&'a str>,
+    pub dst: Option<&'a str>,
+    pub host: Option<&'a str>,
+    pub drop_cause: Option<&'a str>,
+    pub raw_filter: Option<&'a str>,
+}
+
+pub fn compose_network_flow_filter(parts: NetworkFlowFilterParts<'_>) -> Result<Option<String>> {
+    let mut filters = Vec::new();
+
+    if let Some(protocol) = parts.protocol {
+        filters.push(format!("@protocol:{protocol}"));
+    }
+    if let Some(direction) = parts.direction {
+        filters.push(format!("@direction:{direction}"));
+    }
+    if let Some(peer) = parts.peer {
+        filters.push(peer_filter(peer));
+    }
+    if let Some(peer_kind) = parts.peer_kind {
+        filters.push(format!("@peer_kind:{peer_kind}"));
+    }
+    if let Some(status) = parts.status {
+        let status = status.to_ascii_lowercase();
+        if status != "ok" && status != "dropped" {
+            bail!("Invalid network flow status: {status}. Expected ok or dropped.");
+        }
+        filters.push(format!("@status:{status}"));
+    }
+    if let Some(dropped) = parts.dropped {
+        filters.push(format!("@dropped:{dropped}"));
+    }
+    if let Some(port) = parts.port {
+        filters.push(format!("@port:{port}"));
+    }
+    if let Some(src) = parts.src {
+        filters.push(format!("@src:{src}"));
+    }
+    if let Some(dst) = parts.dst {
+        filters.push(format!("@dst:{dst}"));
+    }
+    if let Some(host) = parts.host {
+        filters.push(format!("@host:{host}"));
+    }
+    if let Some(drop_cause) = parts.drop_cause {
+        filters.push(format!("@drop_cause:{drop_cause}"));
+    }
+    if let Some(raw_filter) = parts.raw_filter.filter(|filter| !filter.is_empty()) {
+        filters.push(raw_filter.to_string());
+    }
+
+    Ok((!filters.is_empty()).then(|| filters.join(" ")))
+}
+
+fn peer_filter(peer: &str) -> String {
+    match peer.to_ascii_lowercase().as_str() {
+        "internet" => "@peer_kind:internet".to_string(),
+        "dns" | "local_dns" | "local-dns" => "@peer_kind:local_dns".to_string(),
+        "edge-proxy" | "edge_proxy" => "@peer_kind:edge_proxy".to_string(),
+        _ if peer_is_uuid(peer) => format!("@peer:{peer}"),
+        _ => format!("@peer:{}", serde_json::to_string(peer).unwrap()),
+    }
+}
+
+fn peer_is_uuid(peer: &str) -> bool {
+    peer.len() == 36 && peer.chars().all(|ch| ch.is_ascii_hexdigit() || ch == '-')
+}
+
+fn parse_network_port(value: &str) -> std::result::Result<u16, String> {
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| "port must be a number from 1 to 65535".to_string())?;
+
+    if port == 0 {
+        return Err("port must be a number from 1 to 65535".to_string());
+    }
+
+    Ok(port)
 }
 
 /// Build a Railway query filter string from typed HTTP filter components.
@@ -161,8 +340,8 @@ pub fn compose_http_filter(
 
 #[derive(Parser)]
 #[clap(
-    about = "View build, deploy, or HTTP logs from a Railway deployment",
-    long_about = "View build, deploy, or HTTP logs from a Railway deployment. This will stream logs by default, or fetch historical logs if the --lines, --since, or --until flags are provided.",
+    about = "View build, deploy, HTTP, or network flow logs",
+    long_about = "View build, deploy, HTTP, or network flow logs. This will stream logs by default, or fetch historical logs if the --lines, --since, or --until flags are provided.",
     after_help = "Examples:
 
   Deployment logs:
@@ -189,7 +368,14 @@ pub fn compose_http_filter(
   railway logs --http --method GET --filter \"@totalDuration:>=1000\"  # Slow GET requests (combining typed + raw)
   railway logs --http --filter \"@srcIp:203.0.113.1 @edgeRegion:us-east-1\"  # Filter by source IP and region
   railway logs --http --filter \"@httpStatus:>=400 AND @path:/api\"   # Errors on API routes
-  railway logs --http --filter \"-@method:OPTIONS\"                    # Exclude OPTIONS requests"
+  railway logs --http --filter \"-@method:OPTIONS\"                    # Exclude OPTIONS requests
+
+  Network flow logs:
+  railway logs --network                                              # Stream live network flows
+  railway logs --network --lines 100                                  # Pull a snapshot and exit
+  railway logs --network --direction egress --protocol tcp            # Outbound TCP flows
+  railway logs --network --peer postgres --port 5432                  # Flows to a service peer
+  railway logs --network --status dropped                             # Dropped flows"
 )]
 pub struct Args {
     /// Service to view logs from (defaults to linked service). Can be service name or service ID
@@ -215,6 +401,10 @@ pub struct Args {
     /// Show HTTP request logs
     #[clap(long, group = "log_type")]
     http: bool,
+
+    /// Show network flow logs
+    #[clap(long, group = "log_type")]
+    network: bool,
 
     /// Deployment ID to view logs from. Defaults to most recent successful deployment, or latest deployment if none succeeded
     deployment_id: Option<String>,
@@ -246,6 +436,12 @@ For HTTP logs (--http), all filterable fields:
   Numeric: @httpStatus, @totalDuration, @responseTime,
            @upstreamRqDuration, @txBytes, @rxBytes, @upstreamErrors
 
+For network flow logs (--network), all filterable fields:
+  String:  @protocol, @direction, @peer, @peer_kind, @status,
+           @drop_cause, @src, @dst, @host
+  Numeric: @port
+  Boolean: @dropped
+
 Numeric operators: > >= < <= .. (range, e.g. @httpStatus:200..299)
 Logical operators: AND, OR, - (negation), parentheses for grouping
 
@@ -254,7 +450,9 @@ Examples:
   @totalDuration:>1000
   -@method:OPTIONS
   @httpStatus:>=400 AND @path:/api
-  (@method:GET OR @method:POST) AND @httpStatus:500"
+  (@method:GET OR @method:POST) AND @httpStatus:500
+  @protocol:tcp @direction:egress
+  @peer_kind:internet @port:443"
     )]
     filter: Option<String>,
 
@@ -262,9 +460,9 @@ Examples:
     #[clap(long, requires = "http", value_enum, ignore_case = true)]
     method: Option<HttpMethod>,
 
-    /// Filter HTTP logs by status code (requires --http). Accepts: 200, >=400, 500..599
-    #[clap(long, requires = "http", value_name = "CODE")]
-    status: Option<StatusFilter>,
+    /// Filter HTTP logs by status code, or network flow logs by status (ok, dropped)
+    #[clap(long, value_name = "STATUS")]
+    status: Option<String>,
 
     /// Filter HTTP logs by request path (requires --http)
     #[clap(long, requires = "http", value_name = "PATH")]
@@ -273,6 +471,51 @@ Examples:
     /// Filter HTTP logs by request ID (requires --http)
     #[clap(long = "request-id", requires = "http", value_name = "ID")]
     request_id: Option<String>,
+
+    /// Filter network flow logs by layer 4 protocol
+    #[clap(long, requires = "network", value_enum, ignore_case = true)]
+    protocol: Option<NetworkFlowProtocol>,
+
+    /// Filter network flow logs by traffic direction
+    #[clap(long, requires = "network", value_enum, ignore_case = true)]
+    direction: Option<NetworkFlowDirection>,
+
+    /// Filter network flow logs by peer service name/ID or a well-known peer (internet, dns, edge-proxy)
+    #[clap(long, requires = "network", value_name = "PEER")]
+    peer: Option<String>,
+
+    /// Filter network flow logs by peer kind
+    #[clap(
+        long = "peer-kind",
+        requires = "network",
+        value_enum,
+        ignore_case = true
+    )]
+    peer_kind: Option<NetworkFlowPeerKind>,
+
+    /// Filter network flow logs by whether packets were dropped
+    #[clap(long, requires = "network", value_name = "BOOL")]
+    dropped: Option<bool>,
+
+    /// Filter network flow logs by source or destination port
+    #[clap(long, requires = "network", value_parser = parse_network_port)]
+    port: Option<u16>,
+
+    /// Filter network flow logs by source IP
+    #[clap(long, requires = "network", value_name = "IP")]
+    src: Option<String>,
+
+    /// Filter network flow logs by destination IP
+    #[clap(long, requires = "network", value_name = "IP")]
+    dst: Option<String>,
+
+    /// Filter network flow logs by source or destination IP
+    #[clap(long, requires = "network", value_name = "IP")]
+    host: Option<String>,
+
+    /// Filter network flow logs by drop cause
+    #[clap(long = "drop-cause", requires = "network", value_name = "CAUSE")]
+    drop_cause: Option<String>,
 
     /// Always show logs from the latest deployment, even if it failed or is still building
     #[clap(long)]
@@ -293,7 +536,20 @@ pub async fn command(args: Args) -> Result<()> {
     let backboard = configs.get_backboard();
 
     // Build filter before args is partially moved by service matching below
-    let http_filter = build_http_filter(&args);
+    let http_filter = if args.http {
+        build_http_filter(&args)?
+    } else {
+        None
+    };
+    let network_filter = if args.network {
+        build_network_flow_filter(&args)?
+    } else {
+        None
+    };
+
+    if args.status.is_some() && !args.http && !args.network {
+        bail!("--status can only be used with --http or --network");
+    }
 
     let start_date = args.since.as_ref().map(|s| parse_time(s)).transpose()?;
     let end_date = args.until.as_ref().map(|s| parse_time(s)).transpose()?;
@@ -313,6 +569,42 @@ pub async fn command(args: Args) -> Result<()> {
     let project_id = ctx.project_id;
     let environment_id = ctx.environment_id;
     let service = ctx.service_id;
+
+    if args.network {
+        if args.deployment_id.is_some() || args.latest {
+            bail!(
+                "deployment IDs and --latest can only be used with deployment, build, or HTTP logs"
+            );
+        }
+
+        if !args.json {
+            println!("{}", format_network_flow_log_header());
+        }
+
+        if should_stream {
+            stream_network_flow_logs(environment_id, Some(service), network_filter, |log| {
+                print_network_flow_log(log, args.json)
+            })
+            .await?;
+        } else {
+            fetch_network_flow_logs(
+                FetchNetworkFlowLogsParams {
+                    client: &client,
+                    backboard: &backboard,
+                    environment_id,
+                    service_id: Some(service),
+                    limit: args.lines.or(Some(500)),
+                    filter: network_filter,
+                    start_date,
+                    end_date,
+                },
+                |log| print_network_flow_log(log, args.json),
+            )
+            .await?;
+        }
+
+        return Ok(());
+    }
 
     // Fetch all deployments so we can find a sensible default deployment id if
     // none is provided
@@ -433,7 +725,7 @@ mod tests {
     fn build_http_filter_composes_typed_and_raw() {
         // No filters → None
         let args = Args::parse_from(["logs", "--http"]);
-        assert_eq!(build_http_filter(&args), None);
+        assert_eq!(build_http_filter(&args).unwrap(), None);
 
         // All typed flags composed in order
         let args = Args::parse_from([
@@ -449,7 +741,7 @@ mod tests {
             "abc123",
         ]);
         assert_eq!(
-            build_http_filter(&args),
+            build_http_filter(&args).unwrap(),
             Some("@method:POST @httpStatus:>=400 @path:/api/users @requestId:abc123".to_string())
         );
 
@@ -463,8 +755,55 @@ mod tests {
             "@totalDuration:>=1000",
         ]);
         assert_eq!(
-            build_http_filter(&args),
+            build_http_filter(&args).unwrap(),
             Some("@method:GET @totalDuration:>=1000".to_string())
         );
+    }
+
+    #[test]
+    fn build_network_flow_filter_composes_typed_and_raw() {
+        let args = Args::parse_from(["logs", "--network"]);
+        assert_eq!(build_network_flow_filter(&args).unwrap(), None);
+
+        let args = Args::parse_from([
+            "logs",
+            "--network",
+            "--protocol",
+            "tcp",
+            "--direction",
+            "egress",
+            "--peer",
+            "postgres",
+            "--status",
+            "dropped",
+            "--port",
+            "5432",
+            "--filter",
+            "@drop_cause:NO_SOCKET",
+        ]);
+        assert_eq!(
+            build_network_flow_filter(&args).unwrap(),
+            Some(
+                "@protocol:tcp @direction:egress @peer:\"postgres\" @status:dropped @port:5432 @drop_cause:NO_SOCKET"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn network_flow_peer_well_known_names_use_peer_kind() {
+        let args = Args::parse_from(["logs", "--network", "--peer", "edge-proxy"]);
+
+        assert_eq!(
+            build_network_flow_filter(&args).unwrap(),
+            Some("@peer_kind:edge_proxy".to_string())
+        );
+    }
+
+    #[test]
+    fn network_flow_logs_are_mutually_exclusive_with_other_log_modes() {
+        assert!(Args::try_parse_from(["logs", "--network", "--http"]).is_err());
+        assert!(Args::try_parse_from(["logs", "--network", "--build"]).is_err());
+        assert!(Args::try_parse_from(["logs", "--network", "--deployment"]).is_err());
     }
 }

--- a/src/commands/logs.rs
+++ b/src/commands/logs.rs
@@ -211,6 +211,37 @@ fn build_network_flow_filter(args: &Args) -> Result<Option<String>> {
     })
 }
 
+fn validate_filter_modes(args: &Args) -> Result<()> {
+    if args.status.is_some() && !args.http && !args.network {
+        bail!("--status can only be used with --http or --network");
+    }
+
+    if !args.http && (args.method.is_some() || args.path.is_some() || args.request_id.is_some()) {
+        bail!("--method, --path, and --request-id can only be used with --http");
+    }
+
+    if !args.network && has_network_flow_filter_args(args) {
+        bail!(
+            "--protocol, --direction, --peer, --peer-kind, --dropped, --port, --src, --dst, --host, and --drop-cause can only be used with --network"
+        );
+    }
+
+    Ok(())
+}
+
+fn has_network_flow_filter_args(args: &Args) -> bool {
+    args.protocol.is_some()
+        || args.direction.is_some()
+        || args.peer.is_some()
+        || args.peer_kind.is_some()
+        || args.dropped.is_some()
+        || args.port.is_some()
+        || args.src.is_some()
+        || args.dst.is_some()
+        || args.host.is_some()
+        || args.drop_cause.is_some()
+}
+
 pub struct NetworkFlowFilterParts<'a> {
     pub protocol: Option<&'a NetworkFlowProtocol>,
     pub direction: Option<&'a NetworkFlowDirection>,
@@ -531,6 +562,8 @@ Examples:
 }
 
 pub async fn command(args: Args) -> Result<()> {
+    validate_filter_modes(&args)?;
+
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
@@ -546,10 +579,6 @@ pub async fn command(args: Args) -> Result<()> {
     } else {
         None
     };
-
-    if args.status.is_some() && !args.http && !args.network {
-        bail!("--status can only be used with --http or --network");
-    }
 
     let start_date = args.since.as_ref().map(|s| parse_time(s)).transpose()?;
     let end_date = args.until.as_ref().map(|s| parse_time(s)).transpose()?;
@@ -587,6 +616,7 @@ pub async fn command(args: Args) -> Result<()> {
             })
             .await?;
         } else {
+            let mut has_logs = false;
             fetch_network_flow_logs(
                 FetchNetworkFlowLogsParams {
                     client: &client,
@@ -598,9 +628,16 @@ pub async fn command(args: Args) -> Result<()> {
                     start_date,
                     end_date,
                 },
-                |log| print_network_flow_log(log, args.json),
+                |log| {
+                    has_logs = true;
+                    print_network_flow_log(log, args.json)
+                },
             )
             .await?;
+
+            if !has_logs && !args.json {
+                println!("No network flows found");
+            }
         }
 
         return Ok(());
@@ -721,6 +758,39 @@ pub async fn command(args: Args) -> Result<()> {
 mod tests {
     use super::*;
 
+    fn base_args() -> Args {
+        Args {
+            service: None,
+            environment: None,
+            project: None,
+            deployment: false,
+            build: false,
+            http: false,
+            network: false,
+            deployment_id: None,
+            json: false,
+            lines: None,
+            filter: None,
+            method: None,
+            status: None,
+            path: None,
+            request_id: None,
+            protocol: None,
+            direction: None,
+            peer: None,
+            peer_kind: None,
+            dropped: None,
+            port: None,
+            src: None,
+            dst: None,
+            host: None,
+            drop_cause: None,
+            latest: false,
+            since: None,
+            until: None,
+        }
+    }
+
     #[test]
     fn build_http_filter_composes_typed_and_raw() {
         // No filters → None
@@ -805,5 +875,49 @@ mod tests {
         assert!(Args::try_parse_from(["logs", "--network", "--http"]).is_err());
         assert!(Args::try_parse_from(["logs", "--network", "--build"]).is_err());
         assert!(Args::try_parse_from(["logs", "--network", "--deployment"]).is_err());
+    }
+
+    #[test]
+    fn network_flow_typed_flags_require_network_mode() {
+        let mut args = base_args();
+        args.http = true;
+        args.protocol = Some(NetworkFlowProtocol::Tcp);
+
+        assert!(validate_filter_modes(&args).is_err());
+
+        let mut args = base_args();
+        args.network = true;
+        args.protocol = Some(NetworkFlowProtocol::Tcp);
+
+        assert!(validate_filter_modes(&args).is_ok());
+    }
+
+    #[test]
+    fn http_typed_flags_require_http_mode() {
+        let mut args = base_args();
+        args.network = true;
+        args.method = Some(HttpMethod::Get);
+
+        assert!(validate_filter_modes(&args).is_err());
+
+        let mut args = base_args();
+        args.http = true;
+        args.method = Some(HttpMethod::Get);
+
+        assert!(validate_filter_modes(&args).is_ok());
+    }
+
+    #[test]
+    fn status_requires_http_or_network_mode() {
+        let mut args = base_args();
+        args.status = Some("ok".to_string());
+
+        assert!(validate_filter_modes(&args).is_err());
+
+        let mut args = base_args();
+        args.network = true;
+        args.status = Some("ok".to_string());
+
+        assert!(validate_filter_modes(&args).is_ok());
     }
 }

--- a/src/controllers/deployment.rs
+++ b/src/controllers/deployment.rs
@@ -1,7 +1,9 @@
 use crate::{
     commands::{
         queries::{self},
-        subscriptions::{self, build_logs, deployment, deployment_logs, http_logs},
+        subscriptions::{
+            self, build_logs, deployment, deployment_logs, http_logs, network_flow_logs,
+        },
     },
     post_graphql,
     subscription::subscribe_graphql,
@@ -31,6 +33,17 @@ pub struct FetchLogsParams<'a> {
     pub client: &'a Client,
     pub backboard: &'a str,
     pub deployment_id: String,
+    pub limit: Option<i64>,
+    pub filter: Option<String>,
+    pub start_date: Option<DateTime<Utc>>,
+    pub end_date: Option<DateTime<Utc>>,
+}
+
+pub struct FetchNetworkFlowLogsParams<'a> {
+    pub client: &'a Client,
+    pub backboard: &'a str,
+    pub environment_id: String,
+    pub service_id: Option<String>,
     pub limit: Option<i64>,
     pub filter: Option<String>,
     pub start_date: Option<DateTime<Utc>>,
@@ -129,6 +142,34 @@ pub async fn fetch_http_logs(
     Ok(())
 }
 
+pub async fn fetch_network_flow_logs(
+    params: FetchNetworkFlowLogsParams<'_>,
+    mut on_log: impl FnMut(queries::network_flow_logs::NetworkFlowLogFields),
+) -> Result<()> {
+    let before_limit = params.limit.unwrap_or(500);
+    let vars = queries::network_flow_logs::Variables {
+        environment_id: params.environment_id,
+        service_id: params.service_id,
+        filter: params.filter,
+        before_limit: Some(before_limit),
+        before_date: params.start_date.map(|date| date.to_rfc3339()),
+        anchor_date: params.end_date.map(|date| date.to_rfc3339()),
+        after_date: None,
+        after_limit: None,
+    };
+
+    let response =
+        post_graphql::<queries::NetworkFlowLogs, _>(params.client, params.backboard, vars).await?;
+
+    let logs = take_last_n_logs(response.network_flow_logs, Some(before_limit));
+
+    for log in logs {
+        on_log(log);
+    }
+
+    Ok(())
+}
+
 pub async fn stream_build_logs(
     deployment_id: String,
     filter: Option<String>,
@@ -208,6 +249,93 @@ pub async fn stream_http_logs(
             Ok(())
         }
     }
+}
+
+pub async fn stream_network_flow_logs(
+    environment_id: String,
+    service_id: Option<String>,
+    filter: Option<String>,
+    mut on_log: impl FnMut(network_flow_logs::NetworkFlowLogFields),
+) -> Result<()> {
+    let mut last_capture_end = Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true);
+    let mut seen_flow_ids = HashSet::new();
+    let mut attempt = 0;
+    let mut delay_ms = LOGS_RETRY_CONFIG.initial_delay_ms;
+
+    loop {
+        let vars = subscriptions::network_flow_logs::Variables {
+            environment_id: environment_id.clone(),
+            service_id: service_id.clone(),
+            filter: filter.clone(),
+            before_limit: Some(0),
+            before_date: Some(last_capture_end.clone()),
+            anchor_date: None,
+            after_date: None,
+            after_limit: Some(500),
+        };
+
+        let mut stream = match subscribe_graphql::<subscriptions::NetworkFlowLogs>(vars).await {
+            Ok(stream) => stream,
+            Err(e) => {
+                attempt += 1;
+
+                if attempt >= LOGS_RETRY_CONFIG.max_attempts {
+                    return Err(e);
+                }
+
+                sleep(Duration::from_millis(delay_ms)).await;
+                delay_ms = ((delay_ms as f64 * LOGS_RETRY_CONFIG.backoff_multiplier) as u64)
+                    .min(LOGS_RETRY_CONFIG.max_delay_ms);
+                continue;
+            }
+        };
+
+        attempt = 0;
+        delay_ms = LOGS_RETRY_CONFIG.initial_delay_ms;
+
+        while let Some(response) = stream.next().await {
+            let log = response
+                .context("Network flow log stream error")?
+                .data
+                .context("Failed to retrieve network flow logs")?;
+
+            for line in log.network_flow_logs {
+                if !is_new_network_flow_log(
+                    &line.capture_end,
+                    &line.flow_id,
+                    &mut last_capture_end,
+                    &mut seen_flow_ids,
+                ) {
+                    continue;
+                }
+
+                on_log(line);
+            }
+        }
+    }
+}
+
+fn is_new_network_flow_log(
+    capture_end: &str,
+    flow_id: &str,
+    last_capture_end: &mut String,
+    seen_flow_ids: &mut HashSet<String>,
+) -> bool {
+    if capture_end < last_capture_end.as_str() {
+        return false;
+    }
+
+    if capture_end == last_capture_end.as_str() && seen_flow_ids.contains(flow_id) {
+        return false;
+    }
+
+    if capture_end > last_capture_end.as_str() {
+        *last_capture_end = capture_end.to_owned();
+        seen_flow_ids.clear();
+    }
+
+    seen_flow_ids.insert(flow_id.to_owned());
+    true
 }
 
 async fn wait_for_deployment_removal(deployment_id: &str) {

--- a/src/controllers/deployment.rs
+++ b/src/controllers/deployment.rs
@@ -10,10 +10,10 @@ use crate::{
     util::retry::RetryConfig,
 };
 use anyhow::{Context, Result, anyhow};
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, SecondsFormat, Utc};
 use futures::StreamExt;
 use reqwest::Client;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
@@ -28,6 +28,9 @@ const LOGS_RETRY_CONFIG: RetryConfig = RetryConfig {
 const HTTP_LOG_STREAM_AFTER_WINDOW: Duration = Duration::from_secs(60 * 60);
 const HTTP_LOG_STREAM_BATCH_SIZE: i64 = 500;
 const HTTP_LOG_STREAM_STABLE_CONNECTION_DURATION: Duration = Duration::from_secs(30);
+const NETWORK_FLOW_LOG_DEFAULT_LIMIT: i64 = 500;
+const NETWORK_FLOW_STREAM_LOOKBACK_SECONDS: i64 = 30;
+const NETWORK_FLOW_STREAM_DEDUPE_CACHE_SIZE: usize = 10_000;
 
 pub struct FetchLogsParams<'a> {
     pub client: &'a Client,
@@ -60,6 +63,62 @@ fn take_last_n_logs<T>(mut logs: Vec<T>, limit: Option<i64>) -> Vec<T> {
         }
     }
     logs
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NetworkFlowLogWindow {
+    before_limit: Option<i64>,
+    before_date: Option<String>,
+    anchor_date: Option<String>,
+    after_date: Option<String>,
+    after_limit: Option<i64>,
+}
+
+fn format_network_flow_log_timestamp(date: DateTime<Utc>) -> String {
+    date.to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+fn network_flow_log_window(
+    limit: Option<i64>,
+    start_date: Option<DateTime<Utc>>,
+    end_date: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> NetworkFlowLogWindow {
+    let before_limit = Some(limit.unwrap_or(NETWORK_FLOW_LOG_DEFAULT_LIMIT));
+
+    match (start_date, end_date) {
+        (Some(start), Some(end)) => NetworkFlowLogWindow {
+            before_limit,
+            before_date: Some(format_network_flow_log_timestamp(start)),
+            anchor_date: Some(format_network_flow_log_timestamp(end)),
+            after_date: Some(format_network_flow_log_timestamp(end)),
+            after_limit: Some(0),
+        },
+        (Some(start), None) => NetworkFlowLogWindow {
+            before_limit,
+            before_date: Some(format_network_flow_log_timestamp(start)),
+            anchor_date: Some(format_network_flow_log_timestamp(now)),
+            after_date: Some(format_network_flow_log_timestamp(now)),
+            after_limit: Some(0),
+        },
+        (None, Some(end)) => NetworkFlowLogWindow {
+            before_limit,
+            before_date: Some(format_network_flow_log_timestamp(
+                DateTime::<Utc>::from_timestamp(0, 0)
+                    .expect("Unix epoch should be a valid timestamp"),
+            )),
+            anchor_date: Some(format_network_flow_log_timestamp(end)),
+            after_date: Some(format_network_flow_log_timestamp(end)),
+            after_limit: Some(0),
+        },
+        (None, None) => NetworkFlowLogWindow {
+            before_limit,
+            before_date: None,
+            anchor_date: None,
+            after_date: None,
+            after_limit: None,
+        },
+    }
 }
 
 pub async fn fetch_build_logs(
@@ -146,22 +205,23 @@ pub async fn fetch_network_flow_logs(
     params: FetchNetworkFlowLogsParams<'_>,
     mut on_log: impl FnMut(queries::network_flow_logs::NetworkFlowLogFields),
 ) -> Result<()> {
-    let before_limit = params.limit.unwrap_or(500);
+    let window =
+        network_flow_log_window(params.limit, params.start_date, params.end_date, Utc::now());
     let vars = queries::network_flow_logs::Variables {
         environment_id: params.environment_id,
         service_id: params.service_id,
         filter: params.filter,
-        before_limit: Some(before_limit),
-        before_date: params.start_date.map(|date| date.to_rfc3339()),
-        anchor_date: params.end_date.map(|date| date.to_rfc3339()),
-        after_date: None,
-        after_limit: None,
+        before_limit: window.before_limit,
+        before_date: window.before_date,
+        anchor_date: window.anchor_date,
+        after_date: window.after_date,
+        after_limit: window.after_limit,
     };
 
     let response =
         post_graphql::<queries::NetworkFlowLogs, _>(params.client, params.backboard, vars).await?;
 
-    let logs = take_last_n_logs(response.network_flow_logs, Some(before_limit));
+    let logs = take_last_n_logs(response.network_flow_logs, window.before_limit);
 
     for log in logs {
         on_log(log);
@@ -257,21 +317,22 @@ pub async fn stream_network_flow_logs(
     filter: Option<String>,
     mut on_log: impl FnMut(network_flow_logs::NetworkFlowLogFields),
 ) -> Result<()> {
-    let mut last_capture_end = Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true);
-    let mut seen_flow_ids = HashSet::new();
+    let mut max_capture_end: Option<DateTime<Utc>> = None;
+    let mut seen_flow_ids = NetworkFlowLogDedupe::new(NETWORK_FLOW_STREAM_DEDUPE_CACHE_SIZE);
     let mut attempt = 0;
     let mut delay_ms = LOGS_RETRY_CONFIG.initial_delay_ms;
 
     loop {
+        let before_date = network_flow_stream_before_date(max_capture_end);
         let vars = subscriptions::network_flow_logs::Variables {
             environment_id: environment_id.clone(),
             service_id: service_id.clone(),
             filter: filter.clone(),
-            before_limit: Some(0),
-            before_date: Some(last_capture_end.clone()),
+            before_limit: Some(NETWORK_FLOW_LOG_DEFAULT_LIMIT),
+            before_date: Some(before_date),
             anchor_date: None,
             after_date: None,
-            after_limit: Some(500),
+            after_limit: Some(0),
         };
 
         let mut stream = match subscribe_graphql::<subscriptions::NetworkFlowLogs>(vars).await {
@@ -300,12 +361,9 @@ pub async fn stream_network_flow_logs(
                 .context("Failed to retrieve network flow logs")?;
 
             for line in log.network_flow_logs {
-                if !is_new_network_flow_log(
-                    &line.capture_end,
-                    &line.flow_id,
-                    &mut last_capture_end,
-                    &mut seen_flow_ids,
-                ) {
+                update_max_network_flow_capture_end(&line.capture_end, &mut max_capture_end);
+
+                if !seen_flow_ids.insert(line.flow_id.clone()) {
                     continue;
                 }
 
@@ -315,27 +373,59 @@ pub async fn stream_network_flow_logs(
     }
 }
 
-fn is_new_network_flow_log(
+struct NetworkFlowLogDedupe {
+    seen: HashSet<String>,
+    order: VecDeque<String>,
+    max_size: usize,
+}
+
+impl NetworkFlowLogDedupe {
+    fn new(max_size: usize) -> Self {
+        Self {
+            seen: HashSet::new(),
+            order: VecDeque::new(),
+            max_size,
+        }
+    }
+
+    fn insert(&mut self, flow_id: String) -> bool {
+        if self.seen.contains(&flow_id) {
+            return false;
+        }
+
+        self.seen.insert(flow_id.clone());
+        self.order.push_back(flow_id);
+
+        while self.order.len() > self.max_size {
+            if let Some(oldest) = self.order.pop_front() {
+                self.seen.remove(&oldest);
+            }
+        }
+
+        true
+    }
+}
+
+fn network_flow_stream_before_date(max_capture_end: Option<DateTime<Utc>>) -> String {
+    let anchor = max_capture_end.unwrap_or_else(Utc::now);
+    format_network_flow_log_timestamp(
+        anchor - ChronoDuration::seconds(NETWORK_FLOW_STREAM_LOOKBACK_SECONDS),
+    )
+}
+
+fn update_max_network_flow_capture_end(
     capture_end: &str,
-    flow_id: &str,
-    last_capture_end: &mut String,
-    seen_flow_ids: &mut HashSet<String>,
-) -> bool {
-    if capture_end < last_capture_end.as_str() {
-        return false;
-    }
+    max_capture_end: &mut Option<DateTime<Utc>>,
+) {
+    let Ok(capture_end) =
+        DateTime::parse_from_rfc3339(capture_end).map(|date| date.with_timezone(&Utc))
+    else {
+        return;
+    };
 
-    if capture_end == last_capture_end.as_str() && seen_flow_ids.contains(flow_id) {
-        return false;
+    if max_capture_end.is_none_or(|max| capture_end > max) {
+        *max_capture_end = Some(capture_end);
     }
-
-    if capture_end > last_capture_end.as_str() {
-        *last_capture_end = capture_end.to_owned();
-        seen_flow_ids.clear();
-    }
-
-    seen_flow_ids.insert(flow_id.to_owned());
-    true
 }
 
 async fn wait_for_deployment_removal(deployment_id: &str) {
@@ -568,6 +658,12 @@ pub async fn stream_deploy_logs(
 mod tests {
     use super::*;
 
+    fn dt(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
     #[test]
     fn test_take_last_n_logs_with_limit() {
         let logs = vec!["log1", "log2", "log3", "log4", "log5"];
@@ -619,6 +715,112 @@ mod tests {
         // Limit of 0 should return empty vec
         let result = take_last_n_logs(logs, Some(0));
         assert_eq!(result, Vec::<&str>::new());
+    }
+
+    #[test]
+    fn test_network_flow_log_window_uses_explicit_bounded_range() {
+        let start = dt("2026-06-18T04:41:00Z");
+        let end = dt("2026-06-18T04:42:00Z");
+        let now = dt("2026-06-18T04:43:00Z");
+
+        let window = network_flow_log_window(Some(100), Some(start), Some(end), now);
+
+        assert_eq!(
+            window,
+            NetworkFlowLogWindow {
+                before_limit: Some(100),
+                before_date: Some("2026-06-18T04:41:00.000000000Z".to_string()),
+                anchor_date: Some("2026-06-18T04:42:00.000000000Z".to_string()),
+                after_date: Some("2026-06-18T04:42:00.000000000Z".to_string()),
+                after_limit: Some(0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_network_flow_log_window_resolves_open_ended_ranges() {
+        let start = dt("2026-06-18T04:41:00Z");
+        let end = dt("2026-06-18T04:42:00Z");
+        let now = dt("2026-06-18T04:43:00Z");
+
+        let since_window = network_flow_log_window(None, Some(start), None, now);
+        assert_eq!(
+            since_window,
+            NetworkFlowLogWindow {
+                before_limit: Some(NETWORK_FLOW_LOG_DEFAULT_LIMIT),
+                before_date: Some("2026-06-18T04:41:00.000000000Z".to_string()),
+                anchor_date: Some("2026-06-18T04:43:00.000000000Z".to_string()),
+                after_date: Some("2026-06-18T04:43:00.000000000Z".to_string()),
+                after_limit: Some(0),
+            }
+        );
+
+        let until_window = network_flow_log_window(None, None, Some(end), now);
+        assert_eq!(
+            until_window,
+            NetworkFlowLogWindow {
+                before_limit: Some(NETWORK_FLOW_LOG_DEFAULT_LIMIT),
+                before_date: Some("1970-01-01T00:00:00.000000000Z".to_string()),
+                anchor_date: Some("2026-06-18T04:42:00.000000000Z".to_string()),
+                after_date: Some("2026-06-18T04:42:00.000000000Z".to_string()),
+                after_limit: Some(0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_network_flow_log_window_leaves_unbounded_snapshot_to_api_defaults() {
+        let now = dt("2026-06-18T04:43:00Z");
+
+        let window = network_flow_log_window(Some(20), None, None, now);
+
+        assert_eq!(
+            window,
+            NetworkFlowLogWindow {
+                before_limit: Some(20),
+                before_date: None,
+                anchor_date: None,
+                after_date: None,
+                after_limit: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_network_flow_dedupe_keeps_out_of_order_sibling_flows() {
+        let mut dedupe = NetworkFlowLogDedupe::new(10);
+
+        assert!(dedupe.insert("newer-flow".to_string()));
+        assert!(dedupe.insert("older-sibling-flow".to_string()));
+        assert!(!dedupe.insert("newer-flow".to_string()));
+    }
+
+    #[test]
+    fn test_network_flow_dedupe_bounds_cache_size() {
+        let mut dedupe = NetworkFlowLogDedupe::new(2);
+
+        assert!(dedupe.insert("flow-1".to_string()));
+        assert!(dedupe.insert("flow-2".to_string()));
+        assert!(dedupe.insert("flow-3".to_string()));
+        assert!(dedupe.insert("flow-1".to_string()));
+    }
+
+    #[test]
+    fn test_network_flow_stream_before_date_uses_lookback() {
+        let before_date = network_flow_stream_before_date(Some(dt("2026-06-18T04:43:00Z")));
+
+        assert_eq!(before_date, "2026-06-18T04:42:30.000000000Z");
+    }
+
+    #[test]
+    fn test_update_max_network_flow_capture_end_ignores_older_rows() {
+        let mut max_capture_end = Some(dt("2026-06-18T04:43:00Z"));
+
+        update_max_network_flow_capture_end("2026-06-18T04:42:30Z", &mut max_capture_end);
+        assert_eq!(max_capture_end, Some(dt("2026-06-18T04:43:00Z")));
+
+        update_max_network_flow_capture_end("2026-06-18T04:43:30Z", &mut max_capture_end);
+        assert_eq!(max_capture_end, Some(dt("2026-06-18T04:43:30Z")));
     }
 
     #[test]

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -106,6 +106,14 @@ pub struct HttpLogs;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/NetworkFlowLogs.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct NetworkFlowLogs;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/Domains.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/NetworkFlowLogs.graphql
+++ b/src/gql/queries/strings/NetworkFlowLogs.graphql
@@ -1,0 +1,45 @@
+query NetworkFlowLogs(
+  $environmentId: String!
+  $serviceId: String
+  $filter: String
+  $beforeLimit: Int
+  $beforeDate: String
+  $anchorDate: String
+  $afterDate: String
+  $afterLimit: Int
+) {
+  networkFlowLogs(
+    environmentId: $environmentId
+    serviceId: $serviceId
+    filter: $filter
+    beforeDate: $beforeDate
+    anchorDate: $anchorDate
+    afterDate: $afterDate
+    beforeLimit: $beforeLimit
+    afterLimit: $afterLimit
+  ) {
+    ...NetworkFlowLogFields
+  }
+}
+
+fragment NetworkFlowLogFields on NetworkFlowLog {
+  flowId
+  captureStart
+  captureEnd
+  flowState
+  srcAddr
+  dstAddr
+  srcPort
+  dstPort
+  l4Protocol
+  byteCount
+  packetCount
+  direction
+  l4LatencyMs
+  peerServiceId
+  peerKind
+  dropCause
+  serviceId
+  deploymentId
+  deploymentInstanceId
+}

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -158,12 +158,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "EDGE_CONFIG"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "IN_DASHBOARD_SUPPORT"
             },
             {
@@ -182,12 +176,6 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "POSTGRES_PITR"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
               "name": "PRIORITY_BOARDING"
             },
             {
@@ -195,12 +183,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "PROJECT_SANDBOXES"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "TCPIP_DATABASE_CLIENT"
             }
           ],
           "fields": null,
@@ -217,6 +199,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "ALERT_SUS_USERS_CRON_KILLSWITCH"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "BAN_APPEAL_FORM"
             },
             {
@@ -229,6 +217,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "CLICKHOUSE_WORKSPACE_LIMIT_ENFORCE"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "CTRD_IMAGE_STORE_ROLLOUT"
             },
             {
@@ -236,12 +230,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "DEMO_PERCENTAGE_ROLLOUT"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "HA_STATIC_EGRESS_SELF_SERVICE"
             },
             {
               "deprecationReason": null,
@@ -307,7 +295,19 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "TCPIP_DATABASE_CLIENT"
+              "name": "TEMPORAL_CLOUD_DELETIONS"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "TEMPORAL_CLOUD_DEPLOYS"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "TEMPORAL_CLOUD_SECONDARY"
             },
             {
               "deprecationReason": null,
@@ -372,12 +372,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "USE_EXPRESS_DEPLOY"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "USE_HA_STATIC_EGRESS"
             },
             {
               "deprecationReason": null,
@@ -1582,6 +1576,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "groupId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "id",
               "type": {
                 "kind": "NON_NULL",
@@ -2560,6 +2566,159 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "ChangeSetPreview",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "agentSessionId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "arch",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "caller",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "cliVersion",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "errorMessage",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "installRequestId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "isCi",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "os",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "outcome",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "sessionId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "success",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "transport",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "transportReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "CliAuthEventTrackInput",
           "possibleTypes": null
         },
         {
@@ -7620,6 +7779,18 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "underAttackModeUntil",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,
@@ -7761,6 +7932,16 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "allEnvironments",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "environmentId",
               "type": {
                 "kind": "NON_NULL",
@@ -7790,6 +7971,160 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "EgressGatewayServiceTargetInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "environmentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "environmentName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "gateways",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "EgressGateway",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "success",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "EgressMigrationEnvironmentResult",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "environments",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "EgressMigrationEnvironmentResult",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ips",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "EgressGateway",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "EgressMigrationResult",
           "possibleTypes": null
         },
         {
@@ -7884,6 +8219,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "EnvironmentConfig",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Opaque snapshot token of the environment's IaC-relevant config. Echo it back as baseConfigEtag on environmentApplyChangeSet for optimistic concurrency.",
+              "isDeprecated": false,
+              "name": "configEtag",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -10519,6 +10870,41 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "error",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "prInfo",
+              "type": {
+                "kind": "OBJECT",
+                "name": "GitHubPRInfo",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "GitHubPRInfoResult",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "defaultBranch",
               "type": {
                 "kind": "NON_NULL",
@@ -10913,6 +11299,131 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "GitHubSshKey",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "color",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "groupId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "icon",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isCollapsed",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "project",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Project",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "projectId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "Group",
           "possibleTypes": null
         },
         {
@@ -13695,6 +14206,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "CliAuthEventTrackInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Track CLI authentication-attempt outcomes (signup / sign-in funnel)",
+              "isDeprecated": false,
+              "name": "cliAuthEventTrack",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "CliEventTrackInput",
                       "ofType": null
                     }
@@ -14492,7 +15034,38 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "Rollback from HA static IPs to legacy. Creates legacy association, clears HA, and redeploys.",
+              "description": "Preview the HA static egress IPs that would be assigned, without applying them. Set allEnvironments to cover all of the service's environments.",
+              "isDeprecated": false,
+              "name": "egressGatewayHAMigrationPreview",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EgressMigrationResult",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "EgressGatewayServiceTargetInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Switch a service from HA static egress IPs back to a standard static IP. Set allEnvironments to apply to all of the service's environments.",
               "isDeprecated": false,
               "name": "egressGatewayRollbackFromHA",
               "type": {
@@ -14531,7 +15104,7 @@
                 }
               ],
               "deprecationReason": null,
-              "description": "Upgrade static IPs from legacy to HA. Creates HA associations, clears legacy, and redeploys.",
+              "description": "Enable HA static egress IPs for a service. Set allEnvironments to apply to all of the service's environments.",
               "isDeprecated": false,
               "name": "egressGatewayUpgradeToHA",
               "type": {
@@ -14647,6 +15220,16 @@
             },
             {
               "args": [
+                {
+                  "defaultValue": null,
+                  "description": "Snapshot token from Environment.configEtag the plan was computed against. When set, the apply is rejected if the environment has changed since.",
+                  "name": "baseConfigEtag",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
                 {
                   "defaultValue": null,
                   "description": null,
@@ -18538,6 +19121,37 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "SetServiceUnderAttackModeInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Enables or disables Under Attack Mode for a service. While enabled, the edge serves a browser challenge to unverified visitors of the service's edge-routed domains; non-browser clients (APIs, webhooks) without a clearance cookie are rejected with a 429. Optionally time-boxed via durationSeconds, after which the mode disarms automatically.",
+              "isDeprecated": false,
+              "name": "setServiceUnderAttackMode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EdgeConfig",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "SetupAgentEventTrackInput",
                       "ofType": null
                     }
@@ -18994,6 +19608,75 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "serviceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "sizeMB",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "templateId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "volumeId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Sets the default size (in MB) for a volume mount in a template's config. New volumes created when the template is deployed are provisioned at this size, clamped to the deployer's plan maximum. Pass sizeMB: null to clear the pre-size and fall back to the plan default. Editing a template requires maintainer access.",
+              "isDeprecated": false,
+              "name": "templateVolumeUpdate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Template",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "input",
                   "type": {
                     "kind": "NON_NULL",
@@ -19076,6 +19759,37 @@
                 "kind": "OBJECT",
                 "name": "TrustedDomain",
                 "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "input",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "WorkspaceTrustedDomainUpdateInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Update the role of a trusted domain",
+              "isDeprecated": false,
+              "name": "trustedDomainUpdate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TrustedDomain",
+                  "ofType": null
+                }
               }
             },
             {
@@ -20582,6 +21296,441 @@
           "possibleTypes": null
         },
         {
+          "description": "The direction of a network flow relative to the service",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "egress"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ingress"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "NetworkFlowDirection",
+          "possibleTypes": null
+        },
+        {
+          "description": "The layer 4 protocol of a network flow",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "icmp"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "icmpv6"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "tcp"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "udp"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "unknown"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "NetworkFlowL4Protocol",
+          "possibleTypes": null
+        },
+        {
+          "description": "A single network flow log entry",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of bytes transferred",
+              "isDeprecated": false,
+              "name": "byteCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When the flow capture ended (ISO timestamp)",
+              "isDeprecated": false,
+              "name": "captureEnd",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When the flow capture started (ISO timestamp)",
+              "isDeprecated": false,
+              "name": "captureStart",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The deployment ID",
+              "isDeprecated": false,
+              "name": "deploymentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The deployment instance ID",
+              "isDeprecated": false,
+              "name": "deploymentInstanceId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Traffic direction (ingress or egress)",
+              "isDeprecated": false,
+              "name": "direction",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "NetworkFlowDirection",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "If packets were dropped, the reason",
+              "isDeprecated": false,
+              "name": "dropCause",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Destination IP address",
+              "isDeprecated": false,
+              "name": "dstAddr",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Destination port number",
+              "isDeprecated": false,
+              "name": "dstPort",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Unique identifier for the flow",
+              "isDeprecated": false,
+              "name": "flowId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the flow is partial or complete",
+              "isDeprecated": false,
+              "name": "flowState",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "NetworkFlowState",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Layer 4 latency in milliseconds",
+              "isDeprecated": false,
+              "name": "l4LatencyMs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Layer 4 protocol (TCP, UDP, ICMP, etc)",
+              "isDeprecated": false,
+              "name": "l4Protocol",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "NetworkFlowL4Protocol",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Number of packets transferred",
+              "isDeprecated": false,
+              "name": "packetCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Type of peer (service, internet, DNS, etc)",
+              "isDeprecated": false,
+              "name": "peerKind",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "NetworkFlowPeerKind",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Service instance ID of the peer (for service-to-service flows)",
+              "isDeprecated": false,
+              "name": "peerServiceId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The service ID this flow belongs to",
+              "isDeprecated": false,
+              "name": "serviceId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Source IP address",
+              "isDeprecated": false,
+              "name": "srcAddr",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Source port number",
+              "isDeprecated": false,
+              "name": "srcPort",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "NetworkFlowLog",
+          "possibleTypes": null
+        },
+        {
+          "description": "The type of peer in a network flow",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "edge_proxy"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "internet"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "local_dns"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "service"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "unknown"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "NetworkFlowPeerKind",
+          "possibleTypes": null
+        },
+        {
+          "description": "The state of a network flow",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "complete"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "partial"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "NetworkFlowState",
+          "possibleTypes": null
+        },
+        {
           "description": null,
           "enumValues": null,
           "fields": [
@@ -20680,6 +21829,11 @@
             {
               "kind": "OBJECT",
               "name": "Event",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Group",
               "ofType": null
             },
             {
@@ -23286,6 +24440,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "expiresAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "id",
               "type": {
                 "kind": "NON_NULL",
@@ -23317,6 +24483,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "ALERT_SUS_USERS_CRON_KILLSWITCH"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "BAN_APPEAL_FORM"
             },
             {
@@ -23329,6 +24501,12 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "CLICKHOUSE_WORKSPACE_LIMIT_ENFORCE"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "CTRD_IMAGE_STORE_ROLLOUT"
             },
             {
@@ -23336,12 +24514,6 @@
               "description": null,
               "isDeprecated": false,
               "name": "DEMO_PERCENTAGE_ROLLOUT"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "HA_STATIC_EGRESS_SELF_SERVICE"
             },
             {
               "deprecationReason": null,
@@ -23407,7 +24579,19 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
-              "name": "TCPIP_DATABASE_CLIENT"
+              "name": "TEMPORAL_CLOUD_DELETIONS"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "TEMPORAL_CLOUD_DEPLOYS"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "TEMPORAL_CLOUD_SECONDARY"
             },
             {
               "deprecationReason": null,
@@ -26683,6 +27867,22 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Group",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -27676,6 +28876,96 @@
           "interfaces": null,
           "kind": "ENUM",
           "name": "ProjectRole",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectServiceUsagePageInfo",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "usage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AggregatedUsage",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ProjectServiceUsagePage",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "endCursor",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "hasNextPage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "ProjectServiceUsagePageInfo",
           "possibleTypes": null
         },
         {
@@ -30372,6 +31662,37 @@
               "args": [
                 {
                   "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Whether any service in the environment is on legacy static egress (not HA). Used to surface the HA migration banner.",
+              "isDeprecated": false,
+              "name": "environmentHasLegacyStaticEgress",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
                   "description": "Latest date to look for logs after the anchor",
                   "name": "afterDate",
                   "type": {
@@ -31064,6 +32385,51 @@
                 "kind": "OBJECT",
                 "name": "GitHubPRInfo",
                 "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "prNumber",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "serviceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get info for a GitHub pull request, including fetch errors",
+              "isDeprecated": false,
+              "name": "githubPRInfoResult",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "GitHubPRInfoResult",
+                  "ofType": null
+                }
               }
             },
             {
@@ -32091,6 +33457,115 @@
               "args": [
                 {
                   "defaultValue": null,
+                  "description": "Latest date to look for logs after the anchor",
+                  "name": "afterDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit logs returned after the anchor",
+                  "name": "afterLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Target date time to look for logs",
+                  "name": "anchorDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Oldest date to look for logs before the anchor",
+                  "name": "beforeDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit logs returned before the anchor",
+                  "name": "beforeLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Filter expression (e.g., @protocol:tcp @direction:egress @dropped:true)",
+                  "name": "filter",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Filter by service ID (optional)",
+                  "name": "serviceId",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Fetch individual network flow logs for an environment",
+              "isDeprecated": false,
+              "name": "networkFlowLogs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NetworkFlowLog",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
                   "description": null,
                   "name": "after",
                   "type": {
@@ -32926,6 +34401,117 @@
               }
             },
             {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "Project ID cursor returned from the previous page.",
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "endDate",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "DateTime",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Number of projects to include in this page. Max 50.",
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Whether to include deleted projects in usage.",
+                  "name": "includeDeleted",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "measurements",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "ENUM",
+                          "name": "MetricMeasurement",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "startDate",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "DateTime",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "workspaceId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Get paginated usage grouped by project and service for a workspace.",
+              "isDeprecated": false,
+              "name": "projectServiceUsage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ProjectServiceUsagePage",
+                  "ofType": null
+                }
+              }
+            },
+            {
               "args": [],
               "deprecationReason": null,
               "description": "Get a single project token by the value in the header",
@@ -33338,6 +34924,126 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Sandbox",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "List named sandbox checkpoints in an environment.",
+              "isDeprecated": false,
+              "name": "sandboxCheckpoints",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SandboxCheckpoint",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "after",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "before",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "first",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "id",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "last",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Resumable sessions inside a sandbox — interactive shells and one-off exec commands, live or recently exited. Null when the sandbox can't report them (e.g. its vm-init predates session listing).",
+              "isDeprecated": false,
+              "name": "sandboxSessions",
+              "type": {
+                "kind": "OBJECT",
+                "name": "QuerySandboxSessionsConnection",
                 "ofType": null
               }
             },
@@ -35216,45 +36922,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "environmentId",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "List named sandbox checkpoints in an environment.",
-              "isDeprecated": false,
-              "name": "sandboxCheckpoints",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "SandboxCheckpoint",
-                      "ofType": null
-                    }
-                  }
-                }
-              }
             }
           ],
           "inputFields": null,
@@ -36765,6 +38432,100 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "QueryProjectsConnectionEdge",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "edges",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "QuerySandboxSessionsConnectionEdge",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "pageInfo",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "QuerySandboxSessionsConnection",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "cursor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "node",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SandboxSession",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "QuerySandboxSessionsConnectionEdge",
           "possibleTypes": null
         },
         {
@@ -38620,6 +40381,81 @@
           "possibleTypes": null
         },
         {
+          "description": "A bootable snapshot of a sandbox's disk, scoped to an environment. Built from a template recipe or captured from a running sandbox.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "environmentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The checkpoint's identity within the environment (same as id): a recipe content hash for a built template, or the user-given name for one captured from a sandbox.",
+              "isDeprecated": false,
+              "name": "key",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SandboxCheckpoint",
+          "possibleTypes": null
+        },
+        {
           "description": null,
           "enumValues": null,
           "fields": null,
@@ -38809,6 +40645,187 @@
           "possibleTypes": null
         },
         {
+          "description": "A resumable session inside a sandbox: an interactive shell or a one-off exec command.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether a client is currently connected.",
+              "isDeprecated": false,
+              "name": "attached",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The exec command; empty for an interactive shell.",
+              "isDeprecated": false,
+              "name": "command",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "kind",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SandboxSessionKind",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Stable session name; reconnect/attach by this.",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "runState",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SandboxSessionRunState",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SandboxSession",
+          "possibleTypes": null
+        },
+        {
+          "description": "Whether a session is an interactive shell or a one-off exec command.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "EXEC"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "SHELL"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "SandboxSessionKind",
+          "possibleTypes": null
+        },
+        {
+          "description": "A session's process lifecycle.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Process exit code; only meaningful once running is false.",
+              "isDeprecated": false,
+              "name": "exitCode",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "When the process exited; null while running.",
+              "isDeprecated": false,
+              "name": "exitedAt",
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether the process is still alive.",
+              "isDeprecated": false,
+              "name": "running",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "SandboxSessionRunState",
+          "possibleTypes": null
+        },
+        {
           "description": null,
           "enumValues": [
             {
@@ -38910,6 +40927,41 @@
         },
         {
           "description": null,
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "BUILDING"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "FAILED"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "PENDING"
+            },
+            {
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "READY"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "SandboxTemplateBuildStatus",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
           "enumValues": null,
           "fields": null,
           "inputFields": [
@@ -38965,41 +41017,6 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "SandboxTemplateInput",
-          "possibleTypes": null
-        },
-        {
-          "description": null,
-          "enumValues": [
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "BUILDING"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "FAILED"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "PENDING"
-            },
-            {
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "READY"
-            }
-          ],
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "kind": "ENUM",
-          "name": "SandboxTemplateBuildStatus",
           "possibleTypes": null
         },
         {
@@ -39128,6 +41145,18 @@
             {
               "args": [],
               "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "groupId",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
               "description": "Whether this service has hidden registry credentials from a template. When true, the credentials are stored in the template and used during deployment.",
               "isDeprecated": false,
               "name": "hasHiddenRegistryCredentialsFromTemplate",
@@ -39165,6 +41194,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Whether this service currently has an active restriction.",
+              "isDeprecated": false,
+              "name": "isRestricted",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               }
@@ -41601,6 +43646,69 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "durationSeconds",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "enabled",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "environmentId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "serviceId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "SetServiceUnderAttackModeInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "agentSessionId",
               "type": {
                 "kind": "SCALAR",
@@ -42877,6 +44985,115 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "HttpLog",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "Latest date to look for logs after the anchor",
+                  "name": "afterDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit logs returned after the anchor",
+                  "name": "afterLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Target date time to look for logs",
+                  "name": "anchorDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Oldest date to look for logs before the anchor",
+                  "name": "beforeDate",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Limit logs returned before the anchor",
+                  "name": "beforeLimit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "environmentId",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Filter expression (e.g., @protocol:tcp @direction:egress @dropped:true)",
+                  "name": "filter",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "Filter by service ID (optional)",
+                  "name": "serviceId",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Stream network flow logs for an environment",
+              "isDeprecated": false,
+              "name": "networkFlowLogs",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NetworkFlowLog",
                       "ofType": null
                     }
                   }
@@ -52130,6 +54347,45 @@
             {
               "defaultValue": null,
               "description": null,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "role",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "interfaces": null,
+          "kind": "INPUT_OBJECT",
+          "name": "WorkspaceTrustedDomainUpdateInput",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "defaultValue": null,
+              "description": null,
               "name": "avatar",
               "type": {
                 "kind": "SCALAR",
@@ -53159,81 +55415,6 @@
           "interfaces": null,
           "kind": "INPUT_OBJECT",
           "name": "customerTogglePayoutsToCreditsInput",
-          "possibleTypes": null
-        },
-        {
-          "description": "A bootable snapshot of a sandbox's disk, scoped to an environment. Built from a template recipe or captured from a running sandbox.",
-          "enumValues": null,
-          "fields": [
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "createdAt",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "DateTime",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "environmentId",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "id",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": "The checkpoint's identity within the environment (same as id): a recipe content hash for a built template, or the user-given name for one captured from a sandbox.",
-              "isDeprecated": false,
-              "name": "key",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              }
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "kind": "OBJECT",
-          "name": "SandboxCheckpoint",
           "possibleTypes": null
         }
       ]

--- a/src/gql/subscriptions/mod.rs
+++ b/src/gql/subscriptions/mod.rs
@@ -27,6 +27,14 @@ pub struct HttpLogs;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/subscriptions/strings/NetworkFlowLogs.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct NetworkFlowLogs;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/subscriptions/strings/Deployment.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/subscriptions/strings/NetworkFlowLogs.graphql
+++ b/src/gql/subscriptions/strings/NetworkFlowLogs.graphql
@@ -1,0 +1,45 @@
+subscription NetworkFlowLogs(
+  $environmentId: String!
+  $serviceId: String
+  $filter: String
+  $beforeLimit: Int
+  $beforeDate: String
+  $anchorDate: String
+  $afterDate: String
+  $afterLimit: Int
+) {
+  networkFlowLogs(
+    environmentId: $environmentId
+    serviceId: $serviceId
+    filter: $filter
+    beforeDate: $beforeDate
+    anchorDate: $anchorDate
+    afterDate: $afterDate
+    beforeLimit: $beforeLimit
+    afterLimit: $afterLimit
+  ) {
+    ...NetworkFlowLogFields
+  }
+}
+
+fragment NetworkFlowLogFields on NetworkFlowLog {
+  flowId
+  captureStart
+  captureEnd
+  flowState
+  srcAddr
+  dstAddr
+  srcPort
+  dstPort
+  l4Protocol
+  byteCount
+  packetCount
+  direction
+  l4LatencyMs
+  peerServiceId
+  peerKind
+  dropCause
+  serviceId
+  deploymentId
+  deploymentInstanceId
+}

--- a/src/util/logs.rs
+++ b/src/util/logs.rs
@@ -1,5 +1,6 @@
 use crate::{queries, subscriptions};
 use colored::Colorize;
+use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -164,6 +165,167 @@ pub fn print_http_log<T: HttpLogLike>(log: T, json: bool) {
     println!("{}", format_http_log_string(&log, json));
 }
 
+pub trait NetworkFlowLogLike: Serialize {
+    fn capture_end(&self) -> &str;
+    fn direction_value(&self) -> String;
+    fn l4_protocol_value(&self) -> String;
+    fn src_addr(&self) -> &str;
+    fn src_port(&self) -> i64;
+    fn dst_addr(&self) -> &str;
+    fn dst_port(&self) -> i64;
+    fn peer_kind_value(&self) -> String;
+    fn byte_count(&self) -> i64;
+    fn l4_latency_ms(&self) -> f64;
+    fn drop_cause(&self) -> Option<&str>;
+}
+
+pub fn format_network_flow_log_header() -> String {
+    format!(
+        "{:<24} {:<3} {:<7} {:<30} {:<30} {:<12} {:>10} {:>8} {:<12}",
+        "Time".bold(),
+        "Dir".bold(),
+        "Proto".bold(),
+        "Source".bold(),
+        "Destination".bold(),
+        "Peer".bold(),
+        "Traffic".bold(),
+        "Latency".bold(),
+        "Status".bold()
+    )
+}
+
+pub fn format_network_flow_log_string<T: NetworkFlowLogLike>(log: &T, json: bool) -> String {
+    if json {
+        let mut value = serde_json::to_value(log).unwrap();
+        if let Value::Object(map) = &mut value {
+            map.insert(
+                "timestamp".to_string(),
+                Value::String(log.capture_end().to_string()),
+            );
+        }
+        return serde_json::to_string(&value).unwrap();
+    }
+
+    let direction = log.direction_value();
+    let direction_label = direction_label(&direction);
+    let protocol = log.l4_protocol_value().to_uppercase();
+    let source = endpoint(log.src_addr(), log.src_port());
+    let destination = endpoint(log.dst_addr(), log.dst_port());
+    let peer = peer_label(&log.peer_kind_value());
+    let traffic = format_bytes(log.byte_count());
+    let latency = format_latency(log.l4_latency_ms());
+    let status = log.drop_cause().unwrap_or("OK");
+
+    format!(
+        "{:<24} {:<3} {:<7} {:<30} {:<30} {:<12} {:>10} {:>8} {:<12}",
+        log.capture_end().dimmed(),
+        direction_label,
+        protocol.green(),
+        source,
+        destination,
+        peer,
+        traffic.dimmed(),
+        latency.dimmed(),
+        status_label(status)
+    )
+}
+
+pub fn print_network_flow_log<T: NetworkFlowLogLike>(log: T, json: bool) {
+    println!("{}", format_network_flow_log_string(&log, json));
+}
+
+fn endpoint(addr: &str, port: i64) -> String {
+    format!("{addr}:{port}")
+}
+
+fn direction_label(direction: &str) -> String {
+    let arrow = match direction {
+        "ingress" => {
+            if is_dumb_terminal() {
+                "in"
+            } else {
+                "↑"
+            }
+        }
+        "egress" => {
+            if is_dumb_terminal() {
+                "out"
+            } else {
+                "↓"
+            }
+        }
+        _ => "?",
+    };
+
+    match direction {
+        "egress" => arrow.blue().bold().to_string(),
+        "ingress" => arrow.normal().bold().to_string(),
+        _ => arrow.yellow().bold().to_string(),
+    }
+}
+
+fn is_dumb_terminal() -> bool {
+    std::env::var("TERM").is_ok_and(|term| term == "dumb")
+}
+
+fn peer_label(peer_kind: &str) -> String {
+    match peer_kind {
+        "service" => "Service",
+        "internet" => "Internet",
+        "edge_proxy" => "Edge Proxy",
+        "local_dns" => "DNS",
+        "unknown" => "Unknown",
+        other => other,
+    }
+    .to_string()
+}
+
+fn format_bytes(bytes: i64) -> String {
+    let bytes = bytes as f64;
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes;
+    let mut unit = 0;
+
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+
+    if unit == 0 {
+        format!("{} {}", value as i64, UNITS[unit])
+    } else if value >= 10.0 {
+        format!("{value:.0} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+fn format_latency(latency_ms: f64) -> String {
+    if latency_ms.fract() == 0.0 {
+        format!("{}ms", latency_ms as i64)
+    } else {
+        format!("{latency_ms:.1}ms")
+    }
+}
+
+fn status_label(status: &str) -> colored::ColoredString {
+    if status == "OK" {
+        status.green()
+    } else {
+        status.red()
+    }
+}
+
+fn serialized_enum_value<T>(value: &T) -> String
+where
+    T: Serialize + std::fmt::Debug,
+{
+    serde_json::to_value(value)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .unwrap_or_else(|| format!("{value:?}").to_ascii_lowercase())
+}
+
 // Implementations for all the generated GraphQL log types
 impl LogLike for subscriptions::deployment_logs::LogFields {
     fn message(&self) -> &str {
@@ -267,6 +429,98 @@ impl HttpLogLike for subscriptions::http_logs::HttpLogFields {
     }
 }
 
+impl NetworkFlowLogLike for queries::network_flow_logs::NetworkFlowLogFields {
+    fn capture_end(&self) -> &str {
+        &self.capture_end
+    }
+
+    fn direction_value(&self) -> String {
+        serialized_enum_value(&self.direction)
+    }
+
+    fn l4_protocol_value(&self) -> String {
+        serialized_enum_value(&self.l4_protocol)
+    }
+
+    fn src_addr(&self) -> &str {
+        &self.src_addr
+    }
+
+    fn src_port(&self) -> i64 {
+        self.src_port
+    }
+
+    fn dst_addr(&self) -> &str {
+        &self.dst_addr
+    }
+
+    fn dst_port(&self) -> i64 {
+        self.dst_port
+    }
+
+    fn peer_kind_value(&self) -> String {
+        serialized_enum_value(&self.peer_kind)
+    }
+
+    fn byte_count(&self) -> i64 {
+        self.byte_count
+    }
+
+    fn l4_latency_ms(&self) -> f64 {
+        self.l4_latency_ms
+    }
+
+    fn drop_cause(&self) -> Option<&str> {
+        self.drop_cause.as_deref()
+    }
+}
+
+impl NetworkFlowLogLike for subscriptions::network_flow_logs::NetworkFlowLogFields {
+    fn capture_end(&self) -> &str {
+        &self.capture_end
+    }
+
+    fn direction_value(&self) -> String {
+        serialized_enum_value(&self.direction)
+    }
+
+    fn l4_protocol_value(&self) -> String {
+        serialized_enum_value(&self.l4_protocol)
+    }
+
+    fn src_addr(&self) -> &str {
+        &self.src_addr
+    }
+
+    fn src_port(&self) -> i64 {
+        self.src_port
+    }
+
+    fn dst_addr(&self) -> &str {
+        &self.dst_addr
+    }
+
+    fn dst_port(&self) -> i64 {
+        self.dst_port
+    }
+
+    fn peer_kind_value(&self) -> String {
+        serialized_enum_value(&self.peer_kind)
+    }
+
+    fn byte_count(&self) -> i64 {
+        self.byte_count
+    }
+
+    fn l4_latency_ms(&self) -> f64 {
+        self.l4_latency_ms
+    }
+
+    fn drop_cause(&self) -> Option<&str> {
+        self.drop_cause.as_deref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -294,6 +548,102 @@ mod tests {
         }
     }
 
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct TestNetworkFlowLog {
+        flow_id: String,
+        capture_start: String,
+        capture_end: String,
+        flow_state: String,
+        direction: String,
+        l4_protocol: String,
+        src_addr: String,
+        src_port: i64,
+        dst_addr: String,
+        dst_port: i64,
+        peer_kind: String,
+        peer_service_id: Option<String>,
+        byte_count: i64,
+        packet_count: i64,
+        l4_latency_ms: f64,
+        drop_cause: Option<String>,
+        service_id: String,
+        deployment_id: String,
+        deployment_instance_id: String,
+    }
+
+    impl TestNetworkFlowLog {
+        fn example() -> Self {
+            Self {
+                flow_id: "flow-123".to_string(),
+                capture_start: "2026-06-16T00:15:14.000Z".to_string(),
+                capture_end: "2026-06-16T00:15:14.000Z".to_string(),
+                flow_state: "complete".to_string(),
+                direction: "ingress".to_string(),
+                l4_protocol: "tcp".to_string(),
+                src_addr: "10.202.164.239".to_string(),
+                src_port: 8080,
+                dst_addr: "100.64.0.2".to_string(),
+                dst_port: 51222,
+                peer_kind: "internet".to_string(),
+                peer_service_id: None,
+                byte_count: 418,
+                packet_count: 6,
+                l4_latency_ms: 0.0,
+                drop_cause: None,
+                service_id: "service-123".to_string(),
+                deployment_id: "deployment-123".to_string(),
+                deployment_instance_id: "instance-123".to_string(),
+            }
+        }
+    }
+
+    impl NetworkFlowLogLike for TestNetworkFlowLog {
+        fn capture_end(&self) -> &str {
+            &self.capture_end
+        }
+
+        fn direction_value(&self) -> String {
+            self.direction.clone()
+        }
+
+        fn l4_protocol_value(&self) -> String {
+            self.l4_protocol.clone()
+        }
+
+        fn src_addr(&self) -> &str {
+            &self.src_addr
+        }
+
+        fn src_port(&self) -> i64 {
+            self.src_port
+        }
+
+        fn dst_addr(&self) -> &str {
+            &self.dst_addr
+        }
+
+        fn dst_port(&self) -> i64 {
+            self.dst_port
+        }
+
+        fn peer_kind_value(&self) -> String {
+            self.peer_kind.clone()
+        }
+
+        fn byte_count(&self) -> i64 {
+            self.byte_count
+        }
+
+        fn l4_latency_ms(&self) -> f64 {
+            self.l4_latency_ms
+        }
+
+        fn drop_cause(&self) -> Option<&str> {
+            self.drop_cause.as_deref()
+        }
+    }
+
     #[test]
     fn test_format_attr_log_no_attributes() {
         let log = TestLog {
@@ -305,6 +655,34 @@ mod tests {
         // Should only return the message
         let output = format_attr_log_string(&log, false);
         assert_eq!(output, "Test message");
+    }
+
+    #[test]
+    fn test_format_network_flow_log_json_adds_timestamp_alias() {
+        let output = format_network_flow_log_string(&TestNetworkFlowLog::example(), true);
+        let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(value["timestamp"], "2026-06-16T00:15:14.000Z");
+        assert_eq!(value["flowId"], "flow-123");
+        assert_eq!(value["captureEnd"], "2026-06-16T00:15:14.000Z");
+        assert_eq!(value["dropCause"], serde_json::Value::Null);
+        assert!(value.get("status").is_none());
+    }
+
+    #[test]
+    fn test_format_network_flow_log_table_row() {
+        let header = format_network_flow_log_header();
+        let row = format_network_flow_log_string(&TestNetworkFlowLog::example(), false);
+
+        assert!(header.contains("Time"));
+        assert!(header.contains("Traffic"));
+        assert!(header.contains("Status"));
+        assert!(row.contains("10.202.164.239:8080"));
+        assert!(row.contains("100.64.0.2:51222"));
+        assert!(row.contains("Internet"));
+        assert!(row.contains("418 B"));
+        assert!(row.contains("0ms"));
+        assert!(row.contains("OK"));
     }
 
     #[test]

--- a/src/util/logs.rs
+++ b/src/util/logs.rs
@@ -4,6 +4,15 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
+const NETWORK_FLOW_TIME_WIDTH: usize = 30;
+const NETWORK_FLOW_DIR_WIDTH: usize = 3;
+const NETWORK_FLOW_PROTO_WIDTH: usize = 7;
+const NETWORK_FLOW_ENDPOINT_WIDTH: usize = 47;
+const NETWORK_FLOW_PEER_WIDTH: usize = 12;
+const NETWORK_FLOW_TRAFFIC_WIDTH: usize = 10;
+const NETWORK_FLOW_LATENCY_WIDTH: usize = 8;
+const NETWORK_FLOW_STATUS_WIDTH: usize = 16;
+
 // Trait for common fields on log types
 pub trait LogLike {
     fn message(&self) -> &str;
@@ -181,7 +190,7 @@ pub trait NetworkFlowLogLike: Serialize {
 
 pub fn format_network_flow_log_header() -> String {
     format!(
-        "{:<24} {:<3} {:<7} {:<30} {:<30} {:<12} {:>10} {:>8} {:<12}",
+        "{:<time_width$} {:<dir_width$} {:<proto_width$} {:<endpoint_width$} {:<endpoint_width$} {:<peer_width$} {:>traffic_width$} {:>latency_width$} {:<status_width$}",
         "Time".bold(),
         "Dir".bold(),
         "Proto".bold(),
@@ -190,7 +199,15 @@ pub fn format_network_flow_log_header() -> String {
         "Peer".bold(),
         "Traffic".bold(),
         "Latency".bold(),
-        "Status".bold()
+        "Status".bold(),
+        time_width = NETWORK_FLOW_TIME_WIDTH,
+        dir_width = NETWORK_FLOW_DIR_WIDTH,
+        proto_width = NETWORK_FLOW_PROTO_WIDTH,
+        endpoint_width = NETWORK_FLOW_ENDPOINT_WIDTH,
+        peer_width = NETWORK_FLOW_PEER_WIDTH,
+        traffic_width = NETWORK_FLOW_TRAFFIC_WIDTH,
+        latency_width = NETWORK_FLOW_LATENCY_WIDTH,
+        status_width = NETWORK_FLOW_STATUS_WIDTH,
     )
 }
 
@@ -217,7 +234,7 @@ pub fn format_network_flow_log_string<T: NetworkFlowLogLike>(log: &T, json: bool
     let status = log.drop_cause().unwrap_or("OK");
 
     format!(
-        "{:<24} {:<3} {:<7} {:<30} {:<30} {:<12} {:>10} {:>8} {:<12}",
+        "{:<time_width$} {:<dir_width$} {:<proto_width$} {:<endpoint_width$} {:<endpoint_width$} {:<peer_width$} {:>traffic_width$} {:>latency_width$} {:<status_width$}",
         log.capture_end().dimmed(),
         direction_label,
         protocol.green(),
@@ -226,7 +243,15 @@ pub fn format_network_flow_log_string<T: NetworkFlowLogLike>(log: &T, json: bool
         peer,
         traffic.dimmed(),
         latency.dimmed(),
-        status_label(status)
+        status_label(status),
+        time_width = NETWORK_FLOW_TIME_WIDTH,
+        dir_width = NETWORK_FLOW_DIR_WIDTH,
+        proto_width = NETWORK_FLOW_PROTO_WIDTH,
+        endpoint_width = NETWORK_FLOW_ENDPOINT_WIDTH,
+        peer_width = NETWORK_FLOW_PEER_WIDTH,
+        traffic_width = NETWORK_FLOW_TRAFFIC_WIDTH,
+        latency_width = NETWORK_FLOW_LATENCY_WIDTH,
+        status_width = NETWORK_FLOW_STATUS_WIDTH,
     )
 }
 
@@ -235,32 +260,40 @@ pub fn print_network_flow_log<T: NetworkFlowLogLike>(log: T, json: bool) {
 }
 
 fn endpoint(addr: &str, port: i64) -> String {
-    format!("{addr}:{port}")
+    if addr.contains(':') {
+        format!("[{addr}]:{port}")
+    } else {
+        format!("{addr}:{port}")
+    }
 }
 
 fn direction_label(direction: &str) -> String {
-    let arrow = match direction {
-        "ingress" => {
-            if is_dumb_terminal() {
-                "in"
-            } else {
-                "↑"
-            }
-        }
-        "egress" => {
-            if is_dumb_terminal() {
-                "out"
-            } else {
-                "↓"
-            }
-        }
-        _ => "?",
-    };
+    let arrow = direction_label_for_terminal(direction, is_dumb_terminal());
 
     match direction {
         "egress" => arrow.blue().bold().to_string(),
         "ingress" => arrow.normal().bold().to_string(),
         _ => arrow.yellow().bold().to_string(),
+    }
+}
+
+fn direction_label_for_terminal(direction: &str, is_dumb: bool) -> &'static str {
+    match direction {
+        "ingress" => {
+            if is_dumb {
+                "in"
+            } else {
+                "↓"
+            }
+        }
+        "egress" => {
+            if is_dumb {
+                "out"
+            } else {
+                "↑"
+            }
+        }
+        _ => "?",
     }
 }
 
@@ -683,6 +716,26 @@ mod tests {
         assert!(row.contains("418 B"));
         assert!(row.contains("0ms"));
         assert!(row.contains("OK"));
+    }
+
+    #[test]
+    fn test_format_network_flow_log_brackets_ipv6_endpoints() {
+        let mut log = TestNetworkFlowLog::example();
+        log.src_addr = "fd12:f783:b81d:1:b000:23:a80e:1d89".to_string();
+        log.dst_addr = "fd12:f783:b81d:1:b000:a4:5366:c08c".to_string();
+
+        let row = format_network_flow_log_string(&log, false);
+
+        assert!(row.contains("[fd12:f783:b81d:1:b000:23:a80e:1d89]:8080"));
+        assert!(row.contains("[fd12:f783:b81d:1:b000:a4:5366:c08c]:51222"));
+    }
+
+    #[test]
+    fn test_network_flow_direction_labels_match_dashboard_orientation() {
+        assert_eq!(direction_label_for_terminal("ingress", false), "↓");
+        assert_eq!(direction_label_for_terminal("egress", false), "↑");
+        assert_eq!(direction_label_for_terminal("ingress", true), "in");
+        assert_eq!(direction_label_for_terminal("egress", true), "out");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `railway logs --network` as a mutually exclusive log mode.
- Use the public `networkFlowLogs` query for finite snapshots and subscription for live streaming.
- Add typed network-flow filters that compose with raw `--filter`, plus dashboard-like table output and NDJSON output with `timestamp` as a `captureEnd` alias.

## Validation
- `cargo fmt`
- `cargo test logs::tests --no-default-features`
- `cargo test --no-default-features`