### PR TITLE
fix(install): make install.sh run under any /bin/sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,38 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy --all-targets --all-features
 
+  installer:
+    name: Installer (POSIX sh)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      # install.sh is published at railway.com/install.sh and reached through
+      # `curl … | sh`, so it has to run under whatever /bin/sh the host ships —
+      # dash on Debian/Ubuntu, busybox ash on Alpine — not just bash. Linting as
+      # dash catches bashisms before they reach users (see #319, #990).
+      - name: Shellcheck as dash
+        run: |
+          docker run --rm -v "$PWD:/w" -w /w koalaman/shellcheck:stable \
+            -s dash -S error install.sh agents.sh
+
+      - name: Install under dash (Debian/Ubuntu /bin/sh)
+        run: |
+          docker run --rm -v "$PWD/install.sh:/install.sh:ro" ubuntu:24.04 sh -c '
+            set -e
+            apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null
+            SHELL=/bin/bash dash -s -- -y < /install.sh
+            ~/.railway/bin/railway --version'
+
+      - name: Install under busybox ash (Alpine /bin/sh, no bash present)
+        run: |
+          docker run --rm -v "$PWD/install.sh:/install.sh:ro" alpine:3.20 sh -c '
+            set -e
+            apk add --no-cache curl >/dev/null
+            SHELL=/bin/ash sh -s -- -y < /install.sh
+            ~/.railway/bin/railway --version'
+
   test-plan:
     name: Tests
     strategy:

