### PR TITLE
fix: update audited dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -602,7 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3458,7 +3458,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.1",
+ "socket2 0.5.8",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3467,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes 1.11.1",
  "getrandom 0.3.4",
@@ -3848,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64",
@@ -3870,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3902,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.60.2"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e358980fe9b079b99da387117864ee6f0a3fd02f39e5b5fde6af9c2895374"
+checksum = "324b92f459d3e42da294e14e8eb150d2215fcfb7c966838bc1127cd68bc05a0d"
 dependencies = [
  "aead 0.6.0-rc.10",
  "aes 0.8.4",
@@ -3984,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "russh-cryptovec"
-version = "0.59.0"
+version = "0.60.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36140e8a20297bc2e8338807c3d9ca911f7fa49d7539cbcd6d48d3befd70efd8"
+checksum = "37cb4d0360bdd8935392a306d8b5edb539cc455b30e8bf13dd213a0cf7879b40"
 dependencies = [
  "log",
  "nix 0.31.3",
@@ -4085,7 +4085,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4792,7 +4792,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5458,7 +5458,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ async-trait = "0.1.89"
 ratatui = "0.29"
 scopeguard = "1.2"
 schemars = "0.8"
-rmcp = { version = "0.16", features = ["transport-io"] }
+rmcp = { version = "1.4", features = ["transport-io"] }
 toml = "0.8"
 termimad = "0.28"
 csv = "1.3"

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -1823,6 +1823,18 @@ impl RailwayMcp {
     }
 }
 
+fn railway_mcp_server_info() -> ServerInfo {
+    let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+        .with_server_info(Implementation::new("railway", env!("CARGO_PKG_VERSION")))
+        .with_instructions(
+            "Railway MCP server. Manage your Railway projects, services, deployments, and more.",
+        );
+    // Preserve the protocol version advertised by rmcp 0.16.0 so older MCP
+    // clients are not forced onto the newer 2025-06-18 protocol by this bump.
+    info.protocol_version = ProtocolVersion::V_2025_03_26;
+    info
+}
+
 impl ServerHandler for RailwayMcp {
     async fn initialize(
         &self,
@@ -1903,21 +1915,7 @@ impl ServerHandler for RailwayMcp {
     }
 
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: ProtocolVersion::default(),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            server_info: Implementation {
-                name: "railway".to_string(),
-                title: None,
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                description: None,
-                icons: None,
-                website_url: None,
-            },
-            instructions: Some(
-                "Railway MCP server. Manage your Railway projects, services, deployments, and more.".to_string(),
-            ),
-        }
+        railway_mcp_server_info()
     }
 }
 
@@ -1938,6 +1936,16 @@ mod tests {
         assert!(names.contains(&"create_tcp_proxy"));
         assert!(names.contains(&"get_tcp_proxy"));
         assert!(names.contains(&"remove_tcp_proxy"));
+    }
+
+    #[test]
+    fn server_info_preserves_advertised_protocol_version() {
+        let info = railway_mcp_server_info();
+
+        assert_eq!(info.protocol_version, ProtocolVersion::V_2025_03_26);
+        assert_eq!(info.server_info.name, "railway");
+        assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
+        assert!(info.instructions.is_some());
     }
 
     fn sample_domain() -> McpDomainDetails {


### PR DESCRIPTION
## Summary

- Fix the failing `Cargo audit` check by updating `rmcp` from `0.16` to `1.4`
- Update additional audited dependencies flagged by the current RustSec DB:
  - `quinn-proto` to `0.11.15`
  - `russh` to `0.60.3`
  - `russh-cryptovec` to `0.60.3`
- Adjust MCP server metadata construction for `rmcp` non-exhaustive model structs
- Preserve the previously advertised MCP protocol version, `2025-03-26`, so older clients are not forced onto `rmcp 1.4`'s newer `2025-06-18` default

## Testing

- `cargo fmt --check`
- `cargo check --locked --all-targets`
- `cargo test server_info_preserves_advertised_protocol_version --locked`
- `cargo test --locked`
- `/private/tmp/cargo-audit-root/bin/cargo-audit audit`

## Notes

`cargo audit` now exits successfully. Remaining audit output is limited to allowed warnings.