### PR TITLE
feat(config): opt-in --detailed-exit-code for plan

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -71,6 +71,10 @@ struct SharedArgs {
     /// Show full change details.
     #[clap(long, alias = "full")]
     verbose: bool,
+
+    /// Exit 2 when changes are pending, 0 when none (plan only). For CI gating.
+    #[clap(long)]
+    detailed_exit_code: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -136,7 +140,12 @@ pub async fn command(args: Args) -> Result<()> {
         Command::Stage(_args) => bail!(
             "Staged Railway configuration changes are not available yet. Run `railway config plan` to preview changes or `railway config apply` to apply them."
         ),
-        Command::Apply(args) => run_sync(args, false, true).await,
+        Command::Apply(args) => {
+            if args.detailed_exit_code {
+                bail!("--detailed-exit-code is only valid with `railway config plan`.");
+            }
+            run_sync(args, false, true).await
+        }
         Command::Init(args) => init_config(args).await,
         Command::Pull(args) => pull_config(args).await,
     }
@@ -387,6 +396,7 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         include_types: false,
         runner,
         verbose: false,
+        detailed_exit_code: false,
     };
     let response = runner::run(&args, "current").await?;
     let _ = fs::remove_file(temp_file);
@@ -1185,6 +1195,7 @@ async fn run_sync(args: SharedArgs, stage: bool, apply: bool) -> Result<()> {
         include_types: args.include_types,
         runner: args.runner,
         verbose: args.verbose,
+        detailed_exit_code: args.detailed_exit_code,
     })
     .await
 }

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -54,6 +54,10 @@ pub struct Args {
     /// Show full change details.
     #[clap(long, alias = "full")]
     pub(super) verbose: bool,
+
+    /// Exit 2 when a plan has pending changes, 0 when none (plan only). For CI gating.
+    #[clap(long)]
+    pub(super) detailed_exit_code: bool,
 }
 
 #[derive(Deserialize, serde::Serialize)]
@@ -247,6 +251,7 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
         if !output.ok {
             bail!(runner_diagnostics_message(&output));
         }
+        maybe_detailed_exit(&args, command, &output);
         return Ok(());
     }
 
@@ -255,7 +260,27 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
         bail!(runner_diagnostics_message(&output));
     }
 
+    maybe_detailed_exit(&args, command, &output);
+
     Ok(())
+}
+
+/// Terraform-style `-detailed-exitcode`: on a successful `plan`, exit 2 if changes
+/// are pending (0 if none). Opt-in via --detailed-exit-code, so default behavior is
+/// unchanged and existing CI keeps working. Errors still surface as a non-zero
+/// failure through the normal path; this only distinguishes no-changes from changes.
+fn maybe_detailed_exit(args: &Args, command: &str, output: &RunnerResponse) {
+    if !args.detailed_exit_code || command != "plan" || !output.ok {
+        return;
+    }
+    let pending = output
+        .change_set
+        .as_ref()
+        .map(|change_set| !change_set.changes.is_empty())
+        .unwrap_or(false);
+    if pending {
+        std::process::exit(2);
+    }
 }
 
 async fn preview_before_apply(


### PR DESCRIPTION
Terraform-style detailed exit codes for `railway config plan`, for CI drift-gating:

| exit | meaning |
|---|---|
| `0` | success, **no** changes pending |
| `2` | success, changes pending |
| non-zero (`1`) | error (normal failure path) |

```bash
railway config plan --detailed-exit-code
case $? in
  0) echo "up to date" ;;
  2) railway config apply --yes ;;
  *) echo "plan failed"; exit 1 ;;
esac
```

## CI-safety (the important part)
- **Opt-in.** Without `--detailed-exit-code`, exit behavior is **unchanged** (0 on any successful plan), so existing pipelines and scripts keep working.
- **Plan-only.** Rejected on `apply` (like `--yes` is rejected on `plan`), so it can't change apply semantics.
- **Errors stay errors.** A failed plan (runner/backboard error) still exits non-zero via the normal path — only the *success* case is split into 0 (no changes) vs 2 (changes).
- `2` matches Terraform's `-detailed-exitcode` convention. Note the CLI already uses exit 2 for clap *usage* errors; for a correctly-formed command in CI that distinction doesn't arise (a usage error is a static, immediately-obvious failure).

Minor: the `exit(2)` path skips the post-command update-check notice for that invocation — acceptable for an opt-in CI flag. `cargo check` clean.