--- a/install.sh
+++ b/install.sh
@@ -87,8 +87,10 @@ has() {
 
 RANDOM_FOR_SH=$(od -vAn -N4 -tu4 < /dev/urandom | sed 's/\t*$//g')
 
-# Removes leading whitespace
-RANDOM_FOR_SH=$(echo ${RANDOM_FOR_SH:-$RANDOM})
+# Removes leading whitespace. The fallback is $$ rather than $RANDOM: this
+# script runs under dash and busybox ash (via `curl … | sh`), where $RANDOM is
+# unset and `set -u` would abort with "RANDOM: parameter not set".
+RANDOM_FOR_SH=$(echo ${RANDOM_FOR_SH:-$$})
 
 # Gets path to a temporary file, even if
 get_tmpfile() {
@@ -141,16 +143,41 @@ tildify() {
   fi
 }
 
+# POSIX stand-in for bash's ${var//needle/repl}. This script is reached via
+# `curl … | sh` on systems where /bin/sh is dash (Debian/Ubuntu) or busybox ash
+# (Alpine), neither of which supports pattern-substitution expansion.
+replace_all() {
+  local str="$1"
+  local needle="$2"
+  local repl="$3"
+  local out=""
+  local head
+
+  # Assign the prefix on its own line: `"${str%%"$needle"*}"` nested inside an
+  # outer double-quoted string is left unspecified by POSIX, and this script
+  # runs under whatever /bin/sh the host provides.
+  while :; do
+    case "$str" in
+      *"$needle"*)
+        head=${str%%"$needle"*}
+        out=$out$head$repl
+        str=${str#*"$needle"}
+        ;;
+      *) break ;;
+    esac
+  done
+
+  printf '%s%s' "$out" "$str"
+}
+
 shell_quote() {
-  local value="$1"
-  value=${value//\'/\'\\\'\'}
-  printf "'%s'" "$value"
+  printf "'%s'" "$(replace_all "$1" "'" "'\\''")"
 }
 
 fish_quote() {
-  local value="$1"
-  value=${value//\\/\\\\}
-  value=${value//\'/\\\'}
+  local value
+  value="$(replace_all "$1" '\' '\\')"
+  value="$(replace_all "$value" "'" "\\'")"
   printf "'%s'" "$value"
 }
 
@@ -216,8 +243,12 @@ unpack() {
 
   case "$archive" in
     *.tar.gz)
-      flags=$(test -n)
-      ${sudo} tar "${flags}" -xzf "${archive}" -C "${bin_dir}"
+      # VERBOSE is normalized to "v" or "" during option parsing. Fold it into
+      # the flag bundle rather than passing a separate "${flags}" word: when
+      # empty that expands to an empty argument, which GNU tar ignores but
+      # busybox tar (Alpine) reads as a member name -> "tar: : not found in
+      # archive".
+      ${sudo} tar "-${VERBOSE}xzf" "${archive}" -C "${bin_dir}"
       return 0
       ;;
     *.zip)
@@ -945,7 +976,27 @@ run_agent_setup() {
   # Tell `setup agent` it's running inside the installer so it renders its
   # skills/MCP steps as part of one unified flow (no duplicate header, footer,
   # login prompt, or restart notices — the installer prints those once below).
-  RAILWAY_SETUP_EMBEDDED=1 "$railway_bin" setup agent $yes $remote
+  # Never let this abort the installer bare under `set -e`. The CLI itself is
+  # installed and working by this point, so a failure here must say which half
+  # broke, surface the real status, and still point somewhere useful — the old
+  # behaviour was to die mid-script with no Railway-branded message at all.
+  AGENT_SETUP_RC=0
+  RAILWAY_SETUP_EMBEDDED=1 "$railway_bin" setup agent $yes $remote || AGENT_SETUP_RC=$?
+  if [ "$AGENT_SETUP_RC" -ne 0 ]; then
+    printf "\n"
+    if [ "$AGENT_SETUP_RC" -eq 2 ]; then
+      error "This Railway CLI (${CURRENT_VERSION:-unknown}) does not support 'setup agent'."
+      error "Upgrade it first, then re-run: curl -fsSL railway.com/agents.sh | sh"
+    elif [ "$AGENT_SETUP_RC" -gt 128 ]; then
+      error "Agent setup terminated by signal $((AGENT_SETUP_RC - 128)): $railway_bin setup agent"
+      error "Please report this at https://github.com/railwayapp/cli/issues/new"
+    else
+      error "Agent setup failed (exit $AGENT_SETUP_RC): $railway_bin setup agent"
+    fi
+    info "The Railway CLI itself is installed and usable: $(tildify "$railway_bin")"
+    info "Re-run 'railway setup agent' once the above is resolved."
+    exit "$AGENT_SETUP_RC"
+  fi
 
   # Record login state (and the "Logged in as …" line) for the next-steps
   # block; don't warn here. whoami exits non-zero and prints nothing when

--- a/install.sh
+++ b/install.sh
@@ -153,6 +153,14 @@ replace_all() {
   local out=""
   local head
 
+  # An empty needle matches at every position, so the loop below would never
+  # advance. No caller does this today; guard anyway rather than let a future one
+  # hang the installer with no output.
+  if [ -z "$needle" ]; then
+    printf '%s' "$str"
+    return 0
+  fi
+
   # Assign the prefix on its own line: `"${str%%"$needle"*}"` nested inside an
   # outer double-quoted string is left unspecified by POSIX, and this script
   # runs under whatever /bin/sh the host provides.


### PR DESCRIPTION
The published one-liner `curl -fsSL agents.railway.com | sh` fails on every Debian/Ubuntu host, where `/bin/sh` is dash:

```
✓ CLI — v5.30.3 · ~/.railway/bin
sh: 146: Bad substitution
```

Fixes #990 (bug 3). Same class as #319.

**Why POSIX, not `| bash`** — only 3 constructs were bash-only. Going POSIX keeps the published command unchanged, drops the bash dependency entirely, and fixes Alpine. Switching the wrapper to bash leaves every already-published copy of `| sh` broken.

**Changes**
- `shell_quote`/`fish_quote`: 3 × `${var//…}` → `replace_all` helper
- `$RANDOM` fallback aborts under dash + `set -u` → `$$`
- `unpack()`: `flags=$(test -n)` passed an empty *quoted* arg to tar. GNU tar ignores it; busybox tar reads it as a member name → `tar: : not found in archive`. Also makes `-V` verbose work for the first time.
- `setup agent` failures no longer abort bare under `set -e` — the silent "exit 1" half of #990. Reachable in practice: v4.5.3 exits 2 on `setup agent`, and the brew/sandbox branches deliberately continue with an old CLI.

The shell and tar bugs blocked Alpine independently; both fixed, so Alpine works now.

**Verification**
- quoting helpers byte-identical to the bash originals (quote / backslash / glob / empty inputs) under dash, bash and busybox ash
- full installs pass: ubuntu:24.04, debian:12-slim × `sh`/`dash`/`bash`; alpine:3.20 × `sh`/`ash`
- new CI job lints install.sh + agents.sh as dash, then runs a real install under dash and under busybox ash

🤖 Generated with [Claude Code](https://claude.com/claude-code)