### PR TITLE
feat(config): --show-values to reveal variable values in plan

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -75,6 +75,10 @@ struct SharedArgs {
     /// Exit 2 when changes are pending, 0 when none (plan only). For CI gating.
     #[clap(long)]
     detailed_exit_code: bool,
+
+    /// Print variable values in the plan instead of redacting them.
+    #[clap(long)]
+    show_values: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -397,6 +401,7 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         runner,
         verbose: false,
         detailed_exit_code: false,
+        show_values: false,
     };
     let response = runner::run(&args, "current").await?;
     let _ = fs::remove_file(temp_file);
@@ -1196,6 +1201,7 @@ async fn run_sync(args: SharedArgs, stage: bool, apply: bool) -> Result<()> {
         runner: args.runner,
         verbose: args.verbose,
         detailed_exit_code: args.detailed_exit_code,
+        show_values: args.show_values,
     })
     .await
 }

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -58,6 +58,10 @@ pub struct Args {
     /// Exit 2 when a plan has pending changes, 0 when none (plan only). For CI gating.
     #[clap(long)]
     pub(super) detailed_exit_code: bool,
+
+    /// Print variable values in the plan instead of redacting them.
+    #[clap(long)]
+    pub(super) show_values: bool,
 }
 
 #[derive(Deserialize, serde::Serialize)]
@@ -390,6 +394,7 @@ async fn invoke_runner(
         "file": args.file.as_ref().map(|path| path.to_string_lossy().to_string()),
         "includeTypes": args.include_types,
         "pretty": false,
+        "revealValues": args.show_values,
         "context": {
             "projectId": linked_project.project,
             "projectName": linked_project.name,


### PR DESCRIPTION
The CLI half of `--show-values` (engine half: railway-ts-sdk #34).

Plan output redacts variable values by default (so secrets in `railway.ts` don't hit terminals/CI logs). `--show-values` opts back in to printing them — useful when tuning a non-secret config var:

```
railway config plan                 # web.API_KEY (unset → «hidden»)
railway config plan --show-values   # web.API_KEY (unset → "sk-…")
```

Forwarded to the runner as `request.revealValues`. **Version-safe**: an engine without reveal support simply ignores the unknown request field (stays redacted), so this can merge independently of the SDK change. `cargo check` clean.