### PR TITLE
Pin npm to 11.x for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,11 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
+      # Node 24 bundles npm 12, whose publish provenance path crashes
+      # (npm/cli#9722); npm 11.5+ keeps Trusted Publisher support
+      - name: Pin npm 11
+        run: npm install -g npm@11
+
       - name: NPM publish
         run: npm publish --access public
 


### PR DESCRIPTION
The publish-npm job runs on `setup-node` with Node 24, which bundles npm 12 — and npm 12's publish provenance path crashes with `Cannot find module 'sigstore'`. Adds an explicit `npm install -g npm@11` pin before publish; 11.5+ retains Trusted Publisher support. Unpin when the upstream issue closes.

Companion: railway-ts-sdk#49 pins its `npm@latest` trusted-publisher step the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)