### PR TITLE
feat: persistent ops trail + upgrade guidance for railway postgres

### DIFF
--- a/src/commands/postgres/mod.rs
+++ b/src/commands/postgres/mod.rs
@@ -31,6 +31,7 @@ pub(super) struct ResourceRef {
     pub name: String,
 }
 
+pub mod ops_log;
 pub mod pitr;
 
 /// Manage Postgres plugin features: point-in-time recovery, high availability, and connection pooling
@@ -63,6 +64,16 @@ pub struct Args {
 enum Commands {
     /// Manage point-in-time recovery (continuous backups)
     Pitr(pitr::Args),
+
+    /// Show the local audit trail of postgres operations
+    History(HistoryArgs),
+}
+
+#[derive(Parser)]
+struct HistoryArgs {
+    /// Maximum entries to show (newest last)
+    #[clap(long, default_value_t = 50, value_parser = clap::value_parser!(usize))]
+    limit: usize,
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -76,9 +87,181 @@ pub async fn command(args: Args) -> Result<()> {
 
     crate::util::reporter::set_mode(json);
 
-    match command {
-        Commands::Pitr(sub) => pitr::command(sub, project, service, environment, json).await,
+    // `history` only reads the local trail -- it neither needs resolution
+    // nor should it append to the very log it displays.
+    if let Commands::History(history_args) = &command {
+        return history(history_args, json);
     }
+
+    let started = std::time::Instant::now();
+    let result = match command {
+        Commands::Pitr(sub) => {
+            pitr::command(
+                sub,
+                project.clone(),
+                service.clone(),
+                environment.clone(),
+                json,
+            )
+            .await
+        }
+        Commands::History(_) => unreachable!("handled above"),
+    };
+    let result = result.map_err(add_api_mismatch_guidance);
+
+    // Best-effort persistent audit trail (see ops_log): PITR/HA/PgBouncer
+    // compose, and reconstructing WHICH sequence of operations produced a
+    // misconfigured Postgres needs more than server-side command counters.
+    let (project, environment, service) =
+        resolved_selectors_for_log(project, service, environment).await;
+    ops_log::record(&ops_log::OpsLogEntry {
+        timestamp: chrono::Utc::now(),
+        cli_version: env!("CARGO_PKG_VERSION").to_string(),
+        args: std::env::args().skip(1).collect(),
+        project,
+        environment,
+        service,
+        success: result.is_ok(),
+        error: result.as_ref().err().map(|e| {
+            let message = format!("{e:#}");
+            if message.len() > 512 {
+                message[..512].to_string()
+            } else {
+                message
+            }
+        }),
+        duration_ms: started.elapsed().as_millis() as u64,
+    });
+
+    result
+}
+
+/// The selectors that actually applied: explicit flags win; otherwise the
+/// linked project's ids (config-file read, no network). Best-effort -- the
+/// log entry still lands with whatever could be resolved.
+async fn resolved_selectors_for_log(
+    project: Option<String>,
+    service: Option<String>,
+    environment: Option<String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    if project.is_some() && environment.is_some() && service.is_some() {
+        return (project, environment, service);
+    }
+    let linked = match crate::config::Configs::new() {
+        Ok(configs) => configs.get_linked_project().await.ok(),
+        Err(_) => None,
+    };
+    (
+        project.or_else(|| linked.as_ref().map(|l| l.project.clone())),
+        environment.or_else(|| linked.as_ref().and_then(|l| l.environment.clone())),
+        service.or_else(|| linked.as_ref().and_then(|l| l.service.clone())),
+    )
+}
+
+fn history(args: &HistoryArgs, json: bool) -> Result<()> {
+    let entries = ops_log::read_entries();
+    let start = entries.len().saturating_sub(args.limit);
+    let window = &entries[start..];
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(window)?);
+        return Ok(());
+    }
+
+    if window.is_empty() {
+        println!(
+            "No postgres operations recorded yet (the trail lives at {}).",
+            ops_log::log_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "~/.railway/postgres-ops.jsonl".to_string())
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{:<21} {:<7} {:<9} {:<37} COMMAND",
+        "WHEN (UTC)", "OUTCOME", "DURATION", "PROJECT/SERVICE"
+    );
+    for entry in window {
+        let outcome = if entry.success {
+            "ok".green().to_string()
+        } else {
+            "FAIL".red().to_string()
+        };
+        let target = format!(
+            "{}/{}",
+            entry.project.as_deref().unwrap_or("-"),
+            entry.service.as_deref().unwrap_or("-")
+        );
+        let target = if target.len() > 37 {
+            format!("{}…", &target[..36])
+        } else {
+            target
+        };
+        println!(
+            "{:<21} {:<7} {:<9} {:<37} railway {}",
+            entry.timestamp.format("%Y-%m-%d %H:%M:%S"),
+            outcome,
+            format!("{}ms", entry.duration_ms),
+            target,
+            entry.args.join(" ")
+        );
+        if let Some(error) = &entry.error {
+            println!("{:<40} {}", "", error.lines().next().unwrap_or("").red());
+        }
+    }
+    Ok(())
+}
+
+/// Marker phrases the backend uses (or may use in the future) in a
+/// `UserError` when an operation this CLI build depends on has been
+/// removed or changed and the fix is a newer CLI. Matched
+/// case-insensitively against the whole error chain.
+const UPGRADE_REQUIRED_MARKERS: &[&str] = &[
+    "update your railway cli",
+    "upgrade your railway cli",
+    "update the railway cli",
+    "upgrade the railway cli",
+    "newer version of the railway cli",
+    "railway cli is out of date",
+];
+
+/// GraphQL validation messages that mean the running binary was built
+/// against a different API schema than the server is exposing -- an
+/// operation or field this command depends on no longer exists (removed,
+/// renamed, or re-internalized server-side).
+fn is_schema_mismatch_message(lower_chain: &str) -> bool {
+    lower_chain.contains("cannot query field")
+        || lower_chain.contains("is not defined by type")
+        || lower_chain.contains("unknown argument")
+        || lower_chain.contains("unknown field")
+}
+
+/// `railway postgres` drives API operations that the backend reserves the
+/// right to evolve (they were exposed on the public subgraph specifically
+/// for this CLI). When one disappears or the backend explicitly asks for a
+/// newer CLI, translate the raw GraphQL error into actionable guidance
+/// instead of a cryptic validation dump. Every other error passes through
+/// untouched.
+pub(super) fn add_api_mismatch_guidance(err: anyhow::Error) -> anyhow::Error {
+    let lower_chain = format!("{err:#}").to_ascii_lowercase();
+
+    if UPGRADE_REQUIRED_MARKERS
+        .iter()
+        .any(|marker| lower_chain.contains(marker))
+    {
+        return err.context(
+            "The Railway API requires a newer CLI for this command. Update with `railway upgrade` (or your package manager) and try again.",
+        );
+    }
+
+    if is_schema_mismatch_message(&lower_chain) {
+        return err.context(
+            "This CLI build no longer matches the Railway API -- an operation this command depends on is missing or has changed. Update with `railway upgrade` and try again; if the latest CLI still fails, the operation may have been removed (check the Railway changelog).",
+        );
+    }
+
+    err
 }
 
 /// Shared confirm-before-mutating helper: `--yes` bypasses the prompt; a
@@ -161,6 +344,68 @@ mod tests {
             Args::parse_from(["postgres", "pitr", "status"]).command,
             Commands::Pitr(_)
         ));
