### PR TITLE
fix(npm): install musl binaries on Linux and surface binary crashes

### DIFF
--- a/bin/railway.js
+++ b/bin/railway.js
@@ -12,5 +12,10 @@ try {
 		stdio: "inherit",
 	});
 } catch (e) {
-	exit(1);
+	if (e.signal) {
+		console.error(
+			`The railway binary crashed with ${e.signal}. Please report this at https://github.com/railwayapp/cli/issues`,
+		);
+	}
+	exit(typeof e.status === "number" ? e.status : 1);
 }

--- a/npm-install/postinstall.js
+++ b/npm-install/postinstall.js
@@ -19,9 +19,20 @@ async function install() {
 
 	// Fetch Static Config
 	let { name: binName, path: binPath, url } = CONFIG;
-	let triple = triples.platformArchTriples[process.platform][process.arch][0];
+	// Linux: statically linked musl builds, same policy as install.sh (the gnu
+	// build crashes on some hosts, see #998; arm/arm64 only publish musl).
+	const linuxTargets = {
+		x64: "x86_64-unknown-linux-musl",
+		arm64: "aarch64-unknown-linux-musl",
+		ia32: "i686-unknown-linux-musl",
+		arm: "arm-unknown-linux-musleabihf",
+	};
+	const triple =
+		process.platform === "linux"
+			? linuxTargets[process.arch]
+			: triples.platformArchTriples[process.platform][process.arch][0].raw;
 
-	url = url.replace(/{{triple}}/g, triple.raw);
+	url = url.replace(/{{triple}}/g, triple);
 	url = url.replace(/{{version}}/g, version);
 	url = url.replace(/{{bin_name}}/g, binName);
 	console.log(url);


### PR DESCRIPTION
Fixes #998.

## Problem

When installed via npm on some Linux hosts, `railway login --browserless` (and in fact every network command) exits `1` with no output. The reporter saw a silent failure inside a TTY, which looked like a TTY-detection bug but is actually two stacked defects in the npm distribution channel.

## Root cause

**1. npm ships the `gnu` binary on Linux, which can crash.**
`npm-install/postinstall.js` resolves the download target via `@napi-rs/triples`, whose first Linux entry is the `*-unknown-linux-gnu` triple. On some Linux hosts that binary hits a general protection fault in vendored crypto during the TLS key exchange, so it dies with `SIGSEGV` on the first network call:

```text
traps: railway[…] general protection fault … in railway[…]
```

The musl binary built from the same source works on the same host. This is also why `install.sh` already prefers musl on Linux:

```sh
# use the statically compiled musl bins on linux to avoid linking issues.
linux) platform="unknown-linux-musl" ;;
```

The `gnu`-first ordering has two more consequences: npm installs **404 on `aarch64` and `arm` Linux**, because only musl assets are published for those architectures.

**2. The bin wrapper hides the crash.**
`bin/railway.js` ran the binary and collapsed *any* failure into `exit(1)`, discarding both the crash signal and the binary's real exit code — turning the segfault into a silent `exit 1`.

## Changes

| File | Change |
| --- | --- |
| `npm-install/postinstall.js` | Resolve Linux targets through an explicit musl map matching the published release assets. Other platforms keep the existing `triples` lookup. |
| `bin/railway.js` | Print an actionable message when the binary is killed by a signal, and propagate the binary's real exit code instead of always `1`. |

Two files, one hunk each. No Rust/binary changes.

## Testing

Verified on an affected Linux host by installing this branch as the global package:

- **postinstall** now downloads `…-x86_64-unknown-linux-musl.tar.gz`; the resulting binary is static-pie/musl.
- **`railway login --browserless`** (the exact #998 repro, in a TTY) now prints the device-code sign-in flow and polls, instead of exiting `1` silently.
- **Exit codes** propagate: an unknown subcommand returns `2` (was `1`); an unauthenticated `whoami` returns a clean `1` (was `SIGSEGV`/`139`).
- **Wrapper matrix** (stub binaries): exit `0` → `0`, exit `2` → `2`, `SIGSEGV` → actionable message + `1`.
- **Target map** resolves to a published asset for every Linux arch (`x64`, `arm64`, `ia32`, `arm`); `darwin`/`win32` unchanged.

## Notes

- Suggested release label: `release/patch` — the fix reaches users through a version bump on npm.
- A separate follow-up may be worth opening for *why* the `gnu` artifact faults (toolchain/CPU baseline), so the `gnu` build can either be repaired or dropped from the published matrix. This PR removes user impact by not shipping it to npm Linux users, matching `install.sh`.
