### PR TITLE
fix: agent onboarding hangs found dogfooding in a Railway Sandbox

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -949,9 +949,11 @@ run_agent_setup() {
 
   # Record login state (and the "Logged in as …" line) for the next-steps
   # block; don't warn here. whoami exits non-zero and prints nothing when
-  # unauthenticated.
-  AGENT_WHOAMI="$("$railway_bin" whoami 2>/dev/null)"
-  if [ $? -eq 0 ] && [ -n "$AGENT_WHOAMI" ]; then
+  # unauthenticated — the `|| true` matters under `set -e`: without it, this
+  # assignment itself aborts the whole script for the (extremely common)
+  # not-logged-in-yet case, and print_agent_next_steps() below never runs.
+  AGENT_WHOAMI="$("$railway_bin" whoami 2>/dev/null || true)"
+  if [ -n "$AGENT_WHOAMI" ]; then
     AGENT_LOGGED_IN=1
   else
     AGENT_LOGGED_IN=0
@@ -1047,6 +1049,19 @@ if [ "$AGENTS" = 1 ] && has railway; then
 
   if [ "$NEEDS_UPGRADE" = 0 ]; then
     info "No PATH changes were made."
+    run_agent_setup "$RAILWAY_BIN"
+    exit 0
+  fi
+
+  # Refuse to self-upgrade inside a Railway Sandbox. The sandbox's own
+  # exec/SSH bridge is served by the resident `railway` process, so
+  # replacing that binary in place isn't possible there (extracting or
+  # renaming a new binary over it fails, with no user-facing workaround).
+  # The sandbox's pre-installed CLI is managed by Railway, so continue
+  # with it instead of attempting an upgrade that cannot succeed.
+  if [ -n "${RAILWAY_SANDBOX_ID-}" ]; then
+    info "Running inside a Railway Sandbox — the pre-installed CLI is managed by Railway."
+    info "Continuing with $CURRENT_VERSION."
     run_agent_setup "$RAILWAY_BIN"
     exit 0
   fi

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -135,14 +135,22 @@ pub async fn command(args: Args) -> Result<()> {
         }
         Err(_) => "failed",
     };
-    crate::telemetry::send_auth_event(crate::telemetry::CliAuthTrackEvent {
-        transport,
-        outcome,
-        transport_reason: reason,
-        success: result.is_ok(),
-        error_message: result.as_ref().err().map(|e| e.to_string()),
-    })
-    .await;
+    // Fire-and-forget: telemetry is a side effect, not something the user's
+    // result should wait on. Awaiting it inline used to put a second,
+    // independent network call (with its own timeout) in the critical path
+    // of surfacing the *real* outcome to the user — on a flaky or blocked
+    // network path, that doubles the worst-case wait before anything is
+    // printed at all. `result?` below now runs immediately after the auth
+    // attempt itself resolves.
+    tokio::spawn(crate::telemetry::send_auth_event(
+        crate::telemetry::CliAuthTrackEvent {
+            transport,
+            outcome,
+            transport_reason: reason,
+            success: result.is_ok(),
+            error_message: result.as_ref().err().map(|e| e.to_string()),
+        },
+    ));
 
     let token_resp = result?;
 


### PR DESCRIPTION
## Summary

Ran the documented `curl -fsSL agents.railway.com | sh` flow end to end inside a fresh `railway sandbox create` VM (as a stand-in for what an agent hits on first use), and found two real, reproducible bugs, plus traced a third symptom to something outside this repo.

**1. `install.sh`'s self-upgrade always fails inside a Railway Sandbox.** The sandbox ships a CLI that's one version behind. The installer detects that and tries to upgrade in place, which always fails:
```
tar: railway: Cannot open: File exists
```
Root cause: the sandbox's own exec/SSH bridge is served by that same resident `railway` process, so nothing can replace it in place, not tar, not even a manual `rm`/`mv` (`Device or resource busy`). No workaround is exposed to the user. Fix: detect `RAILWAY_SANDBOX_ID` (already set by the sandbox) and skip the self-upgrade, continuing with the pre-installed version and running agent setup anyway, the same pattern the script already uses for the Homebrew-managed-install case right below it.

**2. Separately, `run_agent_setup` silently dies for any not-yet-logged-in user.** `AGENT_WHOAMI="$("$railway_bin" whoami 2>/dev/null)"` aborts the whole script under `set -e` whenever `whoami` exits non-zero, i.e. whenever the user isn't logged in yet, which is the single most common first-run case. The very next line, `if [ $? -eq 0 ]`, was clearly written to handle exactly this, but it never runs because the assignment already killed the script. Net effect: `print_agent_next_steps()` (the "Setup complete / Next steps: run `railway login`" footer) never prints for a brand-new user, on any platform, not just sandboxes. Fixed with `|| true` on the substitution.

Both fixes verified live: patched `install.sh` into a fresh sandbox and confirmed `--agents -y` now completes cleanly (exit 0) where it previously failed outright.

**3. `railway login` / `--browserless` hangs with zero output over `railway sandbox exec`.** Traced this past the CLI's own auth-detection logic (`exec_context.rs` — confirmed correct, tests pass, headless/browser-reachable detection isn't the issue) all the way to the network layer: a raw `curl -v` from inside a sandbox to `backboard.railway.com/oauth/device/auth` completes a full TLS 1.3 + HTTP/2 handshake, sends the request, and then never receives a response. The identical request from a normal external client gets a 401 in 0.19s. That's a networking/routing issue between Sandbox egress and backboard, not something this repo can fix, so it's out of scope for this PR, flagging separately.

What *is* in scope here: `login`'s outcome telemetry (`send_auth_event`) was `.await`ed inline, in the critical path, before the real result is surfaced to the user via `result?`. That's a second independent network call with its own timeout sitting between "the auth attempt resolved" and "the user sees anything" — on exactly this kind of network incident, that silently doubles the worst-case wait before any output appears. Made it fire-and-forget via `tokio::spawn` so a slow, hung, or failing telemetry call can never delay the user-visible outcome.

## Test plan
- [x] `cargo check` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test exec_context` — all 12 tests pass unchanged (auth-detection logic wasn't touched)
- [x] Live-verified the `install.sh` fix in a fresh `railway sandbox create` VM: unpatched script fails with `tar: railway: Cannot open: File exists`; patched script completes with exit 0 and installs skills/MCP to Claude Code, Codex, OpenCode, and Cursor
- [ ] Would appreciate a maintainer double-check on the `tokio::spawn` telemetry change interacting correctly with process exit timing (i.e. the spawned task doesn't need to complete for the CLI to exit, which is intentional, but flagging in case there's a reason it was awaited inline originally)

## Follow-up needed outside this repo
Filing/flagging separately: traffic from Railway Sandbox compute to `backboard.railway.com`'s OAuth endpoints (and likely other backboard traffic) appears to hang indefinitely rather than complete, which blocks authentication entirely from inside a Sandbox today. That needs eyes from whoever owns Sandbox networking / backboard ingress.