+    }
+
+    #[test]
+    fn parses_history_with_limit() {
+        let args = Args::parse_from(["postgres", "history"]);
+        assert!(matches!(
+            args.command,
+            Commands::History(HistoryArgs { limit: 50 })
+        ));
+        let args = Args::parse_from(["postgres", "history", "--limit", "5"]);
+        assert!(matches!(
+            args.command,
+            Commands::History(HistoryArgs { limit: 5 })
+        ));
+    }
+
+    #[test]
+    fn api_mismatch_guidance_translates_missing_field_validation_errors() {
+        // Real message shape from the public gateway when a mutation this
+        // build uses is not on the Public subgraph.
+        let err = anyhow::anyhow!(
+            "Cannot query field \"volumeInstanceBackupCreateForHaConversion\" on type \"Mutation\"."
+        )
+        .context("Failed to enable PITR");
+        let wrapped = add_api_mismatch_guidance(err);
+        assert!(format!("{wrapped:#}").contains("railway upgrade"));
+
+        // Input-field removal shape ("Field X is not defined by type Y").
+        let err = anyhow::anyhow!(
+            "Variable \"$input\" got invalid value; Field \"stageOnly\" is not defined by type \"TemplateDeployV2Input\"."
+        );
+        let wrapped = add_api_mismatch_guidance(err);
+        assert!(format!("{wrapped:#}").contains("no longer matches the Railway API"));
+    }
+
+    #[test]
+    fn api_mismatch_guidance_surfaces_explicit_upgrade_user_errors() {
+        // If the backend ever retires one of these routes it throws a
+        // UserError telling the caller to update -- the CLI must lead with
+        // actionable guidance, not a bare GraphQL error.
+        let err = anyhow::anyhow!(
+            "This operation has moved. Please update your Railway CLI to continue managing PITR."
+        )
+        .context("Failed to enable PITR");
+        let wrapped = add_api_mismatch_guidance(err);
+        let rendered = format!("{wrapped:#}");
+        assert!(rendered.contains("requires a newer CLI"));
+        assert!(rendered.contains("railway upgrade"));
+        // The server's own message stays visible in the chain.
+        assert!(rendered.contains("This operation has moved"));
+    }
+
+    #[test]
+    fn api_mismatch_guidance_passes_unrelated_errors_through() {
+        let err = anyhow::anyhow!("Problem processing request").context("Failed to enable PITR");
+        let before = format!("{err:#}");
+        let after = format!("{:#}", add_api_mismatch_guidance(err));
+        assert_eq!(before, after);
+
+        let err = anyhow::anyhow!("connection reset by peer");
+        let after = format!("{:#}", add_api_mismatch_guidance(err));
+        assert_eq!(after, "connection reset by peer");
     }
 
     #[test]

