### PR TITLE
fix(oauth): send CLI User-Agent on OAuth requests

### DIFF
--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     config::{Configs, Environment},
+    consts,
     errors::RailwayError,
 };
 
@@ -31,6 +32,7 @@ fn get_oauth_base_url(host: &str) -> String {
 
 fn build_http_client() -> Result<reqwest::Client> {
     let client = reqwest::Client::builder()
+        .user_agent(consts::get_user_agent())
         .danger_accept_invalid_certs(matches!(Configs::get_environment_id(), Environment::Dev))
         .timeout(Duration::from_secs(30))
         .build()?;


### PR DESCRIPTION
## What

Sets `User-Agent: CLI <version>` on the reqwest client used for all OAuth requests (device flow + token refresh), via the same `consts::get_user_agent()` the GraphQL client already uses. Previously `build_http_client()` set no User-Agent, and reqwest sends none by default. Needed for debugging purposes

## Testing

- `cargo check` passes, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)