### PR TITLE
fix(install): resolve the version lazily so offline paths still work

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -447,19 +447,32 @@ RAILWAY_PATH_MARKER_END="# <<< railway initialize <<<"
 SHELL_STARTUP_FILE=""
 SHELL_STARTUP_ACTION=""
 
-DEFAULT_VERSION=$(curl -s https://api.github.com/repos/railwayapp/cli/releases/latest | grep -o '"tag_name":[[:space:]]*"v[^"]*"' | cut -d'"' -f4 | cut -c2-)
+# Resolve the version to install. Deliberately lazy: called only after --help and
+# --remove have had their chance to exit, and skipped outright when the caller
+# pinned RAILWAY_VERSION. Resolving eagerly at startup made every invocation
+# depend on an unauthenticated api.github.com call — rate limited to 60/hour per
+# source IP, which shared CI runners exhaust — so an install with a pinned
+# version would fail, and even `--help` and `-r` could not run. (#1030)
+resolve_railway_version() {
+  if [ -n "${RAILWAY_VERSION-}" ]; then
+    return 0
+  fi
 
-if [ -z "$DEFAULT_VERSION" ]; then
-  error "Failed to fetch latest version from GitHub"
-  exit 1
-fi
+  RAILWAY_VERSION=$(curl -s --max-time 15 https://api.github.com/repos/railwayapp/cli/releases/latest \
+    | grep -o '"tag_name":[[:space:]]*"v[^"]*"' | cut -d'"' -f4 | cut -c2-) || true
+
+  if [ -z "$RAILWAY_VERSION" ]; then
+    error "Could not determine the latest Railway CLI version from GitHub."
+    info "This is usually a transient network failure, or GitHub's unauthenticated"
+    info "API rate limit (60 requests/hour per IP) on a shared runner."
+    info "Pin a version to skip this lookup entirely:"
+    info "  ${BOLD}RAILWAY_VERSION=<x.y.z>${NO_COLOR}"
+    exit 1
+  fi
+}
 
 
 # defaults
-if [ -z "${RAILWAY_VERSION-}" ]; then
-  RAILWAY_VERSION="$DEFAULT_VERSION"
-fi
-
 if [ -z "${RAILWAY_PLATFORM-}" ]; then
   PLATFORM="$(detect_platform)"
 fi
@@ -1090,6 +1103,10 @@ if [ "$HELP" = 1 ]; then
     echo "${help_text}"
     exit 0
 fi
+
+# Everything past this point needs a concrete version; --help and --remove are
+# already done, so this is the first place the lookup can be required.
+resolve_railway_version
 
 RAILWAY_UPGRADE_AGENT=0
 


### PR DESCRIPTION
Fixes #1030.

`install.sh` fetched the latest version from `api.github.com` at startup — ~640 lines before the `--help` and `--remove` short-circuits. That call is unauthenticated and rate limited to 60/hour per source IP, which shared CI runners exhaust.

With the API unreachable:

| command | before | after |
|---|---|---|
| `install.sh --help` | exit 1, no output | exit 0, help printed |
| `install.sh -r` | exit 1, **binary not removed** | exit 0, removed |
| `RAILWAY_VERSION=5.30.4 … -y` | exit 1 | exit 0, installs 5.30.4 |
| unpinned install | exit 1, opaque message | exit 1, actionable message |

**Changes**
- Lookup moves into `resolve_railway_version()`, called after the `--help`/`--remove` blocks.
- Returns early when `RAILWAY_VERSION` is set, so pinned installs never touch the network.
- `DEFAULT_VERSION` dropped — only read by the three lines this replaces.
- `|| true` on the command substitution: without it a failed lookup aborts under `set -e` before the error prints (same failure mode as #1022).
- Adds `--max-time 15`; the old call could hang indefinitely.
- Error names `RAILWAY_VERSION`, the actual workaround.

The issue's suggested patch fixes pinned installs but leaves `--help` and `-r` broken when unpinned, since the fetch sits far above those exits. Deferring the call covers all three.

**Verification** — blackholed `api.github.com` to confirm each row above. `shellcheck -s dash -S error` clean on `install.sh` + `agents.sh`; `--agents -y` installs pass on ubuntu × `sh`/`dash`/`bash` and alpine × `sh`/`ash`.

`release/skip`: install.sh is served from raw master, so no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)