### PR TITLE
fix(install): don't clobber an npm-managed CLI during --agents upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1100,6 +1100,37 @@ if [ "$AGENTS" = 1 ] && has railway; then
     exit 0
   fi
 
+  # Same reasoning as Homebrew, for npm (and the pnpm/yarn/bun/volta/nvm layouts
+  # that all end up pointing into node_modules): `command -v railway` is a
+  # symlink to <prefix>/lib/node_modules/@railway/cli/bin/railway.js, so
+  # EXISTING_BIN_DIR would be npm's own bin dir. Extracting there replaces npm's
+  # symlink with a raw binary that npm still records as its own, so a later
+  # `npm uninstall -g @railway/cli` deletes the binary we just installed —
+  # leaving no railway at all — and `npm install -g` silently reverts it.
+  NPM_INSTALL=0
+  case "$RAILWAY_BIN" in
+    */node_modules/*) NPM_INSTALL=1 ;;
+  esac
+  if [ "$NPM_INSTALL" = 0 ] && [ -L "$RAILWAY_BIN" ]; then
+    case "$(readlink "$RAILWAY_BIN" 2>/dev/null || true)" in
+      */node_modules/*|*.js) NPM_INSTALL=1 ;;
+    esac
+  fi
+
+  if [ "$NPM_INSTALL" = 1 ]; then
+    if [ "$REMOTE" = 1 ]; then
+      error "Railway CLI was installed with npm (version $CURRENT_VERSION)."
+      error "The --remote flag requires Railway CLI $RAILWAY_VERSION or newer."
+      error "Run 'npm install -g @railway/cli@latest' first, then re-run cli.new --agents --remote."
+      exit 1
+    fi
+    warn "Railway CLI was installed with npm."
+    warn "Run 'npm install -g @railway/cli@latest' to update from $CURRENT_VERSION to $RAILWAY_VERSION, then re-run cli.new --agents."
+    info "Continuing with $CURRENT_VERSION."
+    run_agent_setup "$RAILWAY_BIN"
+    exit 0
+  fi
+
   EXISTING_BIN_DIR="$(dirname "$RAILWAY_BIN")"
   info "Newer version available: $RAILWAY_VERSION (you have $CURRENT_VERSION)"
 

--- a/install.sh
+++ b/install.sh
@@ -1100,32 +1100,37 @@ if [ "$AGENTS" = 1 ] && has railway; then
     exit 0
   fi
 
-  # Same reasoning as Homebrew, for npm (and the pnpm/yarn/bun/volta/nvm layouts
-  # that all end up pointing into node_modules): `command -v railway` is a
-  # symlink to <prefix>/lib/node_modules/@railway/cli/bin/railway.js, so
-  # EXISTING_BIN_DIR would be npm's own bin dir. Extracting there replaces npm's
-  # symlink with a raw binary that npm still records as its own, so a later
-  # `npm uninstall -g @railway/cli` deletes the binary we just installed —
-  # leaving no railway at all — and `npm install -g` silently reverts it.
-  NPM_INSTALL=0
+  # Same reasoning as the Homebrew branch above, for the JS package managers.
+  # Every release we publish is a native executable, so a `railway` on PATH that
+  # is a script or a link into node_modules belongs to something else: npm, yarn
+  # and bun symlink a .js entrypoint, pnpm writes a /bin/sh shim. Extracting into
+  # that bin dir replaces the tool's entry with a raw binary it still records as
+  # its own, so a later `npm uninstall -g @railway/cli` deletes the binary we
+  # just installed — leaving no railway at all — and reinstalling reverts it.
+  MANAGED_BIN=0
   case "$RAILWAY_BIN" in
-    */node_modules/*) NPM_INSTALL=1 ;;
+    */node_modules/*) MANAGED_BIN=1 ;;
   esac
-  if [ "$NPM_INSTALL" = 0 ] && [ -L "$RAILWAY_BIN" ]; then
+  if [ "$MANAGED_BIN" = 0 ] && [ -L "$RAILWAY_BIN" ]; then
     case "$(readlink "$RAILWAY_BIN" 2>/dev/null || true)" in
-      */node_modules/*|*.js) NPM_INSTALL=1 ;;
+      */node_modules/*|*.js) MANAGED_BIN=1 ;;
     esac
   fi
+  # Catches pnpm's shell shim, and any hand-rolled wrapper — which we equally
+  # should not overwrite.
+  if [ "$MANAGED_BIN" = 0 ] && [ "$(head -c 2 "$RAILWAY_BIN" 2>/dev/null || true)" = '#!' ]; then
+    MANAGED_BIN=1
+  fi
 
-  if [ "$NPM_INSTALL" = 1 ]; then
+  if [ "$MANAGED_BIN" = 1 ]; then
     if [ "$REMOTE" = 1 ]; then
-      error "Railway CLI was installed with npm (version $CURRENT_VERSION)."
+      error "Railway CLI on PATH is managed by another tool: $RAILWAY_BIN ($CURRENT_VERSION)."
       error "The --remote flag requires Railway CLI $RAILWAY_VERSION or newer."
-      error "Run 'npm install -g @railway/cli@latest' first, then re-run cli.new --agents --remote."
+      error "Update it with that tool first (e.g. 'npm install -g @railway/cli@latest'), then re-run cli.new --agents --remote."
       exit 1
     fi
-    warn "Railway CLI was installed with npm."
-    warn "Run 'npm install -g @railway/cli@latest' to update from $CURRENT_VERSION to $RAILWAY_VERSION, then re-run cli.new --agents."
+    warn "Railway CLI on PATH is managed by another tool: $RAILWAY_BIN"
+    warn "Update it with that tool (e.g. 'npm install -g @railway/cli@latest') to go from $CURRENT_VERSION to $RAILWAY_VERSION, then re-run cli.new --agents."
     info "Continuing with $CURRENT_VERSION."
     run_agent_setup "$RAILWAY_BIN"
     exit 0


### PR DESCRIPTION
With an outdated npm install on PATH, `command -v railway` is a symlink into `<prefix>/lib/node_modules/@railway/cli/bin/railway.js`, so `EXISTING_BIN_DIR` became npm's bin dir and install.sh extracted a raw binary over npm's symlink.

npm still records the package as its own, so a later `npm uninstall -g @railway/cli` deletes the binary install.sh just installed — leaving no `railway` at all. `npm install -g` reverts it the other way.

Mirrors the existing Homebrew branch: detect npm-owned installs, warn, point at `npm install -g @railway/cli@latest`, and continue agent setup with the CLI already present. Refuse early for `--remote`, which needs a newer CLI.

Addresses suggested fix 4 in #990.

**Verification**
- outdated npm install: npm symlink left intact, no `~/.railway/bin` created
- `--remote` + npm: refuses with exit 1
- non-npm install: still upgrades in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)