### PR TITLE
Add outbound network commands

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use reqwest::{
     Client,
     header::{HeaderMap, HeaderValue},
 };
+use serde::de::DeserializeOwned;
 
 use crate::{
     commands::Environment,
@@ -126,45 +127,24 @@ pub async fn post_graphql<Q: GraphQLQuery, U: reqwest::IntoUrl>(
 ) -> Result<Q::ResponseData, RailwayError> {
     let body = Q::build_query(variables);
     let response = client.post(url).json(&body).send().await?;
-    if response.status() == 429 {
-        return Err(RailwayError::Ratelimited);
-    }
-    let res: GraphQLResponse<Q::ResponseData> = response.json().await?;
-    if let Some(errors) = res.errors {
-        let error = &errors[0];
-        if error
-            .message
-            .to_lowercase()
-            .contains("project token not found")
-        {
-            Err(RailwayError::InvalidRailwayToken(
-                RAILWAY_TOKEN_ENV.to_string(),
-            ))
-        } else if error.message.to_lowercase().contains("not authorized") {
-            // Handle unauthorized errors in a custom way
-            Err(auth_failure_error())
-        } else if error.message == "Two Factor Authentication Required" {
-            // Extract workspace name from extensions if available
-            let workspace_name = error
-                .extensions
-                .as_ref()
-                .and_then(|ext| ext.get("workspaceName"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("this workspace")
-                .to_string();
-            let security_url = get_security_url();
-            Err(RailwayError::TwoFactorEnforcementRequired(
-                workspace_name,
-                security_url,
-            ))
-        } else {
-            Err(RailwayError::GraphQLError(error.message.clone()))
-        }
-    } else if let Some(data) = res.data {
-        Ok(data)
-    } else {
-        Err(RailwayError::MissingResponseData)
-    }
+    parse_graphql_response(response).await
+}
+
+pub async fn post_graphql_raw<T, U: reqwest::IntoUrl>(
+    client: &reqwest::Client,
+    url: U,
+    query: &str,
+    variables: serde_json::Value,
+) -> Result<T, RailwayError>
+where
+    T: DeserializeOwned,
+{
+    let body = serde_json::json!({
+        "query": query,
+        "variables": variables,
+    });
+    let response = client.post(url).json(&body).send().await?;
+    parse_graphql_response(response).await
 }
 
 fn get_security_url() -> String {
@@ -244,10 +224,17 @@ pub async fn post_graphql_skip_none<Q: GraphQLQuery, U: reqwest::IntoUrl>(
     }
 
     let response = client.post(url).json(&body_json).send().await?;
+    parse_graphql_response(response).await
+}
+
+async fn parse_graphql_response<T>(response: reqwest::Response) -> Result<T, RailwayError>
+where
+    T: DeserializeOwned,
+{
     if response.status() == 429 {
         return Err(RailwayError::Ratelimited);
     }
-    let res: GraphQLResponse<Q::ResponseData> = response.json().await?;
+    let res: GraphQLResponse<T> = response.json().await?;
     if let Some(errors) = res.errors {
         let error = &errors[0];
         if error

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,7 @@ pub mod logs;
 pub mod mcp;
 pub mod metrics;
 pub mod open;
+pub mod outbound_networking;
 mod output;
 pub mod private_network;
 pub mod project;

--- a/src/commands/outbound_networking.rs
+++ b/src/commands/outbound_networking.rs
@@ -10,11 +10,13 @@ use crate::controllers::{
 use super::*;
 
 const FIELD_LABEL_WIDTH: usize = 20;
+const STAGED_IPV6_MESSAGE: &str =
+    "Commit staged environment changes to trigger redeploy: railway environment edit";
 
 /// Manage outbound networking for a service
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway outbound-network status --service api\n  railway outbound-network static-ip enable --service api\n  railway outbound-network static-ip status --service api --json\n  railway outbound-network static-ip disable --service api\n  railway outbound-network ipv6 enable --service api\n  railway outbound-network ipv6 status --service api --json\n  railway outbound-network ipv6 disable --service api\n\nAutomation notes:\n  Static Outbound IP changes require a redeploy before outbound traffic changes.\n  Outbound IPv6 changes are staged; apply staged changes to trigger redeploy."
+    after_help = "Examples:\n\n  railway outbound-network status --service api\n  railway outbound-network static-ip enable --service api\n  railway outbound-network static-ip status --service api --json\n  railway outbound-network static-ip disable --service api\n  railway outbound-network ipv6 enable --service api\n  railway outbound-network ipv6 status --service api --json\n  railway outbound-network ipv6 disable --service api\n\nAutomation notes:\n  Static Outbound IP changes require a redeploy before outbound traffic changes.\n  Outbound IPv6 changes are staged; commit them with `railway environment edit` to trigger redeploy."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -396,7 +398,7 @@ fn print_ipv6_action(output: &Ipv6ActionOutput) {
                 output.environment.name.bold()
             );
         }
-        println!("Apply staged changes to trigger redeploy.");
+        println!("{STAGED_IPV6_MESSAGE}");
     } else {
         println!(
             "Cleared staged Outbound IPv6 change for service {} in environment {}.",
@@ -439,11 +441,7 @@ fn print_ipv6_fields(ipv6: &Ipv6Status) {
                 .yellow(),
             FIELD_LABEL_WIDTH,
         );
-        print_field(
-            "Message:",
-            &"Apply staged changes to trigger redeploy.",
-            FIELD_LABEL_WIDTH,
-        );
+        print_field("Message:", &STAGED_IPV6_MESSAGE, FIELD_LABEL_WIDTH);
     }
 }
 

--- a/src/commands/outbound_networking.rs
+++ b/src/commands/outbound_networking.rs
@@ -13,7 +13,7 @@ const FIELD_LABEL_WIDTH: usize = 20;
 /// Manage outbound networking for a service
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway outbound-networking status --service api\n  railway outbound-networking static-ip enable --service api\n  railway outbound-networking static-ip status --service api --json\n  railway outbound-networking static-ip disable --service api\n  railway outbound-networking ipv6 enable --service api\n  railway outbound-networking ipv6 status --service api --json\n  railway outbound-networking ipv6 disable --service api\n\nAutomation notes:\n  Static Outbound IP changes require a redeploy before outbound traffic changes.\n  Outbound IPv6 changes are staged; apply staged changes to trigger redeploy."
+    after_help = "Examples:\n\n  railway outbound-network status --service api\n  railway outbound-network static-ip enable --service api\n  railway outbound-network static-ip status --service api --json\n  railway outbound-network static-ip disable --service api\n  railway outbound-network ipv6 enable --service api\n  railway outbound-network ipv6 status --service api --json\n  railway outbound-network ipv6 disable --service api\n\nAutomation notes:\n  Static Outbound IP changes require a redeploy before outbound traffic changes.\n  Outbound IPv6 changes are staged; apply staged changes to trigger redeploy."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -638,36 +638,36 @@ mod tests {
     #[test]
     fn parses_subcommands() {
         assert!(matches!(
-            Args::parse_from(["outbound-networking", "status"]).command,
+            Args::parse_from(["outbound-network", "status"]).command,
             Commands::Status
         ));
         assert!(matches!(
-            Args::parse_from(["outbound-networking", "static-ip", "status"]).command,
+            Args::parse_from(["outbound-network", "static-ip", "status"]).command,
             Commands::StaticIp(StaticIpArgs {
                 command: StaticIpCommands::Status
             })
         ));
         assert!(matches!(
-            Args::parse_from(["outbound-networking", "static-ip", "enable"]).command,
+            Args::parse_from(["outbound-network", "static-ip", "enable"]).command,
             Commands::StaticIp(StaticIpArgs {
                 command: StaticIpCommands::Enable
             })
         ));
         assert!(matches!(
-            Args::parse_from(["outbound-networking", "static-ip", "disable"]).command,
+            Args::parse_from(["outbound-network", "static-ip", "disable"]).command,
             Commands::StaticIp(StaticIpArgs {
                 command: StaticIpCommands::Disable
             })
         ));
         assert!(matches!(
-            Args::parse_from(["outbound-networking", "ipv6", "enable"]).command,
+            Args::parse_from(["outbound-network", "ipv6", "enable"]).command,
             Commands::Ipv6(Ipv6Args {
                 command: Ipv6Commands::Enable
             })
         ));
         assert!(matches!(
             Args::parse_from([
-                "outbound-networking",
+                "outbound-network",
                 "--service",
                 "api",
                 "--environment",

--- a/src/commands/outbound_networking.rs
+++ b/src/commands/outbound_networking.rs
@@ -1,6 +1,7 @@
 use colored::ColoredString;
 use serde::Serialize;
 
+use crate::commands::output::fields::{print_field, print_service_environment_context};
 use crate::controllers::{
     outbound_networking::{self, FeatureAction, Ipv6Status, StaticIpStatus},
     project::{ServiceContext, resolve_service_context},
@@ -126,20 +127,20 @@ async fn status(
     json: bool,
 ) -> Result<()> {
     let ctx = resolve_service_context(project, service, environment).await?;
-    let static_ip = outbound_networking::fetch_static_ip_status(
-        &ctx.client,
-        &ctx.configs,
-        &ctx.environment_id,
-        &ctx.service_id,
-    )
-    .await?;
-    let ipv6 = outbound_networking::fetch_ipv6_status(
-        &ctx.client,
-        &ctx.configs,
-        &ctx.environment_id,
-        &ctx.service_id,
-    )
-    .await?;
+    let (static_ip, ipv6) = tokio::try_join!(
+        outbound_networking::fetch_static_ip_status(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        ),
+        outbound_networking::fetch_ipv6_status(
+            &ctx.client,
+            &ctx.configs,
+            &ctx.environment_id,
+            &ctx.service_id,
+        )
+    )?;
     let output = OutboundNetworkingOutput::new(&ctx, static_ip, ipv6);
 
     if json {
@@ -281,7 +282,11 @@ async fn ipv6_stage(
 fn print_outbound_networking_status(output: &OutboundNetworkingOutput) {
     println!("{}", "Outbound networking".bold());
     println!();
-    print_context(&output.service.name, &output.environment.name);
+    print_service_environment_context(
+        &output.service.name,
+        &output.environment.name,
+        FIELD_LABEL_WIDTH,
+    );
     println!();
     print_static_ip_fields(&output.static_ip);
     println!();
@@ -291,7 +296,11 @@ fn print_outbound_networking_status(output: &OutboundNetworkingOutput) {
 fn print_static_ip_status(output: &StaticIpStatusOutput) {
     println!("{}", "Static Outbound IPs".bold());
     println!();
-    print_context(&output.service.name, &output.environment.name);
+    print_service_environment_context(
+        &output.service.name,
+        &output.environment.name,
+        FIELD_LABEL_WIDTH,
+    );
     println!();
     print_static_ip_fields(&output.static_ip);
 }
@@ -299,7 +308,11 @@ fn print_static_ip_status(output: &StaticIpStatusOutput) {
 fn print_ipv6_status(output: &Ipv6StatusOutput) {
     println!("{}", "Outbound IPv6".bold());
     println!();
-    print_context(&output.service.name, &output.environment.name);
+    print_service_environment_context(
+        &output.service.name,
+        &output.environment.name,
+        FIELD_LABEL_WIDTH,
+    );
     println!();
     print_ipv6_fields(&output.ipv6);
 }
@@ -393,15 +406,18 @@ fn print_ipv6_action(output: &Ipv6ActionOutput) {
     }
 }
 
-fn print_context(service_name: &str, environment_name: &str) {
-    print_field("Service:", &service_name.green().bold());
-    print_field("Environment:", &environment_name.blue().bold());
-}
-
 fn print_static_ip_fields(static_ip: &StaticIpStatus) {
-    print_field("Static IPs:", &status_label(static_ip.enabled));
+    print_field(
+        "Static IPs:",
+        &status_label(static_ip.enabled),
+        FIELD_LABEL_WIDTH,
+    );
     if static_ip.enabled && static_ip.high_availability {
-        print_field("High Availability:", &"enabled".green().bold());
+        print_field(
+            "High Availability:",
+            &"enabled".green().bold(),
+            FIELD_LABEL_WIDTH,
+        );
     }
     if static_ip.enabled {
         println!();
@@ -410,15 +426,24 @@ fn print_static_ip_fields(static_ip: &StaticIpStatus) {
 }
 
 fn print_ipv6_fields(ipv6: &Ipv6Status) {
-    print_field("Outbound IPv6:", &status_label(ipv6.enabled));
+    print_field(
+        "Outbound IPv6:",
+        &status_label(ipv6.enabled),
+        FIELD_LABEL_WIDTH,
+    );
     if let Some(value) = ipv6.pending_value {
         print_field(
             "Pending:",
             &(if value { "enable" } else { "disable" })
                 .to_string()
                 .yellow(),
+            FIELD_LABEL_WIDTH,
         );
-        print_field("Message:", &"Apply staged changes to trigger redeploy.");
+        print_field(
+            "Message:",
+            &"Apply staged changes to trigger redeploy.",
+            FIELD_LABEL_WIDTH,
+        );
     }
 }
 
@@ -460,11 +485,6 @@ fn print_static_ip_table(static_ip: &StaticIpStatus) {
             region_width = region_width
         );
     }
-}
-
-fn print_field(label: &str, value: &dyn std::fmt::Display) {
-    let padded = format!("{label:<FIELD_LABEL_WIDTH$}");
-    println!("{} {value}", padded.dimmed());
 }
 
 fn status_label(enabled: bool) -> ColoredString {

--- a/src/commands/outbound_networking.rs
+++ b/src/commands/outbound_networking.rs
@@ -1,0 +1,718 @@
+use colored::ColoredString;
+use serde::Serialize;
+
+use crate::controllers::{
+    outbound_networking::{self, FeatureAction, Ipv6Status, StaticIpMode, StaticIpStatus},
+    project::{ServiceContext, resolve_service_context},
+};
+
+use super::*;
+
+const FIELD_LABEL_WIDTH: usize = 20;
+
+/// Manage outbound networking for a service
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway outbound-networking status --service api\n  railway outbound-networking static-ip enable --service api\n  railway outbound-networking static-ip status --service api --json\n  railway outbound-networking static-ip disable --service api\n  railway outbound-networking ipv6 enable --service api\n  railway outbound-networking ipv6 status --service api --json\n  railway outbound-networking ipv6 disable --service api\n\nAutomation notes:\n  Static Outbound IP changes require a redeploy before outbound traffic changes.\n  Outbound IPv6 changes are staged; apply staged changes to trigger redeploy."
+)]
+pub struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Service name or ID (defaults to linked service)
+    #[clap(short, long, global = true)]
+    service: Option<String>,
+
+    /// Environment to use (defaults to linked environment)
+    #[clap(short, long, global = true)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID", global = true)]
+    project: Option<String>,
+
+    /// Output in JSON format
+    #[clap(long, global = true)]
+    json: bool,
+}
+
+#[derive(Parser)]
+enum Commands {
+    /// Show outbound networking status
+    Status,
+
+    /// Manage Static Outbound IPs
+    #[clap(name = "static-ip")]
+    StaticIp(StaticIpArgs),
+
+    /// Manage Outbound IPv6
+    Ipv6(Ipv6Args),
+}
+
+#[derive(Parser)]
+struct StaticIpArgs {
+    #[clap(subcommand)]
+    command: StaticIpCommands,
+}
+
+#[derive(Parser)]
+enum StaticIpCommands {
+    /// Show Static Outbound IP status
+    Status,
+
+    /// Enable Static Outbound IPs
+    Enable,
+
+    /// Disable Static Outbound IPs
+    Disable,
+}
+
+#[derive(Parser)]
+struct Ipv6Args {
+    #[clap(subcommand)]
+    command: Ipv6Commands,
+}
+
+#[derive(Parser)]
+enum Ipv6Commands {
+    /// Show Outbound IPv6 status
+    Status,
+
+    /// Stage enabling Outbound IPv6
+    Enable,
+
+    /// Stage disabling Outbound IPv6
+    Disable,
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let Args {
+        command,
+        service,
+        environment,
+        project,
+        json,
+    } = args;
+
+    crate::util::reporter::set_mode(json);
+
+    match command {
+        Commands::Status => status(project, service, environment, json).await?,
+        Commands::StaticIp(args) => match args.command {
+            StaticIpCommands::Status => {
+                static_ip_status(project, service, environment, json).await?
+            }
+            StaticIpCommands::Enable => {
+                static_ip_enable(project, service, environment, json).await?
+            }
+            StaticIpCommands::Disable => {
+                static_ip_disable(project, service, environment, json).await?
+            }
+        },
+        Commands::Ipv6(args) => match args.command {
+            Ipv6Commands::Status => ipv6_status(project, service, environment, json).await?,
+            Ipv6Commands::Enable => ipv6_stage(project, service, environment, true, json).await?,
+            Ipv6Commands::Disable => ipv6_stage(project, service, environment, false, json).await?,
+        },
+    }
+
+    Ok(())
+}
+
+async fn status(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let static_ip = outbound_networking::fetch_static_ip_status(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    let ipv6 = outbound_networking::fetch_ipv6_status(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    let output = OutboundNetworkingOutput::new(&ctx, static_ip, ipv6);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_outbound_networking_status(&output);
+    }
+
+    Ok(())
+}
+
+async fn static_ip_status(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let static_ip = outbound_networking::fetch_static_ip_status(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    let output = StaticIpStatusOutput::new(&ctx, static_ip);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_static_ip_status(&output);
+    }
+
+    Ok(())
+}
+
+async fn static_ip_enable(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let (static_ip, action) = outbound_networking::enable_static_ips(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    let output = StaticIpActionOutput::new(&ctx, action, static_ip);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_static_ip_action(&output);
+    }
+
+    Ok(())
+}
+
+async fn static_ip_disable(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let (static_ip, action) = outbound_networking::disable_static_ips(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    let output = StaticIpActionOutput::new(&ctx, action, static_ip);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_static_ip_action(&output);
+    }
+
+    Ok(())
+}
+
+async fn ipv6_status(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let ipv6 = outbound_networking::fetch_ipv6_status(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+    )
+    .await?;
+    let output = Ipv6StatusOutput::new(&ctx, ipv6);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_ipv6_status(&output);
+    }
+
+    Ok(())
+}
+
+async fn ipv6_stage(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+    value: bool,
+    json: bool,
+) -> Result<()> {
+    let ctx = resolve_service_context(project, service, environment).await?;
+    let (ipv6, action) = outbound_networking::stage_ipv6(
+        &ctx.client,
+        &ctx.configs,
+        &ctx.environment_id,
+        &ctx.service_id,
+        value,
+    )
+    .await?;
+    let output = Ipv6ActionOutput::new(&ctx, action, ipv6);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_ipv6_action(&output);
+    }
+
+    Ok(())
+}
+
+fn print_outbound_networking_status(output: &OutboundNetworkingOutput) {
+    println!("{}", "Outbound networking".bold());
+    println!();
+    print_context(&output.service.name, &output.environment.name);
+    println!();
+    print_static_ip_fields(&output.static_ip);
+    println!();
+    print_ipv6_fields(&output.ipv6);
+}
+
+fn print_static_ip_status(output: &StaticIpStatusOutput) {
+    println!("{}", "Static Outbound IPs".bold());
+    println!();
+    print_context(&output.service.name, &output.environment.name);
+    println!();
+    print_static_ip_fields(&output.static_ip);
+}
+
+fn print_ipv6_status(output: &Ipv6StatusOutput) {
+    println!("{}", "Outbound IPv6".bold());
+    println!();
+    print_context(&output.service.name, &output.environment.name);
+    println!();
+    print_ipv6_fields(&output.ipv6);
+}
+
+fn print_static_ip_action(output: &StaticIpActionOutput) {
+    if !output.changed {
+        println!(
+            "Static Outbound IPs are already {} for service {} in environment {}.",
+            if output.enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            output.service.name.bold(),
+            output.environment.name.bold()
+        );
+        return;
+    }
+
+    println!(
+        "{} Static Outbound IPs for service {} in environment {}.",
+        past_tense(output.action.action),
+        output.service.name.bold(),
+        output.environment.name.bold()
+    );
+    if output.lifecycle.redeploy_required {
+        println!(
+            "Redeploy required before outbound traffic {} these IPs.",
+            if output.enabled {
+                "uses"
+            } else {
+                "stops using"
+            }
+        );
+    }
+    if output.enabled {
+        println!();
+        print_static_ip_table(&output.static_ip);
+    }
+}
+
+fn print_ipv6_action(output: &Ipv6ActionOutput) {
+    if !output.changed {
+        if output.ipv6.pending_value == Some(output.enabled) {
+            println!(
+                "Outbound IPv6 is already staged to be {} for service {} in environment {}.",
+                if output.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+                output.service.name.bold(),
+                output.environment.name.bold()
+            );
+        } else {
+            println!(
+                "Outbound IPv6 is already {} for service {} in environment {}.",
+                if output.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+                output.service.name.bold(),
+                output.environment.name.bold()
+            );
+        }
+        return;
+    }
+
+    if output.lifecycle.staged {
+        if output.enabled {
+            println!(
+                "Staged Outbound IPv6 for service {} in environment {}.",
+                output.service.name.bold(),
+                output.environment.name.bold()
+            );
+        } else {
+            println!(
+                "Staged disabling Outbound IPv6 for service {} in environment {}.",
+                output.service.name.bold(),
+                output.environment.name.bold()
+            );
+        }
+        println!("Apply staged changes to trigger redeploy.");
+    } else {
+        println!(
+            "Cleared staged Outbound IPv6 change for service {} in environment {}.",
+            output.service.name.bold(),
+            output.environment.name.bold()
+        );
+    }
+}
+
+fn print_context(service_name: &str, environment_name: &str) {
+    print_field("Service:", &service_name.green().bold());
+    print_field("Environment:", &environment_name.blue().bold());
+}
+
+fn print_static_ip_fields(static_ip: &StaticIpStatus) {
+    print_field("Static IPs:", &status_label(static_ip.enabled));
+    print_field("Mode:", &mode_label(static_ip.mode));
+    if static_ip.high_availability {
+        print_field("High Availability:", &"enabled".green().bold());
+    }
+    if static_ip.enabled {
+        println!();
+        print_static_ip_table(static_ip);
+    }
+}
+
+fn print_ipv6_fields(ipv6: &Ipv6Status) {
+    print_field("Outbound IPv6:", &status_label(ipv6.enabled));
+    if let Some(value) = ipv6.pending_value {
+        print_field(
+            "Pending:",
+            &(if value { "enable" } else { "disable" })
+                .to_string()
+                .yellow(),
+        );
+        print_field("Message:", &"Apply staged changes to trigger redeploy.");
+    }
+}
+
+fn print_static_ip_table(static_ip: &StaticIpStatus) {
+    if static_ip.ips.is_empty() {
+        return;
+    }
+
+    let ip_width = static_ip
+        .ips
+        .iter()
+        .map(|ip| ip.ipv4.len())
+        .max()
+        .unwrap_or("IP Address".len())
+        .max("IP Address".len())
+        + 3;
+    let region_width = static_ip
+        .ips
+        .iter()
+        .map(|ip| ip.region.len())
+        .max()
+        .unwrap_or("Region".len())
+        .max("Region".len())
+        + 3;
+
+    println!(
+        "{:<ip_width$}{:<region_width$}Type",
+        "IP Address".bold(),
+        "Region".bold(),
+        ip_width = ip_width,
+        region_width = region_width
+    );
+    for ip in &static_ip.ips {
+        println!(
+            "{:<ip_width$}{:<region_width$}Shared",
+            ip.ipv4,
+            ip.region,
+            ip_width = ip_width,
+            region_width = region_width
+        );
+    }
+}
+
+fn print_field(label: &str, value: &dyn std::fmt::Display) {
+    let padded = format!("{label:<FIELD_LABEL_WIDTH$}");
+    println!("{} {value}", padded.dimmed());
+}
+
+fn status_label(enabled: bool) -> ColoredString {
+    if enabled {
+        "enabled".green().bold()
+    } else {
+        "disabled".yellow().bold()
+    }
+}
+
+fn mode_label(mode: StaticIpMode) -> ColoredString {
+    match mode {
+        StaticIpMode::Disabled => "disabled".yellow().bold(),
+        StaticIpMode::Legacy => "legacy".yellow().bold(),
+        StaticIpMode::Ha => "ha".green().bold(),
+    }
+}
+
+fn past_tense(action: &str) -> &'static str {
+    match action {
+        "enable" => "Enabled",
+        "disable" => "Disabled",
+        _ => "Updated",
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceRef {
+    id: String,
+    name: String,
+}
+
+impl ResourceRef {
+    fn service(ctx: &ServiceContext) -> Self {
+        Self {
+            id: ctx.service_id.clone(),
+            name: ctx.service_name.clone(),
+        }
+    }
+
+    fn environment(ctx: &ServiceContext) -> Self {
+        Self {
+            id: ctx.environment_id.clone(),
+            name: ctx.environment_name.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OutboundNetworkingOutput {
+    service: ResourceRef,
+    environment: ResourceRef,
+    static_ip: StaticIpStatus,
+    ipv6: Ipv6Status,
+}
+
+impl OutboundNetworkingOutput {
+    fn new(ctx: &ServiceContext, static_ip: StaticIpStatus, ipv6: Ipv6Status) -> Self {
+        Self {
+            service: ResourceRef::service(ctx),
+            environment: ResourceRef::environment(ctx),
+            static_ip,
+            ipv6,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StaticIpStatusOutput {
+    service: ResourceRef,
+    environment: ResourceRef,
+    static_ip: StaticIpStatus,
+}
+
+impl StaticIpStatusOutput {
+    fn new(ctx: &ServiceContext, static_ip: StaticIpStatus) -> Self {
+        Self {
+            service: ResourceRef::service(ctx),
+            environment: ResourceRef::environment(ctx),
+            static_ip,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Ipv6StatusOutput {
+    service: ResourceRef,
+    environment: ResourceRef,
+    ipv6: Ipv6Status,
+}
+
+impl Ipv6StatusOutput {
+    fn new(ctx: &ServiceContext, ipv6: Ipv6Status) -> Self {
+        Self {
+            service: ResourceRef::service(ctx),
+            environment: ResourceRef::environment(ctx),
+            ipv6,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StaticIpActionOutput {
+    service: ResourceRef,
+    environment: ResourceRef,
+    #[serde(flatten)]
+    action: FeatureAction,
+    static_ip: StaticIpStatus,
+}
+
+impl StaticIpActionOutput {
+    fn new(ctx: &ServiceContext, action: FeatureAction, static_ip: StaticIpStatus) -> Self {
+        Self {
+            service: ResourceRef::service(ctx),
+            environment: ResourceRef::environment(ctx),
+            action,
+            static_ip,
+        }
+    }
+}
+
+impl std::ops::Deref for StaticIpActionOutput {
+    type Target = FeatureAction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.action
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Ipv6ActionOutput {
+    service: ResourceRef,
+    environment: ResourceRef,
+    #[serde(flatten)]
+    action: FeatureAction,
+    ipv6: Ipv6Status,
+}
+
+impl Ipv6ActionOutput {
+    fn new(ctx: &ServiceContext, action: FeatureAction, ipv6: Ipv6Status) -> Self {
+        Self {
+            service: ResourceRef::service(ctx),
+            environment: ResourceRef::environment(ctx),
+            action,
+            ipv6,
+        }
+    }
+}
+
+impl std::ops::Deref for Ipv6ActionOutput {
+    type Target = FeatureAction;
+
+    fn deref(&self) -> &Self::Target {
+        &self.action
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::controllers::outbound_networking::Lifecycle;
+    use clap::Parser;
+
+    #[test]
+    fn parses_subcommands() {
+        assert!(matches!(
+            Args::parse_from(["outbound-networking", "status"]).command,
+            Commands::Status
+        ));
+        assert!(matches!(
+            Args::parse_from(["outbound-networking", "static-ip", "status"]).command,
+            Commands::StaticIp(StaticIpArgs {
+                command: StaticIpCommands::Status
+            })
+        ));
+        assert!(matches!(
+            Args::parse_from(["outbound-networking", "static-ip", "enable"]).command,
+            Commands::StaticIp(StaticIpArgs {
+                command: StaticIpCommands::Enable
+            })
+        ));
+        assert!(matches!(
+            Args::parse_from(["outbound-networking", "static-ip", "disable"]).command,
+            Commands::StaticIp(StaticIpArgs {
+                command: StaticIpCommands::Disable
+            })
+        ));
+        assert!(matches!(
+            Args::parse_from(["outbound-networking", "ipv6", "enable"]).command,
+            Commands::Ipv6(Ipv6Args {
+                command: Ipv6Commands::Enable
+            })
+        ));
+        assert!(matches!(
+            Args::parse_from([
+                "outbound-networking",
+                "--service",
+                "api",
+                "--environment",
+                "production",
+                "--project",
+                "project-id",
+                "--json",
+                "ipv6",
+                "disable"
+            ])
+            .command,
+            Commands::Ipv6(Ipv6Args {
+                command: Ipv6Commands::Disable
+            })
+        ));
+    }
+
+    #[test]
+    fn action_output_has_lifecycle_shape() {
+        let output = serde_json::json!({
+            "feature": "staticIp",
+            "action": "enable",
+            "enabled": true,
+            "changed": true,
+            "lifecycle": Lifecycle::direct(true),
+        });
+
+        assert_eq!(output["lifecycle"]["mode"], "direct");
+        assert_eq!(output["lifecycle"]["staged"], false);
+        assert_eq!(output["lifecycle"]["committed"], true);
+        assert_eq!(output["lifecycle"]["redeployRequired"], true);
+        assert_eq!(output["lifecycle"]["redeployTriggered"], false);
+
+        let output = serde_json::json!({
+            "feature": "ipv6",
+            "action": "enable",
+            "enabled": true,
+            "changed": true,
+            "lifecycle": Lifecycle::environment_patch(true),
+        });
+
+        assert_eq!(output["lifecycle"]["mode"], "environmentPatch");
+        assert_eq!(output["lifecycle"]["staged"], true);
+        assert_eq!(output["lifecycle"]["committed"], false);
+        assert_eq!(output["lifecycle"]["redeployRequired"], false);
+        assert_eq!(output["lifecycle"]["redeployTriggered"], false);
+    }
+}

--- a/src/commands/outbound_networking.rs
+++ b/src/commands/outbound_networking.rs
@@ -2,7 +2,7 @@ use colored::ColoredString;
 use serde::Serialize;
 
 use crate::controllers::{
-    outbound_networking::{self, FeatureAction, Ipv6Status, StaticIpMode, StaticIpStatus},
+    outbound_networking::{self, FeatureAction, Ipv6Status, StaticIpStatus},
     project::{ServiceContext, resolve_service_context},
 };
 
@@ -400,8 +400,7 @@ fn print_context(service_name: &str, environment_name: &str) {
 
 fn print_static_ip_fields(static_ip: &StaticIpStatus) {
     print_field("Static IPs:", &status_label(static_ip.enabled));
-    print_field("Mode:", &mode_label(static_ip.mode));
-    if static_ip.high_availability {
+    if static_ip.enabled && static_ip.high_availability {
         print_field("High Availability:", &"enabled".green().bold());
     }
     if static_ip.enabled {
@@ -473,14 +472,6 @@ fn status_label(enabled: bool) -> ColoredString {
         "enabled".green().bold()
     } else {
         "disabled".yellow().bold()
-    }
-}
-
-fn mode_label(mode: StaticIpMode) -> ColoredString {
-    match mode {
-        StaticIpMode::Disabled => "disabled".yellow().bold(),
-        StaticIpMode::Legacy => "legacy".yellow().bold(),
-        StaticIpMode::Ha => "ha".green().bold(),
     }
 }
 

--- a/src/commands/output/fields.rs
+++ b/src/commands/output/fields.rs
@@ -1,0 +1,17 @@
+use std::fmt;
+
+use colored::Colorize;
+
+pub(in crate::commands) fn print_field(label: &str, value: &dyn fmt::Display, width: usize) {
+    let padded = format!("{label:<width$}");
+    println!("{} {value}", padded.dimmed());
+}
+
+pub(in crate::commands) fn print_service_environment_context(
+    service_name: &str,
+    environment_name: &str,
+    width: usize,
+) {
+    print_field("Service:", &service_name.green().bold(), width);
+    print_field("Environment:", &environment_name.blue().bold(), width);
+}

--- a/src/commands/output/mod.rs
+++ b/src/commands/output/mod.rs
@@ -1,1 +1,2 @@
+pub(in crate::commands) mod fields;
 pub(in crate::commands) mod service_summary;

--- a/src/commands/private_network.rs
+++ b/src/commands/private_network.rs
@@ -1,6 +1,7 @@
 use colored::ColoredString;
 use serde::Serialize;
 
+use crate::commands::output::fields::{print_field, print_service_environment_context};
 use crate::controllers::{
     private_network::{self, PrivateNetworkState, PrivateNetworkStatus, endpoint_dns_suffix},
     project::resolve_service_context,
@@ -113,7 +114,7 @@ async fn status(
 
     println!("{}", "Private networking".bold());
     println!();
-    print_context(&ctx.service_name, &ctx.environment_name);
+    print_service_environment_context(&ctx.service_name, &ctx.environment_name, FIELD_LABEL_WIDTH);
     print_statuses(&statuses);
 
     Ok(())
@@ -150,15 +151,10 @@ async fn update(
 
     println!("{}", "Private networking".bold());
     println!();
-    print_context(&ctx.service_name, &ctx.environment_name);
+    print_service_environment_context(&ctx.service_name, &ctx.environment_name, FIELD_LABEL_WIDTH);
     print_status(&status);
 
     Ok(())
-}
-
-fn print_context(service_name: &str, environment_name: &str) {
-    print_field("Service:", &service_name.green().bold());
-    print_field("Environment:", &environment_name.blue().bold());
 }
 
 fn print_statuses(statuses: &[PrivateNetworkStatus]) {
@@ -170,44 +166,70 @@ fn print_statuses(statuses: &[PrivateNetworkStatus]) {
 fn print_status(status: &PrivateNetworkStatus) {
     println!();
     print_divider();
-    print_field("Network:", &status.network.name.purple().bold());
-    print_field("Network ID:", &status.network.id.clone().dimmed());
+    print_field(
+        "Network:",
+        &status.network.name.purple().bold(),
+        FIELD_LABEL_WIDTH,
+    );
+    print_field(
+        "Network ID:",
+        &status.network.id.clone().dimmed(),
+        FIELD_LABEL_WIDTH,
+    );
     print_field(
         "DNS suffix:",
         &format!("{}.internal", status.network.dns_name).dimmed(),
+        FIELD_LABEL_WIDTH,
     );
     print_field(
         "Address family:",
         &status.network.ip_family.clone().magenta().bold(),
+        FIELD_LABEL_WIDTH,
     );
-    print_field("Status:", &state_label(status.state));
+    print_field("Status:", &state_label(status.state), FIELD_LABEL_WIDTH);
 
     if let Some(hostname) = &status.full_hostname {
-        print_field("Hostname:", &hostname.clone().magenta().bold());
+        print_field(
+            "Hostname:",
+            &hostname.clone().magenta().bold(),
+            FIELD_LABEL_WIDTH,
+        );
     }
     if let Some(short_name) = &status.short_name {
-        print_field("Short name:", &short_name.clone().magenta());
+        print_field(
+            "Short name:",
+            &short_name.clone().magenta(),
+            FIELD_LABEL_WIDTH,
+        );
     }
     if let Some(pending_hostname) = &status.pending_hostname {
-        print_field("Pending:", &pending_hostname.clone().blue().bold());
+        print_field(
+            "Pending:",
+            &pending_hostname.clone().blue().bold(),
+            FIELD_LABEL_WIDTH,
+        );
     }
     if let Some(endpoint) = &status.endpoint {
-        print_field("Endpoint ID:", &endpoint.id.clone().dimmed());
+        print_field(
+            "Endpoint ID:",
+            &endpoint.id.clone().dimmed(),
+            FIELD_LABEL_WIDTH,
+        );
         if !endpoint.private_ips.is_empty() {
-            print_field("Private IPs:", &endpoint.private_ips.join(", "));
+            print_field(
+                "Private IPs:",
+                &endpoint.private_ips.join(", "),
+                FIELD_LABEL_WIDTH,
+            );
         }
     } else {
         print_field(
             "Message:",
             &"Private networking is initializing and will be ready once the deployment of this service is complete."
                 .blue(),
+            FIELD_LABEL_WIDTH,
         );
     }
-}
-
-fn print_field(label: &str, value: &dyn std::fmt::Display) {
-    let padded = format!("{label:<FIELD_LABEL_WIDTH$}");
-    println!("{} {value}", padded.dimmed());
 }
 
 fn print_divider() {

--- a/src/controllers/config/environment.rs
+++ b/src/controllers/config/environment.rs
@@ -144,6 +144,7 @@ pub struct DeployConfig {
     pub pre_deploy_command: Option<serde_json::Value>, // string or [string]
     pub healthcheck_path: Option<String>,
     pub healthcheck_timeout: Option<i64>,
+    pub ipv6_egress_enabled: Option<bool>,
     pub num_replicas: Option<i64>,
     pub multi_region_config: Option<BTreeMap<String, Option<RegionConfig>>>,
     pub cron_schedule: Option<String>,

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -9,6 +9,7 @@ pub mod github;
 pub mod local_override;
 pub mod metrics;
 pub mod metrics_tui;
+pub mod outbound_networking;
 pub mod private_network;
 pub mod project;
 pub mod regions;

--- a/src/controllers/outbound_networking.rs
+++ b/src/controllers/outbound_networking.rs
@@ -50,15 +50,6 @@ impl Lifecycle {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum StaticIpMode {
-    Disabled,
-    Legacy,
-    #[serde(rename = "ha")]
-    Ha,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StaticIpAddress {
@@ -74,7 +65,6 @@ pub struct StaticIpAddress {
 #[serde(rename_all = "camelCase")]
 pub struct StaticIpStatus {
     pub enabled: bool,
-    pub mode: StaticIpMode,
     pub high_availability: bool,
     pub ips: Vec<StaticIpAddress>,
 }
@@ -201,7 +191,6 @@ pub async fn disable_static_ips(
     Ok((
         StaticIpStatus {
             enabled: false,
-            mode: StaticIpMode::Disabled,
             high_availability: false,
             ips: Vec::new(),
         },
@@ -331,17 +320,9 @@ fn static_ip_status_from_gateway_fields<T: EgressGatewayFields>(
         .map(EgressGatewayFields::into_static_ip_address)
         .collect::<Vec<_>>();
     let high_availability = ips.iter().any(|ip| ip.zone.is_some());
-    let mode = if ips.is_empty() {
-        StaticIpMode::Disabled
-    } else if high_availability {
-        StaticIpMode::Ha
-    } else {
-        StaticIpMode::Legacy
-    };
 
     StaticIpStatus {
         enabled: !ips.is_empty(),
-        mode,
         high_availability,
         ips,
     }
@@ -407,23 +388,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn static_ip_status_derives_disabled_legacy_and_ha() {
+    fn static_ip_status_derives_enabled_and_high_availability() {
         let disabled = static_ip_status_from_gateways(vec![]);
         assert!(!disabled.enabled);
-        assert_eq!(disabled.mode, StaticIpMode::Disabled);
         assert!(!disabled.high_availability);
 
-        let legacy = static_ip_status_from_gateways(vec![
+        let single_gateway = static_ip_status_from_gateways(vec![
             queries::egress_gateways::EgressGatewaysEgressGateways {
                 ipv4: "203.0.113.10".to_string(),
                 region: "us-west2".to_string(),
                 zone: None,
             },
         ]);
-        assert!(legacy.enabled);
-        assert_eq!(legacy.mode, StaticIpMode::Legacy);
-        assert!(!legacy.high_availability);
-        assert_eq!(legacy.ips[0].ip_type, "shared");
+        assert!(single_gateway.enabled);
+        assert!(!single_gateway.high_availability);
+        assert_eq!(single_gateway.ips[0].ip_type, "shared");
+        assert!(
+            serde_json::to_value(&single_gateway)
+                .unwrap()
+                .get("mode")
+                .is_none()
+        );
 
         let ha = static_ip_status_from_gateways(vec![
             queries::egress_gateways::EgressGatewaysEgressGateways {
@@ -433,7 +418,6 @@ mod tests {
             },
         ]);
         assert!(ha.enabled);
-        assert_eq!(ha.mode, StaticIpMode::Ha);
         assert!(ha.high_availability);
     }
 

--- a/src/controllers/outbound_networking.rs
+++ b/src/controllers/outbound_networking.rs
@@ -39,10 +39,10 @@ impl Lifecycle {
         }
     }
 
-    pub fn environment_patch(changed: bool) -> Self {
+    pub fn environment_patch(staged: bool) -> Self {
         Self {
             mode: LifecycleMode::EnvironmentPatch,
-            staged: changed,
+            staged,
             committed: false,
             redeploy_required: false,
             redeploy_triggered: false,
@@ -241,16 +241,8 @@ pub async fn stage_ipv6(
     if current.pending_value == Some(value)
         || (current.pending_value.is_none() && current.enabled == value)
     {
-        return Ok((
-            current,
-            FeatureAction {
-                feature: "ipv6",
-                action: if value { "enable" } else { "disable" },
-                enabled: value,
-                changed: false,
-                lifecycle: Lifecycle::environment_patch(false),
-            },
-        ));
+        let staged = current.staged;
+        return Ok((current, ipv6_feature_action(value, false, staged)));
     }
 
     let patch = ipv6_patch(service_id, value);
@@ -268,14 +260,18 @@ pub async fn stage_ipv6(
 
     Ok((
         updated.clone(),
-        FeatureAction {
-            feature: "ipv6",
-            action: if value { "enable" } else { "disable" },
-            enabled: value,
-            changed: true,
-            lifecycle: Lifecycle::environment_patch(updated.staged),
-        },
+        ipv6_feature_action(value, true, updated.staged),
     ))
+}
+
+fn ipv6_feature_action(value: bool, changed: bool, staged: bool) -> FeatureAction {
+    FeatureAction {
+        feature: "ipv6",
+        action: if value { "enable" } else { "disable" },
+        enabled: value,
+        changed,
+        lifecycle: Lifecycle::environment_patch(staged),
+    }
 }
 
 pub trait EgressGatewayFields {
@@ -474,5 +470,18 @@ mod tests {
             staged_ipv6_value_from_patch(&staged, "svc_456").unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn unchanged_ipv6_action_can_still_report_staged_patch() {
+        let action = ipv6_feature_action(true, false, true);
+
+        assert_eq!(action.feature, "ipv6");
+        assert_eq!(action.action, "enable");
+        assert!(action.enabled);
+        assert!(!action.changed);
+        assert!(action.lifecycle.staged);
+        assert!(!action.lifecycle.committed);
+        assert!(!action.lifecycle.redeploy_triggered);
     }
 }

--- a/src/controllers/outbound_networking.rs
+++ b/src/controllers/outbound_networking.rs
@@ -1,0 +1,494 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use reqwest::Client;
+use serde::Serialize;
+
+use crate::{
+    client::post_graphql,
+    config::Configs,
+    controllers::config::{DeployConfig, EnvironmentConfig, ServiceInstance},
+    gql::{mutations, queries},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LifecycleMode {
+    Direct,
+    EnvironmentPatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Lifecycle {
+    pub mode: LifecycleMode,
+    pub staged: bool,
+    pub committed: bool,
+    pub redeploy_required: bool,
+    pub redeploy_triggered: bool,
+}
+
+impl Lifecycle {
+    pub fn direct(changed: bool) -> Self {
+        Self {
+            mode: LifecycleMode::Direct,
+            staged: false,
+            committed: changed,
+            redeploy_required: changed,
+            redeploy_triggered: false,
+        }
+    }
+
+    pub fn environment_patch(changed: bool) -> Self {
+        Self {
+            mode: LifecycleMode::EnvironmentPatch,
+            staged: changed,
+            committed: false,
+            redeploy_required: false,
+            redeploy_triggered: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum StaticIpMode {
+    Disabled,
+    Legacy,
+    #[serde(rename = "ha")]
+    Ha,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StaticIpAddress {
+    pub ipv4: String,
+    pub region: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone: Option<String>,
+    #[serde(rename = "type")]
+    pub ip_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StaticIpStatus {
+    pub enabled: bool,
+    pub mode: StaticIpMode,
+    pub high_availability: bool,
+    pub ips: Vec<StaticIpAddress>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ipv6Status {
+    pub enabled: bool,
+    pub staged: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_value: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureAction {
+    pub feature: &'static str,
+    pub action: &'static str,
+    pub enabled: bool,
+    pub changed: bool,
+    pub lifecycle: Lifecycle,
+}
+
+pub async fn fetch_static_ip_status(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<StaticIpStatus> {
+    let gateways = post_graphql::<queries::EgressGateways, _>(
+        client,
+        configs.get_backboard(),
+        queries::egress_gateways::Variables {
+            environment_id: environment_id.to_string(),
+            service_id: service_id.to_string(),
+        },
+    )
+    .await?
+    .egress_gateways;
+
+    Ok(static_ip_status_from_gateways(gateways))
+}
+
+pub async fn enable_static_ips(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<(StaticIpStatus, FeatureAction)> {
+    let current = fetch_static_ip_status(client, configs, environment_id, service_id).await?;
+    if current.enabled {
+        return Ok((
+            current,
+            FeatureAction {
+                feature: "staticIp",
+                action: "enable",
+                enabled: true,
+                changed: false,
+                lifecycle: Lifecycle::direct(false),
+            },
+        ));
+    }
+
+    let gateways = post_graphql::<mutations::EgressGatewayAssociationCreate, _>(
+        client,
+        configs.get_backboard(),
+        mutations::egress_gateway_association_create::Variables {
+            input: mutations::egress_gateway_association_create::EgressGatewayCreateInput {
+                environment_id: environment_id.to_string(),
+                service_id: service_id.to_string(),
+                region: None,
+            },
+        },
+    )
+    .await?
+    .egress_gateway_association_create;
+
+    let status = static_ip_status_from_gateway_fields(gateways);
+    Ok((
+        status,
+        FeatureAction {
+            feature: "staticIp",
+            action: "enable",
+            enabled: true,
+            changed: true,
+            lifecycle: Lifecycle::direct(true),
+        },
+    ))
+}
+
+pub async fn disable_static_ips(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<(StaticIpStatus, FeatureAction)> {
+    let current = fetch_static_ip_status(client, configs, environment_id, service_id).await?;
+    if !current.enabled {
+        return Ok((
+            current,
+            FeatureAction {
+                feature: "staticIp",
+                action: "disable",
+                enabled: false,
+                changed: false,
+                lifecycle: Lifecycle::direct(false),
+            },
+        ));
+    }
+
+    post_graphql::<mutations::EgressGatewayAssociationsClear, _>(
+        client,
+        configs.get_backboard(),
+        mutations::egress_gateway_associations_clear::Variables {
+            input: mutations::egress_gateway_associations_clear::EgressGatewayServiceTargetInput {
+                environment_id: environment_id.to_string(),
+                service_id: service_id.to_string(),
+                all_environments: None,
+            },
+        },
+    )
+    .await?;
+
+    Ok((
+        StaticIpStatus {
+            enabled: false,
+            mode: StaticIpMode::Disabled,
+            high_availability: false,
+            ips: Vec::new(),
+        },
+        FeatureAction {
+            feature: "staticIp",
+            action: "disable",
+            enabled: false,
+            changed: true,
+            lifecycle: Lifecycle::direct(true),
+        },
+    ))
+}
+
+pub async fn fetch_ipv6_status(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<Ipv6Status> {
+    let config = crate::controllers::config::environment::fetch_environment_config(
+        client,
+        configs,
+        environment_id,
+        false,
+    )
+    .await?
+    .config;
+    let enabled = ipv6_enabled_from_config(&config, service_id);
+    let pending_value =
+        fetch_staged_ipv6_value(client, configs, environment_id, service_id).await?;
+
+    Ok(Ipv6Status {
+        enabled,
+        staged: pending_value.is_some(),
+        pending_value,
+    })
+}
+
+pub async fn stage_ipv6(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+    value: bool,
+) -> Result<(Ipv6Status, FeatureAction)> {
+    let current = fetch_ipv6_status(client, configs, environment_id, service_id).await?;
+
+    if current.pending_value == Some(value)
+        || (current.pending_value.is_none() && current.enabled == value)
+    {
+        return Ok((
+            current,
+            FeatureAction {
+                feature: "ipv6",
+                action: if value { "enable" } else { "disable" },
+                enabled: value,
+                changed: false,
+                lifecycle: Lifecycle::environment_patch(false),
+            },
+        ));
+    }
+
+    let patch = ipv6_patch(service_id, value);
+    post_graphql::<mutations::EnvironmentStageChanges, _>(
+        client,
+        configs.get_backboard(),
+        mutations::environment_stage_changes::Variables {
+            environment_id: environment_id.to_string(),
+            input: patch,
+            merge: Some(true),
+        },
+    )
+    .await?;
+    let updated = fetch_ipv6_status(client, configs, environment_id, service_id).await?;
+
+    Ok((
+        updated.clone(),
+        FeatureAction {
+            feature: "ipv6",
+            action: if value { "enable" } else { "disable" },
+            enabled: value,
+            changed: true,
+            lifecycle: Lifecycle::environment_patch(updated.staged),
+        },
+    ))
+}
+
+pub trait EgressGatewayFields {
+    fn into_static_ip_address(self) -> StaticIpAddress;
+}
+
+impl EgressGatewayFields for queries::egress_gateways::EgressGatewaysEgressGateways {
+    fn into_static_ip_address(self) -> StaticIpAddress {
+        StaticIpAddress {
+            ipv4: self.ipv4,
+            region: self.region,
+            zone: self.zone,
+            ip_type: "shared".to_string(),
+        }
+    }
+}
+
+impl EgressGatewayFields
+    for mutations::egress_gateway_association_create::EgressGatewayAssociationCreateEgressGatewayAssociationCreate
+{
+    fn into_static_ip_address(self) -> StaticIpAddress {
+        StaticIpAddress {
+            ipv4: self.ipv4,
+            region: self.region,
+            zone: self.zone,
+            ip_type: "shared".to_string(),
+        }
+    }
+}
+
+pub fn static_ip_status_from_gateways(
+    gateways: Vec<queries::egress_gateways::EgressGatewaysEgressGateways>,
+) -> StaticIpStatus {
+    static_ip_status_from_gateway_fields(gateways)
+}
+
+fn static_ip_status_from_gateway_fields<T: EgressGatewayFields>(
+    gateways: Vec<T>,
+) -> StaticIpStatus {
+    let ips = gateways
+        .into_iter()
+        .map(EgressGatewayFields::into_static_ip_address)
+        .collect::<Vec<_>>();
+    let high_availability = ips.iter().any(|ip| ip.zone.is_some());
+    let mode = if ips.is_empty() {
+        StaticIpMode::Disabled
+    } else if high_availability {
+        StaticIpMode::Ha
+    } else {
+        StaticIpMode::Legacy
+    };
+
+    StaticIpStatus {
+        enabled: !ips.is_empty(),
+        mode,
+        high_availability,
+        ips,
+    }
+}
+
+pub fn ipv6_patch(service_id: &str, value: bool) -> EnvironmentConfig {
+    EnvironmentConfig {
+        services: BTreeMap::from([(
+            service_id.to_string(),
+            ServiceInstance {
+                deploy: Some(DeployConfig {
+                    ipv6_egress_enabled: Some(value),
+                    ..DeployConfig::default()
+                }),
+                ..ServiceInstance::default()
+            },
+        )]),
+        ..EnvironmentConfig::default()
+    }
+}
+
+pub fn ipv6_enabled_from_config(config: &EnvironmentConfig, service_id: &str) -> bool {
+    config
+        .services
+        .get(service_id)
+        .and_then(|service| service.deploy.as_ref())
+        .and_then(|deploy| deploy.ipv6_egress_enabled)
+        .unwrap_or(false)
+}
+
+pub fn staged_ipv6_value_from_patch(
+    patch: &serde_json::Value,
+    service_id: &str,
+) -> Result<Option<bool>> {
+    let config: EnvironmentConfig = serde_json::from_value(patch.clone())?;
+    Ok(config
+        .services
+        .get(service_id)
+        .and_then(|service| service.deploy.as_ref())
+        .and_then(|deploy| deploy.ipv6_egress_enabled))
+}
+
+async fn fetch_staged_ipv6_value(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<Option<bool>> {
+    let response = post_graphql::<queries::EnvironmentStagedChanges, _>(
+        client,
+        configs.get_backboard(),
+        queries::environment_staged_changes::Variables {
+            environment_id: environment_id.to_string(),
+        },
+    )
+    .await?;
+
+    staged_ipv6_value_from_patch(&response.environment_staged_changes.patch, service_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_ip_status_derives_disabled_legacy_and_ha() {
+        let disabled = static_ip_status_from_gateways(vec![]);
+        assert!(!disabled.enabled);
+        assert_eq!(disabled.mode, StaticIpMode::Disabled);
+        assert!(!disabled.high_availability);
+
+        let legacy = static_ip_status_from_gateways(vec![
+            queries::egress_gateways::EgressGatewaysEgressGateways {
+                ipv4: "203.0.113.10".to_string(),
+                region: "us-west2".to_string(),
+                zone: None,
+            },
+        ]);
+        assert!(legacy.enabled);
+        assert_eq!(legacy.mode, StaticIpMode::Legacy);
+        assert!(!legacy.high_availability);
+        assert_eq!(legacy.ips[0].ip_type, "shared");
+
+        let ha = static_ip_status_from_gateways(vec![
+            queries::egress_gateways::EgressGatewaysEgressGateways {
+                ipv4: "203.0.113.10".to_string(),
+                region: "us-west2".to_string(),
+                zone: Some("zone-a".to_string()),
+            },
+        ]);
+        assert!(ha.enabled);
+        assert_eq!(ha.mode, StaticIpMode::Ha);
+        assert!(ha.high_availability);
+    }
+
+    #[test]
+    fn ipv6_patch_serializes_to_deploy_config() {
+        let value = serde_json::to_value(ipv6_patch("svc_123", true)).unwrap();
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "services": {
+                    "svc_123": {
+                        "deploy": {
+                            "ipv6EgressEnabled": true
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn ipv6_status_reads_current_and_staged_values() {
+        let current = EnvironmentConfig {
+            services: BTreeMap::from([(
+                "svc_123".to_string(),
+                ServiceInstance {
+                    deploy: Some(DeployConfig {
+                        ipv6_egress_enabled: Some(true),
+                        ..DeployConfig::default()
+                    }),
+                    ..ServiceInstance::default()
+                },
+            )]),
+            ..EnvironmentConfig::default()
+        };
+        assert!(ipv6_enabled_from_config(&current, "svc_123"));
+        assert!(!ipv6_enabled_from_config(&current, "svc_456"));
+
+        let staged = serde_json::json!({
+            "services": {
+                "svc_123": {
+                    "deploy": {
+                        "ipv6EgressEnabled": false
+                    }
+                }
+            }
+        });
+        assert_eq!(
+            staged_ipv6_value_from_patch(&staged, "svc_123").unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            staged_ipv6_value_from_patch(&staged, "svc_456").unwrap(),
+            None
+        );
+    }
+}

--- a/src/controllers/outbound_networking.rs
+++ b/src/controllers/outbound_networking.rs
@@ -5,11 +5,14 @@ use reqwest::Client;
 use serde::Serialize;
 
 use crate::{
-    client::post_graphql,
+    client::{post_graphql, post_graphql_raw},
     config::Configs,
     controllers::config::{DeployConfig, EnvironmentConfig, ServiceInstance},
     gql::{mutations, queries},
 };
+
+const ENVIRONMENT_STAGE_CHANGES_MUTATION: &str =
+    include_str!("../gql/mutations/strings/EnvironmentStageChanges.graphql");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -57,8 +60,6 @@ pub struct StaticIpAddress {
     pub region: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zone: Option<String>,
-    #[serde(rename = "type")]
-    pub ip_type: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -76,6 +77,12 @@ pub struct Ipv6Status {
     pub staged: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pending_value: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Ipv6State {
+    status: Ipv6Status,
+    staged_value: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -105,7 +112,12 @@ pub async fn fetch_static_ip_status(
     .await?
     .egress_gateways;
 
-    Ok(static_ip_status_from_gateways(gateways))
+    let ips = gateways
+        .into_iter()
+        .map(|gateway| static_ip_address(gateway.ipv4, gateway.region, gateway.zone))
+        .collect();
+
+    Ok(static_ip_status_from_addresses(ips))
 }
 
 pub async fn enable_static_ips(
@@ -142,7 +154,11 @@ pub async fn enable_static_ips(
     .await?
     .egress_gateway_association_create;
 
-    let status = static_ip_status_from_gateway_fields(gateways);
+    let ips = gateways
+        .into_iter()
+        .map(|gateway| static_ip_address(gateway.ipv4, gateway.region, gateway.zone))
+        .collect();
+    let status = static_ip_status_from_addresses(ips);
     Ok((
         status,
         FeatureAction {
@@ -210,23 +226,11 @@ pub async fn fetch_ipv6_status(
     environment_id: &str,
     service_id: &str,
 ) -> Result<Ipv6Status> {
-    let config = crate::controllers::config::environment::fetch_environment_config(
-        client,
-        configs,
-        environment_id,
-        false,
+    Ok(
+        fetch_ipv6_state(client, configs, environment_id, service_id)
+            .await?
+            .status,
     )
-    .await?
-    .config;
-    let enabled = ipv6_enabled_from_config(&config, service_id);
-    let pending_value =
-        fetch_staged_ipv6_value(client, configs, environment_id, service_id).await?;
-
-    Ok(Ipv6Status {
-        enabled,
-        staged: pending_value.is_some(),
-        pending_value,
-    })
 }
 
 pub async fn stage_ipv6(
@@ -236,13 +240,25 @@ pub async fn stage_ipv6(
     service_id: &str,
     value: bool,
 ) -> Result<(Ipv6Status, FeatureAction)> {
-    let current = fetch_ipv6_status(client, configs, environment_id, service_id).await?;
+    let current = fetch_ipv6_state(client, configs, environment_id, service_id).await?;
 
-    if current.pending_value == Some(value)
-        || (current.pending_value.is_none() && current.enabled == value)
+    if current.staged_value.is_some() && current.status.enabled == value {
+        clear_staged_ipv6_value(client, configs, environment_id, service_id).await?;
+        let updated = fetch_ipv6_state(client, configs, environment_id, service_id)
+            .await?
+            .status;
+        return Ok((
+            updated.clone(),
+            ipv6_feature_action(value, true, updated.staged),
+        ));
+    }
+
+    if current.staged_value == Some(value)
+        || (current.staged_value.is_none() && current.status.enabled == value)
     {
-        let staged = current.staged;
-        return Ok((current, ipv6_feature_action(value, false, staged)));
+        let status = current.status;
+        let staged = status.staged;
+        return Ok((status, ipv6_feature_action(value, false, staged)));
     }
 
     let patch = ipv6_patch(service_id, value);
@@ -274,53 +290,54 @@ fn ipv6_feature_action(value: bool, changed: bool, staged: bool) -> FeatureActio
     }
 }
 
-pub trait EgressGatewayFields {
-    fn into_static_ip_address(self) -> StaticIpAddress;
+fn static_ip_address(ipv4: String, region: String, zone: Option<String>) -> StaticIpAddress {
+    StaticIpAddress { ipv4, region, zone }
 }
 
-impl EgressGatewayFields for queries::egress_gateways::EgressGatewaysEgressGateways {
-    fn into_static_ip_address(self) -> StaticIpAddress {
-        StaticIpAddress {
-            ipv4: self.ipv4,
-            region: self.region,
-            zone: self.zone,
-            ip_type: "shared".to_string(),
-        }
-    }
-}
-
-impl EgressGatewayFields
-    for mutations::egress_gateway_association_create::EgressGatewayAssociationCreateEgressGatewayAssociationCreate
-{
-    fn into_static_ip_address(self) -> StaticIpAddress {
-        StaticIpAddress {
-            ipv4: self.ipv4,
-            region: self.region,
-            zone: self.zone,
-            ip_type: "shared".to_string(),
-        }
-    }
-}
-
-pub fn static_ip_status_from_gateways(
-    gateways: Vec<queries::egress_gateways::EgressGatewaysEgressGateways>,
-) -> StaticIpStatus {
-    static_ip_status_from_gateway_fields(gateways)
-}
-
-fn static_ip_status_from_gateway_fields<T: EgressGatewayFields>(
-    gateways: Vec<T>,
-) -> StaticIpStatus {
-    let ips = gateways
-        .into_iter()
-        .map(EgressGatewayFields::into_static_ip_address)
-        .collect::<Vec<_>>();
+fn static_ip_status_from_addresses(ips: Vec<StaticIpAddress>) -> StaticIpStatus {
     let high_availability = ips.iter().any(|ip| ip.zone.is_some());
 
     StaticIpStatus {
         enabled: !ips.is_empty(),
         high_availability,
         ips,
+    }
+}
+
+async fn fetch_ipv6_state(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<Ipv6State> {
+    let (config, staged_value) = tokio::try_join!(
+        crate::controllers::config::environment::fetch_environment_config(
+            client,
+            configs,
+            environment_id,
+            false,
+        ),
+        fetch_staged_ipv6_value(client, configs, environment_id, service_id)
+    )?;
+
+    Ok(Ipv6State {
+        status: ipv6_status_from_config_and_staged_value(&config.config, service_id, staged_value),
+        staged_value,
+    })
+}
+
+fn ipv6_status_from_config_and_staged_value(
+    config: &EnvironmentConfig,
+    service_id: &str,
+    staged_value: Option<bool>,
+) -> Ipv6Status {
+    let enabled = ipv6_enabled_from_config(config, service_id);
+    let pending_value = staged_value.filter(|value| *value != enabled);
+
+    Ipv6Status {
+        enabled,
+        staged: pending_value.is_some(),
+        pending_value,
     }
 }
 
@@ -338,6 +355,18 @@ pub fn ipv6_patch(service_id: &str, value: bool) -> EnvironmentConfig {
         )]),
         ..EnvironmentConfig::default()
     }
+}
+
+pub fn ipv6_clear_patch(service_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "services": {
+            service_id: {
+                "deploy": {
+                    "ipv6EgressEnabled": null
+                }
+            }
+        }
+    })
 }
 
 pub fn ipv6_enabled_from_config(config: &EnvironmentConfig, service_id: &str) -> bool {
@@ -379,26 +408,50 @@ async fn fetch_staged_ipv6_value(
     staged_ipv6_value_from_patch(&response.environment_staged_changes.patch, service_id)
 }
 
+async fn clear_staged_ipv6_value(
+    client: &Client,
+    configs: &Configs,
+    environment_id: &str,
+    service_id: &str,
+) -> Result<()> {
+    post_graphql_raw::<mutations::environment_stage_changes::ResponseData, _>(
+        client,
+        configs.get_backboard(),
+        ENVIRONMENT_STAGE_CHANGES_MUTATION,
+        serde_json::json!({
+            "environmentId": environment_id,
+            "input": ipv6_clear_patch(service_id),
+            "merge": true,
+        }),
+    )
+    .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn static_ip_status_derives_enabled_and_high_availability() {
-        let disabled = static_ip_status_from_gateways(vec![]);
+        let disabled = static_ip_status_from_addresses(vec![]);
         assert!(!disabled.enabled);
         assert!(!disabled.high_availability);
 
-        let single_gateway = static_ip_status_from_gateways(vec![
-            queries::egress_gateways::EgressGatewaysEgressGateways {
-                ipv4: "203.0.113.10".to_string(),
-                region: "us-west2".to_string(),
-                zone: None,
-            },
-        ]);
+        let single_gateway = static_ip_status_from_addresses(vec![StaticIpAddress {
+            ipv4: "203.0.113.10".to_string(),
+            region: "us-west2".to_string(),
+            zone: None,
+        }]);
         assert!(single_gateway.enabled);
         assert!(!single_gateway.high_availability);
-        assert_eq!(single_gateway.ips[0].ip_type, "shared");
+        assert!(
+            serde_json::to_value(&single_gateway.ips[0])
+                .unwrap()
+                .get("type")
+                .is_none()
+        );
         assert!(
             serde_json::to_value(&single_gateway)
                 .unwrap()
@@ -406,13 +459,11 @@ mod tests {
                 .is_none()
         );
 
-        let ha = static_ip_status_from_gateways(vec![
-            queries::egress_gateways::EgressGatewaysEgressGateways {
-                ipv4: "203.0.113.10".to_string(),
-                region: "us-west2".to_string(),
-                zone: Some("zone-a".to_string()),
-            },
-        ]);
+        let ha = static_ip_status_from_addresses(vec![StaticIpAddress {
+            ipv4: "203.0.113.10".to_string(),
+            region: "us-west2".to_string(),
+            zone: Some("zone-a".to_string()),
+        }]);
         assert!(ha.enabled);
         assert!(ha.high_availability);
     }
@@ -428,6 +479,22 @@ mod tests {
                     "svc_123": {
                         "deploy": {
                             "ipv6EgressEnabled": true
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn ipv6_clear_patch_serializes_null_value() {
+        assert_eq!(
+            ipv6_clear_patch("svc_123"),
+            serde_json::json!({
+                "services": {
+                    "svc_123": {
+                        "deploy": {
+                            "ipv6EgressEnabled": null
                         }
                     }
                 }
@@ -470,6 +537,33 @@ mod tests {
             staged_ipv6_value_from_patch(&staged, "svc_456").unwrap(),
             None
         );
+
+        let status = ipv6_status_from_config_and_staged_value(&current, "svc_123", Some(false));
+        assert!(status.enabled);
+        assert!(status.staged);
+        assert_eq!(status.pending_value, Some(false));
+    }
+
+    #[test]
+    fn ipv6_status_ignores_redundant_staged_value() {
+        let current = EnvironmentConfig {
+            services: BTreeMap::from([(
+                "svc_123".to_string(),
+                ServiceInstance {
+                    deploy: Some(DeployConfig {
+                        ipv6_egress_enabled: Some(true),
+                        ..DeployConfig::default()
+                    }),
+                    ..ServiceInstance::default()
+                },
+            )]),
+            ..EnvironmentConfig::default()
+        };
+
+        let status = ipv6_status_from_config_and_staged_value(&current, "svc_123", Some(true));
+        assert!(status.enabled);
+        assert!(!status.staged);
+        assert_eq!(status.pending_value, None);
     }
 
     #[test]

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -427,6 +427,24 @@ pub struct EnvironmentStageChanges;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/EgressGatewayAssociationCreate.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq",
+    skip_serializing_none
+)]
+pub struct EgressGatewayAssociationCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/mutations/strings/EgressGatewayAssociationsClear.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct EgressGatewayAssociationsClear;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/mutations/strings/ServiceInstanceUpdate.graphql",
     response_derives = "Debug, Serialize, Clone",
     variables_derives = "Default",

--- a/src/gql/mutations/strings/EgressGatewayAssociationCreate.graphql
+++ b/src/gql/mutations/strings/EgressGatewayAssociationCreate.graphql
@@ -1,0 +1,7 @@
+mutation EgressGatewayAssociationCreate($input: EgressGatewayCreateInput!) {
+  egressGatewayAssociationCreate(input: $input) {
+    ipv4
+    region
+    zone
+  }
+}

--- a/src/gql/mutations/strings/EgressGatewayAssociationsClear.graphql
+++ b/src/gql/mutations/strings/EgressGatewayAssociationsClear.graphql
@@ -1,0 +1,3 @@
+mutation EgressGatewayAssociationsClear($input: EgressGatewayServiceTargetInput!) {
+  egressGatewayAssociationsClear(input: $input)
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -148,6 +148,22 @@ pub struct TcpProxies;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/EgressGateways.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq"
+)]
+pub struct EgressGateways;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/EnvironmentStagedChanges.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct EnvironmentStagedChanges;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/PrivateNetworks.graphql",
     response_derives = "Debug, Serialize, Clone, PartialEq"
 )]

--- a/src/gql/queries/strings/EgressGateways.graphql
+++ b/src/gql/queries/strings/EgressGateways.graphql
@@ -1,0 +1,7 @@
+query EgressGateways($environmentId: String!, $serviceId: String!) {
+  egressGateways(environmentId: $environmentId, serviceId: $serviceId) {
+    ipv4
+    region
+    zone
+  }
+}

--- a/src/gql/queries/strings/EnvironmentStagedChanges.graphql
+++ b/src/gql/queries/strings/EnvironmentStagedChanges.graphql
@@ -1,0 +1,7 @@
+query EnvironmentStagedChanges($environmentId: String!) {
+  environmentStagedChanges(environmentId: $environmentId) {
+    id
+    status
+    patch
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ commands!(
     mcp,
     metrics,
     open,
-    outbound_networking as "outbound-networking",
+    outbound_networking as "outbound-network",
     project,
     private_network as "private-network",
     run(local),

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ commands!(
     mcp,
     metrics,
     open,
+    outbound_networking as "outbound-networking",
     project,
     private_network as "private-network",
     run(local),


### PR DESCRIPTION
## Summary

Adds a top-level `railway outbound-network` command for service outbound networking management with dashboard parity through the Railway public GraphQL API.

```bash
railway outbound-network status
railway outbound-network static-ip status
railway outbound-network static-ip enable
railway outbound-network static-ip disable
railway outbound-network ipv6 status
railway outbound-network ipv6 enable
railway outbound-network ipv6 disable
```

All commands support the standard service selectors and JSON output:

```bash
-s, --service <SERVICE>
-e, --environment <ENVIRONMENT>
-p, --project <PROJECT_ID>
--json
```

## Behavior

Static Outbound IP commands use the public egress gateway APIs directly, matching the current dashboard toggle. Enabling creates egress gateway associations, disabling clears them, and both commands report that a redeploy is required before outbound traffic changes.

Static Outbound IP status reports whether the feature is enabled, whether the returned assignment is high availability, and the assigned IPv4 addresses. It does not expose a legacy/single-IP mode in the CLI contract.

Outbound IPv6 commands stage an environment config patch for `deploy.ipv6EgressEnabled`, matching the current dashboard toggle. The CLI does not apply staged changes or trigger a redeploy; it reports that staged changes must be applied.

`railway outbound-network status` summarizes both Static Outbound IPs and Outbound IPv6 for the selected service and environment.

## API

Uses only Railway public GraphQL API operations:

- `egressGateways`
- `egressGatewayAssociationCreate`
- `egressGatewayAssociationsClear`
- `environmentStageChanges`
- `environmentStagedChanges`
- `environment { config }`

## JSON output

Action responses include a shared lifecycle object so automation can distinguish direct mutations from staged environment patches.

Static Outbound IP action responses use `direct` lifecycle mode. Outbound IPv6 action responses use `environmentPatch` lifecycle mode.

## Tests

Added coverage for:

- outbound network subcommand parsing, selectors, and `--json`
- root CLI registration for `railway outbound-network`
- Static Outbound IP status derivation for enabled, disabled, and high-availability gateway data
- Static Outbound IP action lifecycle output
- Outbound IPv6 staged action lifecycle output
- `deploy.ipv6EgressEnabled` environment config serialization
- applied and staged Outbound IPv6 status parsing

Validated with:

```bash
cargo fmt
cargo test
cargo clippy
git diff --check
```

Also validated against a real Railway account by creating a disposable project and service, deploying a minimal Dockerfile app, running the full JSON command matrix, running representative human-output commands, verifying Static Outbound IP enable/disable behavior, verifying Outbound IPv6 staged behavior, and leaving the temporary project available for manual follow-up testing.