### PR TITLE
Reduce autoupdate check window

### DIFF
--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -16,7 +16,7 @@ const SKILLS_PATH_PREFIX: &str = "plugins/railway/skills/";
 /// Returns the bare 40-char commit SHA of the skills repo's default branch.
 const SKILLS_SHA_URL: &str = "https://api.github.com/repos/railwayapp/railway-skills/commits/main";
 /// How often the background task re-checks upstream for a newer skills commit.
-const SKILLS_CHECK_INTERVAL_HOURS: i64 = 12;
+const SKILLS_CHECK_INTERVAL_HOURS: i64 = 1;
 
 /// Install Railway agent skills for AI coding tools (Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, Factory Droid, and all tools that support .agents/skills)
 ///
@@ -353,7 +353,7 @@ pub(crate) fn cached_skill_auto_apply_due() -> bool {
 }
 
 /// Background staleness check, run from the same task as the CLI version check.
-/// 12h-gated and best-effort: refreshes the cached upstream SHA so the next
+/// Hourly-gated and best-effort: refreshes the cached upstream SHA so the next
 /// invocation's banner is accurate. Skips entirely when no skills are installed.
 pub(crate) async fn refresh_skill_update_state() {
     let Some(home) = dirs::home_dir() else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,10 @@ mod commands;
 use commands::*;
 use config::Configs;
 use is_terminal::IsTerminal;
-use util::{check_update::UpdateCheck, compare_semver::compare_semver};
+use util::{
+    check_update::{UPDATE_CHECK_INTERVAL_HOURS, UpdateCheck},
+    compare_semver::compare_semver,
+};
 
 mod client;
 mod config;
@@ -284,11 +287,11 @@ async fn main() -> Result<()> {
     let skipped_version = update.skipped_version.clone();
     let check_gate_armed = update
         .last_update_check
-        .map(|t| (chrono::Utc::now() - t) < chrono::Duration::hours(12))
+        .map(|t| (chrono::Utc::now() - t) < chrono::Duration::hours(UPDATE_CHECK_INTERVAL_HOURS))
         .unwrap_or(false);
 
     // Pass any pending version to spawn_update_task so it can skip the
-    // 12h short-circuit and retry a download that timed out in a
+    // interval short-circuit and retry a download that timed out in a
     // prior run.  The background task clears latest_version on success.
     //
     // If the running binary has already caught up to (or surpassed) the

--- a/src/util/check_update.rs
+++ b/src/util/check_update.rs
@@ -162,12 +162,18 @@ struct GithubApiRelease {
 }
 
 const GITHUB_API_RELEASE_URL: &str = "https://api.github.com/repos/railwayapp/cli/releases/latest";
+/// How often the background task re-checks GitHub for a newer CLI release.
+pub const UPDATE_CHECK_INTERVAL_HOURS: i64 = 1;
+
 pub async fn check_update(force: bool) -> anyhow::Result<Option<String>> {
     let update = UpdateCheck::read().unwrap_or_default();
 
     if let Some(last_update_check) = update.last_update_check {
-        // 12-hour gate: avoid hitting the GitHub API on every invocation.
-        if (chrono::Utc::now() - last_update_check) < chrono::Duration::hours(12) && !force {
+        // Avoid hitting the GitHub API on every invocation.
+        if (chrono::Utc::now() - last_update_check)
+            < chrono::Duration::hours(UPDATE_CHECK_INTERVAL_HOURS)
+            && !force
+        {
             return Ok(None);
         }
     }
@@ -189,7 +195,7 @@ pub async fn check_update(force: bool) -> anyhow::Result<Option<String>> {
             // were changed while the network request was in flight (e.g.
             // `skipped_version` set by a concurrent rollback).
             let mut fresh = UpdateCheck::read().unwrap_or_default();
-            // Don't arm the daily gate when the latest release is the version
+            // Don't arm the interval gate when the latest release is the version
             // the user rolled back from — keep checking so a fix release
             // published shortly after is discovered promptly.
             if fresh.skipped_version.as_deref() != Some(latest_version) {


### PR DESCRIPTION
## Summary

- Reduce the CLI auto-update GitHub freshness gate from 12 hours to 1 hour.
- Reuse a named CLI update interval constant in startup cache dispatch.
- Match Railway skills background freshness checks to the same hourly cadence and update stale comments.

## Impact

Auto-update discovery happens sooner after a release. The install/apply paths still keep their existing package-manager retry throttle and background process guards, so this increases release/SHA check frequency without increasing repeated install pressure.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test`