### PR TITLE
fix(auth): clear dead OAuth credentials on invalid_grant

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -219,7 +219,28 @@ async fn refresh_tokens(configs: &mut Configs) -> Result<()> {
     })?;
 
     let host = configs.get_host();
-    let token_resp = oauth::refresh_access_token(host, refresh_token).await?;
+    let token_resp = match oauth::refresh_access_token(host, refresh_token).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            // A permanently-dead credential is discarded so the next run
+            // starts clean instead of replaying the same doomed refresh.
+            // Transient failures (5xx, rate limits, network) keep their
+            // tokens — clearing on those would turn a brief server blip
+            // into a fleet-wide forced logout.
+            if matches!(
+                e.downcast_ref::<RailwayError>(),
+                Some(RailwayError::OAuthInvalidGrant(_))
+            ) {
+                if let Err(clear_err) = configs.clear_oauth_tokens() {
+                    eprintln!(
+                        "{}: {clear_err}",
+                        "Warning: could not clear the expired login from disk".yellow()
+                    );
+                }
+            }
+            return Err(e);
+        }
+    };
 
     configs.save_oauth_tokens(
         &token_resp.access_token,

--- a/src/commands/mcp/proxy.rs
+++ b/src/commands/mcp/proxy.rs
@@ -236,6 +236,11 @@ async fn fresh_token(state: &ProxyState) -> Option<String> {
         }
     }
     if let Err(e) = ensure_valid_token(&mut configs).await {
+        // On `invalid_grant` the dead credential has already been cleared, so
+        // `get_railway_auth_token()` below returns None and the caller answers
+        // with LOGIN_HINT — actionable inside an MCP harness, where this
+        // stderr line is invisible. Previously the stale token was handed back
+        // and every tool call failed as an opaque "Unauthorized" instead.
         eprintln!("railway mcp proxy: token refresh failed: {e:#}");
     }
     configs.get_railway_auth_token()

--- a/src/config.rs
+++ b/src/config.rs
@@ -297,6 +297,25 @@ impl Configs {
         self.write()
     }
 
