### PR TITLE
Add explicit project targeting to railway status

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -72,12 +72,20 @@ pub async fn command(args: Args) -> Result<()> {
     )?;
 
     if args.json {
+        let json_environment = if should_scope_json_to_environment(
+            target.explicit_project,
+            args.environment.as_deref(),
+        ) {
+            environment
+        } else {
+            None
+        };
         let project_json = project_json_with_environment_instances(
             &client,
             &configs,
             &target.project_id,
             &project,
-            environment,
+            json_environment,
         )
         .await?;
         println!("{}", serde_json::to_string_pretty(&project_json)?);
@@ -137,6 +145,10 @@ pub async fn command(args: Args) -> Result<()> {
     println!();
 
     Ok(())
+}
+
+fn should_scope_json_to_environment(explicit_project: bool, environment_arg: Option<&str>) -> bool {
+    explicit_project || environment_arg.is_some()
 }
 
 fn ensure_status_args(args: &Args) -> Result<()> {
@@ -748,6 +760,13 @@ mod tests {
             let error = ensure_status_args(&args).unwrap_err().to_string();
             assert_eq!(error, "--environment is required when using --project");
         }
+    }
+
+    #[test]
+    fn status_json_scoping_preserves_linked_project_default() {
+        assert!(!should_scope_json_to_environment(false, None));
+        assert!(should_scope_json_to_environment(false, Some("production")));
+        assert!(should_scope_json_to_environment(true, Some("production")));
     }
 
     #[test]

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     controllers::{
         config::{EnvironmentConfig, environment::fetch_environment_config},
-        environment::ensure_environment_accessible,
+        environment::get_matched_environment_edge,
         project::{
             ProjectEnvironmentInstances, ProjectServiceInstanceEdge,
             ensure_project_and_environment_exist, get_environment_instances, get_project,
@@ -218,12 +218,7 @@ fn find_environment<'a>(
     project: &'a ProjectProject,
     environment: &str,
 ) -> Result<&'a ProjectProjectEnvironmentsEdges> {
-    let environment = project
-        .environments
-        .edges
-        .iter()
-        .find(|env| env.node.name == environment || env.node.id == environment)
-        .ok_or_else(|| RailwayError::EnvironmentNotFound(environment.to_string()))?;
+    let environment = get_matched_environment_edge(project, environment.to_string())?;
     ensure_status_environment(&environment.node)?;
     Ok(environment)
 }
@@ -231,7 +226,6 @@ fn find_environment<'a>(
 fn ensure_status_environment(
     environment: &queries::project::ProjectProjectEnvironmentsEdgesNode,
 ) -> Result<()> {
-    ensure_environment_accessible(environment)?;
     if environment.deleted_at.is_some() {
         bail!(RailwayError::EnvironmentDeleted);
     }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -12,13 +12,15 @@ use crate::{
     },
     controllers::{
         config::{EnvironmentConfig, environment::fetch_environment_config},
+        environment::ensure_environment_accessible,
         project::{
             ProjectEnvironmentInstances, ProjectServiceInstanceEdge,
             ensure_project_and_environment_exist, get_environment_instances, get_project,
-            service_instances_in_env, volume_instances_in_env,
+            resolve_project_id_or_name, service_instances_in_env, volume_instances_in_env,
         },
         regions::fetch_region_locations,
     },
+    errors::RailwayError,
     resources::{
         ResourceKind, classify_service_instance, database_label, name_mentions, project_bucket_name,
     },
@@ -26,34 +28,58 @@ use crate::{
 
 use super::*;
 
-/// Show information about the current project
+/// Show information about a Railway project
 #[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway status\n  railway status --json\n  railway status --project project-id --environment production\n  railway status --project project-id --environment production --json\n\nAutomation notes:\n  Explicit --project output requires --environment for both human-readable and JSON output."
+)]
 pub struct Args {
+    /// Project ID/name to inspect (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
+    /// Environment to inspect for human-readable resource details
+    #[clap(short, long)]
+    environment: Option<String>,
+
     /// Output in JSON format
     #[clap(long)]
     json: bool,
 }
 
 pub async fn command(args: Args) -> Result<()> {
+    ensure_status_args(&args)?;
+
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let linked_project = configs.get_linked_project().await?;
-    let project = get_project(&client, &configs, linked_project.project.to_owned()).await?;
+    let target = resolve_status_target(&client, &configs, args.project).await?;
+    let project = get_project(&client, &configs, target.project_id.clone()).await?;
 
-    ensure_project_and_environment_exist(&client, &configs, &linked_project).await?;
+    if target.explicit_project {
+        if project.deleted_at.is_some() {
+            bail!(RailwayError::ProjectDeleted);
+        }
+    } else if let Some(linked_project) = target.linked_project.as_ref() {
+        ensure_project_and_environment_exist(&client, &configs, linked_project).await?;
+    } else if project.deleted_at.is_some() {
+        bail!(RailwayError::ProjectDeleted);
+    }
 
-    let environment = linked_project.environment.as_deref().and_then(|eid| {
-        project
-            .environments
-            .edges
-            .iter()
-            .find(|env| env.node.id == eid)
-    });
+    let environment = status_environment(
+        &project,
+        target.linked_project.as_ref(),
+        args.environment.as_deref(),
+    )?;
 
     if args.json {
-        let project_json =
-            project_json_with_environment_instances(&client, &configs, &linked_project, &project)
-                .await?;
+        let project_json = project_json_with_environment_instances(
+            &client,
+            &configs,
+            &target.project_id,
+            &project,
+            environment,
+        )
+        .await?;
         println!("{}", serde_json::to_string_pretty(&project_json)?);
         return Ok(());
     }
@@ -77,26 +103,23 @@ pub async fn command(args: Args) -> Result<()> {
 
     let environment_instances = if let Some(environment) = environment {
         Some(
-            get_environment_instances(
-                &client,
-                &configs,
-                &linked_project.project,
-                &environment.node.id,
-            )
-            .await?,
+            get_environment_instances(&client, &configs, &target.project_id, &environment.node.id)
+                .await?,
         )
     } else {
         None
     };
 
     print_context(&project, environment);
-    print_linked_service(
-        &project,
-        &linked_project,
-        environment,
-        environment_instances.as_ref(),
-        &region_locations,
-    );
+    if let Some(linked_project) = target.linked_project.as_ref() {
+        print_linked_service(
+            &project,
+            linked_project,
+            environment,
+            environment_instances.as_ref(),
+            &region_locations,
+        );
+    }
     if let (Some(environment), Some(environment_config)) =
         (environment, environment_config.as_ref())
     {
@@ -116,26 +139,117 @@ pub async fn command(args: Args) -> Result<()> {
     Ok(())
 }
 
-async fn project_json_with_environment_instances(
+fn ensure_status_args(args: &Args) -> Result<()> {
+    if args.project.is_some() && args.environment.is_none() {
+        bail!("--environment is required when using --project");
+    }
+    Ok(())
+}
+
+struct StatusTarget {
+    project_id: String,
+    linked_project: Option<LinkedProject>,
+    explicit_project: bool,
+}
+
+async fn resolve_status_target(
     client: &reqwest::Client,
     configs: &Configs,
-    linked_project: &LinkedProject,
-    project: &ProjectProject,
-) -> Result<Value> {
-    let mut project_json = serde_json::to_value(project)?;
-    initialize_environment_instance_fields(&mut project_json);
+    project_arg: Option<String>,
+) -> Result<StatusTarget> {
+    if let Some(project_arg) = project_arg {
+        let project_id = resolve_project_id_or_name(client, configs, &project_arg).await?;
+        let linked_project = configs
+            .get_linked_project()
+            .await
+            .ok()
+            .filter(|linked_project| linked_project.project == project_id);
 
-    let environment_ids = project
+        return Ok(StatusTarget {
+            project_id,
+            linked_project,
+            explicit_project: true,
+        });
+    }
+
+    let linked_project = configs.get_linked_project().await?;
+    Ok(StatusTarget {
+        project_id: linked_project.project.clone(),
+        linked_project: Some(linked_project),
+        explicit_project: false,
+    })
+}
+
+fn status_environment<'a>(
+    project: &'a ProjectProject,
+    linked_project: Option<&LinkedProject>,
+    environment_arg: Option<&str>,
+) -> Result<Option<&'a ProjectProjectEnvironmentsEdges>> {
+    if let Some(environment_arg) = environment_arg {
+        return find_environment(project, environment_arg).map(Some);
+    }
+
+    let linked_environment = linked_project.and_then(|linked_project| {
+        linked_project
+            .environment_name
+            .as_deref()
+            .or(linked_project.environment.as_deref())
+    });
+    if let Some(environment) = linked_environment {
+        return find_environment(project, environment).map(Some);
+    }
+
+    Ok(None)
+}
+
+fn find_environment<'a>(
+    project: &'a ProjectProject,
+    environment: &str,
+) -> Result<&'a ProjectProjectEnvironmentsEdges> {
+    let environment = project
         .environments
         .edges
         .iter()
-        .filter(|env| env.node.can_access)
-        .map(|environment| environment.node.id.clone())
-        .collect::<Vec<_>>();
-    let project_id = linked_project.project.clone();
+        .find(|env| env.node.name == environment || env.node.id == environment)
+        .ok_or_else(|| RailwayError::EnvironmentNotFound(environment.to_string()))?;
+    ensure_status_environment(&environment.node)?;
+    Ok(environment)
+}
+
+fn ensure_status_environment(
+    environment: &queries::project::ProjectProjectEnvironmentsEdgesNode,
+) -> Result<()> {
+    ensure_environment_accessible(environment)?;
+    if environment.deleted_at.is_some() {
+        bail!(RailwayError::EnvironmentDeleted);
+    }
+    Ok(())
+}
+
+async fn project_json_with_environment_instances(
+    client: &reqwest::Client,
+    configs: &Configs,
+    project_id: &str,
+    project: &ProjectProject,
+    environment: Option<&ProjectProjectEnvironmentsEdges>,
+) -> Result<Value> {
+    let mut project_json = serde_json::to_value(project)?;
+    filter_project_json_to_environment(&mut project_json, environment);
+    initialize_environment_instance_fields(&mut project_json);
+
+    let environment_ids = match environment {
+        Some(environment) => vec![environment.node.id.clone()],
+        None => project
+            .environments
+            .edges
+            .iter()
+            .filter(|env| env.node.can_access)
+            .map(|environment| environment.node.id.clone())
+            .collect::<Vec<_>>(),
+    };
     let instances_by_environment =
         futures::future::try_join_all(environment_ids.into_iter().map(|environment_id| {
-            let project_id = project_id.clone();
+            let project_id = project_id.to_string();
             async move {
                 let instances =
                     get_environment_instances(client, configs, &project_id, &environment_id)
@@ -150,6 +264,30 @@ async fn project_json_with_environment_instances(
     }
 
     Ok(project_json)
+}
+
+fn filter_project_json_to_environment(
+    project_json: &mut Value,
+    environment: Option<&ProjectProjectEnvironmentsEdges>,
+) {
+    let Some(environment) = environment else {
+        return;
+    };
+
+    let Some(environment_edges) = project_json
+        .get_mut("environments")
+        .and_then(|environments| environments.get_mut("edges"))
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+
+    environment_edges.retain(|edge| {
+        edge.get("node")
+            .and_then(|node| node.get("id"))
+            .and_then(Value::as_str)
+            == Some(environment.node.id.as_str())
+    });
 }
 
 fn initialize_environment_instance_fields(project_json: &mut Value) {
@@ -585,4 +723,59 @@ fn resource_details(
         region_locations,
     );
     service_resource_details(&row)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_status_project_short_flag() {
+        let args = Args::parse_from(["status", "-p", "project-id"]);
+
+        assert_eq!(args.project.as_deref(), Some("project-id"));
+        assert!(args.environment.is_none());
+        assert!(!args.json);
+    }
+
+    #[test]
+    fn status_project_requires_environment_when_project_is_explicit() {
+        for argv in [
+            ["status", "--project", "project-id"].as_slice(),
+            ["status", "--project", "project-id", "--json"].as_slice(),
+        ] {
+            let args = Args::parse_from(argv);
+            let error = ensure_status_args(&args).unwrap_err().to_string();
+            assert_eq!(error, "--environment is required when using --project");
+        }
+    }
+
+    #[test]
+    fn status_project_allows_project_environment_with_optional_json() {
+        for argv in [
+            [
+                "status",
+                "--project",
+                "project-id",
+                "--environment",
+                "production",
+            ]
+            .as_slice(),
+            [
+                "status",
+                "--project",
+                "project-id",
+                "--environment",
+                "production",
+                "--json",
+            ]
+            .as_slice(),
+        ] {
+            let args = Args::parse_from(argv);
+
+            assert_eq!(args.project.as_deref(), Some("project-id"));
+            assert_eq!(args.environment.as_deref(), Some("production"));
+            ensure_status_args(&args).unwrap();
+        }
+    }
 }

--- a/src/controllers/environment.rs
+++ b/src/controllers/environment.rs
@@ -1,5 +1,8 @@
 use crate::{
-    commands::queries::{RailwayProject, project::ProjectProjectEnvironmentsEdgesNode},
+    commands::queries::{
+        RailwayProject,
+        project::{ProjectProjectEnvironmentsEdges, ProjectProjectEnvironmentsEdgesNode},
+    },
     errors::RailwayError,
 };
 use anyhow::{Result, bail};
@@ -8,6 +11,15 @@ pub fn get_matched_environment(
     project: &RailwayProject,
     environment: String,
 ) -> Result<ProjectProjectEnvironmentsEdgesNode> {
+    Ok(get_matched_environment_edge(project, environment)?
+        .node
+        .clone())
+}
+
+pub fn get_matched_environment_edge<'a>(
+    project: &'a RailwayProject,
+    environment: String,
+) -> Result<&'a ProjectProjectEnvironmentsEdges> {
     let environment = project
         .environments
         .edges
@@ -17,7 +29,7 @@ pub fn get_matched_environment(
 
     ensure_environment_accessible(&environment.node)?;
 
-    Ok(environment.node.clone())
+    Ok(environment)
 }
 
 pub fn ensure_environment_accessible(


### PR DESCRIPTION
## Summary

- Add `--project/-p` and `--environment/-e` to `railway status`
- Require `--environment` whenever `--project` is used, including JSON output
- Scope explicit-project JSON output to the selected environment and avoid relying on local link state for explicit project status

## Testing

- `cargo test commands::status::tests`
- `cargo check`
- Live Railway checks:
  - `target/debug/railway status --project obnet-e2e-624a --environment production --json`
  - `target/debug/railway status --project obnet-e2e-624a --environment production`
  - `target/debug/railway status --project obnet-e2e-624a --json` (expected failure)
