### PR TITLE
fix(ca): stop scanning every environment on startup

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -337,7 +337,13 @@ where
     T: DeserializeOwned,
 {
     if response.status() == 429 {
-        return Err(RailwayError::Ratelimited);
+        // Backboard sets `Retry-After` on every 429 (see getRateLimitHeaders).
+        let retry_after_secs = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.trim().parse::<u64>().ok());
+        return Err(RailwayError::Ratelimited { retry_after_secs });
     }
     let res: GraphQLResponse<T> = response.json().await?;
     if let Some(errors) = res.errors {
@@ -574,7 +580,7 @@ mod tests {
             )
             .await
             .unwrap_err();
-            assert!(matches!(err, RailwayError::Ratelimited));
+            assert!(matches!(err, RailwayError::Ratelimited { .. }));
         }
 
         #[tokio::test]

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -114,6 +114,9 @@ async fn browse() -> Result<()> {
     // return, now only for the rare case that actually needs it.
     // No preferences yet: offer to set them up rather than dropping someone in
     // front of a prompt whose target, agent and skills are all unanswered.
+    // Environments this machine has launched an agent in, so they load without
+    // the user going looking. `railway ca` no longer scans every project.
+    app.known_environments = configs.code_agent_environments();
     app.skills_source = skills_sync::populated_sources(&home)
         .first()
         .map(|(source, _)| source.slug.to_string());

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -54,6 +54,7 @@ pub const KEY_HELP: &[(&str, &[(&str, &str)])] = &[
             ("w", "wake"),
             ("d", "delete, with a confirmation"),
             ("r", "refresh"),
+            ("shift+r", "look for agents in every project"),
         ],
     ),
     (
@@ -649,6 +650,9 @@ pub enum Effect {
     SaveDefaultProject(Box<Target>),
     /// Open a link that was double-clicked in a session.
     OpenUrl(String),
+    /// Look for agents in every project, on request. See
+    /// [`App::scan_environments`].
+    ScanEverywhere,
     /// Put an `ssh` command for one session on the clipboard.
     CopySsh {
         agent_id: String,
@@ -696,6 +700,10 @@ pub struct App {
     /// Whether preferences exist yet. Decides whether the menu carries a Setup
     /// card or leaves setup to ⌥s.
     pub configured: bool,
+    /// Environments this machine has launched an agent in, from the CLI's own
+    /// records. Loaded eagerly, because an agent you made is one you expect to
+    /// find without hunting for it.
+    pub known_environments: Vec<String>,
     /// The target chooser, while it is open.
     pub target_pick: Option<TargetPicker>,
     /// The agent chooser, while it is open.
@@ -776,6 +784,7 @@ impl App {
         let mut app = Self {
             default_project,
             configured,
+            known_environments: Vec::new(),
             target_pick: None,
             agent_pick: None,
             maximized: false,
@@ -2235,26 +2244,50 @@ impl App {
         out
     }
 
-    /// Every environment that has never been fetched, as load requests.
+    /// The environments to fetch before anyone touches a key.
     ///
-    /// Used once at startup to fill the per-project counts: the counts are the
-    /// point of the tree — they are how you find the project that already has
-    /// an agent — and they cannot exist without asking each environment. Runs
-    /// in the background at a bounded rate, so the tree is usable immediately
-    /// and the numbers arrive behind it.
-    pub fn unloaded_environments(&mut self) -> Vec<Effect> {
+    /// Only where the answer is needed immediately: the prompt's target, which
+    /// New Session reads to decide whether it has an agent to work on, and the
+    /// default project, which the tree leads with. Everything else loads when
+    /// its row is expanded.
+    ///
+    /// This used to be every environment in every project in every workspace,
+    /// which is one request each. That is fine on a small account and hundreds
+    /// of requests on a large one — enough to rate limit the caller before the
+    /// tree had finished drawing, and enough backend load per launch to be
+    /// worth not doing. The cost of loading less is that a project's agent
+    /// count appears when you open it rather than immediately.
+    pub fn initial_environments(&mut self) -> Vec<Effect> {
+        let mut wanted: Vec<String> = self.known_environments.clone();
+        if let Some(target) = self.target.as_ref() {
+            wanted.push(target.environment_id.clone());
+        }
+        // The default project's environments, which is where the tree opens and
+        // where a launch with no target lands.
+        if let Some(project_id) = self.default_project.clone() {
+            for ws in &self.tree {
+                for project in &ws.projects {
+                    if project.id != project_id {
+                        continue;
+                    }
+                    wanted.extend(project.envs.iter().map(|env| env.id.clone()));
+                }
+            }
+        }
+
         let mut out = Vec::new();
         for w in 0..self.tree.len() {
             for p in 0..self.tree[w].projects.len() {
                 for e in 0..self.tree[w].projects[p].envs.len() {
                     let env = &mut self.tree[w].projects[p].envs[e];
-                    if env.agents == Load::NotLoaded {
-                        env.agents = Load::Loading;
-                        out.push(Effect::LoadAgents {
-                            environment_id: env.id.clone(),
-                            path: (w, p, e),
-                        });
+                    if env.agents != Load::NotLoaded || !wanted.contains(&env.id) {
+                        continue;
                     }
+                    env.agents = Load::Loading;
+                    out.push(Effect::LoadAgents {
+                        environment_id: env.id.clone(),
+                        path: (w, p, e),
+                    });
                 }
             }
         }
@@ -2698,6 +2731,9 @@ impl App {
             KeyCode::Char('s') => self.agent_op(AgentOp::Sleep),
             KeyCode::Char('w') => self.agent_op(AgentOp::Wake),
             KeyCode::Char('d') => self.agent_op(AgentOp::Delete),
+            // Startup loads only what a keypress needs, so this is how an agent
+            // in a project you haven't opened gets found.
+            KeyCode::Char('R') => Some(Effect::ScanEverywhere),
             KeyCode::Char('r') => {
                 let (w, p, e) = self.env_of(row?.kind)?;
                 let env = self.tree.get_mut(w)?.projects.get_mut(p)?.envs.get_mut(e)?;
@@ -2827,6 +2863,66 @@ impl App {
             }
             None => self.status = format!("Ended {session_name}"),
         }
+    }
+
+    /// Every environment that has not been fetched, as load requests.
+    ///
+    /// The whole-account scan, which is what `shift+r` asks for. Startup no
+    /// longer does this: it is one request per environment, so it costs a large
+    /// account hundreds of them. As a deliberate action the cost is the user's
+    /// to spend, and a rate limit stops it partway rather than pressing on.
+    pub fn scan_environments(&mut self) -> Vec<Effect> {
+        let mut out = Vec::new();
+        for w in 0..self.tree.len() {
+            for p in 0..self.tree[w].projects.len() {
+                for e in 0..self.tree[w].projects[p].envs.len() {
+                    let env = &mut self.tree[w].projects[p].envs[e];
+                    if env.agents != Load::NotLoaded {
+                        continue;
+                    }
+                    env.agents = Load::Loading;
+                    out.push(Effect::LoadAgents {
+                        environment_id: env.id.clone(),
+                        path: (w, p, e),
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    /// A background fetch was refused for rate limiting.
+    ///
+    /// Anything still in flight is put back to "not loaded" rather than left
+    /// spinning: the request is not coming, and a row that never resolves reads
+    /// as a hung UI. Expanding it later retries, which is the right amount of
+    /// work for the user to have to do.
+    pub fn rate_limited(&mut self, retry_after_secs: Option<u64>) {
+        for ws in &mut self.tree {
+            for project in &mut ws.projects {
+                for env in &mut project.envs {
+                    if env.agents == Load::Loading {
+                        env.agents = Load::NotLoaded;
+                    }
+                    if let Load::Loaded(agents) = &mut env.agents {
+                        for agent in agents {
+                            if agent.sessions == LoadSessions::Loading {
+                                agent.sessions = LoadSessions::NotLoaded;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.toast_error(match retry_after_secs {
+            Some(secs) if secs > 90 => format!(
+                "Rate limited — try again in about {} minutes",
+                secs.div_ceil(60)
+            ),
+            Some(secs) => format!("Rate limited — try again in {secs}s"),
+            None => "Rate limited by the API".to_string(),
+        });
+        self.status = "Rate limited. Open a row to load it, or r to retry".into();
     }
 
     /// A lifecycle mutation came back.
@@ -5877,16 +5973,97 @@ mod tests {
         assert!(a.pending_copy.is_none());
     }
 
+    /// Startup loads what a keypress needs and nothing else. Loading every
+    /// environment in every project is one request each, which is what rate
+    /// limited a real account.
     #[test]
-    fn the_startup_sweep_claims_every_environment_once() {
+    fn startup_loads_only_the_target_and_the_default_project() {
         let mut a = app();
-        let first = a.unloaded_environments();
-        assert_eq!(first.len(), 2, "both environments in the fixture");
         assert!(
-            a.unloaded_environments().is_empty(),
-            "a second sweep must not refetch what is already in flight"
+            a.initial_environments().is_empty(),
+            "no target and no default means nothing to load up front"
         );
-        assert!(matches!(first[0], Effect::LoadAgents { .. }));
+
+        let mut a = app();
+        a.target = Some(Target {
+            project_id: "proj_1".into(),
+            project_name: "devtools".into(),
+            environment_id: "env_stg".into(),
+            environment_name: "staging".into(),
+        });
+        let effects = a.initial_environments();
+        assert_eq!(effects.len(), 1, "just the target: {effects:?}");
+        assert!(matches!(
+            &effects[0],
+            Effect::LoadAgents { environment_id, .. } if environment_id == "env_stg"
+        ));
+        assert!(
+            a.initial_environments().is_empty(),
+            "what is already in flight is not asked for twice"
+        );
+    }
+
+    /// The default project is where the tree opens and where an untargeted
+    /// launch lands, so all of its environments load up front.
+    #[test]
+    fn startup_loads_every_environment_of_the_default_project() {
+        let mut a = app();
+        a.default_project = Some("proj_1".into());
+        let effects = a.initial_environments();
+        assert_eq!(effects.len(), 2, "production and staging: {effects:?}");
+    }
+
+    /// An agent this machine made is one you expect to find without hunting,
+    /// even in a project that is neither the target nor the default.
+    #[test]
+    fn startup_loads_environments_this_machine_has_used() {
+        let mut a = app();
+        a.known_environments = vec!["env_stg".into()];
+        let effects = a.initial_environments();
+        assert_eq!(effects.len(), 1);
+        assert!(matches!(
+            &effects[0],
+            Effect::LoadAgents { environment_id, .. } if environment_id == "env_stg"
+        ));
+    }
+
+    /// `shift+r` is how an agent in a project nobody has opened gets found: the
+    /// scan startup used to do, when the user asks for it.
+    #[test]
+    fn shift_r_scans_every_environment() {
+        let mut a = loaded_app();
+        assert_eq!(
+            a.on_key(key(KeyCode::Char('R'))),
+            Some(Effect::ScanEverywhere)
+        );
+
+        let mut a = app();
+        let effects = a.scan_environments();
+        assert_eq!(effects.len(), 2, "every environment in the fixture");
+        assert!(
+            a.scan_environments().is_empty(),
+            "a second scan must not refetch what is already in flight"
+        );
+    }
+
+    /// A rate limit puts what was in flight back, so opening the row retries
+    /// instead of showing a spinner that never resolves.
+    #[test]
+    fn a_rate_limit_releases_what_was_loading() {
+        let mut a = app();
+        a.default_project = Some("proj_1".into());
+        assert_eq!(a.initial_environments().len(), 2);
+        assert_eq!(a.tree[0].projects[0].envs[0].agents, Load::Loading);
+
+        a.rate_limited(Some(43));
+        assert_eq!(a.tree[0].projects[0].envs[0].agents, Load::NotLoaded);
+        assert_eq!(a.tree[0].projects[0].envs[1].agents, Load::NotLoaded);
+        let toast = a.toast.as_ref().expect("a toast");
+        assert!(toast.text.contains("43s"), "{}", toast.text);
+        assert!(!toast.ok, "a rate limit is not a success");
+
+        // And asking again works, rather than being blocked by the old claim.
+        assert_eq!(a.initial_environments().len(), 2);
     }
 
     #[test]

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -187,6 +187,11 @@ enum Message {
         path: (usize, usize, usize),
         result: Result<Vec<Agent>, String>,
     },
+    /// A background fetch was refused for rate limiting. The rest of its batch
+    /// is abandoned; see [`spawn_sweep`].
+    RateLimited {
+        retry_after_secs: Option<u64>,
+    },
     SessionsLoaded {
         path: (usize, usize, usize, usize),
         result: Result<Vec<ConsoleSession>, String>,
@@ -359,12 +364,13 @@ pub async fn run(
         start_launch(app, req, &tx);
     }
 
-    // Fill the per-project counts in the background. Bounded, because this is
-    // one request per environment and a large workspace has dozens — the tree
-    // is interactive throughout and the numbers appear as they land.
-    let sweep = app.unloaded_environments();
+    // Load the environments a keypress would immediately need, in the
+    // background. Everything else waits to be expanded: one request per
+    // environment across a whole account is hundreds on a large one.
+    let stop_fetching: StopFlag = Default::default();
+    let sweep = app.initial_environments();
     if !sweep.is_empty() {
-        spawn_sweep(sweep, &tx, &client, &backboard);
+        spawn_sweep(sweep, &tx, &client, &backboard, stop_fetching.clone());
     }
 
     loop {
@@ -514,6 +520,20 @@ pub async fn run(
                     });
                 }
             }
+            Some(Effect::ScanEverywhere) => {
+                // A deliberate scan clears a previous rate-limit stop: the user
+                // is asking again, and by now the window may have passed.
+                stop_fetching.store(false, std::sync::atomic::Ordering::Relaxed);
+                let effects = app.scan_environments();
+                match effects.len() {
+                    0 => app.status = "Every project is already loaded".into(),
+                    n => {
+                        app.status =
+                            format!("Looking for agents in {n} more environment{}…", plural(n));
+                        spawn_sweep(effects, &tx, &client, &backboard, stop_fetching.clone());
+                    }
+                }
+            }
             Some(Effect::OpenUrl(url)) => {
                 // Best-effort: a machine with no browser is a normal way to run
                 // this, and the ssh command in the toast is still copyable.
@@ -636,6 +656,10 @@ fn handle_message(
     backboard: &str,
 ) -> Option<Effect> {
     match message {
+        Message::RateLimited { retry_after_secs } => {
+            app.rate_limited(retry_after_secs);
+            None
+        }
         Message::AgentsLoaded { path, result } => {
             app.agents_loaded(path, result);
             // Fill in each running agent's session count without waiting for
@@ -805,13 +829,40 @@ const SESSION_SETTLE: [u64; 2] = [900, 2600];
 /// How many count queries are allowed in flight at once.
 const SWEEP_CONCURRENCY: usize = 5;
 
+/// `s` when there is more than one of something.
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+/// A 429 seen by any background fetch. Shared so the rest of a batch stops
+/// rather than spending the caller's remaining budget on requests that will be
+/// refused too.
+type StopFlag = std::sync::Arc<std::sync::atomic::AtomicBool>;
+
+/// Was this a rate limit, and for how long?
+///
+/// `anyhow` erases the type on the way through `fetch_agents`, so the concrete
+/// error is recovered here. Matching on the message would work until someone
+/// reworded it.
+fn rate_limit_from(err: &anyhow::Error) -> Option<Option<u64>> {
+    match err.downcast_ref::<crate::errors::RailwayError>() {
+        Some(crate::errors::RailwayError::Ratelimited { retry_after_secs }) => {
+            Some(*retry_after_secs)
+        }
+        _ => None,
+    }
+}
+
 /// Fetch a batch of environments' agents, a few at a time.
 fn spawn_sweep(
     effects: Vec<Effect>,
     tx: &mpsc::UnboundedSender<Message>,
     client: &reqwest::Client,
     backboard: &str,
+    stop: StopFlag,
 ) {
+    use std::sync::atomic::Ordering;
+
     let tx = tx.clone();
     let client = client.clone();
     let backboard = backboard.to_string();
@@ -825,17 +876,39 @@ fn spawn_sweep(
             else {
                 continue;
             };
+            // Checked before each request rather than only at the top: the answer
+            // arrives partway through a batch.
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
             let Ok(permit) = permits.clone().acquire_owned().await else {
                 return;
             };
             let tx = tx.clone();
             let client = client.clone();
             let backboard = backboard.clone();
+            let stop = stop.clone();
             tokio::spawn(async move {
-                let result = fetch_agents(&client, &backboard, &environment_id)
-                    .await
-                    .map_err(|e| e.to_string());
-                let _ = tx.send(Message::AgentsLoaded { path, result });
+                match fetch_agents(&client, &backboard, &environment_id).await {
+                    Ok(agents) => {
+                        let _ = tx.send(Message::AgentsLoaded {
+                            path,
+                            result: Ok(agents),
+                        });
+                    }
+                    Err(err) => match rate_limit_from(&err) {
+                        Some(retry_after_secs) => {
+                            stop.store(true, Ordering::Relaxed);
+                            let _ = tx.send(Message::RateLimited { retry_after_secs });
+                        }
+                        None => {
+                            let _ = tx.send(Message::AgentsLoaded {
+                                path,
+                                result: Err(err.to_string()),
+                            });
+                        }
+                    },
+                }
                 drop(permit);
             });
         }
@@ -854,9 +927,18 @@ fn spawn_session_fetch(
     let client = client.clone();
     let backboard = backboard.to_string();
     tokio::spawn(async move {
-        let result = fetch_sessions(&client, &backboard, &agent_id)
-            .await
-            .map_err(|e| e.to_string());
+        let result = match fetch_sessions(&client, &backboard, &agent_id).await {
+            Ok(sessions) => Ok(sessions),
+            Err(err) => {
+                // Reported as a rate limit rather than as this agent's failure,
+                // so the pane says what is actually wrong.
+                if let Some(retry_after_secs) = rate_limit_from(&err) {
+                    let _ = tx.send(Message::RateLimited { retry_after_secs });
+                    return;
+                }
+                Err(err.to_string())
+            }
+        };
         let _ = tx.send(Message::SessionsLoaded { path, result });
     });
 }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1005,7 +1005,11 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
                 },
                 ("d", "delete agent"),
             ],
-            _ => vec![("enter", "open"), ("n", "new agent")],
+            _ => vec![
+                ("enter", "open"),
+                ("n", "new agent"),
+                ("shift+r", "find agents"),
+            ],
         }
     };
     // Only worth advertising once there is somewhere to cycle to; on a single

--- a/src/config.rs
+++ b/src/config.rs
@@ -617,6 +617,19 @@ impl Configs {
             .cloned()
     }
 
+    /// Every environment this machine has launched a cloud agent in.
+    ///
+    /// Local knowledge, so it misses agents made from another machine or the
+    /// dashboard, but it is free and it covers the common case of coming back
+    /// to your own work in a project that isn't the default one.
+    pub fn code_agent_environments(&self) -> Vec<String> {
+        self.root_config
+            .code_agents
+            .as_ref()
+            .map(|agents| agents.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
     /// Remember the cloud agent `railway code` is using in this environment.
     /// Caller persists with `write()`.
     pub fn set_code_agent(&mut self, environment_id: &str, id: &str) {

--- a/src/controllers/chat.rs
+++ b/src/controllers/chat.rs
@@ -138,7 +138,12 @@ pub async fn get_thread_messages(
     if !status.is_success() {
         match status.as_u16() {
             401 | 403 => return Err(auth_failure_error().into()),
-            429 => return Err(RailwayError::Ratelimited.into()),
+            429 => {
+                return Err(RailwayError::Ratelimited {
+                    retry_after_secs: None,
+                }
+                .into());
+            }
             _ => {
                 let body = response.text().await.unwrap_or_default();
                 bail!("Get thread messages failed ({}): {}", status, body);
@@ -184,7 +189,12 @@ pub async fn list_threads(
     if !status.is_success() {
         match status.as_u16() {
             401 | 403 => return Err(auth_failure_error().into()),
-            429 => return Err(RailwayError::Ratelimited.into()),
+            429 => {
+                return Err(RailwayError::Ratelimited {
+                    retry_after_secs: None,
+                }
+                .into());
+            }
             _ => {
                 let body = response.text().await.unwrap_or_default();
                 bail!("List threads request failed ({}): {}", status, body);
@@ -244,7 +254,12 @@ pub async fn stream_chat(
     if !status.is_success() {
         match status.as_u16() {
             401 | 403 => return Err(auth_failure_error().into()),
-            429 => return Err(RailwayError::Ratelimited.into()),
+            429 => {
+                return Err(RailwayError::Ratelimited {
+                    retry_after_secs: None,
+                }
+                .into());
+            }
             _ => {
                 let body = response.text().await.unwrap_or_default();
                 bail!("Chat request failed ({}): {}", status, body);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,19 @@ use thiserror::Error;
 /// silently disable mid-session re-auth.
 pub const AUTH_FAILURE_MARKERS: &[&str] = &["Unauthorized", "Not authenticated"];
 
+/// `Retry-After` turned into something worth reading. The server sends it on
+/// every 429; without it the only honest thing to say is "later".
+fn ratelimit_message(retry_after_secs: Option<u64>) -> String {
+    match retry_after_secs {
+        Some(secs) if secs > 90 => format!(
+            "You are being ratelimited. Try again in about {} minutes",
+            secs.div_ceil(60)
+        ),
+        Some(secs) => format!("You are being ratelimited. Try again in {secs} seconds"),
+        None => "You are being ratelimited. Please try again later".to_string(),
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum RailwayError {
     #[error("Unauthorized. Please login with `railway login`")]
@@ -111,8 +124,8 @@ pub enum RailwayError {
     #[error("Connection URL should point to the Railway TCP proxy")]
     InvalidConnectionVariable,
 
-    #[error("You are being ratelimited. Please try again later")]
-    Ratelimited,
+    #[error("{}", ratelimit_message(*retry_after_secs))]
+    Ratelimited { retry_after_secs: Option<u64> },
 
     #[error("Device code expired. Please run `railway login` again.")]
     OAuthDeviceCodeExpired,
@@ -175,7 +188,7 @@ impl RailwayError {
             RailwayError::TwoFactorEnforcementRequired(_, _) => "TWO_FACTOR_REQUIRED",
             RailwayError::ConnectionVariableNotFound(_) => "CONNECTION_VARIABLE_NOT_FOUND",
             RailwayError::InvalidConnectionVariable => "INVALID_CONNECTION_VARIABLE",
-            RailwayError::Ratelimited => "RATELIMITED",
+            RailwayError::Ratelimited { .. } => "RATELIMITED",
             RailwayError::OAuthDeviceCodeExpired => "OAUTH_DEVICE_CODE_EXPIRED",
             RailwayError::OAuthAccessDenied => "OAUTH_ACCESS_DENIED",
             RailwayError::OAuthRefreshFailed(_) => "OAUTH_REFRESH_FAILED",


### PR DESCRIPTION
A user with several workspaces got rate limited opening `railway ca`. Startup asked for agents in every environment of every project of every workspace, one request each — 361 on a six-workspace account, on every launch, uncached. `cloudAgents` requires an `environmentId`, so the fan-out is forced by the query; doing it for the whole account at startup was not.

Startup now loads only what a keypress immediately needs: the prompt's target, the default project's environments, and environments this machine has launched an agent in, from the CLI's own config. That's two or three requests, and everything else loads when its row is expanded, which the tree already did. `shift+r` runs the old whole-account scan on request — that's how an agent created elsewhere (another machine, the dashboard, a project you've never opened) still gets found, with the cost spent when asked for rather than charged to every launch.

Rate limits are handled rather than absorbed. The first 429 stops the rest of the batch instead of spending the remaining budget on requests that will also be refused. Environments still in flight go back to "not loaded," so opening one retries instead of spinning forever. And `Retry-After`, which backboard sets on every 429 and the CLI discarded, is now surfaced: "Rate limited — try again in 43s."

For context, the limiter is 1,000 requests per hour, keyed on the token's workspace or user, and only applies to API-token auth — `railway login` sessions are exempt, `RAILWAY_API_TOKEN` is not. At 360 environments, three launches on a token exceed it.

The real fix is server-side and lands separately: railwayapp/mono#34876 adds `myCloudAgents`, a user-scoped listing that answers "where are my agents" in one query. Once it deploys, a follow-up PR makes it the primary startup path and retires `shift+r`.

## Verification

869 tests, fmt and clippy clean. New tests cover: startup loads only target, default-project, and known environments, claiming each once; `shift+r` scans the rest; and a rate limit releases what was in flight so a retry works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
