### PR TITLE
fix(install): don't require the GitHub API when RAILWAY_VERSION is pinned

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -408,19 +408,26 @@ RAILWAY_PATH_MARKER_END="# <<< railway initialize <<<"
 SHELL_STARTUP_FILE=""
 SHELL_STARTUP_ACTION=""
 
-DEFAULT_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name":[[:space:]]*"v[^"]*"' | cut -d'"' -f4 | cut -c2-)
+# Resolve the version to install, asking GitHub for the latest release only
+# when the caller hasn't pinned one. Called after argument parsing so that a
+# pinned install, --help and --uninstall all work without reaching the GitHub
+# API — an API rate limit shouldn't be able to fail an install of a version the
+# caller already named.
+resolve_version() {
+  if [ -n "${RAILWAY_VERSION-}" ]; then
+    return 0
+  fi
 
-if [ -z "$DEFAULT_VERSION" ]; then
-  error "Failed to fetch latest version from GitHub"
-  exit 1
-fi
+  RAILWAY_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name":[[:space:]]*"v[^"]*"' | cut -d'"' -f4 | cut -c2-)
 
+  if [ -z "$RAILWAY_VERSION" ]; then
+    error "Failed to fetch latest version from GitHub"
+    info "Set RAILWAY_VERSION=<x.y.z> to install a specific version without querying the API."
+    exit 1
+  fi
+}
 
 # defaults
-if [ -z "${RAILWAY_VERSION-}" ]; then
-  RAILWAY_VERSION="$DEFAULT_VERSION"
-fi
-
 if [ -z "${RAILWAY_PLATFORM-}" ]; then
   PLATFORM="$(detect_platform)"
 fi
@@ -1031,6 +1038,8 @@ if [ "$HELP" = 1 ]; then
     echo "${help_text}"
     exit 0
 fi
+
+resolve_version
 
 RAILWAY_UPGRADE_AGENT=0
 


### PR DESCRIPTION
Fixes #1030.

## Problem

`install.sh` queries the GitHub API for the latest release at line 411 — unconditionally, and with a hard `exit 1` on an empty result — *before* it checks whether the caller already pinned `RAILWAY_VERSION` (line 420), and *before* argument parsing (line 451).

```bash
DEFAULT_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o ...)

if [ -z "$DEFAULT_VERSION" ]; then
  error "Failed to fetch latest version from GitHub"
  exit 1
fi

if [ -z "${RAILWAY_VERSION-}" ]; then
  RAILWAY_VERSION="$DEFAULT_VERSION"
fi
```

Three consequences when the API is rate-limited or unreachable:

1. **A pinned install fails.** `RAILWAY_VERSION=5.27.1 bash <(curl -fsSL railway.com/install.sh)` errors out with `Failed to fetch latest version from GitHub`, even though `DEFAULT_VERSION` is discarded on the very next line. This is the reported failure — it bites CI pipelines that pin a version specifically to be insulated from rate limits.
2. **`--help` and `--uninstall` fail too.** Both are handled well after line 411, so removing an already-installed binary requires a working network path to `api.github.com`.
3. It always surfaces as this error rather than a curl failure: `curl -s` (no `-f`) exits **0** on a 403 and prints the rate-limit JSON body, so `set -eu` doesn't catch it — `grep` just finds no `tag_name` and `DEFAULT_VERSION` ends up empty.

## Fix

Move the lookup into `resolve_version()`, return early when `RAILWAY_VERSION` is already set, and call it after argument parsing and after the uninstall/help blocks — immediately before the first use of `$RAILWAY_VERSION`. `DEFAULT_VERSION` had no other readers and is dropped. The unpinned failure path also now hints at pinning.

## Verification

`bash -n` passes. Stubbing `curl` to return GitHub's 403 rate-limit body, on `master` vs. this branch:

| Scenario | `master` | This PR |
|---|---|---|
| `RAILWAY_VERSION=5.27.1` | `Failed to fetch latest version` | resolves `.../download/v5.27.1/...` ✅ |
| `--help` | `Failed to fetch latest version` | prints help ✅ |
| `--uninstall` | `Failed to fetch latest version` | uninstalls ✅ |
| no pin (regression check) | error | same error, plus a pinning hint ✅ |

Shell-only change; no Rust code is touched.