+    /// Drop the stored OAuth credentials after the server has told us they
+    /// are permanently dead (`invalid_grant`).
+    ///
+    /// Without this the CLI re-presents the same revoked refresh token on
+    /// every single invocation, forever: the refresh fails, the stale access
+    /// token is used anyway, and the user sees a generic "Unauthorized" with
+    /// no way out but deleting `~/.railway` by hand. Clearing turns that
+    /// permanent wedge into one clean `railway login`.
+    ///
+    /// Deliberately narrower than `reset()`: only the credential fields are
+    /// touched, so the linked project/environment/service survive and the
+    /// user lands back where they were after logging in.
+    pub fn clear_oauth_tokens(&mut self) -> Result<()> {
+        self.root_config.user.access_token = None;
+        self.root_config.user.refresh_token = None;
+        self.root_config.user.token_expires_at = None;
+        self.write()
+    }
+
     pub fn save_user_id(&mut self, id: &str) -> Result<()> {
         anyhow::ensure!(!id.is_empty(), "user id cannot be empty");
         self.root_config.user.id = Some(id.to_string());

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -112,6 +112,13 @@ pub enum RailwayError {
     #[error("Token refresh failed: {0}. Please run `railway login` again.")]
     OAuthRefreshFailed(String),
 
+    /// The server rejected the stored refresh token with `invalid_grant` —
+    /// it was revoked, expired, or never existed. Unlike every other refresh
+    /// failure this is *permanent*: retrying with the same credential can
+    /// never succeed, so the caller clears it instead of looping forever.
+    #[error("Your saved login is no longer valid ({0}). Please run `railway login` again.")]
+    OAuthInvalidGrant(String),
+
     #[error("OAuth error: {0}")]
     OAuthError(String),
 
@@ -158,6 +165,7 @@ impl RailwayError {
             RailwayError::OAuthDeviceCodeExpired => "OAUTH_DEVICE_CODE_EXPIRED",
             RailwayError::OAuthAccessDenied => "OAUTH_ACCESS_DENIED",
             RailwayError::OAuthRefreshFailed(_) => "OAUTH_REFRESH_FAILED",
+            RailwayError::OAuthInvalidGrant(_) => "OAUTH_INVALID_GRANT",
             RailwayError::OAuthError(_) => "OAUTH_ERROR",
             RailwayError::NotAuthenticated => "NOT_AUTHENTICATED",
         }
@@ -168,7 +176,7 @@ impl RailwayError {
     /// embed guidance in their message.
     pub fn hint(&self) -> Option<&'static str> {
         match self {
-            RailwayError::NotAuthenticated => {
+            RailwayError::NotAuthenticated | RailwayError::OAuthInvalidGrant(_) => {
                 Some("Run `railway login` to authenticate, then re-run.")
             }
             RailwayError::NoLinkedProject | RailwayError::ProjectNotFound => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use clap::error::ErrorKind;
 mod commands;
 use commands::*;
 use config::Configs;
+use errors::RailwayError;
 use is_terminal::IsTerminal;
 use util::{
     check_update::{UPDATE_CHECK_INTERVAL_HOURS, UpdateCheck},
@@ -429,7 +430,18 @@ async fn main() -> Result<()> {
     if command_needs_refresh(&cli) {
         if let Ok(mut configs) = Configs::new() {
             if let Err(e) = client::ensure_valid_token(&mut configs).await {
-                eprintln!("{}: {e}", "Warning: failed to refresh OAuth token".yellow());
+                // A revoked/expired login is the actual cause of the
+                // "Unauthorized" the command is about to fail with, so say so
+                // here rather than letting the generic message stand in for it.
+                // The credential has already been cleared by this point.
+                if matches!(
+                    e.downcast_ref::<RailwayError>(),
+                    Some(RailwayError::OAuthInvalidGrant(_))
+                ) {
+                    eprintln!("{}", format!("{e}").red());
+                } else {
+                    eprintln!("{}: {e}", "Warning: failed to refresh OAuth token".yellow());
+                }
             }
         }
     }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -269,5 +269,54 @@ pub async fn refresh_access_token(host: &str, refresh_token: &str) -> Result<Tok
         error_description: Some(format!("HTTP {status}")),
     });
     let desc = error_resp.error_description.unwrap_or_default();
-    Err(RailwayError::OAuthRefreshFailed(format!("{}: {desc}", error_resp.error)).into())
+    Err(classify_refresh_error(&error_resp.error, desc).into())
+}
+
+/// Split token-endpoint failures into permanent and retryable.
+///
+/// RFC 6749 §5.2: `invalid_grant` means the refresh token is revoked,
+/// expired, or unknown to the server — no retry can ever succeed, so the
+/// caller deletes the stored credential. Everything else (5xx, rate limits,
+/// `unknown` from an unparseable body) may succeed later and must keep its
+/// tokens: backboard serves real 500s on `/token` from Redis and Postgres
+/// pool exhaustion, and treating those as permanent would sign every active
+/// user out during an outage.
+fn classify_refresh_error(error: &str, desc: String) -> RailwayError {
+    if error == "invalid_grant" {
+        return RailwayError::OAuthInvalidGrant(desc);
+    }
+    RailwayError::OAuthRefreshFailed(format!("{error}: {desc}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_grant_is_permanent() {
+        let err = classify_refresh_error("invalid_grant", "refresh token not found".into());
+        assert!(matches!(err, RailwayError::OAuthInvalidGrant(_)));
+    }
+
+    /// The property that keeps a backboard outage from becoming a mass
+    /// logout: only `invalid_grant` may clear credentials.
+    #[test]
+    fn transient_failures_are_not_permanent() {
+        for error in [
+            "unknown",      // unparseable body, e.g. a 500 HTML page
+            "server_error", // Redis/Prisma pool exhaustion on /token
+            "temporarily_unavailable",
+            "slow_down",
+            "invalid_request",
+            "invalid_client",
+        ] {
+            assert!(
+                !matches!(
+                    classify_refresh_error(error, "boom".into()),
+                    RailwayError::OAuthInvalidGrant(_)
+                ),
+                "{error} must not be treated as a permanently dead credential"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

When backboard rejects a refresh with `invalid_grant`, the stored refresh token is gone for good — revoked, expired, or never persisted. The CLI treats that like any other failure: prints a yellow warning, **keeps the credential**, and runs the command anyway with the stale access token. The user sees a generic `Unauthorized. Please run 'railway login' again.`

```rust
// main.rs — before
if let Err(e) = client::ensure_valid_token(&mut configs).await {
    eprintln!("{}: {e}", "Warning: failed to refresh OAuth token".yellow());
}
// …runs the command anyway with dead credentials
```

That makes the wedge **permanent**. Every subsequent invocation replays the same doomed refresh, so the only escape people find is deleting `~/.railway` by hand — which is exactly what the support threads have been reporting since March ([escalation](https://discord.com/channels/713503345364697088/1487308685331136666)).

It also inflates the server-side signal badly: one broken install emits a failed refresh on *every run, forever*.

## Evidence

From backboard wide events (7d):

| Signal | Count |
|---|---|
| `invalid_grant` / `refresh token not found` | 11,322 sampled (~1% rate) |
| …of which `grant_type: refresh_token` | **11,306 / 11,306 — 100%** |
| …of which the CLI's own `client_id` | **98.5%** |

Logins are fine; it is exclusively the hour-later renewal that dies. The rate is already down ~5× from 10.5% → 2.1% of CLI requests since 7/17 thanks to the rotation-exemption and reuse-grace fixes (#32205, #32627, #33128) — this PR targets the residual, which is dominated by installs whose grant was destroyed weeks ago and which can never self-heal.

## Fix

Discard the credential when, and only when, the server says the grant is permanently invalid, and surface the real reason instead of the generic "Unauthorized". `clear_oauth_tokens()` is deliberately narrower than `reset()` — the linked project/environment/service survive, so a re-login drops the user back where they were.

## The load-bearing part: permanent vs. transient

Backboard serves **real 500s on `/token`** — ~869 Redis pool timeouts (`Timeout waiting for a client`) and ~1,596 Prisma connection-pool timeouts per 7d. Clearing credentials on those would convert a brief outage into a **fleet-wide forced logout**.

So only `invalid_grant` (RFC 6749 §5.2) qualifies. A test pins that property:

```rust
#[test]
fn transient_failures_are_not_permanent() {
    for error in ["unknown", "server_error", "temporarily_unavailable",
                  "slow_down", "invalid_request", "invalid_client"] { … }
}
```

## `railway mcp` gets this for free

With the token cleared, `get_railway_auth_token()` returns `None`, so the proxy answers with `LOGIN_HINT` — actionable inside an MCP harness, where its stderr is invisible. Previously it handed back the stale token and every tool call failed as an opaque "Unauthorized".

## Testing

- `cargo check --all-targets` — clean
- `cargo test --bin railway oauth::` — 2 new tests pass
- `cargo fmt --check` — clean

`cargo clippy` fails in my sandbox on pre-existing `E0514` (stale `target/` from another rustc); unrelated to this change.

## Not covered

The upstream cause — concurrent refreshes tripping reuse-detection and revoking the whole grant — was addressed server-side in #32205/#32627 and client-side by the refresh lock in v5.23.2. This PR stops the *aftermath* from being permanent. Separately worth tracking: the 90-day public-client refresh TTL set on 7/03 starts hard-expiring around **2026-10-01**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)