### PR TITLE
fix(add): don't fail after service creation when project context is env-injected

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -337,8 +337,10 @@ async fn create_service(
     }
     let s =
         post_graphql::<mutations::ServiceCreate, _>(client, &configs.get_backboard(), vars).await?;
-    configs.link_service(s.service_create.id.clone())?;
-    configs.write()?;
+
+    // Report the created service before local-link bookkeeping so a config
+    // write failure can never mask a successful creation.
+    let will_link = !Configs::uses_env_project_targeting();
     if json {
         println!(
             "{}",
@@ -346,9 +348,17 @@ async fn create_service(
         );
     } else if let Some(spinner) = spinner {
         spinner.finish_with_message(format!(
-            "Successfully created the service \"{}\" and linked to it",
-            s.service_create.name.blue()
+            "Successfully created the service \"{}\"{}",
+            s.service_create.name.blue(),
+            if will_link { " and linked to it" } else { "" }
         ));
+    }
+
+    // Env-var / token targeted runs have no on-disk link entry to update;
+    // attempting to would fail with ProjectNotFound.
+    if will_link {
+        configs.link_service(s.service_create.id.clone())?;
+        configs.write()?;
     }
     Ok(())
 }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -338,9 +338,12 @@ async fn create_service(
     let s =
         post_graphql::<mutations::ServiceCreate, _>(client, &configs.get_backboard(), vars).await?;
 
+    // Env-var / token targeted runs have no on-disk link entry to update;
+    // linking there would fail with ProjectNotFound.
+    let will_link = !Configs::uses_env_project_targeting();
+
     // Report the created service before local-link bookkeeping so a config
     // write failure can never mask a successful creation.
-    let will_link = !Configs::uses_env_project_targeting();
     if json {
         println!(
             "{}",
@@ -354,8 +357,6 @@ async fn create_service(
         ));
     }
 
-    // Env-var / token targeted runs have no on-disk link entry to update;
-    // attempting to would fail with ProjectNotFound.
     if will_link {
         configs.link_service(s.service_create.id.clone())?;
         configs.write()?;

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -213,9 +213,8 @@ pub async fn fetch_and_create(
         .iter()
         .find(|s| !old_service_ids.contains(&s.node.id));
 
-    // Auto-link if should_link is true and no service is currently linked.
     // Env-var / token targeted runs have no on-disk link entry to update;
-    // attempting to would fail with ProjectNotFound after the template was
+    // linking there would fail with ProjectNotFound after the template was
     // already deployed.
     let should_auto_link = options.should_link
         && linked_project.service.is_none()

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -213,8 +213,14 @@ pub async fn fetch_and_create(
         .iter()
         .find(|s| !old_service_ids.contains(&s.node.id));
 
-    // Auto-link if should_link is true and no service is currently linked
-    if options.should_link && linked_project.service.is_none() {
+    // Auto-link if should_link is true and no service is currently linked.
+    // Env-var / token targeted runs have no on-disk link entry to update;
+    // attempting to would fail with ProjectNotFound after the template was
+    // already deployed.
+    let should_auto_link = options.should_link
+        && linked_project.service.is_none()
+        && !Configs::uses_env_project_targeting();
+    if should_auto_link {
         if let Some(service) = new_service {
             configs.link_service(service.node.id.clone())?;
             configs.write()?;
@@ -241,7 +247,7 @@ pub async fn fetch_and_create(
         println!("{}", output);
     } else if let Some(spinner) = spinner {
         let mut msg = format!("🎉 Added {} to project", template_name.green().bold());
-        if options.should_link && linked_project.service.is_none() && new_service.is_some() {
+        if should_auto_link && new_service.is_some() {
             msg.push_str(" and linked");
         }
         spinner.finish_with_message(msg);

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -162,7 +162,7 @@ async fn ensure_default_target_has_linked_service(target: &TargetArgs) -> Result
     if !std::io::stdout().is_terminal() {
         return Ok(());
     }
-    if Configs::has_env_var_project_config() || Configs::get_railway_token().is_some() {
+    if Configs::uses_env_project_targeting() {
         return Ok(());
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,6 +220,13 @@ impl Configs {
         Self::get_railway_token().is_some() || Self::get_railway_api_token().is_some()
     }
 
+    /// True when project targeting comes from env vars or RAILWAY_TOKEN rather
+    /// than an on-disk link (e.g. CI, cloud agents). In this mode there is no
+    /// local link entry to read or update.
+    pub fn uses_env_project_targeting() -> bool {
+        Self::has_env_var_project_config() || Self::get_railway_token().is_some()
+    }
+
     /// True when the `CI` env var is set to any truthy value (`true`,
     /// `1`, `yes`, ...). Runners differ on the value they export, so
     /// treat anything except empty / `false` / `0` as CI — consistent
@@ -348,7 +355,7 @@ impl Configs {
     }
 
     pub fn get_closest_linked_project_directory(&self) -> Result<String> {
-        if Self::has_env_var_project_config() || Self::get_railway_token().is_some() {
+        if Self::uses_env_project_targeting() {
             return self.get_current_directory();
         }
 


### PR DESCRIPTION
## Problem

Inside a Railway Cloud Agent VM (or any env with `RAILWAY_PROJECT_ID`/`RAILWAY_ENVIRONMENT_ID`/`RAILWAY_TOKEN` targeting and no on-disk link), `railway add --service <name>`:

1. resolves project context from env vars ✓
2. `serviceCreate` mutation succeeds — **the service exists now** ✓
3. `configs.link_service()` → `get_linked_project_mut()` only reads the on-disk `~/.railway` config, finds no entry for cwd → `Project not found. Run railway link` ✗
4. exits nonzero **without ever printing the created `{id, name}`**

Callers (CI scripts, cloud agents) see a failure, never learn the new service id, and improvise — in the observed case, an agent deployed to a preexisting service instead of the one it had just created.

## Fix

- `add`: report the created service (JSON / spinner) **before** local-link bookkeeping, and skip linking entirely when project targeting is env-injected — there is no on-disk entry to update. Spinner only claims "and linked to it" when it actually links.
- `deploy` `fetch_and_create` (used by `railway add --database` and template deploys): same shape, same skip for the post-create auto-link.
- `config`: name the predicate `uses_env_project_targeting()` and reuse it in `get_closest_linked_project_directory`, which already special-cased the identical condition.

`up.rs`'s post-create `link_service` is safe as-is: that flow disk-links the project via `link_project` before linking the service.

## Verification

- `cargo test`: 451 passed
- `cargo clippy --all-targets`: same 44 pre-existing warnings as master, none new