### PR TITLE
Add Railway API escape hatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,6 +3548,7 @@ dependencies = [
  "fs2",
  "futures 0.3.31",
  "futures-util",
+ "graphql-parser",
  "graphql-ws-client",
  "graphql_client",
  "gzp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ chrono = { version = "0.4.39", features = [
   "clock",
 ], default-features = false }
 graphql_client = "0.14.0"
+graphql-parser = "0.4.1"
 tokio = { version = "1.48.0", features = ["full"] }
 clap_complete = "4.5.40"
 open = "5.3.1"

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -1,0 +1,1027 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::{self, Read, Write},
+    time::Instant,
+};
+
+use anyhow::{Context, anyhow, bail};
+use clap::{Args as ClapArgs, Subcommand, ValueEnum};
+use is_terminal::IsTerminal;
+use serde::Serialize;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::telemetry::{self, CliApiTrackEvent};
+
+use super::*;
+
+const BUNDLED_SCHEMA: &str = include_str!("../gql/schema.json");
+const MAX_TELEMETRY_QUERY_BYTES: usize = 8192;
+
+/// Query the Railway public GraphQL API
+#[derive(Parser, Debug)]
+#[command(
+    about = "Query the Railway public GraphQL API",
+    long_about = "Query the Railway public GraphQL API.\n\nUse `railway api search <term>` and `railway api describe <name>` to inspect the schema before running a query."
+)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[command(flatten)]
+    execute: ExecuteArgs,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Print the bundled or live GraphQL introspection schema
+    Schema(SchemaArgs),
+    /// Search GraphQL types and fields
+    Search(SearchArgs),
+    /// Describe a GraphQL type or field
+    Describe(DescribeArgs),
+}
+
+#[derive(ClapArgs, Clone, Debug, Default)]
+struct ExecuteArgs {
+    /// GraphQL query or mutation document. If omitted, stdin is used when piped.
+    #[arg(value_name = "QUERY", allow_hyphen_values = true)]
+    query: Option<String>,
+
+    /// Read the GraphQL document from a file. Use '-' to read from stdin.
+    #[arg(short, long, value_name = "PATH")]
+    file: Option<String>,
+
+    /// JSON variables object, or @PATH to read JSON from a file. Use @- for stdin.
+    #[arg(long, value_name = "JSON|@PATH")]
+    variables: Option<String>,
+
+    /// Set a typed variable as KEY=VALUE. VALUE is parsed as JSON when possible.
+    #[arg(long = "var", value_name = "KEY=VALUE")]
+    vars: Vec<String>,
+
+    /// Set a string variable as KEY=VALUE.
+    #[arg(long = "raw-var", value_name = "KEY=VALUE")]
+    raw_vars: Vec<String>,
+
+    /// GraphQL operation name to execute when the document contains multiple operations.
+    #[arg(long, value_name = "NAME")]
+    operation_name: Option<String>,
+
+    /// Print compact JSON.
+    #[arg(long)]
+    compact: bool,
+
+    /// Exit successfully even when the GraphQL response has an errors array.
+    #[arg(long)]
+    allow_errors: bool,
+}
+
+#[derive(ClapArgs, Debug)]
+struct SchemaArgs {
+    /// Fetch live introspection from the API instead of printing the bundled schema.
+    #[arg(long)]
+    refresh: bool,
+
+    /// Print compact JSON.
+    #[arg(long)]
+    compact: bool,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum SearchKind {
+    All,
+    Type,
+    Query,
+    Mutation,
+    Subscription,
+    Field,
+    Input,
+    Enum,
+}
+
+#[derive(ClapArgs, Debug)]
+struct SearchArgs {
+    /// Search term.
+    term: String,
+
+    /// Restrict search results to a kind.
+    #[arg(long, value_enum, default_value_t = SearchKind::All)]
+    kind: SearchKind,
+
+    /// Maximum number of results to print.
+    #[arg(long, default_value_t = 25, value_name = "N")]
+    limit: usize,
+
+    /// Print compact JSON.
+    #[arg(long)]
+    compact: bool,
+}
+
+#[derive(ClapArgs, Debug)]
+struct DescribeArgs {
+    /// Type name, root field name, or Parent.field.
+    name: String,
+
+    /// Print compact JSON.
+    #[arg(long)]
+    compact: bool,
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    match args.command {
+        Some(Commands::Schema(schema_args)) => run_schema(schema_args).await,
+        Some(Commands::Search(search_args)) => run_search(search_args).await,
+        Some(Commands::Describe(describe_args)) => run_describe(describe_args).await,
+        None => run_execute(args.execute).await,
+    }
+}
+
+async fn run_schema(args: SchemaArgs) -> Result<()> {
+    let started = Instant::now();
+    let mut event = CliApiTrackEvent::new("schema");
+    event.schema_source = Some(if args.refresh { "live" } else { "bundled" }.to_string());
+
+    let result = async {
+        let schema = if args.refresh {
+            let configs = Configs::new()?;
+            let client = GQLClient::new_authorized(&configs)?;
+            let response = send_graphql_request(
+                &client,
+                &configs.get_backboard(),
+                json!({ "query": introspection_query() }),
+            )
+            .await?;
+            event.http_status = Some(response.status.as_u16());
+            event.response_bytes = Some(response.body.len());
+            response_json(&response)?
+        } else {
+            bundled_schema()?
+        };
+
+        print_json(&schema, args.compact)?;
+        Ok(())
+    }
+    .await;
+
+    finish_api_event(&mut event, started, &result).await;
+    result
+}
+
+async fn run_search(args: SearchArgs) -> Result<()> {
+    let started = Instant::now();
+    let mut event = CliApiTrackEvent::new("search");
+    event.schema_source = Some("bundled".to_string());
+    event.search_term = Some(args.term.clone());
+
+    let result = async {
+        let schema = bundled_schema()?;
+        let results = search_schema(&schema, &args.term, &args.kind, args.limit)?;
+        print_json(&json!({ "results": results }), args.compact)?;
+        Ok(())
+    }
+    .await;
+
+    finish_api_event(&mut event, started, &result).await;
+    result
+}
+
+async fn run_describe(args: DescribeArgs) -> Result<()> {
+    let started = Instant::now();
+    let mut event = CliApiTrackEvent::new("describe");
+    event.schema_source = Some("bundled".to_string());
+    event.describe_name = Some(args.name.clone());
+
+    let result = async {
+        let schema = bundled_schema()?;
+        let descriptions = describe_schema_member(&schema, &args.name)?;
+        let output = if descriptions.len() == 1 {
+            descriptions.into_iter().next().unwrap()
+        } else {
+            json!({ "matches": descriptions })
+        };
+        print_json(&output, args.compact)?;
+        Ok(())
+    }
+    .await;
+
+    finish_api_event(&mut event, started, &result).await;
+    result
+}
+
+async fn run_execute(args: ExecuteArgs) -> Result<()> {
+    let started = Instant::now();
+    let mut event = CliApiTrackEvent::new("execute");
+
+    let result = execute_inner(args, &mut event).await;
+    finish_api_event(&mut event, started, &result).await;
+    result
+}
+
+async fn execute_inner(args: ExecuteArgs, event: &mut CliApiTrackEvent) -> Result<()> {
+    let query = resolve_query_source(args.query.as_deref(), args.file.as_deref(), false)?;
+    let variables = parse_variables(&VariableArgs {
+        variables: args.variables.as_deref(),
+        vars: &args.vars,
+        raw_vars: &args.raw_vars,
+        query_reads_stdin: query.read_from_stdin,
+    })?;
+
+    event.operation_name = args.operation_name.clone();
+    event.query_hash = Some(hash_query(&query.document));
+    event.query_document = telemetry_query_document(&query.document);
+    event.variable_keys = variable_keys(&variables);
+    event.variable_shape = Some(variable_shape(&variables));
+
+    let configs = Configs::new()?;
+    event.auth_mode = Some(auth_mode(&configs));
+
+    let client = GQLClient::new_authorized(&configs)?;
+    let body = graphql_body(
+        &query.document,
+        args.operation_name.as_deref(),
+        variables.clone(),
+    );
+
+    let response = send_graphql_request(&client, &configs.get_backboard(), body).await?;
+    event.http_status = Some(response.status.as_u16());
+    event.response_bytes = Some(response.body.len());
+
+    print_response_body(&response.body, args.compact)?;
+
+    let response_json = serde_json::from_str::<Value>(&response.body).ok();
+    if let Some(value) = response_json.as_ref() {
+        event.graphql_error_count = graphql_error_count(value);
+        event.graphql_error_codes = graphql_error_codes(value);
+    }
+
+    if !response.status.is_success() {
+        bail!("Railway API request failed with HTTP {}", response.status);
+    }
+
+    if !args.allow_errors && event.graphql_error_count.unwrap_or(0) > 0 {
+        bail!(
+            "Railway API returned {} GraphQL error(s)",
+            event.graphql_error_count.unwrap_or(0)
+        );
+    }
+
+    Ok(())
+}
+
+async fn finish_api_event(event: &mut CliApiTrackEvent, started: Instant, result: &Result<()>) {
+    event.duration_ms = started.elapsed().as_millis() as u64;
+    event.success = result.is_ok();
+    if let Err(error) = result {
+        event.error_message = Some(truncate_for_telemetry(&error.to_string()));
+    }
+    telemetry::send_api_event(event.clone()).await;
+}
+
+#[derive(Debug)]
+struct QuerySource {
+    document: String,
+    read_from_stdin: bool,
+}
+
+fn resolve_query_source(
+    query: Option<&str>,
+    file: Option<&str>,
+    allow_empty_stdin: bool,
+) -> Result<QuerySource> {
+    if query.is_some() && file.is_some() {
+        bail!("Pass the GraphQL document either as QUERY or --file, not both");
+    }
+
+    if let Some(query) = query {
+        return Ok(QuerySource {
+            document: query.to_string(),
+            read_from_stdin: false,
+        });
+    }
+
+    if let Some(path) = file {
+        if path == "-" {
+            return Ok(QuerySource {
+                document: read_stdin(allow_empty_stdin)?,
+                read_from_stdin: true,
+            });
+        }
+        return Ok(QuerySource {
+            document: fs::read_to_string(path)
+                .with_context(|| format!("Failed to read GraphQL document from {path}"))?,
+            read_from_stdin: false,
+        });
+    }
+
+    if !io::stdin().is_terminal() {
+        return Ok(QuerySource {
+            document: read_stdin(allow_empty_stdin)?,
+            read_from_stdin: true,
+        });
+    }
+
+    bail!(
+        "No GraphQL document provided. Pass QUERY, use --file, or pipe a document on stdin. Use `railway api search <term>` to inspect the schema."
+    );
+}
+
+fn read_stdin(allow_empty: bool) -> Result<String> {
+    let mut buf = String::new();
+    io::stdin()
+        .read_to_string(&mut buf)
+        .context("Failed to read stdin")?;
+    if !allow_empty && buf.trim().is_empty() {
+        bail!("No GraphQL document found on stdin");
+    }
+    Ok(buf)
+}
+
+struct VariableArgs<'a> {
+    variables: Option<&'a str>,
+    vars: &'a [String],
+    raw_vars: &'a [String],
+    query_reads_stdin: bool,
+}
+
+fn parse_variables(args: &VariableArgs<'_>) -> Result<Value> {
+    let mut variables = match args.variables {
+        Some(raw) => read_variables_value(raw, args.query_reads_stdin)?,
+        None => json!({}),
+    };
+
+    let object = variables
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("GraphQL variables must be a JSON object"))?;
+
+    for item in args.vars {
+        let (key, value) = split_key_value(item)?;
+        let parsed = serde_json::from_str::<Value>(value).unwrap_or_else(|_| json!(value));
+        object.insert(key.to_string(), parsed);
+    }
+
+    for item in args.raw_vars {
+        let (key, value) = split_key_value(item)?;
+        object.insert(key.to_string(), Value::String(value.to_string()));
+    }
+
+    Ok(variables)
+}
+
+fn read_variables_value(raw: &str, query_reads_stdin: bool) -> Result<Value> {
+    let json_text = if let Some(path) = raw.strip_prefix('@') {
+        if path == "-" {
+            if query_reads_stdin {
+                bail!("Cannot read both GraphQL document and variables from stdin");
+            }
+            read_stdin(true)?
+        } else {
+            fs::read_to_string(path)
+                .with_context(|| format!("Failed to read variables from {path}"))?
+        }
+    } else {
+        raw.to_string()
+    };
+
+    serde_json::from_str(&json_text).context("Failed to parse GraphQL variables as JSON")
+}
+
+fn split_key_value(item: &str) -> Result<(&str, &str)> {
+    let Some((key, value)) = item.split_once('=') else {
+        bail!("Expected KEY=VALUE, got {item:?}");
+    };
+    if key.trim().is_empty() {
+        bail!("Variable key cannot be empty");
+    }
+    Ok((key.trim(), value))
+}
+
+fn graphql_body(query: &str, operation_name: Option<&str>, variables: Value) -> Value {
+    let mut body = json!({
+        "query": query,
+        "variables": variables,
+    });
+    if let Some(operation_name) = operation_name {
+        body["operationName"] = Value::String(operation_name.to_string());
+    }
+    body
+}
+
+#[derive(Debug)]
+struct ApiHttpResponse {
+    status: reqwest::StatusCode,
+    body: String,
+}
+
+async fn send_graphql_request(
+    client: &reqwest::Client,
+    url: &str,
+    body: Value,
+) -> Result<ApiHttpResponse> {
+    let response = client.post(url).json(&body).send().await?;
+    let status = response.status();
+    let body = response.text().await?;
+
+    Ok(ApiHttpResponse { status, body })
+}
+
+fn response_json(response: &ApiHttpResponse) -> Result<Value> {
+    serde_json::from_str(&response.body).with_context(|| {
+        format!(
+            "Railway API returned HTTP {} with a non-JSON response body",
+            response.status
+        )
+    })
+}
+
+fn print_response_body(body: &str, compact: bool) -> Result<()> {
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => print_json(&value, compact),
+        Err(_) => {
+            print!("{body}");
+            io::stdout().flush()?;
+            Ok(())
+        }
+    }
+}
+
+fn print_json<T: Serialize>(value: &T, compact: bool) -> Result<()> {
+    if compact {
+        println!("{}", serde_json::to_string(value)?);
+    } else {
+        println!("{}", serde_json::to_string_pretty(value)?);
+    }
+    Ok(())
+}
+
+fn auth_mode(configs: &Configs) -> String {
+    if Configs::get_railway_token().is_some() {
+        return "project_token".to_string();
+    }
+    if Configs::get_railway_api_token().is_some() {
+        return "api_token".to_string();
+    }
+    if configs.get_railway_auth_token().is_some() {
+        return "login".to_string();
+    }
+    "none".to_string()
+}
+
+fn bundled_schema() -> Result<Value> {
+    serde_json::from_str(BUNDLED_SCHEMA).context("Bundled GraphQL schema is invalid JSON")
+}
+
+fn schema_root(schema: &Value) -> Result<&Value> {
+    schema
+        .pointer("/data/__schema")
+        .or_else(|| schema.get("__schema"))
+        .ok_or_else(|| anyhow!("GraphQL introspection schema is missing data.__schema"))
+}
+
+fn type_by_name<'a>(schema: &'a Value, name: &str) -> Result<Option<&'a Value>> {
+    Ok(schema_root(schema)?
+        .get("types")
+        .and_then(Value::as_array)
+        .and_then(|types| {
+            types
+                .iter()
+                .find(|ty| ty.get("name").and_then(Value::as_str) == Some(name))
+        }))
+}
+
+fn root_type_name(schema: &Value, operation_type: &str) -> Result<Option<String>> {
+    let key = match operation_type {
+        "query" => "queryType",
+        "mutation" => "mutationType",
+        "subscription" => "subscriptionType",
+        _ => return Ok(None),
+    };
+
+    Ok(schema_root(schema)?
+        .get(key)
+        .and_then(|value| value.get("name"))
+        .and_then(Value::as_str)
+        .map(str::to_string))
+}
+
+fn root_type<'a>(schema: &'a Value, operation_type: &str) -> Result<Option<&'a Value>> {
+    let Some(name) = root_type_name(schema, operation_type)? else {
+        return Ok(None);
+    };
+    type_by_name(schema, &name)
+}
+
+fn type_ref_to_string(type_ref: &Value) -> String {
+    match type_ref.get("kind").and_then(Value::as_str) {
+        Some("NON_NULL") => format!(
+            "{}!",
+            type_ref
+                .get("ofType")
+                .map(type_ref_to_string)
+                .unwrap_or_else(|| "Unknown".to_string())
+        ),
+        Some("LIST") => format!(
+            "[{}]",
+            type_ref
+                .get("ofType")
+                .map(type_ref_to_string)
+                .unwrap_or_else(|| "Unknown".to_string())
+        ),
+        _ => type_ref
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("Unknown")
+            .to_string(),
+    }
+}
+
+fn named_type(type_ref: &Value) -> Option<String> {
+    if let Some(name) = type_ref.get("name").and_then(Value::as_str) {
+        return Some(name.to_string());
+    }
+    type_ref.get("ofType").and_then(named_type)
+}
+
+fn is_required_type(type_ref: &Value) -> bool {
+    type_ref.get("kind").and_then(Value::as_str) == Some("NON_NULL")
+}
+
+fn field_to_json(parent: &str, operation_type: Option<&str>, field: &Value) -> Value {
+    let args: Vec<Value> = field
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|args| args.iter().map(arg_to_json).collect())
+        .unwrap_or_default();
+    let required_args: Vec<String> = field
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|args| {
+            args.iter()
+                .filter(|arg| {
+                    arg.get("defaultValue").is_none_or(Value::is_null)
+                        && arg.get("type").is_some_and(is_required_type)
+                })
+                .filter_map(|arg| arg.get("name").and_then(Value::as_str).map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "kind": operation_type.map_or("field".to_string(), str::to_string),
+        "parent": parent,
+        "name": field.get("name").and_then(Value::as_str),
+        "description": field.get("description").cloned().unwrap_or(Value::Null),
+        "type": field.get("type").map(type_ref_to_string).unwrap_or_else(|| "Unknown".to_string()),
+        "namedType": field.get("type").and_then(named_type),
+        "args": args,
+        "requiredArgs": required_args,
+        "isDeprecated": field.get("isDeprecated").and_then(Value::as_bool).unwrap_or(false),
+        "deprecationReason": field.get("deprecationReason").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn arg_to_json(arg: &Value) -> Value {
+    json!({
+        "name": arg.get("name").and_then(Value::as_str),
+        "description": arg.get("description").cloned().unwrap_or(Value::Null),
+        "type": arg.get("type").map(type_ref_to_string).unwrap_or_else(|| "Unknown".to_string()),
+        "namedType": arg.get("type").and_then(named_type),
+        "required": arg.get("defaultValue").is_none_or(Value::is_null)
+            && arg.get("type").is_some_and(is_required_type),
+        "defaultValue": arg.get("defaultValue").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn type_to_json(ty: &Value) -> Value {
+    let kind = ty.get("kind").and_then(Value::as_str).unwrap_or("UNKNOWN");
+    let fields: Vec<Value> = ty
+        .get("fields")
+        .and_then(Value::as_array)
+        .map(|fields| {
+            fields
+                .iter()
+                .map(|field| {
+                    field_to_json(
+                        ty.get("name").and_then(Value::as_str).unwrap_or(""),
+                        None,
+                        field,
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let input_fields: Vec<Value> = ty
+        .get("inputFields")
+        .and_then(Value::as_array)
+        .map(|fields| fields.iter().map(arg_to_json).collect())
+        .unwrap_or_default();
+    let enum_values: Vec<Value> = ty
+        .get("enumValues")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .map(|value| {
+                    json!({
+                        "name": value.get("name").and_then(Value::as_str),
+                        "description": value.get("description").cloned().unwrap_or(Value::Null),
+                        "isDeprecated": value.get("isDeprecated").and_then(Value::as_bool).unwrap_or(false),
+                        "deprecationReason": value.get("deprecationReason").cloned().unwrap_or(Value::Null),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "kind": kind,
+        "name": ty.get("name").and_then(Value::as_str),
+        "description": ty.get("description").cloned().unwrap_or(Value::Null),
+        "fields": fields,
+        "inputFields": input_fields,
+        "enumValues": enum_values,
+    })
+}
+
+fn search_schema(
+    schema: &Value,
+    term: &str,
+    kind: &SearchKind,
+    limit: usize,
+) -> Result<Vec<Value>> {
+    let needle = term.to_ascii_lowercase();
+    let mut results = Vec::new();
+    let root = schema_root(schema)?;
+    let types = root
+        .get("types")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("GraphQL schema is missing types"))?;
+
+    for ty in types {
+        if results.len() >= limit {
+            break;
+        }
+
+        let type_name = ty.get("name").and_then(Value::as_str).unwrap_or("");
+        let type_kind = ty.get("kind").and_then(Value::as_str).unwrap_or("");
+        let type_description = ty.get("description").and_then(Value::as_str).unwrap_or("");
+
+        if matches_kind_for_type(type_kind, kind)
+            && text_matches(&needle, &[type_name, type_description])
+        {
+            results.push(json!({
+                "kind": type_kind.to_ascii_lowercase(),
+                "name": type_name,
+                "description": ty.get("description").cloned().unwrap_or(Value::Null),
+            }));
+        }
+
+        if results.len() >= limit {
+            break;
+        }
+
+        let field_kind = operation_kind_for_root_type(schema, type_name)?;
+        if let Some(fields) = ty.get("fields").and_then(Value::as_array) {
+            for field in fields {
+                if results.len() >= limit {
+                    break;
+                }
+
+                let result_kind = field_kind.as_deref().unwrap_or("field");
+                if !matches_kind_for_field(result_kind, kind) {
+                    continue;
+                }
+                let field_name = field.get("name").and_then(Value::as_str).unwrap_or("");
+                let field_description = field
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if text_matches(&needle, &[field_name, field_description, type_name]) {
+                    results.push(field_to_json(type_name, field_kind.as_deref(), field));
+                }
+            }
+        }
+
+        if let Some(input_fields) = ty.get("inputFields").and_then(Value::as_array) {
+            for field in input_fields {
+                if results.len() >= limit {
+                    break;
+                }
+                if !matches!(
+                    kind,
+                    SearchKind::All | SearchKind::Input | SearchKind::Field
+                ) {
+                    continue;
+                }
+                let field_name = field.get("name").and_then(Value::as_str).unwrap_or("");
+                let field_description = field
+                    .get("description")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if text_matches(&needle, &[field_name, field_description, type_name]) {
+                    let mut value = arg_to_json(field);
+                    value["kind"] = json!("inputField");
+                    value["parent"] = json!(type_name);
+                    results.push(value);
+                }
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+fn matches_kind_for_type(type_kind: &str, wanted: &SearchKind) -> bool {
+    match wanted {
+        SearchKind::All => true,
+        SearchKind::Type => true,
+        SearchKind::Input => type_kind == "INPUT_OBJECT",
+        SearchKind::Enum => type_kind == "ENUM",
+        SearchKind::Field | SearchKind::Query | SearchKind::Mutation | SearchKind::Subscription => {
+            false
+        }
+    }
+}
+
+fn matches_kind_for_field(result_kind: &str, wanted: &SearchKind) -> bool {
+    match wanted {
+        SearchKind::All | SearchKind::Field => true,
+        SearchKind::Query => result_kind == "query",
+        SearchKind::Mutation => result_kind == "mutation",
+        SearchKind::Subscription => result_kind == "subscription",
+        SearchKind::Type | SearchKind::Input | SearchKind::Enum => false,
+    }
+}
+
+fn text_matches(needle: &str, values: &[&str]) -> bool {
+    values
+        .iter()
+        .any(|value| value.to_ascii_lowercase().contains(needle))
+}
+
+fn operation_kind_for_root_type(schema: &Value, type_name: &str) -> Result<Option<String>> {
+    for operation_type in ["query", "mutation", "subscription"] {
+        if root_type_name(schema, operation_type)?.as_deref() == Some(type_name) {
+            return Ok(Some(operation_type.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+fn describe_schema_member(schema: &Value, name: &str) -> Result<Vec<Value>> {
+    let mut descriptions = Vec::new();
+
+    if let Some((parent_name, field_name)) = name.split_once('.') {
+        let Some(parent) = type_by_name(schema, parent_name)? else {
+            bail!("No GraphQL type named {parent_name:?}");
+        };
+        let Some(field) = fields(parent)
+            .into_iter()
+            .find(|field| field.get("name").and_then(Value::as_str) == Some(field_name))
+        else {
+            bail!("No field named {field_name:?} on type {parent_name:?}");
+        };
+        descriptions.push(field_to_json(parent_name, None, field));
+        return Ok(descriptions);
+    }
+
+    if let Some(ty) = type_by_name(schema, name)? {
+        descriptions.push(type_to_json(ty));
+    }
+
+    for operation_type in ["query", "mutation", "subscription"] {
+        let Some(root) = root_type(schema, operation_type)? else {
+            continue;
+        };
+        let root_name = root.get("name").and_then(Value::as_str).unwrap_or("");
+        for field in fields(root) {
+            if field.get("name").and_then(Value::as_str) == Some(name) {
+                descriptions.push(field_to_json(root_name, Some(operation_type), field));
+            }
+        }
+    }
+
+    if descriptions.is_empty() {
+        bail!("No GraphQL type or root field named {name:?}");
+    }
+
+    Ok(descriptions)
+}
+
+fn fields(ty: &Value) -> Vec<&Value> {
+    ty.get("fields")
+        .and_then(Value::as_array)
+        .map(|fields| fields.iter().collect())
+        .unwrap_or_default()
+}
+
+fn graphql_error_count(value: &Value) -> Option<usize> {
+    value.get("errors").and_then(Value::as_array).map(Vec::len)
+}
+
+fn graphql_error_codes(value: &Value) -> Vec<String> {
+    value
+        .get("errors")
+        .and_then(Value::as_array)
+        .map(|errors| {
+            errors
+                .iter()
+                .filter_map(|error| {
+                    error
+                        .pointer("/extensions/code")
+                        .and_then(Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn variable_keys(variables: &Value) -> Vec<String> {
+    variables
+        .as_object()
+        .map(|object| object.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn variable_shape(value: &Value) -> Value {
+    match value {
+        Value::Null => json!({ "type": "null" }),
+        Value::Bool(_) => json!({ "type": "boolean" }),
+        Value::Number(number) => {
+            let number_type = if number.is_i64() || number.is_u64() {
+                "integer"
+            } else {
+                "number"
+            };
+            json!({ "type": number_type })
+        }
+        Value::String(_) => json!({ "type": "string" }),
+        Value::Array(values) => {
+            let item_shapes: Vec<Value> = values.iter().take(5).map(variable_shape).collect();
+            json!({ "type": "array", "length": values.len(), "items": item_shapes })
+        }
+        Value::Object(object) => {
+            let fields: BTreeMap<String, Value> = object
+                .iter()
+                .map(|(key, value)| (key.clone(), variable_shape(value)))
+                .collect();
+            json!({ "type": "object", "fields": fields })
+        }
+    }
+}
+
+fn hash_query(query: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(query.as_bytes());
+    hex_encode(&hasher.finalize())
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn telemetry_query_document(query: &str) -> Option<String> {
+    if query.len() <= MAX_TELEMETRY_QUERY_BYTES {
+        Some(query.to_string())
+    } else {
+        let end = query
+            .char_indices()
+            .map(|(idx, _)| idx)
+            .take_while(|idx| *idx <= MAX_TELEMETRY_QUERY_BYTES)
+            .last()
+            .unwrap_or(0);
+        Some(query[..end].to_string())
+    }
+}
+
+fn truncate_for_telemetry(value: &str) -> String {
+    if value.len() > 256 {
+        let end = value
+            .char_indices()
+            .map(|(idx, _)| idx)
+            .take_while(|idx| *idx <= 256)
+            .last()
+            .unwrap_or(0);
+        value[..end].to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn introspection_query() -> &'static str {
+    r#"
+query IntrospectionQuery {
+  __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          name
+          description
+          type { ...TypeRef }
+          defaultValue
+        }
+        type { ...TypeRef }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+      interfaces { ...TypeRef }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes { ...TypeRef }
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+    }
+  }
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_variables_from_json_and_flags() {
+        let variables = parse_variables(&VariableArgs {
+            variables: Some(r#"{"projectId":"p1","count":1}"#),
+            vars: &["enabled=true".to_string(), "labels=[\"api\"]".to_string()],
+            raw_vars: &["name=web".to_string()],
+            query_reads_stdin: false,
+        })
+        .unwrap();
+
+        assert_eq!(variables["projectId"], json!("p1"));
+        assert_eq!(variables["count"], json!(1));
+        assert_eq!(variables["enabled"], json!(true));
+        assert_eq!(variables["labels"], json!(["api"]));
+        assert_eq!(variables["name"], json!("web"));
+    }
+}

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -16,7 +16,6 @@ use crate::telemetry::{self, CliApiTrackEvent};
 
 use super::*;
 
-const BUNDLED_SCHEMA: &str = include_str!("../gql/schema.json");
 const MAX_TELEMETRY_QUERY_BYTES: usize = 8192;
 
 /// Query the Railway public GraphQL API
@@ -35,7 +34,7 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Print the bundled or live GraphQL introspection schema
+    /// Print the live GraphQL introspection schema
     Schema(SchemaArgs),
     /// Search GraphQL types and fields
     Search(SearchArgs),
@@ -80,10 +79,6 @@ struct ExecuteArgs {
 
 #[derive(ClapArgs, Debug)]
 struct SchemaArgs {
-    /// Fetch live introspection from the API instead of printing the bundled schema.
-    #[arg(long)]
-    refresh: bool,
-
     /// Print compact JSON.
     #[arg(long)]
     compact: bool,
@@ -141,25 +136,10 @@ pub async fn command(args: Args) -> Result<()> {
 async fn run_schema(args: SchemaArgs) -> Result<()> {
     let started = Instant::now();
     let mut event = CliApiTrackEvent::new("schema");
-    event.schema_source = Some(if args.refresh { "live" } else { "bundled" }.to_string());
+    event.schema_source = Some("live".to_string());
 
     let result = async {
-        let schema = if args.refresh {
-            let configs = Configs::new()?;
-            let client = GQLClient::new_authorized(&configs)?;
-            let response = send_graphql_request(
-                &client,
-                &configs.get_backboard(),
-                json!({ "query": introspection_query() }),
-            )
-            .await?;
-            event.http_status = Some(response.status.as_u16());
-            event.response_bytes = Some(response.body.len());
-            response_json(&response)?
-        } else {
-            bundled_schema()?
-        };
-
+        let schema = fetch_live_schema(&mut event).await?;
         print_json(&schema, args.compact)?;
         Ok(())
     }
@@ -172,11 +152,11 @@ async fn run_schema(args: SchemaArgs) -> Result<()> {
 async fn run_search(args: SearchArgs) -> Result<()> {
     let started = Instant::now();
     let mut event = CliApiTrackEvent::new("search");
-    event.schema_source = Some("bundled".to_string());
+    event.schema_source = Some("live".to_string());
     event.search_term = Some(args.term.clone());
 
     let result = async {
-        let schema = bundled_schema()?;
+        let schema = fetch_live_schema(&mut event).await?;
         let results = search_schema(&schema, &args.term, &args.kind, args.limit)?;
         print_json(&json!({ "results": results }), args.compact)?;
         Ok(())
@@ -190,11 +170,11 @@ async fn run_search(args: SearchArgs) -> Result<()> {
 async fn run_describe(args: DescribeArgs) -> Result<()> {
     let started = Instant::now();
     let mut event = CliApiTrackEvent::new("describe");
-    event.schema_source = Some("bundled".to_string());
+    event.schema_source = Some("live".to_string());
     event.describe_name = Some(args.name.clone());
 
     let result = async {
-        let schema = bundled_schema()?;
+        let schema = fetch_live_schema(&mut event).await?;
         let descriptions = describe_schema_member(&schema, &args.name)?;
         let output = if descriptions.len() == 1 {
             descriptions.into_iter().next().unwrap()
@@ -468,8 +448,26 @@ fn auth_mode(configs: &Configs) -> String {
     "none".to_string()
 }
 
-fn bundled_schema() -> Result<Value> {
-    serde_json::from_str(BUNDLED_SCHEMA).context("Bundled GraphQL schema is invalid JSON")
+async fn fetch_live_schema(event: &mut CliApiTrackEvent) -> Result<Value> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let response = send_graphql_request(
+        &client,
+        &configs.get_backboard(),
+        json!({ "query": introspection_query() }),
+    )
+    .await?;
+    event.http_status = Some(response.status.as_u16());
+    event.response_bytes = Some(response.body.len());
+
+    if !response.status.is_success() {
+        bail!(
+            "Failed to fetch the GraphQL schema: Railway API returned HTTP {}",
+            response.status
+        );
+    }
+
+    response_json(&response)
 }
 
 fn schema_root(schema: &Value) -> Result<&Value> {

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -1,8 +1,6 @@
 use std::{
-    collections::BTreeMap,
     fs,
     io::{self, Read, Write},
-    time::Instant,
 };
 
 use anyhow::{Context, anyhow, bail};
@@ -10,13 +8,8 @@ use clap::{Args as ClapArgs, Subcommand, ValueEnum};
 use is_terminal::IsTerminal;
 use serde::Serialize;
 use serde_json::{Value, json};
-use sha2::{Digest, Sha256};
-
-use crate::telemetry::{self, CliApiTrackEvent};
 
 use super::*;
-
-const MAX_TELEMETRY_QUERY_BYTES: usize = 8192;
 
 /// Query the Railway public GraphQL API
 #[derive(Parser, Debug)]
@@ -134,72 +127,23 @@ pub async fn command(args: Args) -> Result<()> {
 }
 
 async fn run_schema(args: SchemaArgs) -> Result<()> {
-    let started = Instant::now();
-    let mut event = CliApiTrackEvent::new("schema");
-    event.schema_source = Some("live".to_string());
-
-    let result = async {
-        let schema = fetch_live_schema(&mut event).await?;
-        print_json(&schema, args.compact)?;
-        Ok(())
-    }
-    .await;
-
-    finish_api_event(&mut event, started, &result).await;
-    result
+    let schema = fetch_live_schema().await?;
+    print_json(&schema, args.compact)
 }
 
 async fn run_search(args: SearchArgs) -> Result<()> {
-    let started = Instant::now();
-    let mut event = CliApiTrackEvent::new("search");
-    event.schema_source = Some("live".to_string());
-    event.search_term = Some(args.term.clone());
-
-    let result = async {
-        let schema = fetch_live_schema(&mut event).await?;
-        let results = search_schema(&schema, &args.term, &args.kind, args.limit)?;
-        print_json(&json!({ "results": results }), args.compact)?;
-        Ok(())
-    }
-    .await;
-
-    finish_api_event(&mut event, started, &result).await;
-    result
+    let schema = fetch_live_schema().await?;
+    let results = search_schema(&schema, &args.term, &args.kind, args.limit)?;
+    print_json(&json!({ "results": results }), args.compact)
 }
 
 async fn run_describe(args: DescribeArgs) -> Result<()> {
-    let started = Instant::now();
-    let mut event = CliApiTrackEvent::new("describe");
-    event.schema_source = Some("live".to_string());
-    event.describe_name = Some(args.name.clone());
-
-    let result = async {
-        let schema = fetch_live_schema(&mut event).await?;
-        let descriptions = describe_schema_member(&schema, &args.name)?;
-        let output = if descriptions.len() == 1 {
-            descriptions.into_iter().next().unwrap()
-        } else {
-            json!({ "matches": descriptions })
-        };
-        print_json(&output, args.compact)?;
-        Ok(())
-    }
-    .await;
-
-    finish_api_event(&mut event, started, &result).await;
-    result
+    let schema = fetch_live_schema().await?;
+    let descriptions = describe_schema_member(&schema, &args.name)?;
+    print_json(&json!({ "matches": descriptions }), args.compact)
 }
 
 async fn run_execute(args: ExecuteArgs) -> Result<()> {
-    let started = Instant::now();
-    let mut event = CliApiTrackEvent::new("execute");
-
-    let result = execute_inner(args, &mut event).await;
-    finish_api_event(&mut event, started, &result).await;
-    result
-}
-
-async fn execute_inner(args: ExecuteArgs, event: &mut CliApiTrackEvent) -> Result<()> {
     let query = resolve_query_source(args.query.as_deref(), args.file.as_deref(), false)?;
     let variables = parse_variables(&VariableArgs {
         variables: args.variables.as_deref(),
@@ -208,55 +152,29 @@ async fn execute_inner(args: ExecuteArgs, event: &mut CliApiTrackEvent) -> Resul
         query_reads_stdin: query.read_from_stdin,
     })?;
 
-    event.operation_name = args.operation_name.clone();
-    event.query_hash = Some(hash_query(&query.document));
-    event.query_document = telemetry_query_document(&query.document);
-    event.variable_keys = variable_keys(&variables);
-    event.variable_shape = Some(variable_shape(&variables));
-
     let configs = Configs::new()?;
-    event.auth_mode = Some(auth_mode(&configs));
-
     let client = GQLClient::new_authorized(&configs)?;
-    let body = graphql_body(
-        &query.document,
-        args.operation_name.as_deref(),
-        variables.clone(),
-    );
+    let body = graphql_body(&query.document, args.operation_name.as_deref(), variables);
 
     let response = send_graphql_request(&client, &configs.get_backboard(), body).await?;
-    event.http_status = Some(response.status.as_u16());
-    event.response_bytes = Some(response.body.len());
 
     print_response_body(&response.body, args.compact)?;
-
-    let response_json = serde_json::from_str::<Value>(&response.body).ok();
-    if let Some(value) = response_json.as_ref() {
-        event.graphql_error_count = graphql_error_count(value);
-        event.graphql_error_codes = graphql_error_codes(value);
-    }
 
     if !response.status.is_success() {
         bail!("Railway API request failed with HTTP {}", response.status);
     }
 
-    if !args.allow_errors && event.graphql_error_count.unwrap_or(0) > 0 {
-        bail!(
-            "Railway API returned {} GraphQL error(s)",
-            event.graphql_error_count.unwrap_or(0)
-        );
+    if !args.allow_errors {
+        let error_count = serde_json::from_str::<Value>(&response.body)
+            .ok()
+            .and_then(|value| graphql_error_count(&value))
+            .unwrap_or(0);
+        if error_count > 0 {
+            bail!("Railway API returned {error_count} GraphQL error(s)");
+        }
     }
 
     Ok(())
-}
-
-async fn finish_api_event(event: &mut CliApiTrackEvent, started: Instant, result: &Result<()>) {
-    event.duration_ms = started.elapsed().as_millis() as u64;
-    event.success = result.is_ok();
-    if let Err(error) = result {
-        event.error_message = Some(truncate_for_telemetry(&error.to_string()));
-    }
-    telemetry::send_api_event(event.clone()).await;
 }
 
 #[derive(Debug)]
@@ -435,20 +353,7 @@ fn print_json<T: Serialize>(value: &T, compact: bool) -> Result<()> {
     Ok(())
 }
 
-fn auth_mode(configs: &Configs) -> String {
-    if Configs::get_railway_token().is_some() {
-        return "project_token".to_string();
-    }
-    if Configs::get_railway_api_token().is_some() {
-        return "api_token".to_string();
-    }
-    if configs.get_railway_auth_token().is_some() {
-        return "login".to_string();
-    }
-    "none".to_string()
-}
-
-async fn fetch_live_schema(event: &mut CliApiTrackEvent) -> Result<Value> {
+async fn fetch_live_schema() -> Result<Value> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let response = send_graphql_request(
@@ -457,8 +362,6 @@ async fn fetch_live_schema(event: &mut CliApiTrackEvent) -> Result<Value> {
         json!({ "query": introspection_query() }),
     )
     .await?;
-    event.http_status = Some(response.status.as_u16());
-    event.response_bytes = Some(response.body.len());
 
     if !response.status.is_success() {
         bail!(
@@ -467,7 +370,25 @@ async fn fetch_live_schema(event: &mut CliApiTrackEvent) -> Result<Value> {
         );
     }
 
-    response_json(&response)
+    let schema = response_json(&response)?;
+
+    if let Some(errors) = schema
+        .get("errors")
+        .and_then(Value::as_array)
+        .filter(|errors| !errors.is_empty())
+    {
+        let detail = errors
+            .first()
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown error");
+        bail!(
+            "Failed to fetch the GraphQL schema: Railway API returned {} GraphQL error(s): {detail}",
+            errors.len()
+        );
+    }
+
+    Ok(schema)
 }
 
 fn schema_root(schema: &Value) -> Result<&Value> {
@@ -818,102 +739,6 @@ fn graphql_error_count(value: &Value) -> Option<usize> {
     value.get("errors").and_then(Value::as_array).map(Vec::len)
 }
 
-fn graphql_error_codes(value: &Value) -> Vec<String> {
-    value
-        .get("errors")
-        .and_then(Value::as_array)
-        .map(|errors| {
-            errors
-                .iter()
-                .filter_map(|error| {
-                    error
-                        .pointer("/extensions/code")
-                        .and_then(Value::as_str)
-                        .map(str::to_string)
-                })
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-fn variable_keys(variables: &Value) -> Vec<String> {
-    variables
-        .as_object()
-        .map(|object| object.keys().cloned().collect())
-        .unwrap_or_default()
-}
-
-fn variable_shape(value: &Value) -> Value {
-    match value {
-        Value::Null => json!({ "type": "null" }),
-        Value::Bool(_) => json!({ "type": "boolean" }),
-        Value::Number(number) => {
-            let number_type = if number.is_i64() || number.is_u64() {
-                "integer"
-            } else {
-                "number"
-            };
-            json!({ "type": number_type })
-        }
-        Value::String(_) => json!({ "type": "string" }),
-        Value::Array(values) => {
-            let item_shapes: Vec<Value> = values.iter().take(5).map(variable_shape).collect();
-            json!({ "type": "array", "length": values.len(), "items": item_shapes })
-        }
-        Value::Object(object) => {
-            let fields: BTreeMap<String, Value> = object
-                .iter()
-                .map(|(key, value)| (key.clone(), variable_shape(value)))
-                .collect();
-            json!({ "type": "object", "fields": fields })
-        }
-    }
-}
-
-fn hash_query(query: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(query.as_bytes());
-    hex_encode(&hasher.finalize())
-}
-
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut output = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        output.push(HEX[(byte >> 4) as usize] as char);
-        output.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    output
-}
-
-fn telemetry_query_document(query: &str) -> Option<String> {
-    if query.len() <= MAX_TELEMETRY_QUERY_BYTES {
-        Some(query.to_string())
-    } else {
-        let end = query
-            .char_indices()
-            .map(|(idx, _)| idx)
-            .take_while(|idx| *idx <= MAX_TELEMETRY_QUERY_BYTES)
-            .last()
-            .unwrap_or(0);
-        Some(query[..end].to_string())
-    }
-}
-
-fn truncate_for_telemetry(value: &str) -> String {
-    if value.len() > 256 {
-        let end = value
-            .char_indices()
-            .map(|(idx, _)| idx)
-            .take_while(|idx| *idx <= 256)
-            .last()
-            .unwrap_or(0);
-        value[..end].to_string()
-    } else {
-        value.to_string()
-    }
-}
-
 fn introspection_query() -> &'static str {
     r#"
 query IntrospectionQuery {
@@ -1005,6 +830,221 @@ fragment TypeRef on __Type {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fixture_schema() -> Value {
+        json!({
+            "data": {
+                "__schema": {
+                    "queryType": { "name": "Query" },
+                    "mutationType": { "name": "Mutation" },
+                    "subscriptionType": null,
+                    "types": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "Query",
+                            "description": null,
+                            "fields": [
+                                {
+                                    "name": "project",
+                                    "description": "Look up a project by ID.",
+                                    "args": [
+                                        {
+                                            "name": "id",
+                                            "description": null,
+                                            "type": {
+                                                "kind": "NON_NULL",
+                                                "name": null,
+                                                "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                                            },
+                                            "defaultValue": null
+                                        }
+                                    ],
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": { "kind": "OBJECT", "name": "Project", "ofType": null }
+                                    },
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
+                                }
+                            ],
+                            "inputFields": null,
+                            "enumValues": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "Mutation",
+                            "description": null,
+                            "fields": [
+                                {
+                                    "name": "projectDelete",
+                                    "description": null,
+                                    "args": [
+                                        {
+                                            "name": "id",
+                                            "description": null,
+                                            "type": {
+                                                "kind": "NON_NULL",
+                                                "name": null,
+                                                "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                                            },
+                                            "defaultValue": null
+                                        }
+                                    ],
+                                    "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
+                                }
+                            ],
+                            "inputFields": null,
+                            "enumValues": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "Project",
+                            "description": "A Railway project.",
+                            "fields": [
+                                {
+                                    "name": "id",
+                                    "description": null,
+                                    "args": [],
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                                    },
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
+                                },
+                                {
+                                    "name": "name",
+                                    "description": null,
+                                    "args": [],
+                                    "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+                                    "isDeprecated": false,
+                                    "deprecationReason": null
+                                }
+                            ],
+                            "inputFields": null,
+                            "enumValues": null
+                        },
+                        {
+                            "kind": "INPUT_OBJECT",
+                            "name": "ProjectUpdateInput",
+                            "description": null,
+                            "fields": null,
+                            "inputFields": [
+                                {
+                                    "name": "name",
+                                    "description": null,
+                                    "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "enumValues": null
+                        }
+                    ]
+                }
+            }
+        })
+    }
+
+    fn result_names(results: &[Value]) -> Vec<&str> {
+        results
+            .iter()
+            .filter_map(|result| result.get("name").and_then(Value::as_str))
+            .collect()
+    }
+
+    #[test]
+    fn search_finds_types_and_fields() {
+        let schema = fixture_schema();
+        let results = search_schema(&schema, "project", &SearchKind::All, 25).unwrap();
+        let names = result_names(&results);
+
+        assert!(names.contains(&"Project"));
+        assert!(names.contains(&"project"));
+        assert!(names.contains(&"projectDelete"));
+        assert!(names.contains(&"ProjectUpdateInput"));
+    }
+
+    #[test]
+    fn search_restricts_results_by_kind() {
+        let schema = fixture_schema();
+
+        let mutations = search_schema(&schema, "project", &SearchKind::Mutation, 25).unwrap();
+        assert_eq!(result_names(&mutations), vec!["projectDelete"]);
+
+        let queries = search_schema(&schema, "project", &SearchKind::Query, 25).unwrap();
+        assert_eq!(result_names(&queries), vec!["project"]);
+    }
+
+    #[test]
+    fn search_respects_limit() {
+        let schema = fixture_schema();
+        let results = search_schema(&schema, "project", &SearchKind::All, 2).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn describe_returns_type_with_fields() {
+        let schema = fixture_schema();
+        let descriptions = describe_schema_member(&schema, "Project").unwrap();
+
+        assert_eq!(descriptions.len(), 1);
+        assert_eq!(descriptions[0]["kind"], json!("OBJECT"));
+        assert_eq!(descriptions[0]["name"], json!("Project"));
+        let fields = descriptions[0]["fields"].as_array().unwrap();
+        assert_eq!(result_names(fields), vec!["id", "name"]);
+    }
+
+    #[test]
+    fn describe_returns_root_field_with_required_args() {
+        let schema = fixture_schema();
+        let descriptions = describe_schema_member(&schema, "project").unwrap();
+
+        assert_eq!(descriptions.len(), 1);
+        assert_eq!(descriptions[0]["kind"], json!("query"));
+        assert_eq!(descriptions[0]["type"], json!("Project!"));
+        assert_eq!(descriptions[0]["requiredArgs"], json!(["id"]));
+    }
+
+    #[test]
+    fn describe_resolves_parent_dot_field() {
+        let schema = fixture_schema();
+        let descriptions = describe_schema_member(&schema, "Project.name").unwrap();
+
+        assert_eq!(descriptions.len(), 1);
+        assert_eq!(descriptions[0]["parent"], json!("Project"));
+        assert_eq!(descriptions[0]["name"], json!("name"));
+        assert_eq!(descriptions[0]["type"], json!("String"));
+    }
+
+    #[test]
+    fn describe_fails_for_unknown_name() {
+        let schema = fixture_schema();
+        assert!(describe_schema_member(&schema, "DoesNotExist").is_err());
+        assert!(describe_schema_member(&schema, "Project.doesNotExist").is_err());
+    }
+
+    #[test]
+    fn type_refs_render_wrapped_types() {
+        let non_null_list = json!({
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+                }
+            }
+        });
+
+        assert_eq!(type_ref_to_string(&non_null_list), "[String!]!");
+    }
 
     #[test]
     fn parses_variables_from_json_and_flags() {

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{HashMap, HashSet},
     fs,
     io::{self, Read, Write},
     time::Instant,
@@ -6,7 +7,7 @@ use std::{
 
 use anyhow::{Context, anyhow, bail};
 use clap::{Args as ClapArgs, Subcommand, ValueEnum};
-use graphql_parser::query::{Definition, OperationDefinition, Selection};
+use graphql_parser::query::{Definition, OperationDefinition, Selection, SelectionSet};
 use is_terminal::IsTerminal;
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -139,8 +140,11 @@ async fn run_schema(args: SchemaArgs) -> Result<()> {
 
 async fn run_search(args: SearchArgs) -> Result<()> {
     let schema = fetch_live_schema().await?;
-    let results = search_schema(&schema, &args.term, &args.kind, args.limit)?;
-    print_json(&json!({ "results": results }), args.compact)
+    let search = search_schema(&schema, &args.term, &args.kind, args.limit)?;
+    print_json(
+        &json!({ "results": search.results, "total": search.total }),
+        args.compact,
+    )
 }
 
 async fn run_describe(args: DescribeArgs) -> Result<()> {
@@ -161,7 +165,10 @@ async fn run_execute(args: ExecuteArgs) -> Result<()> {
             command: "api".to_string(),
             sub_command: Some(format!("execute:{summary}")),
             duration_ms: started.elapsed().as_millis() as u64,
-            success: result.is_ok(),
+            // Only an operation that ran without GraphQL errors counts as a
+            // successfully used capability; `--allow-errors` changes the exit
+            // status, never this flag.
+            success: matches!(result, Ok(0)),
             error_message: None,
             os: std::env::consts::OS,
             arch: std::env::consts::ARCH,
@@ -171,10 +178,14 @@ async fn run_execute(args: ExecuteArgs) -> Result<()> {
         .await;
     }
 
-    result
+    result.map(|_| ())
 }
 
-async fn execute_document(args: &ExecuteArgs, query: &QuerySource) -> Result<()> {
+/// Executes the document and returns the number of GraphQL errors in the
+/// response. The count is computed even when `--allow-errors` downgrades
+/// those errors to a zero exit status, so telemetry never records a
+/// rejected operation as a successfully used capability.
+async fn execute_document(args: &ExecuteArgs, query: &QuerySource) -> Result<usize> {
     let variables = parse_variables(&VariableArgs {
         variables: args.variables.as_deref(),
         vars: &args.vars,
@@ -194,23 +205,24 @@ async fn execute_document(args: &ExecuteArgs, query: &QuerySource) -> Result<()>
         bail!("Railway API request failed with HTTP {}", response.status);
     }
 
-    if !args.allow_errors {
-        let error_count = serde_json::from_str::<Value>(&response.body)
-            .ok()
-            .and_then(|value| graphql_error_count(&value))
-            .unwrap_or(0);
-        if error_count > 0 {
-            bail!("Railway API returned {error_count} GraphQL error(s)");
-        }
+    let error_count = serde_json::from_str::<Value>(&response.body)
+        .ok()
+        .and_then(|value| graphql_error_count(&value))
+        .unwrap_or(0);
+
+    if !args.allow_errors && error_count > 0 {
+        bail!("Railway API returned {error_count} GraphQL error(s)");
     }
 
-    Ok(())
+    Ok(error_count)
 }
 
 /// Summarizes the operation that will execute as `<type>:<field>[+<field>...]`,
-/// e.g. `mutation:serviceInstanceUpdate`. Only operation types and top-level
-/// field names are captured — never arguments or values — so this is safe to
-/// report in telemetry for understanding which API capabilities get used.
+/// e.g. `mutation:serviceInstanceUpdate`. Root-level fragment spreads and
+/// inline fragments are resolved to the fields they select. Only operation
+/// types and top-level field names are captured — never arguments or values —
+/// so this is safe to report in telemetry for understanding which API
+/// capabilities get used.
 fn operation_summary(document: &str, operation_name: Option<&str>) -> Option<String> {
     let ast = graphql_parser::parse_query::<&str>(document).ok()?;
     let operations: Vec<&OperationDefinition<&str>> = ast
@@ -219,6 +231,14 @@ fn operation_summary(document: &str, operation_name: Option<&str>) -> Option<Str
         .filter_map(|definition| match definition {
             Definition::Operation(operation) => Some(operation),
             Definition::Fragment(_) => None,
+        })
+        .collect();
+    let fragments: HashMap<&str, &SelectionSet<&str>> = ast
+        .definitions
+        .iter()
+        .filter_map(|definition| match definition {
+            Definition::Fragment(fragment) => Some((fragment.name, &fragment.selection_set)),
+            Definition::Operation(_) => None,
         })
         .collect();
 
@@ -241,13 +261,15 @@ fn operation_summary(document: &str, operation_name: Option<&str>) -> Option<Str
         OperationDefinition::SelectionSet(selection_set) => ("query", selection_set),
     };
 
-    let fields: Vec<&str> = selection_set
-        .items
-        .iter()
-        .filter_map(|selection| match selection {
-            Selection::Field(field) => Some(field.name),
-            _ => None,
-        })
+    let mut fields = Vec::new();
+    collect_root_fields(selection_set, &fragments, &mut HashSet::new(), &mut fields);
+
+    // GraphQL merges a field selected both directly and via a fragment, so
+    // report each root field once.
+    let mut seen = HashSet::new();
+    let fields: Vec<&str> = fields
+        .into_iter()
+        .filter(|field| seen.insert(*field))
         .take(MAX_OPERATION_SUMMARY_FIELDS)
         .collect();
 
@@ -256,6 +278,32 @@ fn operation_summary(document: &str, operation_name: Option<&str>) -> Option<Str
     }
 
     Some(format!("{operation_type}:{}", fields.join("+")))
+}
+
+/// Collects the root-level field names of a selection set, following
+/// fragment spreads and inline fragments. `visited` breaks cycles between
+/// fragment spreads, which are invalid GraphQL but still parse.
+fn collect_root_fields<'a>(
+    selection_set: &'a SelectionSet<'a, &'a str>,
+    fragments: &HashMap<&'a str, &'a SelectionSet<'a, &'a str>>,
+    visited: &mut HashSet<&'a str>,
+    fields: &mut Vec<&'a str>,
+) {
+    for selection in &selection_set.items {
+        match selection {
+            Selection::Field(field) => fields.push(field.name),
+            Selection::FragmentSpread(spread) => {
+                if visited.insert(spread.fragment_name) {
+                    if let Some(fragment) = fragments.get(spread.fragment_name) {
+                        collect_root_fields(fragment, fragments, visited, fields);
+                    }
+                }
+            }
+            Selection::InlineFragment(inline) => {
+                collect_root_fields(&inline.selection_set, fragments, visited, fields);
+            }
+        }
+    }
 }
 
 fn operation_definition_name<'a>(operation: &OperationDefinition<'a, &'a str>) -> Option<&'a str> {
@@ -650,6 +698,78 @@ fn type_to_json(ty: &Value) -> Value {
         "fields": fields,
         "inputFields": input_fields,
         "enumValues": enum_values,
+        "interfaces": type_name_list(ty, "interfaces"),
+        "possibleTypes": type_name_list(ty, "possibleTypes"),
+    })
+}
+
+/// Renders a type's `interfaces` or `possibleTypes` introspection list as
+/// type names, so `describe` exposes union members, interface implementors,
+/// and implemented interfaces — enough to construct inline fragments without
+/// reading the full schema.
+fn type_name_list(ty: &Value, key: &str) -> Vec<Value> {
+    ty.get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .map(|item| json!(type_ref_to_string(item)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Search results after ranking and truncation. `total` counts every match
+/// in the schema so callers can tell when `limit` cut the list short.
+struct SearchResults {
+    results: Vec<Value>,
+    total: usize,
+}
+
+/// Result buckets, best first: executable root operations, then types, then
+/// object fields, then input-object fields. Ranking the whole schema before
+/// truncating keeps a small `--limit` from being exhausted by alphabetically
+/// early type/field matches while every executable operation is dropped.
+const RANK_OPERATION: u8 = 0;
+const RANK_TYPE: u8 = 1;
+const RANK_FIELD: u8 = 2;
+const RANK_INPUT_FIELD: u8 = 3;
+
+/// Match quality returned by [`field_match_quality`] for a field that only
+/// matched because its parent type name did. Every field of a matching type
+/// matches this way, so these rank below any name or description match.
+const QUALITY_PARENT_TYPE: u8 = 4;
+
+/// Ranks how well `needle` (lowercased) matches a schema member, lower being
+/// better: exact name, name prefix, name substring, description substring.
+fn match_quality(needle: &str, name: &str, description: &str) -> Option<u8> {
+    let name = name.to_ascii_lowercase();
+    if name == needle {
+        return Some(0);
+    }
+    if name.starts_with(needle) {
+        return Some(1);
+    }
+    if name.contains(needle) {
+        return Some(2);
+    }
+    if description.to_ascii_lowercase().contains(needle) {
+        return Some(3);
+    }
+    None
+}
+
+fn field_match_quality(
+    needle: &str,
+    name: &str,
+    description: &str,
+    parent_type_name: &str,
+) -> Option<u8> {
+    match_quality(needle, name, description).or_else(|| {
+        parent_type_name
+            .to_ascii_lowercase()
+            .contains(needle)
+            .then_some(QUALITY_PARENT_TYPE)
     })
 }
 
@@ -658,9 +778,9 @@ fn search_schema(
     term: &str,
     kind: &SearchKind,
     limit: usize,
-) -> Result<Vec<Value>> {
+) -> Result<SearchResults> {
     let needle = term.to_ascii_lowercase();
-    let mut results = Vec::new();
+    let mut matches: Vec<(u8, u8, Value)> = Vec::new();
     let root = schema_root(schema)?;
     let types = root
         .get("types")
@@ -668,35 +788,27 @@ fn search_schema(
         .ok_or_else(|| anyhow!("GraphQL schema is missing types"))?;
 
     for ty in types {
-        if results.len() >= limit {
-            break;
-        }
-
         let type_name = ty.get("name").and_then(Value::as_str).unwrap_or("");
         let type_kind = ty.get("kind").and_then(Value::as_str).unwrap_or("");
         let type_description = ty.get("description").and_then(Value::as_str).unwrap_or("");
 
-        if matches_kind_for_type(type_kind, kind)
-            && text_matches(&needle, &[type_name, type_description])
-        {
-            results.push(json!({
-                "kind": type_kind.to_ascii_lowercase(),
-                "name": type_name,
-                "description": ty.get("description").cloned().unwrap_or(Value::Null),
-            }));
-        }
-
-        if results.len() >= limit {
-            break;
+        if matches_kind_for_type(type_kind, kind) {
+            if let Some(quality) = match_quality(&needle, type_name, type_description) {
+                matches.push((
+                    RANK_TYPE,
+                    quality,
+                    json!({
+                        "kind": type_kind.to_ascii_lowercase(),
+                        "name": type_name,
+                        "description": ty.get("description").cloned().unwrap_or(Value::Null),
+                    }),
+                ));
+            }
         }
 
         let field_kind = operation_kind_for_root_type(schema, type_name)?;
         if let Some(fields) = ty.get("fields").and_then(Value::as_array) {
             for field in fields {
-                if results.len() >= limit {
-                    break;
-                }
-
                 let result_kind = field_kind.as_deref().unwrap_or("field");
                 if !matches_kind_for_field(result_kind, kind) {
                     continue;
@@ -706,17 +818,25 @@ fn search_schema(
                     .get("description")
                     .and_then(Value::as_str)
                     .unwrap_or("");
-                if text_matches(&needle, &[field_name, field_description, type_name]) {
-                    results.push(field_to_json(type_name, field_kind.as_deref(), field));
+                if let Some(quality) =
+                    field_match_quality(&needle, field_name, field_description, type_name)
+                {
+                    let rank = if field_kind.is_some() {
+                        RANK_OPERATION
+                    } else {
+                        RANK_FIELD
+                    };
+                    matches.push((
+                        rank,
+                        quality,
+                        field_to_json(type_name, field_kind.as_deref(), field),
+                    ));
                 }
             }
         }
 
         if let Some(input_fields) = ty.get("inputFields").and_then(Value::as_array) {
             for field in input_fields {
-                if results.len() >= limit {
-                    break;
-                }
                 if !matches!(
                     kind,
                     SearchKind::All | SearchKind::Input | SearchKind::Field
@@ -728,17 +848,28 @@ fn search_schema(
                     .get("description")
                     .and_then(Value::as_str)
                     .unwrap_or("");
-                if text_matches(&needle, &[field_name, field_description, type_name]) {
+                if let Some(quality) =
+                    field_match_quality(&needle, field_name, field_description, type_name)
+                {
                     let mut value = arg_to_json(field);
                     value["kind"] = json!("inputField");
                     value["parent"] = json!(type_name);
-                    results.push(value);
+                    matches.push((RANK_INPUT_FIELD, quality, value));
                 }
             }
         }
     }
 
-    Ok(results)
+    // Stable sort: schema order breaks ties within a (rank, quality) bucket.
+    matches.sort_by_key(|(rank, quality, _)| (*rank, *quality));
+    let total = matches.len();
+    let results = matches
+        .into_iter()
+        .take(limit)
+        .map(|(_, _, value)| value)
+        .collect();
+
+    Ok(SearchResults { results, total })
 }
 
 fn matches_kind_for_type(type_kind: &str, wanted: &SearchKind) -> bool {
@@ -761,12 +892,6 @@ fn matches_kind_for_field(result_kind: &str, wanted: &SearchKind) -> bool {
         SearchKind::Subscription => result_kind == "subscription",
         SearchKind::Type | SearchKind::Input | SearchKind::Enum => false,
     }
-}
-
-fn text_matches(needle: &str, values: &[&str]) -> bool {
-    values
-        .iter()
-        .any(|value| value.to_ascii_lowercase().contains(needle))
 }
 
 fn operation_kind_for_root_type(schema: &Value, type_name: &str) -> Result<Option<String>> {
@@ -993,6 +1118,9 @@ mod tests {
                             "kind": "OBJECT",
                             "name": "Project",
                             "description": "A Railway project.",
+                            "interfaces": [
+                                { "kind": "INTERFACE", "name": "Node", "ofType": null }
+                            ],
                             "fields": [
                                 {
                                     "name": "id",
@@ -1032,6 +1160,18 @@ mod tests {
                                 }
                             ],
                             "enumValues": null
+                        },
+                        {
+                            "kind": "UNION",
+                            "name": "InvitationTarget",
+                            "description": null,
+                            "fields": null,
+                            "inputFields": null,
+                            "enumValues": null,
+                            "possibleTypes": [
+                                { "kind": "OBJECT", "name": "InviteCode", "ofType": null },
+                                { "kind": "OBJECT", "name": "ProjectInvitation", "ofType": null }
+                            ]
                         }
                     ]
                 }
@@ -1049,8 +1189,8 @@ mod tests {
     #[test]
     fn search_finds_types_and_fields() {
         let schema = fixture_schema();
-        let results = search_schema(&schema, "project", &SearchKind::All, 25).unwrap();
-        let names = result_names(&results);
+        let search = search_schema(&schema, "project", &SearchKind::All, 25).unwrap();
+        let names = result_names(&search.results);
 
         assert!(names.contains(&"Project"));
         assert!(names.contains(&"project"));
@@ -1063,17 +1203,47 @@ mod tests {
         let schema = fixture_schema();
 
         let mutations = search_schema(&schema, "project", &SearchKind::Mutation, 25).unwrap();
-        assert_eq!(result_names(&mutations), vec!["projectDelete"]);
+        assert_eq!(result_names(&mutations.results), vec!["projectDelete"]);
 
         let queries = search_schema(&schema, "project", &SearchKind::Query, 25).unwrap();
-        assert_eq!(result_names(&queries), vec!["project"]);
+        assert_eq!(result_names(&queries.results), vec!["project"]);
     }
 
     #[test]
-    fn search_respects_limit() {
+    fn search_ranks_operations_before_types_and_fields() {
         let schema = fixture_schema();
-        let results = search_schema(&schema, "project", &SearchKind::All, 2).unwrap();
-        assert_eq!(results.len(), 2);
+        let search = search_schema(&schema, "project", &SearchKind::All, 25).unwrap();
+
+        // Root operations first (exact match before prefix), then types,
+        // then fields that only matched via their parent type name, then
+        // input fields.
+        assert_eq!(
+            result_names(&search.results),
+            vec![
+                "project",
+                "projectDelete",
+                "Project",
+                "ProjectUpdateInput",
+                "id",
+                "name",
+                "name"
+            ]
+        );
+        assert_eq!(search.total, 7);
+    }
+
+    #[test]
+    fn search_truncates_after_ranking() {
+        let schema = fixture_schema();
+        let search = search_schema(&schema, "project", &SearchKind::All, 2).unwrap();
+
+        // A small limit keeps the best-ranked results — the executable
+        // operations — and still reports how many matches exist in total.
+        assert_eq!(
+            result_names(&search.results),
+            vec!["project", "projectDelete"]
+        );
+        assert_eq!(search.total, 7);
     }
 
     #[test]
@@ -1084,8 +1254,24 @@ mod tests {
         assert_eq!(descriptions.len(), 1);
         assert_eq!(descriptions[0]["kind"], json!("OBJECT"));
         assert_eq!(descriptions[0]["name"], json!("Project"));
+        assert_eq!(descriptions[0]["interfaces"], json!(["Node"]));
+        assert_eq!(descriptions[0]["possibleTypes"], json!([]));
         let fields = descriptions[0]["fields"].as_array().unwrap();
         assert_eq!(result_names(fields), vec!["id", "name"]);
+    }
+
+    #[test]
+    fn describe_lists_union_members() {
+        let schema = fixture_schema();
+        let descriptions = describe_schema_member(&schema, "InvitationTarget").unwrap();
+
+        assert_eq!(descriptions.len(), 1);
+        assert_eq!(descriptions[0]["kind"], json!("UNION"));
+        assert_eq!(
+            descriptions[0]["possibleTypes"],
+            json!(["InviteCode", "ProjectInvitation"])
+        );
+        assert_eq!(descriptions[0]["fields"], json!([]));
     }
 
     #[test]
@@ -1176,6 +1362,53 @@ mod tests {
         );
         assert_eq!(operation_summary(document, Some("C")), None);
         assert_eq!(operation_summary(document, None), None);
+    }
+
+    #[test]
+    fn summarizes_fragment_based_operations() {
+        assert_eq!(
+            operation_summary(
+                "query Q { ...Root } fragment Root on Query { me { id } }",
+                None
+            ),
+            Some("query:me".to_string())
+        );
+        assert_eq!(
+            operation_summary(
+                "query { me { id } ...Rest } fragment Rest on Query { projects { id } }",
+                None
+            ),
+            Some("query:me+projects".to_string())
+        );
+        assert_eq!(
+            operation_summary("query { ... on Query { me { id } } }", None),
+            Some("query:me".to_string())
+        );
+    }
+
+    #[test]
+    fn summarizes_cyclic_and_duplicate_fragments_safely() {
+        // Cyclic spreads are invalid GraphQL but still parse; the summary
+        // must terminate and keep the fields it can reach.
+        assert_eq!(
+            operation_summary(
+                "query { ...A } fragment A on Query { ...B } fragment B on Query { ...A me { id } }",
+                None
+            ),
+            Some("query:me".to_string())
+        );
+        // GraphQL merges a field selected both directly and via a fragment,
+        // so it is reported once.
+        assert_eq!(
+            operation_summary(
+                "query { me { id } ...R } fragment R on Query { me { name } }",
+                None
+            ),
+            Some("query:me".to_string())
+        );
+        // A spread without a matching fragment definition contributes
+        // nothing, so the document produces no summary.
+        assert_eq!(operation_summary("query { ...Missing }", None), None);
     }
 
     #[test]

--- a/src/commands/api.rs
+++ b/src/commands/api.rs
@@ -1,15 +1,21 @@
 use std::{
     fs,
     io::{self, Read, Write},
+    time::Instant,
 };
 
 use anyhow::{Context, anyhow, bail};
 use clap::{Args as ClapArgs, Subcommand, ValueEnum};
+use graphql_parser::query::{Definition, OperationDefinition, Selection};
 use is_terminal::IsTerminal;
 use serde::Serialize;
 use serde_json::{Value, json};
 
+use crate::telemetry;
+
 use super::*;
+
+const MAX_OPERATION_SUMMARY_FIELDS: usize = 5;
 
 /// Query the Railway public GraphQL API
 #[derive(Parser, Debug)]
@@ -144,7 +150,31 @@ async fn run_describe(args: DescribeArgs) -> Result<()> {
 }
 
 async fn run_execute(args: ExecuteArgs) -> Result<()> {
+    let started = Instant::now();
     let query = resolve_query_source(args.query.as_deref(), args.file.as_deref(), false)?;
+    let summary = operation_summary(&query.document, args.operation_name.as_deref());
+
+    let result = execute_document(&args, &query).await;
+
+    if let Some(summary) = summary {
+        telemetry::send(telemetry::CliTrackEvent {
+            command: "api".to_string(),
+            sub_command: Some(format!("execute:{summary}")),
+            duration_ms: started.elapsed().as_millis() as u64,
+            success: result.is_ok(),
+            error_message: None,
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            cli_version: env!("CARGO_PKG_VERSION"),
+            is_ci: Configs::env_is_ci(),
+        })
+        .await;
+    }
+
+    result
+}
+
+async fn execute_document(args: &ExecuteArgs, query: &QuerySource) -> Result<()> {
     let variables = parse_variables(&VariableArgs {
         variables: args.variables.as_deref(),
         vars: &args.vars,
@@ -175,6 +205,66 @@ async fn run_execute(args: ExecuteArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Summarizes the operation that will execute as `<type>:<field>[+<field>...]`,
+/// e.g. `mutation:serviceInstanceUpdate`. Only operation types and top-level
+/// field names are captured — never arguments or values — so this is safe to
+/// report in telemetry for understanding which API capabilities get used.
+fn operation_summary(document: &str, operation_name: Option<&str>) -> Option<String> {
+    let ast = graphql_parser::parse_query::<&str>(document).ok()?;
+    let operations: Vec<&OperationDefinition<&str>> = ast
+        .definitions
+        .iter()
+        .filter_map(|definition| match definition {
+            Definition::Operation(operation) => Some(operation),
+            Definition::Fragment(_) => None,
+        })
+        .collect();
+
+    let operation = match operation_name {
+        Some(name) => *operations
+            .iter()
+            .find(|operation| operation_definition_name(operation) == Some(name))?,
+        None => match operations.as_slice() {
+            [single] => single,
+            _ => return None,
+        },
+    };
+
+    let (operation_type, selection_set) = match operation {
+        OperationDefinition::Query(query) => ("query", &query.selection_set),
+        OperationDefinition::Mutation(mutation) => ("mutation", &mutation.selection_set),
+        OperationDefinition::Subscription(subscription) => {
+            ("subscription", &subscription.selection_set)
+        }
+        OperationDefinition::SelectionSet(selection_set) => ("query", selection_set),
+    };
+
+    let fields: Vec<&str> = selection_set
+        .items
+        .iter()
+        .filter_map(|selection| match selection {
+            Selection::Field(field) => Some(field.name),
+            _ => None,
+        })
+        .take(MAX_OPERATION_SUMMARY_FIELDS)
+        .collect();
+
+    if fields.is_empty() {
+        return None;
+    }
+
+    Some(format!("{operation_type}:{}", fields.join("+")))
+}
+
+fn operation_definition_name<'a>(operation: &OperationDefinition<'a, &'a str>) -> Option<&'a str> {
+    match operation {
+        OperationDefinition::Query(query) => query.name,
+        OperationDefinition::Mutation(mutation) => mutation.name,
+        OperationDefinition::Subscription(subscription) => subscription.name,
+        OperationDefinition::SelectionSet(_) => None,
+    }
 }
 
 #[derive(Debug)]
@@ -1044,6 +1134,54 @@ mod tests {
         });
 
         assert_eq!(type_ref_to_string(&non_null_list), "[String!]!");
+    }
+
+    #[test]
+    fn summarizes_single_operations() {
+        assert_eq!(
+            operation_summary("query { me { id } }", None),
+            Some("query:me".to_string())
+        );
+        assert_eq!(
+            operation_summary("{ me { id } }", None),
+            Some("query:me".to_string())
+        );
+        assert_eq!(
+            operation_summary(
+                "mutation Update($id: String!) { serviceInstanceUpdate(serviceId: $id) }",
+                None
+            ),
+            Some("mutation:serviceInstanceUpdate".to_string())
+        );
+        assert_eq!(
+            operation_summary(
+                "query { me { id } projects { edges { node { id } } } }",
+                None
+            ),
+            Some("query:me+projects".to_string())
+        );
+    }
+
+    #[test]
+    fn summarizes_operation_selected_by_name() {
+        let document = "query A { me { id } } mutation B { projectDelete(id: \"x\") }";
+
+        assert_eq!(
+            operation_summary(document, Some("B")),
+            Some("mutation:projectDelete".to_string())
+        );
+        assert_eq!(
+            operation_summary(document, Some("A")),
+            Some("query:me".to_string())
+        );
+        assert_eq!(operation_summary(document, Some("C")), None);
+        assert_eq!(operation_summary(document, None), None);
+    }
+
+    #[test]
+    fn summarizes_nothing_for_invalid_documents() {
+        assert_eq!(operation_summary("not graphql", None), None);
+        assert_eq!(operation_summary("", None), None);
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub fn get_dynamic_args(cmd: clap::Command) -> clap::Command {
 }
 
 pub mod add;
+pub mod api;
 pub mod autoupdate;
 pub mod bucket;
 pub mod cdn;

--- a/src/main.rs
+++ b/src/main.rs
@@ -505,22 +505,9 @@ fn command_needs_refresh(cli: &clap::ArgMatches) -> bool {
             )
     );
 
-    let is_offline_api_discovery_command = matches!(
-        cli.subcommand(),
-        Some(("api", api_matches))
-            if matches!(api_matches.subcommand_name(), Some("search" | "describe"))
-                || matches!(
-                    api_matches.subcommand(),
-                    Some(("schema", schema_matches)) if !schema_matches.get_flag("refresh")
-                )
-    );
-
     cli.subcommand_name()
         .map(|cmd| {
-            !NO_AUTH_COMMANDS.contains(&cmd)
-                && !is_mcp_install
-                && !is_public_templates_command
-                && !is_offline_api_discovery_command
+            !NO_AUTH_COMMANDS.contains(&cmd) && !is_mcp_install && !is_public_templates_command
         })
         .unwrap_or(false)
 }
@@ -919,23 +906,21 @@ mod cli_tests {
                 "--allow-errors",
             ]);
             assert_parses(&["api", "schema"]);
-            assert_parses(&["api", "schema", "--refresh", "--compact"]);
+            assert_parses(&["api", "schema", "--compact"]);
             assert_parses(&["api", "search", "deployment", "--kind", "mutation"]);
             assert_parses(&["api", "describe", "ServiceInstanceUpdateInput"]);
         }
 
         #[test]
-        fn api_discovery_auth_refresh_is_subcommand_aware() {
+        fn api_commands_need_auth_refresh() {
             let search = parse(&["api", "search", "serviceInstance"]).unwrap();
             let describe = parse(&["api", "describe", "ServiceInstanceUpdateInput"]).unwrap();
             let schema = parse(&["api", "schema"]).unwrap();
-            let live_schema = parse(&["api", "schema", "--refresh"]).unwrap();
             let execute = parse(&["api", "{ me { id } }"]).unwrap();
 
-            assert!(!command_needs_refresh(&search));
-            assert!(!command_needs_refresh(&describe));
-            assert!(!command_needs_refresh(&schema));
-            assert!(command_needs_refresh(&live_schema));
+            assert!(command_needs_refresh(&search));
+            assert!(command_needs_refresh(&describe));
+            assert!(command_needs_refresh(&schema));
             assert!(command_needs_refresh(&execute));
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ mod telemetry;
 commands!(
     add,
     agent,
+    api,
     autoupdate,
     bucket,
     cdn,
@@ -504,9 +505,22 @@ fn command_needs_refresh(cli: &clap::ArgMatches) -> bool {
             )
     );
 
+    let is_offline_api_discovery_command = matches!(
+        cli.subcommand(),
+        Some(("api", api_matches))
+            if matches!(api_matches.subcommand_name(), Some("search" | "describe"))
+                || matches!(
+                    api_matches.subcommand(),
+                    Some(("schema", schema_matches)) if !schema_matches.get_flag("refresh")
+                )
+    );
+
     cli.subcommand_name()
         .map(|cmd| {
-            !NO_AUTH_COMMANDS.contains(&cmd) && !is_mcp_install && !is_public_templates_command
+            !NO_AUTH_COMMANDS.contains(&cmd)
+                && !is_mcp_install
+                && !is_public_templates_command
+                && !is_offline_api_discovery_command
         })
         .unwrap_or(false)
 }
@@ -876,6 +890,53 @@ mod cli_tests {
             assert_parses(&["setup", "agent", "-y"]);
             assert_parses(&["setup", "agent", "--remote"]);
             assert_parses(&["setup", "agent", "--remote", "-y"]);
+        }
+
+        #[test]
+        fn api_command_parses() {
+            assert_subcommand(&["api", "{ me { id } }"], "api");
+            assert_parses(&["api", "--file", "query.graphql"]);
+            assert_parses(&[
+                "api",
+                "--file",
+                "query.graphql",
+                "--variables",
+                "@vars.json",
+                "--var",
+                "limit=10",
+                "--raw-var",
+                "name=web",
+                "--operation-name",
+                "Project",
+                "--compact",
+            ]);
+            assert_parses(&[
+                "api",
+                "--file",
+                "query.graphql",
+                "--variables",
+                "@vars.json",
+                "--allow-errors",
+            ]);
+            assert_parses(&["api", "schema"]);
+            assert_parses(&["api", "schema", "--refresh", "--compact"]);
+            assert_parses(&["api", "search", "deployment", "--kind", "mutation"]);
+            assert_parses(&["api", "describe", "ServiceInstanceUpdateInput"]);
+        }
+
+        #[test]
+        fn api_discovery_auth_refresh_is_subcommand_aware() {
+            let search = parse(&["api", "search", "serviceInstance"]).unwrap();
+            let describe = parse(&["api", "describe", "ServiceInstanceUpdateInput"]).unwrap();
+            let schema = parse(&["api", "schema"]).unwrap();
+            let live_schema = parse(&["api", "schema", "--refresh"]).unwrap();
+            let execute = parse(&["api", "{ me { id } }"]).unwrap();
+
+            assert!(!command_needs_refresh(&search));
+            assert!(!command_needs_refresh(&describe));
+            assert!(!command_needs_refresh(&schema));
+            assert!(command_needs_refresh(&live_schema));
+            assert!(command_needs_refresh(&execute));
         }
 
         #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -32,51 +32,6 @@ pub struct SetupAgentTrackEvent {
     pub configured_clients: Option<Vec<String>>,
 }
 
-#[derive(Clone)]
-pub struct CliApiTrackEvent {
-    pub action: &'static str,
-    pub duration_ms: u64,
-    pub success: bool,
-    pub error_message: Option<String>,
-    pub operation_name: Option<String>,
-    pub query_hash: Option<String>,
-    pub query_document: Option<String>,
-    pub variable_keys: Vec<String>,
-    pub variable_shape: Option<Value>,
-    pub auth_mode: Option<String>,
-    pub http_status: Option<u16>,
-    pub graphql_error_count: Option<usize>,
-    pub graphql_error_codes: Vec<String>,
-    pub response_bytes: Option<usize>,
-    pub schema_source: Option<String>,
-    pub search_term: Option<String>,
-    pub describe_name: Option<String>,
-}
-
-impl CliApiTrackEvent {
-    pub fn new(action: &'static str) -> Self {
-        Self {
-            action,
-            duration_ms: 0,
-            success: false,
-            error_message: None,
-            operation_name: None,
-            query_hash: None,
-            query_document: None,
-            variable_keys: Vec::new(),
-            variable_shape: None,
-            auth_mode: None,
-            http_status: None,
-            graphql_error_count: None,
-            graphql_error_codes: Vec::new(),
-            response_bytes: None,
-            schema_source: None,
-            search_term: None,
-            describe_name: None,
-        }
-    }
-}
-
 pub enum SetupAgentPhase {
     Start,
     Finish,
@@ -2173,63 +2128,6 @@ pub async fn send_auth_event(event: CliAuthTrackEvent) {
 
     let body = json!({
         "query": "mutation CliAuthEventTrack($input: CliAuthEventTrackInput!) { cliAuthEventTrack(input: $input) }",
-        "variables": { "input": input },
-    });
-
-    let _ = post_telemetry_body(&client, configs.get_backboard(), body).await;
-}
-
-pub async fn send_api_event(event: CliApiTrackEvent) {
-    if is_telemetry_disabled() {
-        return;
-    }
-
-    let configs = match Configs::new() {
-        Ok(c) => c,
-        Err(_) => return,
-    };
-
-    let client = GQLClient::new_authorized(&configs)
-        .or_else(|_| GQLClient::new_public())
-        .ok();
-    let Some(client) = client else {
-        return;
-    };
-
-    let context = TelemetryContext::current(&configs);
-    let input = json!({
-        "action": event.action,
-        "durationMs": event.duration_ms as i64,
-        "success": event.success,
-        "errorMessage": event.error_message,
-        "operationName": event.operation_name,
-        "queryHash": event.query_hash,
-        "queryDocument": event.query_document,
-        "variableKeys": event.variable_keys,
-        "variableShape": event.variable_shape,
-        "authMode": event.auth_mode,
-        "httpStatus": event.http_status,
-        "graphqlErrorCount": event.graphql_error_count,
-        "graphqlErrorCodes": event.graphql_error_codes,
-        "responseBytes": event.response_bytes,
-        "schemaSource": event.schema_source,
-        "searchTerm": event.search_term,
-        "describeName": event.describe_name,
-        "sessionId": context.session_id,
-        "caller": context.caller,
-        "agentSessionId": context.agent_session_id,
-        "installRequestId": context.install_request_id,
-        "projectId": context.project_id,
-        "environmentId": context.environment_id,
-        "serviceId": context.service_id,
-        "cliVersion": env!("CARGO_PKG_VERSION"),
-        "os": std::env::consts::OS,
-        "arch": std::env::consts::ARCH,
-        "isCi": Configs::env_is_ci(),
-    });
-
-    let body = json!({
-        "query": "mutation CliApiEventTrack($input: CliApiEventTrackInput!) { cliApiEventTrack(input: $input) }",
         "variables": { "input": input },
     });
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -32,6 +32,51 @@ pub struct SetupAgentTrackEvent {
     pub configured_clients: Option<Vec<String>>,
 }
 
+#[derive(Clone)]
+pub struct CliApiTrackEvent {
+    pub action: &'static str,
+    pub duration_ms: u64,
+    pub success: bool,
+    pub error_message: Option<String>,
+    pub operation_name: Option<String>,
+    pub query_hash: Option<String>,
+    pub query_document: Option<String>,
+    pub variable_keys: Vec<String>,
+    pub variable_shape: Option<Value>,
+    pub auth_mode: Option<String>,
+    pub http_status: Option<u16>,
+    pub graphql_error_count: Option<usize>,
+    pub graphql_error_codes: Vec<String>,
+    pub response_bytes: Option<usize>,
+    pub schema_source: Option<String>,
+    pub search_term: Option<String>,
+    pub describe_name: Option<String>,
+}
+
+impl CliApiTrackEvent {
+    pub fn new(action: &'static str) -> Self {
+        Self {
+            action,
+            duration_ms: 0,
+            success: false,
+            error_message: None,
+            operation_name: None,
+            query_hash: None,
+            query_document: None,
+            variable_keys: Vec::new(),
+            variable_shape: None,
+            auth_mode: None,
+            http_status: None,
+            graphql_error_count: None,
+            graphql_error_codes: Vec::new(),
+            response_bytes: None,
+            schema_source: None,
+            search_term: None,
+            describe_name: None,
+        }
+    }
+}
+
 pub enum SetupAgentPhase {
     Start,
     Finish,
@@ -2128,6 +2173,63 @@ pub async fn send_auth_event(event: CliAuthTrackEvent) {
 
     let body = json!({
         "query": "mutation CliAuthEventTrack($input: CliAuthEventTrackInput!) { cliAuthEventTrack(input: $input) }",
+        "variables": { "input": input },
+    });
+
+    let _ = post_telemetry_body(&client, configs.get_backboard(), body).await;
+}
+
+pub async fn send_api_event(event: CliApiTrackEvent) {
+    if is_telemetry_disabled() {
+        return;
+    }
+
+    let configs = match Configs::new() {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let client = GQLClient::new_authorized(&configs)
+        .or_else(|_| GQLClient::new_public())
+        .ok();
+    let Some(client) = client else {
+        return;
+    };
+
+    let context = TelemetryContext::current(&configs);
+    let input = json!({
+        "action": event.action,
+        "durationMs": event.duration_ms as i64,
+        "success": event.success,
+        "errorMessage": event.error_message,
+        "operationName": event.operation_name,
+        "queryHash": event.query_hash,
+        "queryDocument": event.query_document,
+        "variableKeys": event.variable_keys,
+        "variableShape": event.variable_shape,
+        "authMode": event.auth_mode,
+        "httpStatus": event.http_status,
+        "graphqlErrorCount": event.graphql_error_count,
+        "graphqlErrorCodes": event.graphql_error_codes,
+        "responseBytes": event.response_bytes,
+        "schemaSource": event.schema_source,
+        "searchTerm": event.search_term,
+        "describeName": event.describe_name,
+        "sessionId": context.session_id,
+        "caller": context.caller,
+        "agentSessionId": context.agent_session_id,
+        "installRequestId": context.install_request_id,
+        "projectId": context.project_id,
+        "environmentId": context.environment_id,
+        "serviceId": context.service_id,
+        "cliVersion": env!("CARGO_PKG_VERSION"),
+        "os": std::env::consts::OS,
+        "arch": std::env::consts::ARCH,
+        "isCi": Configs::env_is_ci(),
+    });
+
+    let body = json!({
+        "query": "mutation CliApiEventTrack($input: CliApiEventTrackInput!) { cliApiEventTrack(input: $input) }",
         "variables": { "input": input },
     });
 


### PR DESCRIPTION
## Summary

Adds `railway api`, a discovery-first interface for exploring Railway's public GraphQL schema and executing authenticated operations directly from the CLI.

Agents can search and describe the live introspection schema, then run precise API operations before those capabilities have first-class CLI commands.

## What Changed

- Added schema discovery commands, all backed by live introspection fetched from the Railway API (nothing is bundled with the CLI):
  - `railway api search <term>`
  - `railway api describe <name>`
  - `railway api schema`
- Schema fetches fail with a clear error when the API returns a non-2xx status or GraphQL errors, instead of printing an error payload as if it were a schema.
- Search output is `{"results": [...], "total": N}`, and results are ranked before `--limit` is applied: executable root operations first, then types, then fields, with name-match quality (exact > prefix > substring > description > parent-type-only) breaking ties. A default limit therefore surfaces `query deployment` and the `deployment*` mutations instead of being exhausted by alphabetically early type/field matches, and `total` makes truncation detectable.
- `railway api describe` always prints `{"matches": [...]}` so the output shape is stable for machine consumers, and includes `interfaces` and `possibleTypes` so union members and interface implementors are visible when constructing inline fragments (e.g. `PublicProjectInvitation` → `InviteCode | ProjectInvitation`).
- Added `railway api [QUERY]` for executing GraphQL documents against the Railway public API.
- Supports query input via inline argument, stdin, or `--file`.
- Supports variables via `--variables`, `--var`, and `--raw-var`.
- Added `--operation-name`, `--compact`, and `--allow-errors`.
- Executed operations are tracked via the existing `cliEventTrack` telemetry event — see the Telemetry section below. No backend changes required.
- Added CLI parse and auth-refresh tests, plus fixture-based unit tests for schema search ranking and truncation, describe (including union members), type-ref rendering, and operation-name extraction (including fragment resolution).

## Telemetry

Every `railway api` invocation sends the standard generic CLI event (command, subcommand, duration, success, error message) via the existing `commands!` macro — nothing new there.

In addition, direct execution parses the GraphQL document with `graphql-parser` and reports **which operation ran** as a second `cliEventTrack` event:

- `command: "api"`, `sub_command: "execute:<type>:<field>[+<field>...]"`
- Examples: `execute:query:me`, `execute:mutation:serviceInstanceUpdate`, `execute:query:me+projects` (multiple root fields join with `+`, capped at 5)
- Root-level fragment spreads and inline fragments are resolved to the fields they select, so fragment-shaped documents report the same summary as their expanded form.
- The event carries duration and a success flag. Success means the operation executed without GraphQL errors: `--allow-errors` only changes the CLI exit status, so an error response can never be recorded as a successfully used capability.

### What this tells us

`SELECT sub_command, success, COUNT(*) ... WHERE command = 'api' AND sub_command LIKE 'execute:%'` gives:

- **`success = true`** → which existing API capabilities agents and users actually use. This is the prioritization signal for promoting operations to first-class CLI commands.
- **`success = false`** → failed operations, including documents that name **operations that don't exist**. The summary is extracted syntactically (no schema validation client-side), so a guessed field like `execute:query:serviceRestart` still gets reported and then fails API validation. Hallucinated names are effectively feature requests — they show what agents expect the API to offer.

### Privacy

Only the operation type and top-level field names are extracted from the parsed AST. Arguments, variables, and inline literals are never captured, so no user data or secrets can reach telemetry.

### Edge cases

- Syntactically invalid documents produce no operation event (there is no meaningful name to report); the generic event still records the failed invocation.
- Multi-operation documents without `--operation-name` produce no operation event — we report what ran, never a guess.
- Fragment resolution guards against cyclic spreads (invalid GraphQL, but they still parse), and a field selected both directly and via a fragment is reported once, matching GraphQL's field merging.
- Telemetry failures never affect command execution (existing fire-and-forget behavior with a 3s timeout).
- Guessed operation names make `sub_command` values unbounded; expect a long tail of junk values in the `success = false` bucket.

A richer dedicated event (e.g. with GraphQL error codes to cleanly separate "operation doesn't exist" from "operation failed") was considered and deferred: it needs a new backboard mutation first.

## Why

The intended workflow is discovery-first: search for a capability, inspect the relevant field or type, and then execute a precise operation without guessing the API shape or authentication details. Discovery always reflects the current live schema, so results never drift from what the API actually supports.

## Discovery-first workflow

```sh
# Fetch and print the current live schema from the Railway API.
railway api schema

# Search the live schema for matching types and fields.
railway api search serviceInstance

# Narrow schema search results to mutation fields.
railway api search serviceInstance --kind mutation

# Inspect a root field, including its arguments and return type.
railway api describe serviceInstance

# Inspect a GraphQL type and its fields.
railway api describe ServiceInstance

# Execute an authenticated inline query.
railway api 'query { me { id name } }'

# Execute a saved query with variables from a JSON file.
railway api --file query.graphql --variables @vars.json
```

## Validation

- `cargo fmt --all --check`
- `cargo clippy --bin railway` (no warnings in changed files)
- `cargo test --bin railway` (468 passed)
- Manually verified against the live API:
  - `railway api --help`
  - `railway api schema`
  - `railway api search` — `search deployment` returns `Query.deployment`, `Subscription.deployment`, and the `deployment*` mutations first, with `total` reported
  - `railway api describe` — including `describe PublicProjectInvitation` listing its union members
  - authenticated read-only queries including `me`, workspace projects, project by ID, service instance, and deployment by ID
  - fragment-shaped documents (`query Q { ...Root } fragment Root on Query { me { id } }`) execute and summarize correctly
  - `--allow-errors` exits 0 on an HTTP 200 response carrying a GraphQL errors array and 1 without the flag; validation errors return HTTP 400 and exit 1 either way
