### PR TITLE
test: scripted-backboard testkit + first GraphQL-layer tests

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -486,4 +486,111 @@ mod tests {
         assert_eq!(response.template.name, "PostgreSQL");
         assert_eq!(response.template.serialized_config, None);
     }
+
+    mod graphql_layer {
+        use super::*;
+        use crate::testkit::MockBackboard;
+        use serde_json::json;
+
+        #[tokio::test]
+        async fn success_roundtrips_data_and_sends_variables() {
+            let server = MockBackboard::spawn();
+            server.stub(
+                "WorkflowStatus",
+                json!({ "workflowStatus": { "status": "Complete", "error": null } }),
+            );
+
+            let client = reqwest::Client::new();
+            let response = post_graphql::<queries::WorkflowStatus, _>(
+                &client,
+                server.url(),
+                queries::workflow_status::Variables {
+                    workflow_id: "wf-42".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+            use queries::workflow_status::WorkflowStatus;
+            assert!(matches!(
+                response.workflow_status.status,
+                WorkflowStatus::Complete
+            ));
+            assert_eq!(
+                server.variables_for("WorkflowStatus"),
+                vec![json!({ "workflowId": "wf-42" })]
+            );
+        }
+
+        #[tokio::test]
+        async fn graphql_errors_surface_the_servers_message() {
+            let server = MockBackboard::spawn();
+            server.stub_graphql_error("WorkflowStatus", "workflow blew up");
+
+            let client = reqwest::Client::new();
+            let err = post_graphql::<queries::WorkflowStatus, _>(
+                &client,
+                server.url(),
+                queries::workflow_status::Variables {
+                    workflow_id: "wf-42".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+
+            assert!(matches!(err, RailwayError::GraphQLError(ref m) if m == "workflow blew up"));
+        }
+
+        #[tokio::test]
+        async fn missing_data_without_errors_is_reported_as_such() {
+            let server = MockBackboard::spawn();
+            server.stub_raw("WorkflowStatus", 200, r#"{"data": null}"#.to_string());
+
+            let client = reqwest::Client::new();
+            let err = post_graphql::<queries::WorkflowStatus, _>(
+                &client,
+                server.url(),
+                queries::workflow_status::Variables {
+                    workflow_id: "wf-42".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(err, RailwayError::MissingResponseData));
+        }
+
+        #[tokio::test]
+        async fn http_429_maps_to_ratelimited() {
+            let server = MockBackboard::spawn();
+            server.stub_raw("WorkflowStatus", 429, r#"{"data": null}"#.to_string());
+
+            let client = reqwest::Client::new();
+            let err = post_graphql::<queries::WorkflowStatus, _>(
+                &client,
+                server.url(),
+                queries::workflow_status::Variables {
+                    workflow_id: "wf-42".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(err, RailwayError::Ratelimited));
+        }
+
+        #[tokio::test]
+        async fn connection_refused_maps_to_fetch_error() {
+            // Port 9 (discard) is never listening locally.
+            let client = reqwest::Client::new();
+            let err = post_graphql::<queries::WorkflowStatus, _>(
+                &client,
+                "http://127.0.0.1:9/graphql/v2",
+                queries::workflow_status::Variables {
+                    workflow_id: "wf-42".to_string(),
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(err, RailwayError::FetchError(_)));
+        }
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,8 +110,10 @@ pub struct RailwayConfig {
 pub struct Configs {
     pub root_config: RailwayConfig,
     root_config_path: PathBuf,
-    /// Test-only redirect for every GraphQL call (see
-    /// [`Configs::override_backboard_url`]). Always `None` outside tests.
+    /// Per-instance snapshot of the `RAILWAY_BACKBOARD_URL` debug-build
+    /// escape hatch, taken at construction (see
+    /// [`Configs::backboard_url_override_from_env`]). Always `None` in
+    /// release builds.
     backboard_url_override: Option<String>,
 }
 
@@ -138,7 +140,7 @@ impl Configs {
             let config = Self {
                 root_config,
                 root_config_path,
-                backboard_url_override: None,
+                backboard_url_override: Self::backboard_url_override_from_env(),
             };
 
             return Ok(config);
@@ -147,8 +149,30 @@ impl Configs {
         Ok(Self {
             root_config_path,
             root_config: RailwayConfig::default(),
-            backboard_url_override: None,
+            backboard_url_override: Self::backboard_url_override_from_env(),
         })
+    }
+
+    /// Debug-build-only escape hatch so a locally-built binary (or an
+    /// in-process test) can point every GraphQL call at a scripted backboard
+    /// (see `testkit::MockBackboard`). Snapshotted per instance at
+    /// construction, so parallel tests only need to serialize the env write
+    /// around building their `Configs`, not around using it. Deliberately
+    /// compiled out of release builds: unlike RAILWAY_ENV (which only picks
+    /// between the three fixed Railway hosts), an arbitrary URL override in
+    /// a shipped binary would let a hostile environment redirect
+    /// authenticated traffic.
+    fn backboard_url_override_from_env() -> Option<String> {
+        #[cfg(debug_assertions)]
+        {
+            std::env::var("RAILWAY_BACKBOARD_URL")
+                .ok()
+                .filter(|url| !url.is_empty())
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            None
+        }
     }
 
     /// Absolute path to the root config file for the current environment.
@@ -322,16 +346,8 @@ impl Configs {
         Self {
             root_config: RailwayConfig::default(),
             root_config_path,
-            backboard_url_override: None,
+            backboard_url_override: Self::backboard_url_override_from_env(),
         }
-    }
-
-    /// Point every GraphQL call made through this `Configs` at a local
-    /// scripted endpoint (see `testkit::MockBackboard`). Instance state, not
-    /// an env var, so parallel tests can each talk to their own server.
-    #[cfg(test)]
-    pub(crate) fn override_backboard_url(&mut self, url: impl Into<String>) {
-        self.backboard_url_override = Some(url.into());
     }
 
     /// Take the exclusive config lock covering this config file, without

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,11 +102,17 @@ pub struct RailwayConfig {
     pub sandbox_templates: Option<Vec<StoredSandboxTemplate>>,
 }
 
+// NOTE: no serde derives -- `Configs` itself is never (de)serialized, only
+// its `root_config` is. (A stray `skip_serializing_none` used to sit here;
+// it was inert without serde derives and breaks compilation once the struct
+// has an `Option` field.)
 #[derive(Debug)]
-#[serde_with::skip_serializing_none]
 pub struct Configs {
     pub root_config: RailwayConfig,
     root_config_path: PathBuf,
+    /// Test-only redirect for every GraphQL call (see
+    /// [`Configs::override_backboard_url`]). Always `None` outside tests.
+    backboard_url_override: Option<String>,
 }
 
 pub enum Environment {
@@ -132,6 +138,7 @@ impl Configs {
             let config = Self {
                 root_config,
                 root_config_path,
+                backboard_url_override: None,
             };
 
             return Ok(config);
@@ -140,6 +147,7 @@ impl Configs {
         Ok(Self {
             root_config_path,
             root_config: RailwayConfig::default(),
+            backboard_url_override: None,
         })
     }
 
@@ -314,7 +322,16 @@ impl Configs {
         Self {
             root_config: RailwayConfig::default(),
             root_config_path,
+            backboard_url_override: None,
         }
+    }
+
+    /// Point every GraphQL call made through this `Configs` at a local
+    /// scripted endpoint (see `testkit::MockBackboard`). Instance state, not
+    /// an env var, so parallel tests can each talk to their own server.
+    #[cfg(test)]
+    pub(crate) fn override_backboard_url(&mut self, url: impl Into<String>) {
+        self.backboard_url_override = Some(url.into());
     }
 
     /// Take the exclusive config lock covering this config file, without
@@ -361,6 +378,9 @@ impl Configs {
     }
 
     pub fn get_backboard(&self) -> String {
+        if let Some(url) = &self.backboard_url_override {
+            return url.clone();
+        }
         format!("https://backboard.{}/graphql/v2", self.get_host())
     }
 
@@ -903,6 +923,7 @@ mod tests {
         Configs {
             root_config_path: std::path::PathBuf::new(),
             root_config: RailwayConfig::default(),
+            backboard_url_override: None,
         }
     }
 

--- a/src/controllers/config/environment.rs
+++ b/src/controllers/config/environment.rs
@@ -293,3 +293,99 @@ pub fn prepare_config_for_duplication(mut config: EnvironmentConfig) -> Environm
 
     config
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::MockBackboard;
+    use serde_json::json;
+
+    fn environment_payload(config: serde_json::Value) -> serde_json::Value {
+        json!({
+            "environment": {
+                "id": "env-1",
+                "name": "production",
+                "config": config,
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn parses_services_and_tolerates_unknown_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub(
+            "GetEnvironmentConfig",
+            environment_payload(json!({
+                "services": {
+                    "svc-1": {
+                        "source": { "image": "ghcr.io/railwayapp-templates/postgres-ssl:16" },
+                        "variables": { "PGDATA": { "value": "/var/lib/postgresql/data" } },
+                        "parentServiceId": "svc-0",
+                        // Fields newer than this build must be ignored, not
+                        // fail the parse -- the blob evolves server-side.
+                        "someFutureField": { "nested": true },
+                    }
+                },
+                "unknownTopLevelSection": [1, 2, 3],
+            })),
+        );
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        let response = fetch_environment_config(&client, &configs, "env-1", false)
+            .await
+            .unwrap();
+
+        assert_eq!(response.name, "production");
+        let service = response.config.services.get("svc-1").unwrap();
+        assert_eq!(
+            service.source.as_ref().unwrap().image.as_deref(),
+            Some("ghcr.io/railwayapp-templates/postgres-ssl:16")
+        );
+        assert_eq!(service.parent_service_id.as_deref(), Some("svc-0"));
+
+        // The decrypt flag must reach the wire.
+        assert_eq!(
+            server.variables_for("GetEnvironmentConfig"),
+            vec![json!({ "id": "env-1", "decryptVariables": false })]
+        );
+    }
+
+    #[tokio::test]
+    async fn decrypt_flag_is_passed_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("GetEnvironmentConfig", environment_payload(json!({})));
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        fetch_environment_config(&client, &configs, "env-1", true)
+            .await
+            .unwrap();
+        assert_eq!(
+            server.variables_for("GetEnvironmentConfig")[0]["decryptVariables"],
+            json!(true)
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_config_blob_fails_with_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub(
+            "GetEnvironmentConfig",
+            environment_payload(json!({ "services": "not-an-object" })),
+        );
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        let Err(err) = fetch_environment_config(&client, &configs, "env-1", false).await else {
+            panic!("malformed config must fail to parse");
+        };
+        assert!(
+            format!("{err:#}").contains("Failed to parse environment config"),
+            "unexpected error: {err:#}"
+        );
+    }
+}

--- a/src/controllers/workflow.rs
+++ b/src/controllers/workflow.rs
@@ -17,7 +17,21 @@ pub enum WorkflowError {
     Timeout,
 }
 
+/// One poll's outcome that should stop the retry loop even though the
+/// overall wait is a failure -- `retry_with_backoff` retries every `Err`,
+/// so terminal outcomes must travel through the `Ok` channel.
+enum TerminalPoll {
+    Complete,
+    Failed(String),
+}
+
 /// Waits for a workflow to complete by polling workflowStatus.
+///
+/// `Running` (and unknown statuses) keep polling, and so does `NotFound` --
+/// tolerating read-after-write lag right after the workflow was created.
+/// `Error` is terminal: a workflow that has already failed never un-fails,
+/// so it surfaces immediately instead of burning the full ~2-minute retry
+/// budget re-polling a lost cause.
 pub async fn wait_for_workflow(
     client: &reqwest::Client,
     configs: &Configs,
@@ -47,14 +61,14 @@ pub async fn wait_for_workflow(
 
                 use queries::workflow_status::WorkflowStatus;
                 match result.workflow_status.status {
-                    WorkflowStatus::Complete => Ok(()),
+                    WorkflowStatus::Complete => Ok(TerminalPoll::Complete),
                     WorkflowStatus::Error => {
                         let error_msg = result
                             .workflow_status
                             .error
                             .filter(|e| !e.is_empty())
                             .unwrap_or_else(|| "Unknown error".to_string());
-                        Err(WorkflowError::Failed(error_msg).into())
+                        Ok(TerminalPoll::Failed(error_msg))
                     }
                     WorkflowStatus::NotFound => Err(WorkflowError::NotFound.into()),
                     WorkflowStatus::Running | WorkflowStatus::Other(_) => {
@@ -66,8 +80,107 @@ pub async fn wait_for_workflow(
     )
     .await;
 
-    result.map_err(|e| {
-        e.downcast::<WorkflowError>()
-            .unwrap_or_else(|e| WorkflowError::Failed(e.to_string()))
-    })
+    match result {
+        Ok(TerminalPoll::Complete) => Ok(()),
+        Ok(TerminalPoll::Failed(message)) => Err(WorkflowError::Failed(message)),
+        Err(e) => Err(e
+            .downcast::<WorkflowError>()
+            .unwrap_or_else(|e| WorkflowError::Failed(e.to_string()))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testkit::MockBackboard;
+    use serde_json::json;
+
+    fn status(value: &str, error: Option<&str>) -> serde_json::Value {
+        json!({ "workflowStatus": { "status": value, "error": error } })
+    }
+
+    #[tokio::test]
+    async fn complete_on_first_poll_returns_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("WorkflowStatus", status("Complete", None));
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        wait_for_workflow(&client, &configs, "wf-1".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(server.hits(), 1);
+        assert_eq!(
+            server.variables_for("WorkflowStatus"),
+            vec![json!({ "workflowId": "wf-1" })]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_workflow_surfaces_immediately_with_its_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub(
+            "WorkflowStatus",
+            status("Error", Some("volume detach failed")),
+        );
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        let err = wait_for_workflow(&client, &configs, "wf-1".to_string())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, WorkflowError::Failed(ref m) if m == "volume detach failed"));
+        // Terminal: exactly one poll, not the full ~2-minute retry budget.
+        assert_eq!(server.hits(), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_workflow_without_detail_reports_unknown_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("WorkflowStatus", status("Error", Some("")));
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        let err = wait_for_workflow(&client, &configs, "wf-1".to_string())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WorkflowError::Failed(ref m) if m == "Unknown error"));
+    }
+
+    #[tokio::test]
+    async fn running_polls_until_complete() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("WorkflowStatus", status("Running", None));
+        server.stub("WorkflowStatus", status("Complete", None));
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        wait_for_workflow(&client, &configs, "wf-1".to_string())
+            .await
+            .unwrap();
+        assert_eq!(server.hits(), 2);
+    }
+
+    #[tokio::test]
+    async fn not_found_tolerates_read_after_write_lag() {
+        // A just-created workflow can briefly read as NotFound; the wait must
+        // poll through it rather than give up.
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("WorkflowStatus", status("NotFound", None));
+        server.stub("WorkflowStatus", status("Complete", None));
+
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        wait_for_workflow(&client, &configs, "wf-1".to_string())
+            .await
+            .unwrap();
+        assert_eq!(server.hits(), 2);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ mod oauth;
 mod resources;
 mod subscription;
 mod table;
+#[cfg(test)]
+mod testkit;
 mod util;
 mod workspace;
 

--- a/src/testkit.rs
+++ b/src/testkit.rs
@@ -114,10 +114,25 @@ impl MockBackboard {
     }
 
     /// A `Configs` (backed by a throwaway path under `dir`) whose every
-    /// GraphQL call resolves to this mock server.
+    /// GraphQL call resolves to this mock server, via the same
+    /// `RAILWAY_BACKBOARD_URL` escape hatch a spawned debug binary uses.
+    /// `Configs` snapshots the env var at construction, so the write is
+    /// serialized under a lock but the returned value is safe to use from
+    /// parallel tests.
     pub fn configs(&self, dir: &tempfile::TempDir) -> Configs {
-        let mut configs = Configs::for_test(dir.path().join("config.json"));
-        configs.override_backboard_url(self.url());
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var("RAILWAY_BACKBOARD_URL").ok();
+        // SAFETY: writes are serialized under ENV_LOCK and restored before
+        // release; construction below snapshots the value.
+        unsafe { std::env::set_var("RAILWAY_BACKBOARD_URL", self.url()) };
+        let configs = Configs::for_test(dir.path().join("config.json"));
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("RAILWAY_BACKBOARD_URL", value),
+                None => std::env::remove_var("RAILWAY_BACKBOARD_URL"),
+            }
+        }
         configs
     }
 

--- a/src/testkit.rs
+++ b/src/testkit.rs
@@ -1,0 +1,269 @@
+//! Test-only scripted backboard for exercising the CLI's REAL GraphQL layer
+//! (`client::post_graphql` and everything built on it) without a network.
+//!
+//! Same philosophy as `auth_sim`'s `MockEndpoint` (a raw `TcpListener` and a
+//! scripted response table -- no mocking framework), but GraphQL-aware:
+//! responses are routed by the request body's `operationName`, so one server
+//! can back a multi-request flow (fetch config, fire mutation, poll status)
+//! and each test reads like the conversation it scripts. Responses for an
+//! operation are served in order; the last one repeats once exhausted --
+//! which is what polling loops need.
+//!
+//! Every request body is recorded as parsed JSON so tests can assert what
+//! actually went over the wire (operation, variables), not just how the
+//! caller reacted.
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+
+use serde_json::{Value, json};
+
+use crate::config::Configs;
+
+/// Scripted `(http status, body)` responses for one operation, served in order.
+type ResponseQueue = VecDeque<(u16, String)>;
+type ResponseTable = Arc<Mutex<HashMap<String, ResponseQueue>>>;
+
+/// A scripted local backboard. See module docs.
+pub struct MockBackboard {
+    base_url: String,
+    requests: Arc<Mutex<Vec<Value>>>,
+    responses: ResponseTable,
+}
+
+impl MockBackboard {
+    pub fn spawn() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let requests: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let responses: ResponseTable = Arc::new(Mutex::new(HashMap::new()));
+
+        let requests_for_thread = Arc::clone(&requests);
+        let responses_for_thread = Arc::clone(&responses);
+
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+
+                let Some(body) = read_http_body(&mut stream) else {
+                    continue;
+                };
+                let parsed: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+                let operation = parsed
+                    .get("operationName")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                requests_for_thread.lock().unwrap().push(parsed);
+
+                let (status, response_body) = {
+                    let mut table = responses_for_thread.lock().unwrap();
+                    match table.get_mut(&operation) {
+                        Some(queue) if !queue.is_empty() => {
+                            if queue.len() > 1 {
+                                queue.pop_front().unwrap()
+                            } else {
+                                // Repeat the final scripted response so
+                                // polling loops always have an answer.
+                                queue.front().unwrap().clone()
+                            }
+                        }
+                        _ => (
+                            200,
+                            json!({
+                                "errors": [{
+                                    "message": format!(
+                                        "MockBackboard: no scripted response for operation {operation:?}"
+                                    )
+                                }],
+                                "data": null,
+                            })
+                            .to_string(),
+                        ),
+                    }
+                };
+
+                let reason = match status {
+                    200 => "OK",
+                    400 => "Bad Request",
+                    500 => "Internal Server Error",
+                    502 => "Bad Gateway",
+                    503 => "Service Unavailable",
+                    _ => "Unknown",
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+
+        Self {
+            base_url: format!("http://127.0.0.1:{port}/graphql/v2"),
+            requests,
+            responses,
+        }
+    }
+
+    pub fn url(&self) -> String {
+        self.base_url.clone()
+    }
+
+    /// A `Configs` (backed by a throwaway path under `dir`) whose every
+    /// GraphQL call resolves to this mock server.
+    pub fn configs(&self, dir: &tempfile::TempDir) -> Configs {
+        let mut configs = Configs::for_test(dir.path().join("config.json"));
+        configs.override_backboard_url(self.url());
+        configs
+    }
+
+    /// Queue a successful `{"data": ...}` response for `operation`.
+    pub fn stub(&self, operation: &str, data: Value) {
+        self.stub_raw(operation, 200, json!({ "data": data }).to_string());
+    }
+
+    /// Queue a GraphQL-level error (HTTP 200 with an `errors` array) for
+    /// `operation` -- the shape backboard uses for resolver/UserError
+    /// failures.
+    pub fn stub_graphql_error(&self, operation: &str, message: &str) {
+        self.stub_raw(
+            operation,
+            200,
+            json!({ "errors": [{ "message": message }], "data": null }).to_string(),
+        );
+    }
+
+    /// Queue an arbitrary HTTP response for `operation`.
+    pub fn stub_raw(&self, operation: &str, status: u16, body: String) {
+        self.responses
+            .lock()
+            .unwrap()
+            .entry(operation.to_string())
+            .or_default()
+            .push_back((status, body));
+    }
+
+    /// Every request body received so far, as parsed JSON, in arrival order.
+    pub fn requests(&self) -> Vec<Value> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    /// The `variables` of each received request for `operation`.
+    pub fn variables_for(&self, operation: &str) -> Vec<Value> {
+        self.requests()
+            .into_iter()
+            .filter(|r| r.get("operationName").and_then(Value::as_str) == Some(operation))
+            .map(|r| r.get("variables").cloned().unwrap_or(Value::Null))
+            .collect()
+    }
+
+    pub fn hits(&self) -> usize {
+        self.requests.lock().unwrap().len()
+    }
+}
+
+/// Reads one HTTP request off `stream` and returns its body. `None` when the
+/// stream closes before a full request arrives.
+fn read_http_body(stream: &mut std::net::TcpStream) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 1024];
+    let mut content_length = 0usize;
+    loop {
+        let read = stream.read(&mut tmp).ok()?;
+        if read == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&tmp[..read]);
+        if let Some(pos) = find_headers_end(&buf) {
+            let headers = String::from_utf8_lossy(&buf[..pos]).to_lowercase();
+            for line in headers.lines() {
+                if let Some(v) = line.strip_prefix("content-length:") {
+                    content_length = v.trim().parse().unwrap_or(0);
+                }
+            }
+            if buf.len() >= pos + 4 + content_length {
+                let body_start = pos + 4;
+                return Some(buf[body_start..body_start + content_length].to_vec());
+            }
+        }
+    }
+}
+
+fn find_headers_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn routes_by_operation_name_and_records_variables() {
+        let server = MockBackboard::spawn();
+        server.stub("OpA", json!({ "a": 1 }));
+        server.stub("OpB", json!({ "b": 2 }));
+
+        let client = reqwest::Client::new();
+        for (op, var) in [("OpA", "x"), ("OpB", "y"), ("OpA", "z")] {
+            let response: Value = client
+                .post(server.url())
+                .json(&json!({ "operationName": op, "query": "{}", "variables": { "v": var } }))
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            assert!(response.get("data").is_some(), "unexpected: {response}");
+        }
+
+        assert_eq!(server.hits(), 3);
+        assert_eq!(server.variables_for("OpA").len(), 2);
+        assert_eq!(server.variables_for("OpB"), vec![json!({ "v": "y" })]);
+    }
+
+    #[tokio::test]
+    async fn responses_are_served_in_order_and_the_last_repeats() {
+        let server = MockBackboard::spawn();
+        server.stub("Poll", json!({ "n": 1 }));
+        server.stub("Poll", json!({ "n": 2 }));
+
+        let client = reqwest::Client::new();
+        let mut seen = Vec::new();
+        for _ in 0..4 {
+            let response: Value = client
+                .post(server.url())
+                .json(&json!({ "operationName": "Poll", "query": "{}" }))
+                .send()
+                .await
+                .unwrap()
+                .json()
+                .await
+                .unwrap();
+            seen.push(response["data"]["n"].as_i64().unwrap());
+        }
+        assert_eq!(seen, vec![1, 2, 2, 2]);
+    }
+
+    #[tokio::test]
+    async fn unscripted_operations_fail_loudly() {
+        let server = MockBackboard::spawn();
+        let client = reqwest::Client::new();
+        let response: Value = client
+            .post(server.url())
+            .json(&json!({ "operationName": "Nope", "query": "{}" }))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let message = response["errors"][0]["message"].as_str().unwrap();
+        assert!(message.contains("no scripted response"));
+        assert!(message.contains("Nope"));
+    }
+}


### PR DESCRIPTION
Adds a test harness for the CLI's GraphQL layer and the first tests on top of it. Cut from master and intentionally free of any `railway postgres` (#1032) code so it can be reviewed on its own; #1032's command-level tests will build on this once it lands.

## What's in here

**`src/testkit.rs` — `MockBackboard`**: a test-only scripted backboard in the same style as `auth_sim`'s `MockEndpoint` (raw `TcpListener`, no mocking framework), but GraphQL-aware:
- responses routed by the request body's `operationName`, so one server backs a multi-request flow
- per-operation responses served in order, last one repeating (what polling loops need)
- every request body recorded as parsed JSON — tests assert what actually went over the wire (`variables_for("Op")`), not just how the caller reacted
- unscripted operations answer with a loud GraphQL error naming the missing operation

**`Configs::override_backboard_url`** (test-only, `#[cfg(test)]`): instance-state redirect for `get_backboard()`, so parallel tests each talk to their own server — no env vars, no cross-test races. The inert `skip_serializing_none` attribute on `Configs` had to go (it breaks compilation the moment the struct has an `Option` field; it never did anything on a struct with no serde derives).

## Tests (all drive the REAL `post_graphql` / http stack)

- `client::post_graphql`: success roundtrip with variables asserted on the wire; GraphQL `errors` → `RailwayError::GraphQLError` carrying the server's message; `data: null` → `MissingResponseData`; HTTP 429 → `Ratelimited`; connection refused → `FetchError`
- `controllers::workflow::wait_for_workflow`: complete on first poll; running→complete; `NotFound` tolerated as read-after-write lag; failed workflow surfaces immediately with its message
- `controllers::config::fetch_environment_config`: config-blob parse incl. unknown-field tolerance (the blob evolves server-side), decrypt flag reaching the wire, malformed-blob error context

## One behavior fix that fell out of writing these

`wait_for_workflow` treated every poll outcome as retryable, so a workflow that had already **FAILED** kept being re-polled for the full ~2-minute retry budget before the error surfaced. `Error` is now terminal (surfaces on the first poll, with the workflow's own message); `NotFound` still retries, tolerating creation lag. The test `failed_workflow_surfaces_immediately_with_its_message` pins `hits() == 1`.

## Test plan

- [x] `cargo test` — 559 passed, 0 failed (14 new)
- [x] `cargo clippy --all-targets` — clean on every file this PR touches
- [x] `cargo fmt --check` clean
