### PR TITLE
fix(variable): accept empty values in KEY=VALUE pairs; confirm sets on non-TTY

### DIFF
--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -2158,7 +2158,15 @@ mod tests {
     #[test]
     fn invalid_pair_errors() {
         assert!(parse_variable_args(&args(&["NOVALUE"])).is_err());
-        assert!(parse_variable_args(&args(&["FOO=bar,NOVALUE=,BAZ=qux"])).is_err());
+        assert!(parse_variable_args(&args(&["FOO=bar,=nokey,BAZ=qux"])).is_err());
+    }
+
+    #[test]
+    fn empty_value_sets_the_empty_string() {
+        let vars = parse_variable_args(&args(&["FOO=bar,BLANK=,BAZ=qux"])).unwrap();
+        assert_eq!(vars.len(), 3);
+        assert_eq!(vars[1].key, "BLANK");
+        assert_eq!(vars[1].value, "");
     }
 
     #[test]

--- a/src/commands/variable.rs
+++ b/src/commands/variable.rs
@@ -349,6 +349,12 @@ async fn set_variables_internal(
 
     if let Some(sp) = spinner {
         sp.finish_with_message(format!("Set variables {fmt_keys}"));
+        // The spinner draws to stderr and draws nothing at all when stderr
+        // is not a terminal, so a scripted/piped run used to succeed in
+        // complete silence. Give it a plain stdout confirmation instead.
+        if !std::io::stderr().is_terminal() {
+            println!("Set variables {}", keys.join(", "));
+        }
     } else {
         println!("{}", serde_json::json!({"keys": keys, "set": true}));
     }

--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -51,13 +51,51 @@ impl FromStr for Variable {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let s = s.splitn(2, '=').collect::<Vec<&str>>();
-        if s.len() != 2 || s.iter().any(|v| v.is_empty()) {
+        // Only the KEY must be non-empty: `KEY=` sets the variable to the
+        // empty string, matching what the dashboard allows. Rejecting it
+        // here failed the whole invocation at argv-parse time — with
+        // multiple --set flags, one `KEY=` killed every other pair too,
+        // with the error visible only on stderr.
+        if s.len() != 2 || s[0].is_empty() {
             anyhow::bail!("Invalid variable format: {}", s.join("="))
         }
         Ok(Self {
             key: s[0].to_string(),
             value: s[1].to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod variable_from_str_tests {
+    use super::*;
+
+    #[test]
+    fn key_value_parses() {
+        let v: Variable = "FOO=bar".parse().unwrap();
+        assert_eq!((v.key.as_str(), v.value.as_str()), ("FOO", "bar"));
+    }
+
+    #[test]
+    fn empty_value_sets_the_empty_string() {
+        let v: Variable = "REPLICA_OF=".parse().unwrap();
+        assert_eq!((v.key.as_str(), v.value.as_str()), ("REPLICA_OF", ""));
+    }
+
+    #[test]
+    fn value_may_contain_equals_signs() {
+        let v: Variable = "URL=postgres://u:p@h/db?a=b".parse().unwrap();
+        assert_eq!(v.value, "postgres://u:p@h/db?a=b");
+    }
+
+    #[test]
+    fn empty_key_is_rejected() {
+        assert!("=value".parse::<Variable>().is_err());
+    }
+
+    #[test]
+    fn missing_equals_is_rejected() {
+        assert!("JUSTAKEY".parse::<Variable>().is_err());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -643,6 +643,9 @@ mod cli_tests {
         fn variable_legacy_flags() {
             assert_parses(&["variable", "--set", "KEY=value"]);
             assert_parses(&["variable", "--set", "KEY=value", "--set", "KEY2=value2"]);
+            // Empty VALUE is legal (sets the empty string); it used to fail
+            // clap parsing and abort the whole invocation, other pairs included.
+            assert_parses(&["variable", "--set", "KEY=", "--set", "KEY2=value2"]);
             assert_parses(&["variable", "-s", "myservice"]);
             assert_parses(&["variable", "-e", "production"]);
             assert_parses(&["variable", "--kv"]);


### PR DESCRIPTION
Two paper cuts that compound into "my variables silently didn't apply":

1. **`--set KEY=` rejected the whole invocation.** `Variable`'s `FromStr` rejected an empty *value*, not just an empty key — and with the legacy `--set` flag that parse runs inside clap, so one `KEY=` aborted the entire command at argv-parse time: every other `--set` pair unapplied, error on stderr only. Setting a variable to the empty string is legitimate (the dashboard allows it); only an empty KEY is malformed. The same `FromStr` backs `variable set`, so `railway variable set KEY=` works now too (sandbox's comma-pair parsing inherits the same semantics; its test specimen updated accordingly).

2. **Success was invisible in scripts.** The only success output was the indicatif spinner, which draws to stderr and draws *nothing* when stderr is not a terminal — a scripted run that succeeded was indistinguishable from one that did nothing. Now prints a plain stdout confirmation when stderr is not a TTY.

## Verification

- Unit tests for the `FromStr` edges (empty value OK, empty key rejected, missing `=` rejected, values containing `=`) + clap smoke test for `--set KEY= --set KEY2=value2`.
- `cargo test`: 933 passed.
- Live e2e, piped (non-TTY):
  ```
  $ cargo run -- variables --set "FIRETEST_A=1" --set "FIRETEST_B=" --skip-deploys -s Redis-1 | cat
  Set variables FIRETEST_A, FIRETEST_B
  $ railway variable list -s Redis-1 --kv | grep FIRETEST
  FIRETEST_A=1
  FIRETEST_B=
  ```
  (released CLI: exit 2 at parse time, nothing applied, nothing on stdout).