### PR TITLE
fix(auth): retry transient refreshes, and stop railway mcp freezing its token

### DIFF
--- a/src/auth_sim.rs
+++ b/src/auth_sim.rs
@@ -1,0 +1,616 @@
+//! Simulation harness for the CLI's OAuth refresh behaviour.
+//!
+//! These tests exist to answer one question with evidence rather than code
+//! reading: when a user's refresh token is dead server-side, or when the token
+//! endpoint is briefly 5xx, what actually happens to the credentials on disk
+//! and to the user-facing outcome?
+//!
+//! Every experiment runs the REAL HTTP layer ([`oauth::attempt_refresh`]) and
+//! the REAL config read/modify/write cycle ([`Configs`]) against a local
+//! scripted token endpoint. `legacy_policy` reproduces production's current
+//! behaviour; `refresh_with_policy` is the proposed replacement. Because both
+//! share the same HTTP and config code, any difference is attributable to the
+//! policy alone.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::client::{RefreshOutcome, refresh_with_policy};
+use crate::config::Configs;
+use crate::oauth;
+
+/// A scripted local endpoint. Serves `responses` in order, repeating the last
+/// one once exhausted, and records every request it receives so tests can assert
+/// both how many arrived and what headers they carried.
+struct MockEndpoint {
+    base_url: String,
+    requests: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl MockEndpoint {
+    fn spawn(responses: Vec<(u16, String)>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let requests_for_thread = Arc::clone(&requests);
+
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+
+                // Drain headers and any body so the client never sees a broken
+                // pipe on the next request.
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 1024];
+                let mut content_length = 0usize;
+                loop {
+                    let Ok(read) = stream.read(&mut tmp) else {
+                        break;
+                    };
+                    if read == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&tmp[..read]);
+                    if let Some(pos) = find_headers_end(&buf) {
+                        let headers = String::from_utf8_lossy(&buf[..pos]).to_lowercase();
+                        for line in headers.lines() {
+                            if let Some(v) = line.strip_prefix("content-length:") {
+                                content_length = v.trim().parse().unwrap_or(0);
+                            }
+                        }
+                        if buf.len() >= pos + 4 + content_length {
+                            break;
+                        }
+                    }
+                }
+
+                let mut seen = requests_for_thread.lock().unwrap();
+                let idx = seen.len().min(responses.len().saturating_sub(1));
+                seen.push(String::from_utf8_lossy(&buf).to_string());
+                drop(seen);
+
+                let (status, body) = &responses[idx];
+                let reason = match status {
+                    200 => "OK",
+                    400 => "Bad Request",
+                    500 => "Internal Server Error",
+                    503 => "Service Unavailable",
+                    _ => "Unknown",
+                };
+                let resp = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(resp.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+
+        Self {
+            base_url: format!("http://127.0.0.1:{port}/oauth"),
+            requests,
+        }
+    }
+
+    fn hits(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+
+    /// The `authorization` header of each request, in arrival order.
+    fn auth_headers(&self) -> Vec<String> {
+        self.requests
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|req| {
+                req.lines()
+                    .find(|l| l.to_ascii_lowercase().starts_with("authorization:"))
+                    .map(|l| l["authorization:".len()..].trim().to_string())
+                    .unwrap_or_else(|| "(none)".to_string())
+            })
+            .collect()
+    }
+}
+
+fn find_headers_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+fn dead_grant() -> (u16, String) {
+    (
+        400,
+        r#"{"error":"invalid_grant","error_description":"grant request is invalid"}"#.to_string(),
+    )
+}
+fn server_error() -> (u16, String) {
+    (500, r#"{"error":"server_error"}"#.to_string())
+}
+fn fresh_tokens() -> (u16, String) {
+    (
+        200,
+        r#"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600}"#
+            .to_string(),
+    )
+}
+fn ok_empty() -> (u16, String) {
+    (200, r#"{"data":{}}"#.to_string())
+}
+
+/// A temp config file seeded with an expired access token and a refresh token,
+/// i.e. exactly the state a CLI process is in when it starts up an hour after
+/// the last command.
+struct Fixture {
+    path: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut configs = Configs::for_test(path.clone());
+        // expires_in of 1s, then we treat it as already past: save_oauth_tokens
+        // requires a positive expires_in, so age it directly afterwards.
+        configs
+            .save_oauth_tokens("stale-access", Some("the-refresh-token"), 1)
+            .unwrap();
+        configs.root_config.user.token_expires_at = Some(0); // long expired
+        configs.write().unwrap();
+        Self { path, _dir: dir }
+    }
+
+    /// A freshly-loaded Configs, standing in for a brand-new CLI process.
+    fn load(&self) -> Configs {
+        let mut configs = Configs::for_test(self.path.clone());
+        configs.reload().unwrap();
+        configs
+    }
+}
+
+/// Reproduction of production's CURRENT refresh policy (cli 5.30.1):
+/// one attempt, no 400-vs-5xx distinction, and credentials are never cleared.
+/// Mirrors what `client::refresh_tokens` did at cli 5.30.1.
+async fn legacy_policy(configs: &mut Configs, base_url: &str) -> Result<(), String> {
+    let refresh_token = match configs.get_refresh_token() {
+        Some(t) => t.to_owned(),
+        None => return Err("No refresh token available".to_string()),
+    };
+    let client = reqwest::Client::new();
+    match oauth::attempt_refresh(&client, base_url, &refresh_token).await {
+        Ok(resp) => {
+            configs
+                .save_oauth_tokens(
+                    &resp.access_token,
+                    resp.refresh_token.as_deref(),
+                    resp.expires_in,
+                )
+                .unwrap();
+            Ok(())
+        }
+        // Production collapses every failure into one error and leaves the
+        // stored credentials exactly as they were.
+        Err(f) => Err(match f {
+            oauth::RefreshFailure::Terminal(e) | oauth::RefreshFailure::Transient(e) => {
+                e.to_string()
+            }
+        }),
+    }
+}
+
+const INVOCATIONS: usize = 20;
+
+#[tokio::test]
+async fn legacy_dead_grant_retries_forever_and_keeps_dead_credentials() {
+    let server = MockEndpoint::spawn(vec![dead_grant()]);
+    let fixture = Fixture::new();
+
+    for _ in 0..INVOCATIONS {
+        let mut configs = fixture.load();
+        let result = legacy_policy(&mut configs, &server.base_url).await;
+        assert!(result.is_err(), "dead grant should fail");
+    }
+
+    // Every single invocation hit the token endpoint with the same dead token.
+    assert_eq!(
+        server.hits(),
+        INVOCATIONS,
+        "legacy policy re-presents a known-dead refresh token on every invocation"
+    );
+
+    // And the dead credentials are still sitting on disk, so this never ends.
+    let configs = fixture.load();
+    assert!(
+        configs.has_oauth_token(),
+        "legacy policy leaves the dead access token on disk"
+    );
+    assert_eq!(
+        configs.get_refresh_token(),
+        Some("the-refresh-token"),
+        "legacy policy leaves the dead refresh token on disk"
+    );
+}
+
+#[tokio::test]
+async fn fixed_dead_grant_clears_credentials_and_stops_after_one_attempt() {
+    let server = MockEndpoint::spawn(vec![dead_grant()]);
+    let fixture = Fixture::new();
+
+    let mut outcomes = Vec::new();
+    for _ in 0..INVOCATIONS {
+        let mut configs = fixture.load();
+        outcomes.push(refresh_with_policy(&mut configs, &server.base_url, Duration::ZERO).await);
+    }
+
+    // The first invocation learns the grant is dead; the rest have nothing to
+    // present, so the token endpoint is never touched again.
+    assert_eq!(
+        server.hits(),
+        1,
+        "fixed policy must present a dead refresh token exactly once, got {} hits",
+        server.hits()
+    );
+    assert!(matches!(outcomes[0], RefreshOutcome::SessionExpired(_)));
+    assert!(
+        outcomes[1..]
+            .iter()
+            .all(|o| matches!(o, RefreshOutcome::NoRefreshToken)),
+        "after clearing, later invocations have no token to retry"
+    );
+
+    let configs = fixture.load();
+    assert!(!configs.has_oauth_token());
+    assert_eq!(configs.get_refresh_token(), None);
+}
+
+#[tokio::test]
+async fn legacy_transient_5xx_is_indistinguishable_from_a_dead_grant() {
+    let dead = MockEndpoint::spawn(vec![dead_grant()]);
+    let flaky = MockEndpoint::spawn(vec![server_error()]);
+    let f1 = Fixture::new();
+    let f2 = Fixture::new();
+
+    let dead_err = legacy_policy(&mut f1.load(), &dead.base_url)
+        .await
+        .unwrap_err();
+    let flaky_err = legacy_policy(&mut f2.load(), &flaky.base_url)
+        .await
+        .unwrap_err();
+
+    // Both surface as the same RailwayError variant, whose message tells the
+    // user to run `railway login` — even though in the 5xx case the stored
+    // refresh token is perfectly good.
+    let dead_rendered = crate::errors::RailwayError::OAuthRefreshFailed(dead_err).to_string();
+    let flaky_rendered = crate::errors::RailwayError::OAuthRefreshFailed(flaky_err).to_string();
+    assert!(dead_rendered.contains("Couldn't refresh") || dead_rendered.contains("railway login"));
+    assert!(
+        flaky_rendered.contains("Couldn't refresh") || flaky_rendered.contains("railway login")
+    );
+
+    // And critically: exactly one attempt. No retry for a transient failure.
+    assert_eq!(
+        flaky.hits(),
+        1,
+        "legacy policy does not retry a transient 5xx"
+    );
+}
+
+#[tokio::test]
+async fn fixed_transient_5xx_retries_and_preserves_credentials() {
+    let server = MockEndpoint::spawn(vec![server_error()]);
+    let fixture = Fixture::new();
+
+    let mut configs = fixture.load();
+    let outcome = refresh_with_policy(&mut configs, &server.base_url, Duration::ZERO).await;
+
+    assert!(
+        matches!(outcome, RefreshOutcome::Transient(_)),
+        "a 5xx must be transient, got {outcome:?}"
+    );
+    assert_eq!(
+        server.hits(),
+        oauth::REFRESH_MAX_ATTEMPTS as usize,
+        "fixed policy retries transient failures"
+    );
+
+    // The whole point: a backboard blip must not cost the user their session.
+    let reloaded = fixture.load();
+    assert_eq!(reloaded.get_refresh_token(), Some("the-refresh-token"));
+    assert!(reloaded.has_oauth_token());
+}
+
+#[tokio::test]
+async fn fixed_policy_recovers_when_the_token_endpoint_comes_back() {
+    // Mirrors the 2026-07-30/31 backboard DB incidents: the token endpoint
+    // 5xx'd for a window, then recovered.
+    let server = MockEndpoint::spawn(vec![server_error(), server_error(), fresh_tokens()]);
+    let fixture = Fixture::new();
+
+    let mut configs = fixture.load();
+    let outcome = refresh_with_policy(&mut configs, &server.base_url, Duration::ZERO).await;
+
+    assert!(
+        matches!(outcome, RefreshOutcome::Refreshed),
+        "the user should never notice a brief outage, got {outcome:?}"
+    );
+    let reloaded = fixture.load();
+    assert_eq!(reloaded.get_refresh_token(), Some("new-refresh"));
+    assert!(
+        !reloaded.is_token_expired(),
+        "fresh token must not be expired"
+    );
+}
+
+/// The property that stops a backboard misconfiguration from becoming a mass
+/// logout: only `invalid_grant` may clear credentials. `invalid_client` and
+/// friends describe the client registration or the request, not the user's
+/// grant, and the CLI ships one hardcoded `client_id` for everybody.
+#[tokio::test]
+async fn only_invalid_grant_clears_credentials() {
+    for code in [
+        "invalid_client",
+        "unauthorized_client",
+        "invalid_scope",
+        "invalid_request",
+        "unsupported_grant_type",
+        "server_error",
+        "temporarily_unavailable",
+        "slow_down",
+        "unknown",
+    ] {
+        let body = format!(r#"{{"error":"{code}","error_description":"boom"}}"#);
+        let server = MockEndpoint::spawn(vec![(400, body)]);
+        let fixture = Fixture::new();
+        let mut configs = fixture.load();
+
+        let outcome = refresh_with_policy(&mut configs, &server.base_url, Duration::ZERO).await;
+
+        assert!(
+            matches!(outcome, RefreshOutcome::Transient(_)),
+            "{code} must not be treated as a permanently dead credential, got {outcome:?}"
+        );
+        assert_eq!(
+            fixture.load().get_refresh_token(),
+            Some("the-refresh-token"),
+            "{code} must leave the refresh token on disk"
+        );
+    }
+}
+
+#[tokio::test]
+async fn fixed_policy_treats_unparseable_4xx_as_transient() {
+    // A WAF block or proxy error page must not be mistaken for a dead grant —
+    // discarding a working refresh token is the expensive mistake.
+    let server = MockEndpoint::spawn(vec![(400, "<html>blocked by proxy</html>".to_string())]);
+    let fixture = Fixture::new();
+
+    let mut configs = fixture.load();
+    let outcome = refresh_with_policy(&mut configs, &server.base_url, Duration::ZERO).await;
+
+    assert!(
+        matches!(outcome, RefreshOutcome::Transient(_)),
+        "unparseable 4xx must not clear credentials, got {outcome:?}"
+    );
+    assert_eq!(
+        fixture.load().get_refresh_token(),
+        Some("the-refresh-token")
+    );
+}
+
+/// Durability of the credential clear against a concurrent stale writer.
+///
+/// A process can hold a `Configs` for hours (`railway mcp` holds one for a whole
+/// editor session) and then write it for an unrelated reason such as linking a
+/// project. Serialising its whole snapshot used to put the credentials it loaded
+/// at startup back on disk, undoing another process's refresh or clear and
+/// restarting the retry loop. `write` now takes the credential fields from disk,
+/// so only the auth path can move them.
+#[tokio::test]
+async fn stale_writer_cannot_resurrect_cleared_credentials() {
+    let server = MockEndpoint::spawn(vec![dead_grant()]);
+    let fixture = Fixture::new();
+
+    // Process B starts and loads the config while the credentials still exist.
+    let mut stale_process = fixture.load();
+    assert!(stale_process.has_oauth_token());
+
+    // Process A discovers the grant is dead and clears.
+    let mut clearing_process = fixture.load();
+    let outcome =
+        refresh_with_policy(&mut clearing_process, &server.base_url, Duration::ZERO).await;
+    assert!(matches!(outcome, RefreshOutcome::SessionExpired(_)));
+    assert_eq!(fixture.load().get_refresh_token(), None, "clear persisted");
+
+    // Process B now writes for an unrelated reason, using its stale snapshot.
+    stale_process.root_config.user.id = Some("some-user".to_string());
+    stale_process.write().unwrap();
+
+    let after = fixture.load();
+    assert_eq!(
+        after.get_refresh_token(),
+        None,
+        "the stale writer must not resurrect the dead refresh token"
+    );
+    assert!(!after.has_oauth_token());
+    // ...while its own, non-credential change still lands.
+    assert_eq!(after.root_config.user.id.as_deref(), Some("some-user"));
+}
+
+/// The mirror case: a stale writer must not undo a successful refresh either.
+#[tokio::test]
+async fn stale_writer_cannot_undo_a_refresh() {
+    let server = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = Fixture::new();
+
+    let mut stale_process = fixture.load();
+    let mut refreshing = fixture.load();
+    assert!(matches!(
+        refresh_with_policy(&mut refreshing, &server.base_url, Duration::ZERO).await,
+        RefreshOutcome::Refreshed
+    ));
+
+    stale_process.root_config.user.id = Some("some-user".to_string());
+    stale_process.write().unwrap();
+
+    let after = fixture.load();
+    assert_eq!(
+        after.get_refresh_token(),
+        Some("new-refresh"),
+        "the refreshed credentials must survive an unrelated concurrent write"
+    );
+    assert_eq!(
+        after.get_railway_auth_token().as_deref(),
+        Some("new-access")
+    );
+}
+
+/// `railway logout` must still be able to erase credentials. Ordinary writes
+/// adopt whatever is on disk, so logout has to go through the credential-owning
+/// write — mirrors `commands::logout`.
+#[tokio::test]
+async fn logout_clears_credentials() {
+    let fixture = Fixture::new();
+    let mut configs = fixture.load();
+    assert!(configs.has_oauth_token());
+
+    configs.reset().unwrap();
+    configs.write_credentials().unwrap();
+
+    let after = fixture.load();
+    assert!(
+        !after.has_oauth_token(),
+        "logout must erase the access token"
+    );
+    assert_eq!(after.get_refresh_token(), None);
+}
+
+/// The other half of that invariant: a plain `write` must NOT be able to erase
+/// credentials, which is what stops a stale in-memory snapshot from clobbering
+/// them.
+#[tokio::test]
+async fn plain_write_cannot_erase_credentials() {
+    let fixture = Fixture::new();
+    let mut configs = fixture.load();
+
+    configs.reset().unwrap();
+    configs.write().unwrap();
+
+    let after = fixture.load();
+    assert_eq!(
+        after.get_refresh_token(),
+        Some("the-refresh-token"),
+        "a non-credential write must leave the stored credentials alone"
+    );
+}
+
+/// The local `railway mcp` defect, isolated: `GQLClient::new_authorized` bakes
+/// the bearer into the client's default headers, so a client built at process
+/// start keeps sending the startup token no matter what happens on disk.
+#[tokio::test]
+async fn baked_in_bearer_ignores_new_credentials_on_disk() {
+    let backboard = MockEndpoint::spawn(vec![ok_empty()]);
+    let fixture = Fixture::new();
+
+    // Startup: build the client once, exactly as serve_stdio does.
+    let startup_configs = fixture.load();
+    let frozen = crate::client::GQLClient::new_authorized(&startup_configs).unwrap();
+
+    // A `railway login` in another terminal replaces the credentials on disk.
+    let mut relogin = fixture.load();
+    relogin
+        .save_oauth_tokens("brand-new-access", Some("brand-new-refresh"), 3600)
+        .unwrap();
+    assert_eq!(
+        fixture.load().get_railway_auth_token().as_deref(),
+        Some("brand-new-access")
+    );
+
+    // The frozen client still sends the startup token.
+    let _ = frozen.post(&backboard.base_url).json(&()).send().await;
+    assert_eq!(
+        backboard.auth_headers(),
+        vec!["Bearer stale-access".to_string()],
+        "EXPECTED DEFECT: the client built at startup keeps using the startup token"
+    );
+
+    // Rebuilding from the current on-disk config is what picks up the new token.
+    let rebuilt = crate::client::GQLClient::new_authorized(&fixture.load()).unwrap();
+    let _ = rebuilt.post(&backboard.base_url).json(&()).send().await;
+    assert_eq!(
+        backboard.auth_headers()[1],
+        "Bearer brand-new-access",
+        "a per-request client adopts the new credentials"
+    );
+}
+
+/// The mid-session expiry path: an expired access token must trigger a real
+/// refresh and the resulting client must carry the NEW bearer.
+#[tokio::test]
+async fn expired_token_refreshes_and_new_bearer_reaches_the_wire() {
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let backboard = MockEndpoint::spawn(vec![ok_empty()]);
+    let fixture = Fixture::new();
+
+    let mut configs = fixture.load();
+    assert!(configs.is_token_expired(), "fixture starts expired");
+
+    let outcome = refresh_with_policy(&mut configs, &token_endpoint.base_url, Duration::ZERO).await;
+    assert!(matches!(outcome, RefreshOutcome::Refreshed));
+
+    let client = crate::client::GQLClient::new_authorized(&fixture.load()).unwrap();
+    let _ = client.post(&backboard.base_url).json(&()).send().await;
+
+    assert_eq!(
+        backboard.auth_headers(),
+        vec!["Bearer new-access".to_string()],
+        "the refreshed token must be the one used for the request"
+    );
+}
+
+/// Load guard for the per-tool-call sync: the expiry predicate that gates the
+/// network call must report a freshly-saved token as valid, so the steady-state
+/// path does no refresh I/O at all.
+#[tokio::test]
+async fn a_freshly_saved_token_is_not_considered_expired() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.json");
+    let mut configs = Configs::for_test(path.clone());
+    configs
+        .save_oauth_tokens("good-access", Some("good-refresh"), 3600)
+        .unwrap();
+
+    let mut reloaded = Configs::for_test(path);
+    reloaded.reload().unwrap();
+    assert!(
+        !reloaded.is_token_expired(),
+        "a token minted seconds ago must not be treated as expired, or every \
+         tool call would refresh"
+    );
+
+    // ...and the 60s safety buffer still classifies a nearly-dead token as expired.
+    reloaded.root_config.user.token_expires_at = Some(chrono::Utc::now().timestamp() + 30);
+    assert!(reloaded.is_token_expired());
+}
+
+/// A dead grant inside a long-lived MCP session must not become a retry storm:
+/// credentials are cleared once, and later tool calls have nothing to present.
+#[tokio::test]
+async fn dead_grant_in_a_long_session_refreshes_once_not_per_tool_call() {
+    let token_endpoint = MockEndpoint::spawn(vec![dead_grant()]);
+    let fixture = Fixture::new();
+
+    for _ in 0..INVOCATIONS {
+        let mut configs = fixture.load();
+        if configs.get_refresh_token().is_some() {
+            refresh_with_policy(&mut configs, &token_endpoint.base_url, Duration::ZERO).await;
+        }
+    }
+
+    assert_eq!(
+        token_endpoint.hits(),
+        1,
+        "a dead grant must be discovered once per session, not once per tool call"
+    );
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -184,7 +184,7 @@ pub(crate) fn auth_failure_error() -> RailwayError {
 /// the lock performs the single refresh, and the others pick up its result.
 pub async fn ensure_valid_token(configs: &mut Configs) -> Result<()> {
     // Env var tokens are not managed by us
-    if Configs::get_railway_token().is_some() || Configs::get_railway_api_token().is_some() {
+    if Configs::is_using_token_auth() {
         return Ok(());
     }
 
@@ -193,139 +193,114 @@ pub async fn ensure_valid_token(configs: &mut Configs) -> Result<()> {
         return Ok(());
     }
 
-    // Serialize the refresh across concurrent CLI processes. If we can't take
-    // the lock (e.g. a stale/wedged lock, unsupported filesystem), fall back to
-    // refreshing without it rather than wedging the CLI — see `refresh_tokens`.
-    let lock_guard = ConfigLockGuard::acquire();
-
-    // Re-read credentials now that we hold the lock: another process may have
-    // already refreshed while we were waiting, in which case we skip the
-    // refresh entirely and use the freshly-rotated token it wrote.
-    if lock_guard.is_some() {
-        configs.reload()?;
-        if !configs.has_oauth_token() || !configs.is_token_expired() {
-            return Ok(());
+    match refresh_locked(configs, false).await {
+        RefreshOutcome::Refreshed | RefreshOutcome::AlreadyFresh => Ok(()),
+        RefreshOutcome::SessionExpired(e) | RefreshOutcome::Transient(e) => Err(e.into()),
+        RefreshOutcome::NoRefreshToken => {
+            Err(RailwayError::OAuthRefreshFailed("No refresh token available".to_string()).into())
         }
     }
-
-    refresh_tokens(configs).await
 }
 
-/// Perform the actual OAuth refresh + persist. The caller is expected to hold
-/// the config lock (when available) and to have re-checked expiry.
-async fn refresh_tokens(configs: &mut Configs) -> Result<()> {
-    let refresh_token = configs.get_refresh_token().ok_or_else(|| {
-        RailwayError::OAuthRefreshFailed("No refresh token available".to_string())
-    })?;
+/// What a refresh attempt did to the stored credentials.
+#[derive(Debug)]
+pub(crate) enum RefreshOutcome {
+    /// New tokens persisted.
+    Refreshed,
+    /// Another process refreshed while we waited for the lock; its result is now
+    /// loaded and valid, so there was nothing left to do.
+    AlreadyFresh,
+    /// The grant is dead and the credentials have been cleared from disk. The
+    /// user must run `railway login`; retrying will never succeed.
+    SessionExpired(RailwayError),
+    /// Refresh failed but the credentials are intact and still worth using. The
+    /// command should proceed and may well succeed.
+    Transient(RailwayError),
+    /// Nothing to refresh with.
+    NoRefreshToken,
+}
 
-    let host = configs.get_host();
-    let token_resp = match oauth::refresh_access_token(host, refresh_token).await {
-        Ok(resp) => resp,
-        Err(e) => {
-            // A permanently-dead credential is discarded so the next run
-            // starts clean instead of replaying the same doomed refresh.
-            // Transient failures (5xx, rate limits, network) keep their
-            // tokens — clearing on those would turn a brief server blip
-            // into a fleet-wide forced logout.
-            if matches!(
-                e.downcast_ref::<RailwayError>(),
-                Some(RailwayError::OAuthInvalidGrant(_))
-            ) {
-                if let Err(clear_err) = configs.clear_oauth_tokens() {
-                    eprintln!(
-                        "{}: {clear_err}",
-                        "Warning: could not clear the expired login from disk".yellow()
-                    );
-                }
-            }
-            return Err(e);
-        }
+/// Backoff between transient refresh attempts.
+const REFRESH_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Take the config lock, re-read credentials, and refresh.
+///
+/// The lock matters because the refresh is a read-modify-write of the on-disk
+/// credentials and backboard reuse-detects the refresh token: two processes
+/// refreshing concurrently means the second presents an already-consumed token
+/// and the server revokes the whole grant — a hard logout. Whichever process
+/// wins the lock performs the single refresh; the others re-read and pick up its
+/// result. If the lock cannot be taken we refresh anyway rather than wedge.
+///
+/// `force` skips the "someone else already did it" short-circuit, for callers
+/// reacting to an actual authorization failure rather than to local expiry.
+async fn refresh_locked(configs: &mut Configs, force: bool) -> RefreshOutcome {
+    let _lock = configs.acquire_lock().await;
+
+    if configs.reload().is_err() {
+        return RefreshOutcome::NoRefreshToken;
+    }
+    if !force && (!configs.has_oauth_token() || !configs.is_token_expired()) {
+        return RefreshOutcome::AlreadyFresh;
+    }
+
+    let base_url = oauth::get_oauth_base_url(configs.get_host());
+    refresh_with_policy(configs, &base_url, REFRESH_BACKOFF).await
+}
+
+/// Refresh unconditionally, ignoring the local expiry timestamp.
+///
+/// `ensure_valid_token` trusts `tokenExpiresAt`, so it does nothing when the
+/// stored token merely *looks* valid. A token can die server-side well before
+/// that — the grant is revoked, or evicted by the per-grant refresh-token cap —
+/// and in that state a long-lived process would otherwise never recover. Call
+/// this after an actual authorization failure.
+pub(crate) async fn force_refresh(configs: &mut Configs) -> RefreshOutcome {
+    if Configs::is_using_token_auth() {
+        // Env-var tokens are not ours to refresh.
+        return RefreshOutcome::NoRefreshToken;
+    }
+    refresh_locked(configs, true).await
+}
+
+/// Refresh against an explicit base URL and apply the credential policy:
+/// clear on a dead grant, preserve on anything transient.
+pub(crate) async fn refresh_with_policy(
+    configs: &mut Configs,
+    base_url: &str,
+    backoff: Duration,
+) -> RefreshOutcome {
+    let Some(refresh_token) = configs.get_refresh_token().map(str::to_owned) else {
+        return RefreshOutcome::NoRefreshToken;
     };
 
-    configs.save_oauth_tokens(
-        &token_resp.access_token,
-        token_resp.refresh_token.as_deref(),
-        token_resp.expires_in,
-    )?;
-
-    Ok(())
-}
-
-/// How long to wait for the config lock before giving up and refreshing
-/// without it. Kept short so a stale lock can never wedge the CLI for long.
-const CONFIG_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
-/// Poll interval while waiting for the config lock.
-const CONFIG_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
-
-/// RAII guard around an exclusive advisory lock on the config lockfile.
-/// Releasing the lock (and dropping the file handle) happens on drop, covering
-/// all error paths.
-struct ConfigLockGuard {
-    file: std::fs::File,
-}
-
-impl ConfigLockGuard {
-    /// Try to acquire the exclusive config lock, retrying up to
-    /// [`CONFIG_LOCK_TIMEOUT`]. Returns `None` (with a warning) on any failure
-    /// so the caller can fall back to an unlocked refresh rather than wedge.
-    fn acquire() -> Option<Self> {
-        use fs2::FileExt;
-
-        let lock_path = match Configs::config_lock_path() {
-            Ok(path) => path,
-            Err(e) => {
-                eprintln!(
-                    "{}: {e}",
-                    "Warning: could not determine config lock path".yellow()
-                );
-                return None;
+    match oauth::refresh_access_token_at(base_url, &refresh_token, backoff).await {
+        Ok(token_resp) => {
+            if let Err(e) = configs.save_oauth_tokens(
+                &token_resp.access_token,
+                token_resp.refresh_token.as_deref(),
+                token_resp.expires_in,
+            ) {
+                return RefreshOutcome::Transient(RailwayError::OAuthRefreshFailed(format!(
+                    "failed to persist tokens: {e}"
+                )));
             }
-        };
-
-        if let Some(parent) = lock_path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                eprintln!(
-                    "{}: {e}",
-                    "Warning: could not create config directory for lock".yellow()
-                );
-                return None;
-            }
+            RefreshOutcome::Refreshed
         }
-
-        let file = match std::fs::File::create(&lock_path) {
-            Ok(file) => file,
-            Err(e) => {
+        // A permanently-dead credential is discarded so the next run starts
+        // clean instead of replaying the same doomed refresh. Transient failures
+        // keep their tokens — clearing on those would turn a brief server blip
+        // into a fleet-wide forced logout.
+        Err(oauth::RefreshFailure::Terminal(err)) => {
+            if let Err(clear_err) = configs.clear_oauth_tokens() {
                 eprintln!(
-                    "{}: {e}",
-                    "Warning: could not open config lock file".yellow()
+                    "{}: {clear_err}",
+                    "Warning: could not clear the expired login from disk".yellow()
                 );
-                return None;
             }
-        };
-
-        let deadline = std::time::Instant::now() + CONFIG_LOCK_TIMEOUT;
-        loop {
-            if file.try_lock_exclusive().is_ok() {
-                return Some(Self { file });
-            }
-            if std::time::Instant::now() >= deadline {
-                eprintln!(
-                    "{}",
-                    "Warning: timed out waiting for config lock; refreshing without it".yellow()
-                );
-                return None;
-            }
-            std::thread::sleep(CONFIG_LOCK_POLL_INTERVAL);
+            RefreshOutcome::SessionExpired(err)
         }
-    }
-}
-
-impl Drop for ConfigLockGuard {
-    fn drop(&mut self) {
-        use fs2::FileExt;
-        // Best-effort unlock; the lock is also released when the file handle is
-        // dropped immediately after.
-        let _ = FileExt::unlock(&self.file);
+        Err(oauth::RefreshFailure::Transient(err)) => RefreshOutcome::Transient(err),
     }
 }
 

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -7,7 +7,9 @@ pub struct Args {}
 pub async fn command(_args: Args) -> Result<()> {
     let mut configs = Configs::new()?;
     configs.reset()?;
-    configs.write()?;
+    // Logout owns the credentials it is erasing: an ordinary `write` would
+    // re-adopt whatever is still on disk and leave the user logged in.
+    configs.write_credentials()?;
     println!("Logged out successfully");
     Ok(())
 }

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -32,9 +32,26 @@ use crate::{
 
 #[derive(Clone)]
 pub struct RailwayMcp {
-    pub(crate) client: reqwest::Client,
+    /// Swappable HTTP client. `GQLClient::new_authorized` bakes the bearer
+    /// token into the client's default headers, so the client is only valid for
+    /// as long as that token is. This server outlives its access token (1h) by
+    /// hours, so the client has to be replaceable — otherwise every tool call
+    /// after expiry fails and `railway login` cannot heal the running process.
+    /// Paired with the bearer token it carries, so the two can never disagree.
+    /// Rebuilding a `reqwest::Client` throws away its connection pool and costs
+    /// a fresh TLS handshake (~130ms per call, measured), so it is replaced only
+    /// when the token actually changes rather than on every tool call.
+    client: Arc<std::sync::RwLock<AuthedClient>>,
     pub(crate) configs: Arc<Configs>,
     tool_router: ToolRouter<Self>,
+}
+
+/// An HTTP client together with the bearer token baked into its default
+/// headers. Kept as one value so a reader can never see a new client with a
+/// stale token.
+struct AuthedClient {
+    http: reqwest::Client,
+    token: Option<String>,
 }
 
 pub(crate) struct ResolvedContext {
@@ -53,10 +70,84 @@ pub(crate) struct ResolvedServiceContext {
 
 impl RailwayMcp {
     pub fn new(client: reqwest::Client, configs: Configs) -> Self {
+        let token = configs.get_railway_auth_token();
         Self {
-            client,
+            client: Arc::new(std::sync::RwLock::new(AuthedClient {
+                http: client,
+                token,
+            })),
             configs: Arc::new(configs),
             tool_router: Self::tool_router(),
+        }
+    }
+
+    /// The HTTP client to use for this request. Cloning a `reqwest::Client` is
+    /// cheap (it is an `Arc` internally) and shares the connection pool.
+    ///
+    /// A poisoned lock means a previous swap panicked mid-write; the inner
+    /// client is still a valid value, so keep serving with it.
+    pub(crate) fn client(&self) -> reqwest::Client {
+        self.client
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .http
+            .clone()
+    }
+
+    /// Re-resolve credentials from disk, refresh them if needed, and swap in a
+    /// client carrying the current bearer token. Returns whether the token
+    /// changed, i.e. whether a request that just failed on auth is worth
+    /// retrying.
+    ///
+    /// Called at the start of every tool call. This is what makes the server
+    /// survive its own access-token lifetime, and what lets a `railway login` in
+    /// another terminal take effect without restarting the editor.
+    ///
+    /// `force` ignores the local expiry timestamp, for use after an actual
+    /// authorization failure: a token can die server-side (grant revoked, or
+    /// evicted by the per-grant refresh-token cap) while still looking valid
+    /// here.
+    ///
+    /// Failures are deliberately silent: stdout is the JSON-RPC channel, the
+    /// existing client may still work, and the tool call's own error is a better
+    /// signal than one from a speculative refresh.
+    pub(crate) async fn sync_client(&self, force: bool) -> bool {
+        let Ok(mut configs) = Configs::new() else {
+            return false;
+        };
+        if force {
+            let _ = crate::client::force_refresh(&mut configs).await;
+        } else {
+            let _ = crate::client::ensure_valid_token(&mut configs).await;
+        }
+
+        let token = configs.get_railway_auth_token();
+        // Steady state: the token is unchanged, so keep the existing client and
+        // its warm connection pool. This is the common path on every tool call.
+        if self
+            .client
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .token
+            == token
+        {
+            return false;
+        }
+        // A cleared token cannot authorize anything, so there is nothing to
+        // install and no point retrying.
+        if token.is_none() {
+            return false;
+        }
+        match crate::client::GQLClient::new_authorized(&configs) {
+            Ok(http) => {
+                *self
+                    .client
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    AuthedClient { http, token };
+                true
+            }
+            Err(_) => false,
         }
     }
 
@@ -78,7 +169,7 @@ impl RailwayMcp {
                 )
             })?;
 
-        let project = get_project(&self.client, &self.configs, project_id.clone())
+        let project = get_project(&self.client(), &self.configs, project_id.clone())
             .await
             .map_err(|e| McpError::internal_error(format!("Failed to get project: {e}"), None))?;
 
@@ -125,7 +216,7 @@ impl RailwayMcp {
             first: Some(1),
         };
         let response = post_graphql::<queries::Deployments, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -191,7 +282,7 @@ impl RailwayMcp {
         ctx: &ResolvedServiceContext,
     ) -> Result<queries::domains::DomainsDomains, McpError> {
         post_graphql::<queries::Domains, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             queries::domains::Variables {
                 environment_id: ctx.environment_id.clone(),
@@ -580,11 +671,31 @@ fn validate_domain_port(port: i64) -> Result<i64, McpError> {
     }
 }
 
+/// Whether a tool result failed because the request was not authorized.
+///
+/// Matches on the rendered message because the underlying `RailwayError` is
+/// already flattened into an `McpError` string by the time it reaches the
+/// dispatcher. The markers live in `errors.rs` beside the variants they
+/// describe, with a test pinning the coupling.
+///
+/// A false positive here is bounded: `sync_client` only reports success when the
+/// bearer token actually changed, so an unrelated error mentioning
+/// "Unauthorized" cannot by itself cause the tool to be re-run.
+fn is_auth_failure(result: &Result<CallToolResult, McpError>) -> bool {
+    let Err(err) = result else {
+        return false;
+    };
+    let rendered = err.to_string();
+    crate::errors::AUTH_FAILURE_MARKERS
+        .iter()
+        .any(|marker| rendered.contains(marker))
+}
+
 #[tool_router]
 impl RailwayMcp {
     #[tool(description = "Check Railway authentication status and return the current user")]
     async fn whoami(&self) -> Result<CallToolResult, McpError> {
-        let user = get_user(&self.client, &self.configs).await.map_err(|e| {
+        let user = get_user(&self.client(), &self.configs).await.map_err(|e| {
             McpError::internal_error(
                 format!("Not authenticated. Run 'railway login' first. Error: {e}"),
                 None,
@@ -678,7 +789,7 @@ impl RailwayMcp {
             }
         };
 
-        let project = get_project(&self.client, &self.configs, project_id)
+        let project = get_project(&self.client(), &self.configs, project_id)
             .await
             .map_err(|e| McpError::internal_error(format!("Failed to get project: {e}"), None))?;
 
@@ -718,7 +829,7 @@ impl RailwayMcp {
         };
 
         let response = post_graphql::<queries::Deployments, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -759,7 +870,7 @@ impl RailwayMcp {
             .await?;
 
         let variables = get_service_variables(
-            &self.client,
+            &self.client(),
             &self.configs,
             ctx.project_id,
             ctx.environment_id,
@@ -854,7 +965,7 @@ impl RailwayMcp {
 
         let backboard = self.configs.get_backboard();
         let fetch_params = FetchLogsParams {
-            client: &self.client,
+            client: &self.client(),
             backboard: &backboard,
             deployment_id: deployment_id.clone(),
             limit: Some(lines),
@@ -937,7 +1048,7 @@ impl RailwayMcp {
         };
 
         post_graphql::<mutations::VariableCollectionUpsert, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -975,7 +1086,7 @@ impl RailwayMcp {
                 },
             };
             let result = post_graphql::<mutations::CustomDomainCreate, _>(
-                &self.client,
+                &self.client(),
                 self.configs.get_backboard(),
                 create_vars,
             )
@@ -1011,7 +1122,7 @@ impl RailwayMcp {
                 target_port,
             };
             let result = post_graphql::<mutations::ServiceDomainCreate, _>(
-                &self.client,
+                &self.client(),
                 self.configs.get_backboard(),
                 create_vars,
             )
@@ -1085,7 +1196,7 @@ impl RailwayMcp {
         }
 
         post_graphql::<mutations::CustomDomainIssueCertificate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             mutations::custom_domain_issue_certificate::Variables {
                 id: domain.id.clone(),
@@ -1126,7 +1237,7 @@ impl RailwayMcp {
         match domain.kind {
             McpDomainKind::Custom => {
                 post_graphql::<mutations::CustomDomainDelete, _>(
-                    &self.client,
+                    &self.client(),
                     self.configs.get_backboard(),
                     mutations::custom_domain_delete::Variables {
                         id: domain.id.clone(),
@@ -1139,7 +1250,7 @@ impl RailwayMcp {
             }
             McpDomainKind::Service => {
                 post_graphql::<mutations::ServiceDomainDelete, _>(
-                    &self.client,
+                    &self.client(),
                     self.configs.get_backboard(),
                     mutations::service_domain_delete::Variables {
                         id: domain.id.clone(),
@@ -1200,7 +1311,7 @@ impl RailwayMcp {
                 }
 
                 post_graphql::<mutations::CustomDomainUpdate, _>(
-                    &self.client,
+                    &self.client(),
                     self.configs.get_backboard(),
                     mutations::custom_domain_update::Variables {
                         environment_id: domain.environment_id.clone(),
@@ -1215,7 +1326,7 @@ impl RailwayMcp {
             }
             McpDomainKind::Service => {
                 post_graphql::<mutations::ServiceDomainUpdate, _>(
-                    &self.client,
+                    &self.client(),
                     self.configs.get_backboard(),
                     mutations::service_domain_update::Variables {
                         input: mutations::service_domain_update::ServiceDomainUpdateInput {
@@ -1266,7 +1377,7 @@ impl RailwayMcp {
                 )
             })?;
 
-        let project = get_project(&self.client, &self.configs, project_id.clone())
+        let project = get_project(&self.client(), &self.configs, project_id.clone())
             .await
             .map_err(|e| McpError::internal_error(format!("Failed to get project: {e}"), None))?;
 
@@ -1290,7 +1401,7 @@ impl RailwayMcp {
                 )
             })?;
             let instances = get_environment_instances(
-                &self.client,
+                &self.client(),
                 &self.configs,
                 &project_id,
                 &environment.id,
@@ -1386,7 +1497,7 @@ impl RailwayMcp {
             )
         })?;
 
-        let project = get_project(&self.client, &self.configs, project_id.clone())
+        let project = get_project(&self.client(), &self.configs, project_id.clone())
             .await
             .map_err(|e| McpError::internal_error(format!("Failed to get project: {e}"), None))?;
 
@@ -1801,7 +1912,7 @@ impl RailwayMcp {
 
         let hostname = self.configs.get_host();
         let response = upload_deploy_tarball(
-            &self.client,
+            &self.client(),
             hostname,
             &ctx.project_id,
             &ctx.environment_id,
@@ -1875,8 +1986,29 @@ impl ServerHandler for RailwayMcp {
             .map(|info| telemetry::McpClientInfo {
                 name: info.client_info.name.clone(),
             });
-        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
-        let result = self.tool_router.call(tcc).await;
+        // Single choke point for every tool call: make sure the credentials we
+        // are about to use are current. Without this the bearer token captured
+        // at process start is used forever.
+        self.sync_client(false).await;
+
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(
+            self,
+            request.clone(),
+            context.clone(),
+        );
+        let mut result = self.tool_router.call(tcc).await;
+
+        // Reactive re-auth. The pre-dispatch sync trusts the local expiry
+        // timestamp, so it does nothing for a token that merely looks valid but
+        // has already died server-side (grant revoked, or evicted by the
+        // per-grant refresh-token cap). Without this the session would stay
+        // broken for its entire life. Retry only when re-auth actually produced
+        // a different token — otherwise a retry cannot help, and re-running a
+        // tool that was rejected on authorization is pointless.
+        if is_auth_failure(&result) && self.sync_client(true).await {
+            let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+            result = self.tool_router.call(tcc).await;
+        }
         let duration_ms = start.elapsed().as_millis() as u64;
 
         telemetry::send_mcp_tool_with_client(

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -33,7 +33,16 @@ pub async fn command(args: Args) -> Result<()> {
 
 async fn serve_stdio() -> Result<()> {
     let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
+    // Start even when there are no usable credentials. Refusing to boot makes
+    // the harness report an opaque "MCP server failed" that no later
+    // `railway login` can clear, because the process is already gone. Serving
+    // with an unauthenticated client instead means tool calls return an
+    // actionable auth error, and `refresh_credentials` swaps in an authorized
+    // client as soon as the user signs in — no editor restart.
+    let client = match GQLClient::new_authorized(&configs) {
+        Ok(client) => client,
+        Err(_) => GQLClient::new_public()?,
+    };
     let handler = RailwayMcp::new(client, configs);
 
     let service = handler

--- a/src/commands/mcp/tools/observability.rs
+++ b/src/commands/mcp/tools/observability.rs
@@ -34,7 +34,7 @@ impl RailwayMcp {
 
         let backboard = self.configs.get_backboard();
         fetch_http_logs_for_deployment(
-            &self.client,
+            &self.client(),
             &backboard,
             deployment_id,
             lines.unwrap_or(200),
@@ -83,7 +83,7 @@ impl RailwayMcp {
 
         let backboard = self.configs.get_backboard();
         let result = fetch_resource_metrics(FetchResourceMetricsParams {
-            client: &self.client,
+            client: &self.client(),
             backboard: &backboard,
             service_id: &ctx.service_id,
             environment_id: &ctx.environment_id,

--- a/src/commands/mcp/tools/private_network.rs
+++ b/src/commands/mcp/tools/private_network.rs
@@ -14,7 +14,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
         let statuses = private_network::fetch_private_network_statuses(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,
@@ -36,7 +36,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
         let status = private_network::update_private_network_endpoint_name(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,

--- a/src/commands/mcp/tools/project.rs
+++ b/src/commands/mcp/tools/project.rs
@@ -59,7 +59,7 @@ impl RailwayMcp {
         };
 
         let result = post_graphql::<mutations::ProjectCreate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -109,7 +109,7 @@ impl RailwayMcp {
         };
 
         let result = post_graphql::<mutations::EnvironmentCreate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -148,7 +148,7 @@ impl RailwayMcp {
         let branch = if let Some(repo) = params.source_repo.as_deref() {
             validate_repo_name(repo).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
             Some(
-                resolve_repo_branch(&self.client, &self.configs, repo, params.branch)
+                resolve_repo_branch(&self.client(), &self.configs, repo, params.branch)
                     .await
                     .map_err(|e| {
                         McpError::invalid_params(
@@ -180,7 +180,7 @@ impl RailwayMcp {
         };
 
         let result = post_graphql::<mutations::ServiceCreate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -216,7 +216,7 @@ impl RailwayMcp {
 
         let (repo, branch, image) = if let Some(repo) = params.source_repo {
             validate_repo_name(&repo).map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-            let branch = resolve_repo_branch(&self.client, &self.configs, &repo, params.branch)
+            let branch = resolve_repo_branch(&self.client(), &self.configs, &repo, params.branch)
                 .await
                 .map_err(|e| {
                     McpError::invalid_params(format!("Failed to resolve repo branch: {e}"), None)
@@ -227,7 +227,7 @@ impl RailwayMcp {
         };
 
         let result = post_graphql::<mutations::ServiceConnect, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             mutations::service_connect::Variables {
                 id: ctx.service_id.clone(),
@@ -264,7 +264,7 @@ impl RailwayMcp {
             .await?;
 
         let result = post_graphql::<mutations::ServiceDisconnect, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             mutations::service_disconnect::Variables {
                 id: ctx.service_id.clone(),
@@ -295,7 +295,7 @@ impl RailwayMcp {
         };
 
         post_graphql::<mutations::ServiceDelete, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -332,7 +332,7 @@ impl RailwayMcp {
         let region = match params.region {
             Some(region_input) => {
                 let regions =
-                    fetch_regions_for_project(&self.client, &self.configs, Some(&ctx.project_id))
+                    fetch_regions_for_project(&self.client(), &self.configs, Some(&ctx.project_id))
                         .await
                         .map_err(|e| {
                             McpError::internal_error(format!("Failed to fetch regions: {e}"), None)
@@ -371,7 +371,7 @@ impl RailwayMcp {
         };
 
         let result = post_graphql::<mutations::ServiceInstanceUpdate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -413,7 +413,7 @@ impl RailwayMcp {
         output.push_str("--------|--------|-------------------|---------------\n");
 
         let environment_instances =
-            get_environment_instances(&self.client, &self.configs, &ctx.project_id, &env.node.id)
+            get_environment_instances(&self.client(), &self.configs, &ctx.project_id, &env.node.id)
                 .await
                 .map_err(|e| {
                     McpError::internal_error(

--- a/src/commands/mcp/tools/service.rs
+++ b/src/commands/mcp/tools/service.rs
@@ -42,13 +42,13 @@ impl RailwayMcp {
             .await?;
         let ctx = &service_ctx.context;
         let regions =
-            fetch_regions_for_project(&self.client, &self.configs, Some(&service_ctx.project_id))
+            fetch_regions_for_project(&self.client(), &self.configs, Some(&service_ctx.project_id))
                 .await
                 .map_err(|e| {
                     McpError::internal_error(format!("Failed to fetch regions: {e}"), None)
                 })?;
         let config_resp = fetch_environment_config(
-            &self.client,
+            &self.client(),
             &self.configs,
             &service_ctx.environment_id,
             false,
@@ -58,7 +58,7 @@ impl RailwayMcp {
             McpError::internal_error(format!("Failed to fetch environment config: {e}"), None)
         })?;
         let environment_instances = get_environment_instances(
-            &self.client,
+            &self.client(),
             &self.configs,
             &service_ctx.project_id,
             &service_ctx.environment_id,
@@ -156,7 +156,7 @@ impl RailwayMcp {
             .await?;
 
         let config_resp =
-            fetch_environment_config(&self.client, &self.configs, &ctx.environment_id, false)
+            fetch_environment_config(&self.client(), &self.configs, &ctx.environment_id, false)
                 .await
                 .map_err(|e| {
                     McpError::internal_error(
@@ -253,7 +253,7 @@ impl RailwayMcp {
         };
 
         post_graphql::<mutations::VariableCollectionUpsert, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -304,7 +304,7 @@ impl RailwayMcp {
         };
 
         let deploy_resp = post_graphql::<mutations::TemplateDeploy, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             deploy_vars,
         )

--- a/src/commands/mcp/tools/storage.rs
+++ b/src/commands/mcp/tools/storage.rs
@@ -42,7 +42,7 @@ impl RailwayMcp {
 
         if unmerged > 0 {
             post_graphql::<mutations::EnvironmentStageChanges, _>(
-                &self.client,
+                &self.client(),
                 self.configs.get_backboard(),
                 mutations::environment_stage_changes::Variables {
                     environment_id: ctx.environment_id.clone(),
@@ -55,7 +55,7 @@ impl RailwayMcp {
             Ok(PatchMode::Stage)
         } else {
             post_graphql::<mutations::EnvironmentPatchCommit, _>(
-                &self.client,
+                &self.client(),
                 self.configs.get_backboard(),
                 mutations::environment_patch_commit::Variables {
                     environment_id: ctx.environment_id.clone(),
@@ -94,7 +94,7 @@ impl RailwayMcp {
         };
 
         let create_resp = post_graphql::<mutations::BucketCreate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             create_vars,
         )
@@ -214,7 +214,7 @@ impl RailwayMcp {
         };
 
         let resp = post_graphql::<mutations::VolumeCreate, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )
@@ -239,7 +239,7 @@ impl RailwayMcp {
                 name,
             };
             post_graphql::<mutations::VolumeNameUpdate, _>(
-                &self.client,
+                &self.client(),
                 self.configs.get_backboard(),
                 vars,
             )
@@ -275,7 +275,7 @@ impl RailwayMcp {
                 mount_path,
             };
             post_graphql::<mutations::VolumeMountPathUpdate, _>(
-                &self.client,
+                &self.client(),
                 self.configs.get_backboard(),
                 vars,
             )
@@ -308,7 +308,7 @@ impl RailwayMcp {
         };
 
         post_graphql::<mutations::VolumeDelete, _>(
-            &self.client,
+            &self.client(),
             self.configs.get_backboard(),
             vars,
         )

--- a/src/commands/mcp/tools/tcp_proxy.rs
+++ b/src/commands/mcp/tools/tcp_proxy.rs
@@ -16,7 +16,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
         let proxies = tcp_proxy::fetch_tcp_proxies(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,
@@ -39,7 +39,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
         let proxies = tcp_proxy::fetch_tcp_proxies(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,
@@ -59,7 +59,7 @@ impl RailwayMcp {
 
         let service_name = service_name(&ctx);
         let mode = tcp_proxy::apply_tcp_proxy_patch(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.context.project,
             &ctx.environment_id,
@@ -74,7 +74,7 @@ impl RailwayMcp {
 
         if mode == PatchMode::Commit {
             tcp_proxy::verify_tcp_proxy_configured(
-                &self.client,
+                &self.client(),
                 &self.configs,
                 &ctx.environment_id,
                 &ctx.service_id,
@@ -87,7 +87,7 @@ impl RailwayMcp {
         }
 
         let active_proxy = tcp_proxy::fetch_tcp_proxies(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,
@@ -110,7 +110,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
         let proxies = tcp_proxy::fetch_tcp_proxies(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,
@@ -132,7 +132,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
         let proxies = tcp_proxy::fetch_tcp_proxies(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,
@@ -148,7 +148,7 @@ impl RailwayMcp {
         }
 
         tcp_proxy::delete_tcp_proxy(
-            &self.client,
+            &self.client(),
             &self.configs,
             &ctx.environment_id,
             &ctx.service_id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,30 +155,11 @@ impl Configs {
         Ok(std::path::Path::new(&home_dir).join(root_config_partial_path))
     }
 
-    /// Path to the lockfile used to serialize credential read-modify-write
-    /// cycles (token refresh) across concurrent CLI invocations. This is a
-    /// dedicated lockfile, never `config.json` itself, so locking never
-    /// interferes with the atomic config write.
-    pub fn config_lock_path() -> Result<PathBuf> {
-        let home_dir = dirs::home_dir().context("Unable to get home directory")?;
-        Ok(home_dir.join(".railway").join(".config.lock"))
-    }
-
     /// Re-read the root config from disk, discarding any in-memory state.
     /// Used after acquiring the config lock so a refresh sees credentials
     /// freshly written by another concurrent process.
     pub fn reload(&mut self) -> Result<()> {
-        match File::open(&self.root_config_path) {
-            Ok(mut file) => {
-                let mut serialized_config = vec![];
-                file.read_to_end(&mut serialized_config)?;
-                self.root_config = serde_json::from_slice(&serialized_config)
-                    .unwrap_or_else(|_| RailwayConfig::default());
-            }
-            Err(_) => {
-                self.root_config = RailwayConfig::default();
-            }
-        }
+        self.root_config = Self::read_root_config(&self.root_config_path).unwrap_or_default();
         Ok(())
     }
 
@@ -294,7 +275,7 @@ impl Configs {
         }
         self.root_config.user.token_expires_at = Some(expires_at);
         self.root_config.user.token = None; // Clear legacy token
-        self.write()
+        self.write_credentials()
     }
 
     /// Drop the stored OAuth credentials after the server has told us they
@@ -313,13 +294,49 @@ impl Configs {
         self.root_config.user.access_token = None;
         self.root_config.user.refresh_token = None;
         self.root_config.user.token_expires_at = None;
-        self.write()
+        // `get_railway_auth_token` falls back to the legacy `token`, so leaving
+        // it behind would keep an old install looking authenticated after the
+        // clear.
+        self.root_config.user.token = None;
+        self.write_credentials()
     }
 
     pub fn save_user_id(&mut self, id: &str) -> Result<()> {
         anyhow::ensure!(!id.is_empty(), "user id cannot be empty");
         self.root_config.user.id = Some(id.to_string());
         self.write()
+    }
+
+    /// Build a `Configs` backed by an explicit path, for tests that need to
+    /// exercise the real read/modify/write cycle without touching `$HOME`.
+    #[cfg(test)]
+    pub(crate) fn for_test(root_config_path: PathBuf) -> Self {
+        Self {
+            root_config: RailwayConfig::default(),
+            root_config_path,
+        }
+    }
+
+    /// Take the exclusive config lock covering this config file, without
+    /// blocking the async runtime.
+    ///
+    /// Acquisition polls with a blocking sleep, so under contention it would
+    /// park a tokio worker for up to `CONFIG_LOCK_TIMEOUT` and starve unrelated
+    /// tasks — the long-running MCP server serves tool calls concurrently, so
+    /// that is a real stall, not a theoretical one.
+    pub(crate) async fn acquire_lock(&self) -> ConfigLock {
+        let path = self.root_config_path.clone();
+        tokio::task::spawn_blocking(move || ConfigLock::acquire(&path))
+            .await
+            .unwrap_or(ConfigLock { file: None })
+    }
+
+    /// Read and parse the root config, or `None` when it is absent or corrupt.
+    fn read_root_config(path: &std::path::Path) -> Option<RailwayConfig> {
+        let mut file = File::open(path).ok()?;
+        let mut buf = vec![];
+        file.read_to_end(&mut buf).ok()?;
+        serde_json::from_slice(&buf).ok()
     }
 
     pub fn get_environment_id() -> Environment {
@@ -731,7 +748,47 @@ impl Configs {
             )
     }
 
+    /// Persist the config, taking the credential fields from disk rather than
+    /// from this (possibly stale) in-memory snapshot.
+    ///
+    /// A process can hold a `Configs` for a long time — `railway mcp` keeps one
+    /// for the whole editor session — and then write it for an unrelated reason
+    /// such as linking a project. Serialising its whole snapshot would put
+    /// whatever credentials it loaded at startup back on disk, undoing a token
+    /// refresh (or a `clear_oauth_tokens` after a dead grant) performed by
+    /// another process in the meantime. Credentials belong to the auth paths, so
+    /// an ordinary write never carries them: see [`Self::write_credentials`].
     pub fn write(&self) -> Result<()> {
+        let mut to_write = serde_json::to_value(&self.root_config)?;
+        // Re-read immediately before writing so the window in which a
+        // concurrent refresh could be lost is microseconds rather than the
+        // lifetime of this `Configs`.
+        if let Some(disk) = Self::read_root_config(&self.root_config_path) {
+            // Merge on the typed struct so the field set is checked by the
+            // compiler: a new credential field on `RailwayUser` is picked up
+            // automatically instead of being silently dropped. Everything that
+            // is not a credential (`id`) stays owned by this caller, so
+            // `save_user_id` still works.
+            let merged = RailwayUser {
+                id: self.root_config.user.id.clone(),
+                ..disk.user
+            };
+            to_write["user"] = serde_json::to_value(merged)?;
+        }
+        self.write_value(&to_write)
+    }
+
+    /// Persist the config including this instance's credential fields.
+    ///
+    /// Only the auth paths may claim that ownership: login/refresh
+    /// ([`Self::save_oauth_tokens`]), a dead grant
+    /// ([`Self::clear_oauth_tokens`]), and logout.
+    pub(crate) fn write_credentials(&self) -> Result<()> {
+        let value = serde_json::to_value(&self.root_config)?;
+        self.write_value(&value)
+    }
+
+    fn write_value(&self, value: &serde_json::Value) -> Result<()> {
         let config_dir = self
             .root_config_path
             .parent()
@@ -744,11 +801,17 @@ impl Configs {
         // umask — the common 022 would leave it world-readable.
         secure_config_dir(config_dir)?;
 
-        // Use temporary file to achieve atomic write:
-        //  1. Open file ~/railway/config.tmp
-        //  2. Serialize config to temporary file
-        //  3. Rename temporary file to ~/railway/config.json (atomic operation)
-        let tmp_file_path = self.root_config_path.with_extension("tmp");
+        // Use a temporary file to achieve an atomic write. The name is unique per
+        // writer — matching `util::write_atomic`'s pid+nanos convention — because
+        // a shared `config.tmp` opened with truncate lets two concurrent writers
+        // interleave into one file and produce malformed JSON, which the loader
+        // then "repairs" by discarding every token. Threads matter as much as
+        // processes here: the MCP server serves tool calls concurrently.
+        let pid = std::process::id();
+        let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default();
+        let tmp_file_path = self
+            .root_config_path
+            .with_extension(format!("tmp.{pid}-{nanos}"));
         let mut options = File::options();
         options.create(true).write(true).truncate(true);
         // Set the mode at creation so the tokens are never briefly readable.
@@ -760,11 +823,12 @@ impl Configs {
         let tmp_file = options.open(&tmp_file_path)?;
         // An existing tmp file keeps its old mode, so enforce it either way.
         secure_config_file(&tmp_file_path)?;
-        serde_json::to_writer_pretty(&tmp_file, &self.root_config)?;
+        serde_json::to_writer_pretty(&tmp_file, value)?;
         tmp_file.sync_all()?;
 
-        // Rename file to final destination to achieve atomic write
-        fs::rename(tmp_file_path.as_path(), &self.root_config_path)?;
+        // Rename to the final destination. `rename_replacing` is atomic on both
+        // Unix and Windows.
+        crate::util::rename_replacing(tmp_file_path.as_path(), &self.root_config_path)?;
 
         Ok(())
     }
@@ -885,6 +949,62 @@ mod tests {
         );
 
         assert!(has_credentials);
+    }
+}
+
+/// How long to wait for the config lock before giving up and proceeding without
+/// it. Kept short so a stale lock can never wedge the CLI for long.
+const CONFIG_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Poll interval while waiting for the config lock.
+const CONFIG_LOCK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// RAII guard around an exclusive advisory lock on the config lockfile.
+/// Releasing happens on drop, covering all error paths.
+pub(crate) struct ConfigLock {
+    file: Option<File>,
+}
+
+impl ConfigLock {
+    /// Acquire the lock guarding `config_path`. The lockfile is a sibling of the
+    /// config (never the config itself, so locking cannot interfere with the
+    /// atomic rename). Failure to lock is non-fatal: proceeding unlocked is
+    /// strictly better than wedging the CLI, and the credential merge in `write`
+    /// still narrows the race to microseconds.
+    fn acquire(config_path: &std::path::Path) -> Self {
+        let lock_path = config_path.with_extension("lock");
+        if let Some(parent) = lock_path.parent() {
+            if create_dir_all(parent).is_err() {
+                return Self { file: None };
+            }
+        }
+        let Ok(file) = File::create(&lock_path) else {
+            return Self { file: None };
+        };
+
+        use fs2::FileExt;
+        let deadline = std::time::Instant::now() + CONFIG_LOCK_TIMEOUT;
+        loop {
+            if file.try_lock_exclusive().is_ok() {
+                return Self { file: Some(file) };
+            }
+            if std::time::Instant::now() >= deadline {
+                eprintln!(
+                    "{}",
+                    "Warning: timed out waiting for config lock; proceeding without it".yellow()
+                );
+                return Self { file: None };
+            }
+            std::thread::sleep(CONFIG_LOCK_POLL_INTERVAL);
+        }
+    }
+}
+
+impl Drop for ConfigLock {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.take() {
+            use fs2::FileExt;
+            let _ = FileExt::unlock(&file);
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,17 @@
 use reqwest::header::InvalidHeaderValue;
 use thiserror::Error;
 
+/// Substrings that identify an authorization failure in a *rendered* error
+/// message.
+///
+/// The MCP tool layer flattens `RailwayError` into an opaque `McpError` string
+/// before its dispatcher sees it, so recovery there has to match on text. These
+/// markers are declared next to the variants they describe, and
+/// `auth_failure_markers_cover_unauthorized_variants` fails if a variant's
+/// message stops containing one — otherwise rewording an `#[error(...)]` would
+/// silently disable mid-session re-auth.
+pub const AUTH_FAILURE_MARKERS: &[&str] = &["Unauthorized", "Not authenticated"];
+
 #[derive(Error, Debug)]
 pub enum RailwayError {
     #[error("Unauthorized. Please login with `railway login`")]
@@ -109,7 +120,10 @@ pub enum RailwayError {
     #[error("Authorization was denied by the user.")]
     OAuthAccessDenied,
 
-    #[error("Token refresh failed: {0}. Please run `railway login` again.")]
+    /// Transient refresh failure: the stored credentials are still valid, so
+    /// this must NOT tell the user to log in again. A backboard blip used to
+    /// send everyone who refreshed during it to `railway login` for nothing.
+    #[error("Couldn't refresh your session: {0}. This is usually temporary — please try again.")]
     OAuthRefreshFailed(String),
 
     /// The server rejected the stored refresh token with `invalid_grant` —
@@ -184,6 +198,29 @@ impl RailwayError {
             }
             RailwayError::NoServiceLinked => Some("Run `railway service` to link a service."),
             _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant that means "the server refused this on authorization" must
+    /// be recognisable from its rendered message alone.
+    #[test]
+    fn auth_failure_markers_cover_unauthorized_variants() {
+        let variants = [
+            RailwayError::Unauthorized,
+            RailwayError::UnauthorizedLogin,
+            RailwayError::UnauthorizedToken("RAILWAY_TOKEN".to_string()),
+        ];
+        for variant in variants {
+            let rendered = variant.to_string();
+            assert!(
+                AUTH_FAILURE_MARKERS.iter().any(|m| rendered.contains(m)),
+                "no AUTH_FAILURE_MARKERS entry matches {rendered:?}; mid-session re-auth would stop working for this variant"
+            );
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use util::{
     compare_semver::compare_semver,
 };
 
+#[cfg(test)]
+mod auth_sim;
 mod client;
 mod config;
 mod consts;

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -26,7 +26,7 @@ pub fn get_oauth_client_id() -> &'static str {
     })
 }
 
-fn get_oauth_base_url(host: &str) -> String {
+pub(crate) fn get_oauth_base_url(host: &str) -> String {
     format!("https://backboard.{host}/oauth")
 }
 
@@ -243,9 +243,80 @@ pub async fn poll_for_token(host: &str, device_auth: &DeviceAuthResponse) -> Res
     }
 }
 
-pub async fn refresh_access_token(host: &str, refresh_token: &str) -> Result<TokenResponse> {
-    let client = build_http_client()?;
-    let url = format!("{}/token", get_oauth_base_url(host));
+/// Why a refresh attempt failed, and whether the stored credentials are still
+/// worth keeping.
+///
+/// Wraps the [`RailwayError`] that [`classify_refresh_error`] already produces,
+/// so the permanent-vs-retryable decision lives in exactly one place and the
+/// typed error survives all the way to the caller.
+#[derive(Debug)]
+pub enum RefreshFailure {
+    /// The grant is dead server-side. Clear the credentials and re-login.
+    Terminal(RailwayError),
+    /// Transient — keep the credentials and try again later.
+    Transient(RailwayError),
+}
+
+impl RefreshFailure {
+    fn classify(error: &str, desc: String) -> Self {
+        match classify_refresh_error(error, desc) {
+            permanent @ RailwayError::OAuthInvalidGrant(_) => Self::Terminal(permanent),
+            other => Self::Transient(other),
+        }
+    }
+}
+
+/// Number of attempts for a transient failure (1 initial + 2 retries).
+pub const REFRESH_MAX_ATTEMPTS: u32 = 3;
+
+/// Refresh against an explicit OAuth base URL, retrying transient failures with
+/// exponential backoff. Takes a base URL (rather than a host) so the retry and
+/// classification policy can be exercised against a local server in tests.
+///
+/// Hand-rolled rather than using [`crate::util::retry::retry_with_backoff`]:
+/// that helper retries every `Err`, and here a `Terminal` failure must abort
+/// immediately — expressing that through it would mean returning
+/// `Result<Result<_, RefreshFailure>>` from the closure, which reads worse than
+/// the loop.
+pub async fn refresh_access_token_at(
+    base_url: &str,
+    refresh_token: &str,
+    backoff: Duration,
+) -> std::result::Result<TokenResponse, RefreshFailure> {
+    // One client for all attempts: building one re-parses the whole system root
+    // store (~80ms) and starts with a cold connection pool, so rebuilding per
+    // attempt would add ~160ms of pure setup to a retried refresh.
+    let client = build_http_client()
+        .map_err(|e| RefreshFailure::Transient(RailwayError::OAuthRefreshFailed(e.to_string())))?;
+
+    for attempt in 0..REFRESH_MAX_ATTEMPTS {
+        if attempt > 0 {
+            // Exponential backoff. A refresh storm after an outage is itself a
+            // load problem, so back off rather than hammering a recovering
+            // token endpoint.
+            tokio::time::sleep(backoff * (1 << (attempt - 1))).await;
+        }
+
+        match attempt_refresh(&client, base_url, refresh_token).await {
+            Ok(resp) => return Ok(resp),
+            // A dead grant will still be dead on the next attempt; fail fast so
+            // the caller can clear credentials and prompt a login.
+            Err(failure @ RefreshFailure::Terminal(_)) => return Err(failure),
+            // Out of attempts — surface the last cause rather than a summary.
+            Err(failure) if attempt + 1 == REFRESH_MAX_ATTEMPTS => return Err(failure),
+            Err(_) => {}
+        }
+    }
+
+    unreachable!("the final attempt returns rather than falling through")
+}
+
+pub(crate) async fn attempt_refresh(
+    client: &reqwest::Client,
+    base_url: &str,
+    refresh_token: &str,
+) -> std::result::Result<TokenResponse, RefreshFailure> {
+    let url = format!("{base_url}/token");
     let client_id = get_oauth_client_id();
 
     let resp = client
@@ -256,12 +327,29 @@ pub async fn refresh_access_token(host: &str, refresh_token: &str) -> Result<Tok
             ("client_id", client_id),
         ])
         .send()
-        .await?;
+        .await
+        // Connection refused / reset / timeout: the credentials are untouched.
+        .map_err(|e| {
+            RefreshFailure::Transient(RailwayError::OAuthRefreshFailed(format!(
+                "network error: {e}"
+            )))
+        })?;
 
     let status = resp.status();
     if status.is_success() {
-        let token_resp: TokenResponse = resp.json().await?;
-        return Ok(token_resp);
+        return resp.json::<TokenResponse>().await.map_err(|e| {
+            RefreshFailure::Transient(RailwayError::OAuthRefreshFailed(format!(
+                "malformed token response: {e}"
+            )))
+        });
+    }
+
+    // 5xx is the server's problem, never the token's — don't even look at the
+    // body for an error code.
+    if status.is_server_error() {
+        return Err(RefreshFailure::Transient(RailwayError::OAuthRefreshFailed(
+            format!("HTTP {status}"),
+        )));
     }
 
     let error_resp: TokenErrorResponse = resp.json().await.unwrap_or(TokenErrorResponse {
@@ -269,7 +357,7 @@ pub async fn refresh_access_token(host: &str, refresh_token: &str) -> Result<Tok
         error_description: Some(format!("HTTP {status}")),
     });
     let desc = error_resp.error_description.unwrap_or_default();
-    Err(classify_refresh_error(&error_resp.error, desc).into())
+    Err(RefreshFailure::classify(&error_resp.error, desc))
 }
 
 /// Split token-endpoint failures into permanent and retryable.


### PR DESCRIPTION
Builds on #1034 and is rebased onto it. That PR clears credentials on `invalid_grant`; this covers the rest of the auth-expiry work. `classify_refresh_error` and its two tests are reused unchanged.

## Transient refresh failures

#1034 correctly declines to clear credentials on a 5xx, but there is no retry, and `OAuthRefreshFailed` still tells the user to run `railway login`. Backboard served 1,811 5xx on `/token` over two days (Jul 30 16:00–19:00 and Jul 31 11:00 UTC, Redis and Prisma pool exhaustion). Each one failed a command and sent the user to re-authenticate for nothing.

`refresh_access_token_at` now retries transient failures three times with exponential backoff, and fails fast on a dead grant. `RefreshFailure::{Terminal, Transient}` wraps the `RailwayError` that `classify_refresh_error` returns, so the permanent-versus-retryable decision stays in one place. The `OAuthRefreshFailed` message no longer mentions logging in, since `OAuthInvalidGrant` is the variant that means it.

## The local MCP server cannot refresh

`GQLClient::new_authorized` bakes the bearer token into the HTTP client's default headers, and the handler held an immutable `Arc<Configs>`. A `railway mcp` process outlives its 1h access token by hours, so once that token expired every tool call failed, and running `railway login` in another terminal did nothing until the editor restarted.

Fourteen days of `cli_mcp`, matched on `%railway login%` because the messages are prefixed (`-32603: Failed to …`):

| Message | Events | Users |
|---|---|---|
| `Failed to get project: Unauthorized` | 61,326 | 7,791 |
| `Not authenticated. Run 'railway login' first` (the `whoami` tool, pure authentication) | 7,655 | 3,227 |

Of 16,620 sessions that went from working to auth-failure, 50.6% never succeeded again in that session. 6,868 users hit auth failures only through MCP and never through a CLI command.

Credentials are now re-resolved at the `call_tool` choke point and the client is swappable. An authorization failure forces a refresh and retries once, which covers tokens that die server-side before local expiry — grant revocation, or eviction by the per-grant refresh-token cap. The client is rebuilt only when the token actually changes, because rebuilding discards the connection pool and costs roughly 130ms per call.

`serve_stdio` also falls back to an unauthenticated client so the server always starts. On current master a dead grant leaves no token, `new_authorized` fails, and `railway mcp` exits without completing the handshake:

```
$ echo '{…initialize…}' | HOME=$tmp railway mcp
Your saved login is no longer valid (grant request is invalid). Please run `railway login` again.
  EXIT=1
```

With the fallback it starts, returns an auth error the agent can act on, and picks up credentials once the user logs in.

## Config writes could undo the clear

`Configs::write` serialised the whole in-memory snapshot, so a process that held a `Configs` for hours and then wrote for an unrelated reason, such as linking a project, put its startup credentials back on disk. Writes now take the credential fields from disk through a typed merge on `RailwayUser`. Only `save_oauth_tokens`, `clear_oauth_tokens` and logout go through `write_credentials`.

`clear_oauth_tokens` also clears the legacy `token` field. `get_railway_auth_token` falls back to it, so on master it survives the clear and leaves an old install looking authenticated.

Temp files are named per writer: a shared name opened with `truncate` lets two concurrent writers interleave into malformed JSON, which the loader then replaces with defaults, discarding every token. `util::rename_replacing` makes the rename atomic on Windows, and lock acquisition moved to `spawn_blocking` so it no longer parks a tokio worker.

## Verification

`src/auth_sim.rs` runs the real HTTP layer and the real config read/modify/write cycle against a scripted token endpoint. It includes a reproduction of the pre-#1034 policy, so the before/after differences come from the policy rather than the harness.

| Scenario | pre-#1034 | this PR |
|---|---|---|
| Dead grant, 20 invocations | 20 requests, credentials kept | 1 request, credentials cleared |
| 5xx | 1 attempt, tells the user to log in | 3 attempts, credentials kept |
| 500, 500, 200 | — | refreshes, no user-visible error |
| 9 non-`invalid_grant` codes | — | transient, credentials kept |

Driving `railway mcp` over stdio against production, master → this PR:

- dead token, then valid credentials written mid-session: still broken → recovers
- fresh install with no login, then login: exits 1 → recovers
- mid-session expiry with only `tokenExpiresAt` changed, no valid token ever supplied: still broken → recovers
- token valid locally but rejected by the server: still broken → recovers

543 tests pass, including the two from #1034. Tool-call latency is 240ms against a 238ms baseline, with 8 of 8 pipelined calls answered. Logout still clears tokens, and a normal run leaves credentials intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
