### PR TITLE
fix(auth): serialize token refresh to prevent self-inflicted logout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -173,16 +173,47 @@ pub(crate) fn auth_failure_error() -> RailwayError {
 }
 
 /// Ensures the OAuth access token is still valid, refreshing if needed.
+///
+/// The refresh is a read-modify-write of the on-disk credentials, and the
+/// backboard server rotates (and reuse-detects) the refresh token on every
+/// refresh. If two CLI invocations refresh concurrently, the second presents
+/// an already-consumed refresh token and the server revokes the entire grant —
+/// a hard logout. To prevent this we serialize the refresh behind an exclusive
+/// file lock on a dedicated lockfile under `~/.railway/`, then re-read the
+/// config and re-check expiry after acquiring the lock: whichever process wins
+/// the lock performs the single refresh, and the others pick up its result.
 pub async fn ensure_valid_token(configs: &mut Configs) -> Result<()> {
     // Env var tokens are not managed by us
     if Configs::get_railway_token().is_some() || Configs::get_railway_api_token().is_some() {
         return Ok(());
     }
 
+    // Fast path: nothing to refresh.
     if !configs.has_oauth_token() || !configs.is_token_expired() {
         return Ok(());
     }
 
+    // Serialize the refresh across concurrent CLI processes. If we can't take
+    // the lock (e.g. a stale/wedged lock, unsupported filesystem), fall back to
+    // refreshing without it rather than wedging the CLI — see `refresh_tokens`.
+    let lock_guard = ConfigLockGuard::acquire();
+
+    // Re-read credentials now that we hold the lock: another process may have
+    // already refreshed while we were waiting, in which case we skip the
+    // refresh entirely and use the freshly-rotated token it wrote.
+    if lock_guard.is_some() {
+        configs.reload()?;
+        if !configs.has_oauth_token() || !configs.is_token_expired() {
+            return Ok(());
+        }
+    }
+
+    refresh_tokens(configs).await
+}
+
+/// Perform the actual OAuth refresh + persist. The caller is expected to hold
+/// the config lock (when available) and to have re-checked expiry.
+async fn refresh_tokens(configs: &mut Configs) -> Result<()> {
     let refresh_token = configs.get_refresh_token().ok_or_else(|| {
         RailwayError::OAuthRefreshFailed("No refresh token available".to_string())
     })?;
@@ -197,6 +228,84 @@ pub async fn ensure_valid_token(configs: &mut Configs) -> Result<()> {
     )?;
 
     Ok(())
+}
+
+/// How long to wait for the config lock before giving up and refreshing
+/// without it. Kept short so a stale lock can never wedge the CLI for long.
+const CONFIG_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+/// Poll interval while waiting for the config lock.
+const CONFIG_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// RAII guard around an exclusive advisory lock on the config lockfile.
+/// Releasing the lock (and dropping the file handle) happens on drop, covering
+/// all error paths.
+struct ConfigLockGuard {
+    file: std::fs::File,
+}
+
+impl ConfigLockGuard {
+    /// Try to acquire the exclusive config lock, retrying up to
+    /// [`CONFIG_LOCK_TIMEOUT`]. Returns `None` (with a warning) on any failure
+    /// so the caller can fall back to an unlocked refresh rather than wedge.
+    fn acquire() -> Option<Self> {
+        use fs2::FileExt;
+
+        let lock_path = match Configs::config_lock_path() {
+            Ok(path) => path,
+            Err(e) => {
+                eprintln!(
+                    "{}: {e}",
+                    "Warning: could not determine config lock path".yellow()
+                );
+                return None;
+            }
+        };
+
+        if let Some(parent) = lock_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                eprintln!(
+                    "{}: {e}",
+                    "Warning: could not create config directory for lock".yellow()
+                );
+                return None;
+            }
+        }
+
+        let file = match std::fs::File::create(&lock_path) {
+            Ok(file) => file,
+            Err(e) => {
+                eprintln!(
+                    "{}: {e}",
+                    "Warning: could not open config lock file".yellow()
+                );
+                return None;
+            }
+        };
+
+        let deadline = std::time::Instant::now() + CONFIG_LOCK_TIMEOUT;
+        loop {
+            if file.try_lock_exclusive().is_ok() {
+                return Some(Self { file });
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!(
+                    "{}",
+                    "Warning: timed out waiting for config lock; refreshing without it".yellow()
+                );
+                return None;
+            }
+            std::thread::sleep(CONFIG_LOCK_POLL_INTERVAL);
+        }
+    }
+}
+
+impl Drop for ConfigLockGuard {
+    fn drop(&mut self) {
+        use fs2::FileExt;
+        // Best-effort unlock; the lock is also released when the file handle is
+        // dropped immediately after.
+        let _ = FileExt::unlock(&self.file);
+    }
 }
 
 /// Like post_graphql, but removes null values from the variables object before sending.

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,15 +117,7 @@ pub enum Environment {
 
 impl Configs {
     pub fn new() -> Result<Self> {
-        let environment = Self::get_environment_id();
-        let root_config_partial_path = match environment {
-            Environment::Production => ".railway/config.json",
-            Environment::Staging => ".railway/config-staging.json",
-            Environment::Dev => ".railway/config-dev.json",
-        };
-
-        let home_dir = dirs::home_dir().context("Unable to get home directory")?;
-        let root_config_path = std::path::Path::new(&home_dir).join(root_config_partial_path);
+        let root_config_path = Self::root_config_path()?;
 
         if let Ok(mut file) = File::open(&root_config_path) {
             let mut serialized_config = vec![];
@@ -149,6 +141,45 @@ impl Configs {
             root_config_path,
             root_config: RailwayConfig::default(),
         })
+    }
+
+    /// Absolute path to the root config file for the current environment.
+    fn root_config_path() -> Result<PathBuf> {
+        let root_config_partial_path = match Self::get_environment_id() {
+            Environment::Production => ".railway/config.json",
+            Environment::Staging => ".railway/config-staging.json",
+            Environment::Dev => ".railway/config-dev.json",
+        };
+
+        let home_dir = dirs::home_dir().context("Unable to get home directory")?;
+        Ok(std::path::Path::new(&home_dir).join(root_config_partial_path))
+    }
+
+    /// Path to the lockfile used to serialize credential read-modify-write
+    /// cycles (token refresh) across concurrent CLI invocations. This is a
+    /// dedicated lockfile, never `config.json` itself, so locking never
+    /// interferes with the atomic config write.
+    pub fn config_lock_path() -> Result<PathBuf> {
+        let home_dir = dirs::home_dir().context("Unable to get home directory")?;
+        Ok(home_dir.join(".railway").join(".config.lock"))
+    }
+
+    /// Re-read the root config from disk, discarding any in-memory state.
+    /// Used after acquiring the config lock so a refresh sees credentials
+    /// freshly written by another concurrent process.
+    pub fn reload(&mut self) -> Result<()> {
+        match File::open(&self.root_config_path) {
+            Ok(mut file) => {
+                let mut serialized_config = vec![];
+                file.read_to_end(&mut serialized_config)?;
+                self.root_config = serde_json::from_slice(&serialized_config)
+                    .unwrap_or_else(|_| RailwayConfig::default());
+            }
+            Err(_) => {
+                self.root_config = RailwayConfig::default();
+            }
+        }
+        Ok(())
     }
 
     pub fn reset(&mut self) -> Result<()> {
@@ -254,7 +285,13 @@ impl Configs {
         anyhow::ensure!(expires_in > 0, "Server returned non-positive expires_in");
         let expires_at = chrono::Utc::now().timestamp() + expires_in;
         self.root_config.user.access_token = Some(access_token.to_string());
-        self.root_config.user.refresh_token = refresh_token.map(|s| s.to_string());
+        // Only overwrite the stored refresh token when the server actually
+        // returned a new one. A 200 response that omits `refresh_token` means
+        // the existing refresh token is still valid, so preserve it rather than
+        // nulling it out (which would force a re-login on the next refresh).
+        if let Some(refresh_token) = refresh_token {
+            self.root_config.user.refresh_token = Some(refresh_token.to_string());
+        }
         self.root_config.user.token_expires_at = Some(expires_at);
         self.root_config.user.token = None; // Clear legacy token
         self.write()


### PR DESCRIPTION
## Problem

The Railway CLI logs users out frequently, forcing repeated `railway login`.

Root cause is a concurrency race in credential refresh:
- The CLI persists OAuth credentials to `~/.railway/config.json` with a whole-file, last-writer-wins write and **no lock**.
- The server rotates the refresh token on every refresh and reuse-detects it: presenting an already-consumed (rotated) refresh token revokes the entire grant.
- So two concurrent CLI invocations past the 1h access-token expiry (e.g. a long-running `railway mcp` process alongside an interactive command, or a shell-prompt integration) both read the same refresh token and both POST `grant_type=refresh_token`. The second presents a now-consumed token → grant revoked → hard logout. Last-writer-wins can also overwrite a freshly-rotated token with a stale one.

Confirmed in production: ~128k/7d `refresh token not found` failures on the server's token endpoint, 99.6% from the CLI's OAuth client.

## Change

- **Serialize refresh behind an exclusive file lock** (`~/.railway/.config.lock`, a dedicated lockfile — never `config.json` itself). After acquiring the lock, re-read the config and re-check expiry: only the lock winner refreshes; the others pick up its freshly-rotated token.
  - RAII guard releases the lock on every path (including errors / early returns).
  - 10s acquisition timeout with a graceful **unlocked fallback** (warn + refresh anyway) so a stale lock can never wedge the CLI.
  - Fast path (token still valid) is unchanged and takes no lock.
- **Preserve the existing refresh token** when a refresh response omits one, instead of nulling it.

## Companion

This is the client-side half. The complementary server-side change (stop rotating public-client refresh tokens on every refresh) is in `railwayapp/mono`: railwayapp/mono#32205.

## Testing

- `cargo check` clean; `cargo fmt --check` clean.
- `cargo test --bin railway config::` (24 passed) and `client::` (4 passed).
- clippy failures in this tree are pre-existing (graphql_client-generated code) and unrelated — confirmed by re-running on a clean tree.

## Review notes

- `fs2` advisory locks coordinate correctly between cooperating CLI processes (the race in scope). On network filesystems advisory locking can be unreliable, but `~/.railway` is normally local; the unlocked fallback degrades to today's behavior rather than wedging.
- Lock timeout is 10s (`CONFIG_LOCK_TIMEOUT`) — comfortably covers a refresh round-trip; bump if refreshes can ever exceed that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