--- a/src/commands/postgres/ops_log.rs
+++ b/src/commands/postgres/ops_log.rs
@@ -1,0 +1,174 @@
+//! Persistent local audit trail for `railway postgres` operations.
+//!
+//! Every invocation appends one JSONL entry to
+//! `~/.railway/postgres-ops.jsonl` (override with
+//! `RAILWAY_POSTGRES_OPS_LOG`, e.g. in tests): timestamp, CLI version, the
+//! full argument vector, the project/environment/service selectors in
+//! play, outcome and duration. PITR, HA and PgBouncer compose -- and when a
+//! Postgres ends up misconfigured after some sequence of feature
+//! enables/converts/reverts, this trail is how that sequence gets
+//! reconstructed (`railway postgres history`, or just reading the file).
+//!
+//! Server-side command telemetry already exists but carries no resource
+//! identifiers; this log is the local, resource-aware complement. Entries
+//! older than [`RETENTION_DAYS`] are pruned on every append, so the file
+//! stays bounded without a separate cleanup path. Everything here is
+//! best-effort: an unwritable log must never fail the actual command.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+pub const RETENTION_DAYS: i64 = 90;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpsLogEntry {
+    pub timestamp: DateTime<Utc>,
+    pub cli_version: String,
+    /// Full argv (minus the binary path). Postgres subcommands carry no
+    /// secrets -- ids, counts, names and timestamps only.
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<String>,
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub duration_ms: u64,
+}
+
+pub fn log_path() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("RAILWAY_POSTGRES_OPS_LOG")
+        && !path.is_empty()
+    {
+        return Some(PathBuf::from(path));
+    }
+    dirs::home_dir().map(|home| home.join(".railway").join("postgres-ops.jsonl"))
+}
+
+/// Appends `entry`, pruning anything older than the retention window.
+/// Best-effort by contract: all errors are swallowed.
+pub fn record(entry: &OpsLogEntry) {
+    let Some(path) = log_path() else { return };
+    let _ = record_at(&path, entry);
+}
+
+fn record_at(path: &PathBuf, entry: &OpsLogEntry) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let cutoff = Utc::now() - Duration::days(RETENTION_DAYS);
+    let mut lines: Vec<String> = match std::fs::read_to_string(path) {
+        Ok(existing) => existing
+            .lines()
+            .filter(|line| {
+                serde_json::from_str::<OpsLogEntry>(line)
+                    .map(|parsed| parsed.timestamp >= cutoff)
+                    // Keep unparseable lines rather than silently dropping
+                    // someone's data on a format change.
+                    .unwrap_or(true)
+            })
+            .map(String::from)
+            .collect(),
+        Err(_) => Vec::new(),
+    };
+    lines.push(serde_json::to_string(entry)?);
+
+    let mut file = std::fs::File::create(path)?;
+    for line in &lines {
+        writeln!(file, "{line}")?;
+    }
+    Ok(())
+}
+
+/// All retained entries, oldest first. Unparseable lines are skipped.
+pub fn read_entries() -> Vec<OpsLogEntry> {
+    let Some(path) = log_path() else {
+        return Vec::new();
+    };
+    match std::fs::read_to_string(path) {
+        Ok(contents) => contents
+            .lines()
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(ts: DateTime<Utc>, args: &[&str]) -> OpsLogEntry {
+        OpsLogEntry {
+            timestamp: ts,
+            cli_version: "0.0.0-test".to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            project: Some("proj-1".to_string()),
+            environment: Some("env-1".to_string()),
+            service: Some("svc-1".to_string()),
+            success: true,
+            error: None,
+            duration_ms: 42,
+        }
+    }
+
+    #[test]
+    fn appends_and_reads_back_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ops.jsonl");
+
+        record_at(&path, &entry(Utc::now(), &["postgres", "pitr", "enable"])).unwrap();
+        record_at(&path, &entry(Utc::now(), &["postgres", "ha", "convert"])).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let parsed: Vec<OpsLogEntry> = contents
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].args[1], "pitr");
+        assert_eq!(parsed[1].args[1], "ha");
+    }
+
+    #[test]
+    fn prunes_entries_past_retention_on_append() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ops.jsonl");
+
+        let stale = entry(
+            Utc::now() - Duration::days(RETENTION_DAYS + 1),
+            &["postgres", "pitr", "enable"],
+        );
+        let fresh = entry(Utc::now(), &["postgres", "pitr", "disable"]);
+        record_at(&path, &stale).unwrap();
+        record_at(&path, &fresh).unwrap();
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let parsed: Vec<OpsLogEntry> = contents
+            .lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect();
+        assert_eq!(parsed.len(), 1, "stale entry pruned");
+        assert_eq!(parsed[0].args[2], "disable");
+    }
+
+    #[test]
+    fn unparseable_lines_survive_pruning() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ops.jsonl");
+        std::fs::write(&path, "not json at all\n").unwrap();
+
+        record_at(&path, &entry(Utc::now(), &["postgres", "pitr", "status"])).unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.lines().count() == 2);
+        assert!(contents.starts_with("not json at all"));
+    }
+}


### PR DESCRIPTION
Part 7/9 of the **railway postgres pitr/ha/pgbouncer** stack (split out of #1032 for reviewability — see that PR for the full context, live-prod e2e evidence, and the test-postgres-cli harness). Each PR is based on the previous one and is independently green (cargo test/clippy/fmt).

Every `railway postgres` invocation now appends to a local audit trail
(`~/.railway/postgres-ops.jsonl`, 90-day retention, `RAILWAY_POSTGRES_OPS_LOG`
override) with the resolved project/environment/service, argv, and outcome —
readable via the new `railway postgres history`. PITR/HA/PgBouncer compose,
and reconstructing WHICH sequence of operations produced a misconfigured
Postgres needs more than server-side command counters.

Also translates schema-mismatch and "update your CLI" errors from the
backend into `railway upgrade` guidance instead of a raw GraphQL dump —
these commands drive API operations the backend reserves the right to
evolve.

Part 7/9 of the railway postgres pitr/ha/pgbouncer stack.
