### PR TITLE
Infer feature flag project from CLI context

### DIFF
--- a/src/commands/flag.rs
+++ b/src/commands/flag.rs
@@ -12,13 +12,13 @@ use crate::{
 #[derive(Parser)]
 #[command(subcommand_required = true, arg_required_else_help = true)]
 #[clap(
-    after_help = "Examples:\n\n  railway flag list\n  railway flag set checkout.v2 true\n  railway flag set theme \"blue\"\n  railway flag set checkout.v2 true --when 'workspace_plan == \"enterprise\"'\n  railway flag set checkout.v2 true --when \"bucket(workspace_id) < 0.25\"\n  railway flag delete checkout.v2\n  railway flag unset checkout.v2 --rule-id enterprise-on\n"
+    after_help = "Examples:\n\n  railway flag list\n  railway flag set checkout.v2 true\n  railway flag set theme \"blue\"\n  railway flag set checkout.v2 true --when 'plan == \"enterprise\"'\n  railway flag set checkout.v2 true --when \"bucket(key) < 0.25\"\n  railway flag delete checkout.v2\n  railway flag unset checkout.v2 --rule-id enterprise-on\n"
 )]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
 
-    /// Flag scope, e.g. workspace:<id> or project:<id> (defaults to linked project's workspace)
+    /// Project containing the flags, as project:<id> (defaults to the project token or linked project)
     #[clap(long, global = true)]
     scope: Option<String>,
 
@@ -33,7 +33,7 @@ pub struct Args {
 
 #[derive(Parser)]
 enum Commands {
-    /// List feature flags for a scope
+    /// List feature flags for the current project
     #[clap(visible_alias = "ls")]
     List(ListArgs),
 
@@ -100,7 +100,7 @@ struct UnsetArgs {
 pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let owner = resolve_scope_owner(&client, &configs, args.scope.or(args.owner)).await?;
+    let owner = resolve_scope_owner(&configs, args.scope.or(args.owner)).await?;
 
     match args.command {
         Commands::List(list_args) => {
@@ -543,5 +543,13 @@ mod flag_list_tests {
             "source": { "type": "literal", "value": true },
         });
         assert_eq!(rule_value(&rule), Some(&serde_json::Value::Bool(true)));
+    }
+
+    #[test]
+    fn accepts_project_scope_after_subcommand() {
+        let args = Args::try_parse_from(["railway flag", "list", "--scope", "project:project-id"])
+            .expect("--scope should be accepted after a subcommand");
+
+        assert_eq!(args.scope.as_deref(), Some("project:project-id"));
     }
 }

--- a/src/controllers/signals.rs
+++ b/src/controllers/signals.rs
@@ -5,23 +5,16 @@ use serde_json::Value;
 use crate::{
     client::post_graphql,
     commands::Configs,
-    gql::{
-        queries,
-        signals::{
-            Signal, SignalCreate, SignalDefaultSet, SignalDelete, SignalReplace, SignalRuleSet,
-            SignalRuleUnset, Signals, signal, signal_create, signal_default_set, signal_delete,
-            signal_replace, signal_rule_set, signal_rule_unset, signals,
-        },
+    gql::signals::{
+        Signal, SignalCreate, SignalDefaultSet, SignalDelete, SignalReplace, SignalRuleSet,
+        SignalRuleUnset, Signals, signal, signal_create, signal_default_set, signal_delete,
+        signal_replace, signal_rule_set, signal_rule_unset, signals,
     },
 };
 
 pub type SignalType = signal_create::SignalType;
 
-pub async fn resolve_scope_owner(
-    client: &Client,
-    configs: &Configs,
-    explicit: Option<String>,
-) -> Result<String> {
+pub async fn resolve_scope_owner(configs: &Configs, explicit: Option<String>) -> Result<String> {
     if let Some(scope) = explicit {
         return parse_scope(&scope);
     }
@@ -32,20 +25,11 @@ pub async fn resolve_scope_owner(
         return parse_scope(&from_env);
     }
 
-    let linked = configs
-        .get_linked_project()
-        .await
-        .context("No linked project. Link one with `railway link` or pass --scope.")?;
-    let vars = queries::project::Variables {
-        id: linked.project.clone(),
-    };
-    let project = post_graphql::<queries::Project, _>(client, configs.get_backboard(), vars)
-        .await?
-        .project;
-    let workspace_id = project
-        .workspace_id
-        .context("Linked project has no workspace id; pass --scope explicitly.")?;
-    Ok(format!("workspace:{workspace_id}"))
+    let linked = configs.get_linked_project().await.context(
+        "Could not determine a project. Set RAILWAY_TOKEN to a project token, link a project with \
+         `railway link`, or pass --scope project:<id>.",
+    )?;
+    Ok(format!("project:{}", linked.project))
 }
 
 fn parse_scope(raw: &str) -> Result<String> {


### PR DESCRIPTION
Default railway flag to the project resolved from RAILWAY_TOKEN or railway link instead of the linked project's workspace. Project-token writes depend on railwayapp/mono#33088.