### PR TITLE
feat(ca): answer "where are my agents" with one myCloudAgents request

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -1363,11 +1363,14 @@ impl App {
 
     /// The whole account's agents arrived in one `myCloudAgents` request.
     ///
-    /// Every environment becomes loaded: one absent from the response holds no
-    /// agents of the caller's, and saying so is what lets the tree show counts
-    /// everywhere without a request per environment. An environment that has
-    /// already answered — a launch just filled the target — keeps what it has,
-    /// which is at least as fresh and may carry session state.
+    /// Every unanswered environment becomes loaded: one absent from the
+    /// response holds no agents of the caller's, and saying so is what lets
+    /// the tree show counts everywhere without a request per environment. An
+    /// environment that has already answered — a launch just filled the
+    /// target — keeps what it has, which is at least as fresh and may carry
+    /// session state. One still loading keeps its spinner too: its request
+    /// went out after this one, so its reply is strictly newer, and settling
+    /// over it could hide an agent created since this snapshot.
     pub fn my_agents_loaded(&mut self, agents: Vec<(String, Agent)>) {
         let anchor = self.selected_row().map(|row| row.kind);
         let mut by_env: HashMap<String, Vec<Agent>> = HashMap::new();
@@ -1377,7 +1380,7 @@ impl App {
         for ws in &mut self.tree {
             for project in &mut ws.projects {
                 for env in &mut project.envs {
-                    if matches!(env.agents, Load::Loaded(_)) {
+                    if !matches!(env.agents, Load::NotLoaded | Load::Failed(_)) {
                         continue;
                     }
                     env.agents = Load::Loaded(by_env.remove(&env.id).unwrap_or_default());
@@ -1387,6 +1390,19 @@ impl App {
         self.settle_watched_agents();
         self.restore_cursor(anchor);
         self.select_pending();
+    }
+
+    /// Whether any environment still has no answer.
+    ///
+    /// Guards the account-wide fetch on re-entry from a session: a tree that
+    /// has already settled would discard the reply, so the request would be
+    /// spent for nothing.
+    pub fn has_unloaded_environments(&self) -> bool {
+        self.tree.iter().any(|ws| {
+            ws.projects
+                .iter()
+                .any(|project| project.envs.iter().any(|env| env.agents == Load::NotLoaded))
+        })
     }
 
     /// Fold up a project whose last agent has gone.
@@ -1455,9 +1471,31 @@ impl App {
     pub fn sessions_loaded(
         &mut self,
         path: (usize, usize, usize, usize),
+        agent_id: &str,
         result: Result<Vec<ConsoleSession>, String>,
     ) {
-        let (w, p, e, a) = path;
+        let (w, p, e, _) = path;
+        // Resolved by id rather than trusting the index the request went out
+        // with: the environment can be refetched while sessions are in
+        // flight, and a new agent shifting the list would otherwise attach
+        // these sessions to whoever now sits at that index.
+        let a = match self
+            .tree
+            .get(w)
+            .and_then(|ws| ws.projects.get(p))
+            .and_then(|proj| proj.envs.get(e))
+            .map(|env| &env.agents)
+        {
+            Some(Load::Loaded(agents)) => {
+                match agents.iter().position(|agent| agent.id == agent_id) {
+                    Some(a) => a,
+                    // The agent is gone (deleted, or the refetch dropped it);
+                    // its sessions have nowhere to belong.
+                    None => return,
+                }
+            }
+            _ => return,
+        };
         if let Some(Load::Loaded(agents)) = self
             .tree
             .get_mut(w)
@@ -5059,6 +5097,7 @@ mod tests {
         // Still listed: keep hiding it, the kill has not landed yet.
         a.sessions_loaded(
             (0, 0, 0, 0),
+            "ca_1",
             Ok(vec![ConsoleSession {
                 name: "claude-one".into(),
                 kind: "SHELL".into(),
@@ -5071,7 +5110,7 @@ mod tests {
         assert!(!a.rows().iter().any(|r| r.label == "claude-one"));
 
         // Gone from the agent: stop tracking it.
-        a.sessions_loaded((0, 0, 0, 0), Ok(Vec::new()));
+        a.sessions_loaded((0, 0, 0, 0), "ca_1", Ok(Vec::new()));
         assert!(a.ending.is_empty());
     }
 
@@ -5248,6 +5287,7 @@ mod tests {
 
         a.sessions_loaded(
             (0, 0, 0, 0),
+            "ca_1",
             Ok(vec![ConsoleSession {
                 name: "claude-one".into(),
                 kind: "SHELL".into(),
@@ -5320,6 +5360,7 @@ mod tests {
         }
         a.sessions_loaded(
             (0, 0, 0, 0),
+            "ca_1",
             Ok(vec![ConsoleSession {
                 name: "claude-new".into(),
                 kind: "SHELL".into(),
@@ -5635,6 +5676,7 @@ mod tests {
 
         a.sessions_loaded(
             (0, 0, 0, 0),
+            "ca_1",
             Ok(vec![ConsoleSession {
                 name: "sess-7".into(),
                 command: Some("claude".into()),
@@ -6090,23 +6132,84 @@ mod tests {
 
     /// An environment that already answered keeps what it has: a launch may
     /// have just filled the target, and its rows can carry session state the
-    /// account-wide reply doesn't.
+    /// account-wide reply doesn't. One still loading keeps its spinner: its
+    /// request went out after this one, so its reply is strictly newer.
     #[test]
     fn my_agents_loaded_keeps_environments_that_already_answered() {
         let mut a = app();
         a.tree[0].projects[0].envs[0].agents =
             Load::Loaded(vec![agent("ca_fresh", "just-launched", "starting")]);
+        a.tree[0].projects[0].envs[1].agents = Load::Loading;
 
-        a.my_agents_loaded(vec![(
-            "env_prod".into(),
-            agent("ca_stale", "from-before", "running"),
-        )]);
+        a.my_agents_loaded(vec![
+            (
+                "env_prod".into(),
+                agent("ca_stale", "from-before", "running"),
+            ),
+            ("env_stg".into(), agent("ca_old", "snapshot", "running")),
+        ]);
 
         let prod = &a.tree[0].projects[0].envs[0].agents;
         let Load::Loaded(agents) = prod else {
             panic!("production should stay loaded: {prod:?}");
         };
         assert_eq!(agents[0].id, "ca_fresh");
+        assert_eq!(
+            a.tree[0].projects[0].envs[1].agents,
+            Load::Loading,
+            "an in-flight fetch answers with newer data than this snapshot"
+        );
+    }
+
+    /// A sessions reply is applied to the agent it was asked about, not to
+    /// whichever agent now sits at the index the request went out with — an
+    /// environment refetch can insert a newer agent above it meanwhile.
+    #[test]
+    fn a_sessions_reply_follows_its_agent_when_the_list_shifts() {
+        let mut a = loaded_app();
+        // The env was refetched while ca_1's sessions were in flight: a newer
+        // agent now occupies index 0.
+        a.agents_loaded(
+            (0, 0, 0),
+            Ok(vec![
+                agent("ca_new", "just-created", "starting"),
+                agent("ca_1", "nimble-otter", "running"),
+            ]),
+        );
+
+        a.sessions_loaded(
+            (0, 0, 0, 0),
+            "ca_1",
+            Ok(vec![ConsoleSession {
+                name: "claude-one".into(),
+                kind: "SHELL".into(),
+                command: None,
+                running: true,
+                attached: false,
+            }]),
+        );
+
+        let Load::Loaded(agents) = &a.tree[0].projects[0].envs[0].agents else {
+            panic!("loaded");
+        };
+        assert!(
+            matches!(agents[0].sessions, LoadSessions::NotLoaded),
+            "the newcomer at index 0 must not inherit ca_1's sessions"
+        );
+        assert!(matches!(agents[1].sessions, LoadSessions::Loaded(ref s) if s.len() == 1));
+
+        // And a reply for an agent that no longer exists goes nowhere.
+        a.sessions_loaded((0, 0, 0, 0), "ca_gone", Ok(Vec::new()));
+    }
+
+    /// Re-entry from a session must not respend the account-wide request the
+    /// settled tree would discard.
+    #[test]
+    fn a_settled_tree_reports_no_unloaded_environments() {
+        let mut a = app();
+        assert!(a.has_unloaded_environments());
+        a.my_agents_loaded(Vec::new());
+        assert!(!a.has_unloaded_environments());
     }
 
     /// `shift+r` is how an agent in a project nobody has opened gets found: the

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -6,9 +6,13 @@
 //! testable without a terminal or a network.
 //!
 //! The tree is workspace → project → environment → agent. Structure comes from
-//! one `UserProjects` call; agents are per environment and load only when an
-//! environment is expanded, because the only list query we have takes one
-//! environment at a time and a workspace can hold dozens.
+//! one `UserProjects` call; agents arrive from one `myCloudAgents` call, which
+//! answers for the whole account at once. Against a backboard that predates
+//! that field, agents are per environment and load only when an environment is
+//! expanded, because `cloudAgents` takes one environment at a time and a
+//! workspace can hold dozens.
+
+use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -1357,6 +1361,34 @@ impl App {
         self.select_pending();
     }
 
+    /// The whole account's agents arrived in one `myCloudAgents` request.
+    ///
+    /// Every environment becomes loaded: one absent from the response holds no
+    /// agents of the caller's, and saying so is what lets the tree show counts
+    /// everywhere without a request per environment. An environment that has
+    /// already answered — a launch just filled the target — keeps what it has,
+    /// which is at least as fresh and may carry session state.
+    pub fn my_agents_loaded(&mut self, agents: Vec<(String, Agent)>) {
+        let anchor = self.selected_row().map(|row| row.kind);
+        let mut by_env: HashMap<String, Vec<Agent>> = HashMap::new();
+        for (environment_id, agent) in agents {
+            by_env.entry(environment_id).or_default().push(agent);
+        }
+        for ws in &mut self.tree {
+            for project in &mut ws.projects {
+                for env in &mut project.envs {
+                    if matches!(env.agents, Load::Loaded(_)) {
+                        continue;
+                    }
+                    env.agents = Load::Loaded(by_env.remove(&env.id).unwrap_or_default());
+                }
+            }
+        }
+        self.settle_watched_agents();
+        self.restore_cursor(anchor);
+        self.select_pending();
+    }
+
     /// Fold up a project whose last agent has gone.
     ///
     /// After a delete the tree would otherwise sit open on an empty
@@ -2244,7 +2276,8 @@ impl App {
         out
     }
 
-    /// The environments to fetch before anyone touches a key.
+    /// The environments to fetch before anyone touches a key, on a backboard
+    /// that predates `myCloudAgents`.
     ///
     /// Only where the answer is needed immediately: the prompt's target, which
     /// New Session reads to decide whether it has an agent to work on, and the
@@ -6025,6 +6058,55 @@ mod tests {
             &effects[0],
             Effect::LoadAgents { environment_id, .. } if environment_id == "env_stg"
         ));
+    }
+
+    /// One `myCloudAgents` reply answers for the whole account: agents land in
+    /// their environments, and every other environment is loaded as empty —
+    /// absence from the response means "none of yours here", not "unknown".
+    #[test]
+    fn my_agents_loaded_settles_every_environment() {
+        let mut a = app();
+        a.my_agents_loaded(vec![
+            ("env_stg".into(), agent("ca_1", "fix-login", "running")),
+            ("env_stg".into(), agent("ca_2", "bump-deps", "sleeping")),
+            // An environment the tree doesn't know is ignored, not invented.
+            ("env_gone".into(), agent("ca_3", "orphan", "running")),
+        ]);
+
+        let stg = &a.tree[0].projects[0].envs[1].agents;
+        let Load::Loaded(agents) = stg else {
+            panic!("staging should be loaded: {stg:?}");
+        };
+        assert_eq!(
+            agents.iter().map(|a| a.id.as_str()).collect::<Vec<_>>(),
+            ["ca_1", "ca_2"]
+        );
+        assert_eq!(
+            a.tree[0].projects[0].envs[0].agents,
+            Load::Loaded(vec![]),
+            "an environment absent from the reply has no agents of the caller's"
+        );
+    }
+
+    /// An environment that already answered keeps what it has: a launch may
+    /// have just filled the target, and its rows can carry session state the
+    /// account-wide reply doesn't.
+    #[test]
+    fn my_agents_loaded_keeps_environments_that_already_answered() {
+        let mut a = app();
+        a.tree[0].projects[0].envs[0].agents =
+            Load::Loaded(vec![agent("ca_fresh", "just-launched", "starting")]);
+
+        a.my_agents_loaded(vec![(
+            "env_prod".into(),
+            agent("ca_stale", "from-before", "running"),
+        )]);
+
+        let prod = &a.tree[0].projects[0].envs[0].agents;
+        let Load::Loaded(agents) = prod else {
+            panic!("production should stay loaded: {prod:?}");
+        };
+        assert_eq!(agents[0].id, "ca_fresh");
     }
 
     /// `shift+r` is how an agent in a project nobody has opened gets found: the

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -200,6 +200,10 @@ enum Message {
     },
     SessionsLoaded {
         path: (usize, usize, usize, usize),
+        /// Applied by id, not by the index the request was issued with: the
+        /// environment can be refetched while sessions are in flight, and a
+        /// new agent shifting the list would attach these to the wrong row.
+        agent_id: String,
         result: Result<Vec<ConsoleSession>, String>,
     },
     LaunchStep(String),
@@ -437,9 +441,13 @@ pub async fn run(
 
     // Ask for every agent the caller owns, in one request. If the platform
     // predates `myCloudAgents`, the reply says so and startup degrades to
-    // loading just the environments a keypress would immediately need.
+    // loading just the environments a keypress would immediately need. On
+    // re-entry after a session the tree has already settled, and the settle
+    // would discard a fresh answer — so don't spend the request.
     let stop_fetching: StopFlag = Default::default();
-    spawn_my_agents_fetch(&tx, &client, &backboard);
+    if app.has_unloaded_environments() {
+        spawn_my_agents_fetch(&tx, &client, &backboard);
+    }
 
     loop {
         let mut rects = app.panes;
@@ -704,12 +712,31 @@ pub async fn run(
                 let client = client.clone();
                 let backboard = backboard.clone();
                 tokio::spawn(async move {
-                    let result = fetch_agents(&client, &backboard, &environment_id)
-                        .await
-                        .map_err(|e| e.to_string());
                     // A closed receiver just means the TUI already handed back;
                     // the next entry re-requests, so the drop is harmless.
-                    let _ = tx.send(Message::AgentsLoaded { path, result });
+                    match fetch_agents(&client, &backboard, &environment_id).await {
+                        Ok(agents) => {
+                            let _ = tx.send(Message::AgentsLoaded {
+                                path,
+                                result: Ok(agents),
+                            });
+                        }
+                        // The same classification the background fetches do:
+                        // a 429 puts the row back to "not loaded" with the
+                        // Retry-After toast, instead of pinning "rate limited"
+                        // to this one environment as if it were its failure.
+                        Err(err) => match rate_limit_from(&err) {
+                            Some(retry_after_secs) => {
+                                let _ = tx.send(Message::RateLimited { retry_after_secs });
+                            }
+                            None => {
+                                let _ = tx.send(Message::AgentsLoaded {
+                                    path,
+                                    result: Err(err.to_string()),
+                                });
+                            }
+                        },
+                    }
                 });
             }
         }
@@ -732,41 +759,54 @@ fn handle_message(
         Message::AgentsLoaded { path, result } => {
             app.agents_loaded(path, result);
             // Fill in each running agent's session count without waiting for
-            // someone to expand it.
-            for effect in app.sessions_to_prefetch() {
-                if let Effect::LoadSessions { agent_id, path } = effect {
-                    spawn_session_fetch(agent_id, path, tx, client, backboard);
-                }
+            // someone to expand it. Bounded: one environment usually holds a
+            // handful of agents, but nothing guarantees it.
+            let prefetch = app.sessions_to_prefetch();
+            if !prefetch.is_empty() {
+                spawn_session_prefetch(prefetch, tx, client, backboard, stop_fetching.clone());
             }
             // A launch that just created an agent asked for it to be opened;
             // its row only exists now.
             app.expand_pending()
         }
-        Message::MyAgentsLoaded { result } => {
-            match result {
-                Ok(agents) => {
-                    app.my_agents_loaded(agents);
-                    for effect in app.sessions_to_prefetch() {
-                        if let Effect::LoadSessions { agent_id, path } = effect {
-                            spawn_session_fetch(agent_id, path, tx, client, backboard);
-                        }
-                    }
+        Message::MyAgentsLoaded { result } => match result {
+            Ok(agents) => {
+                app.my_agents_loaded(agents);
+                let prefetch = app.sessions_to_prefetch();
+                if !prefetch.is_empty() {
+                    spawn_session_prefetch(prefetch, tx, client, backboard, stop_fetching.clone());
                 }
-                // Whether the field doesn't exist yet or the request died,
-                // the per-environment path still works, so startup degrades
-                // to what it loaded before `myCloudAgents`: the environments
-                // a keypress would immediately need.
-                Err(_) => {
-                    let sweep = app.initial_environments();
-                    if !sweep.is_empty() {
-                        spawn_sweep(sweep, tx, client, backboard, stop_fetching.clone());
-                    }
-                }
+                // Normally redundant — a launch's own refetch answers this —
+                // but it is the safety net when that refetch failed before
+                // this settle arrived.
+                app.expand_pending()
             }
-            None
-        }
-        Message::SessionsLoaded { path, result } => {
-            app.sessions_loaded(path, result);
+            // Whether the field doesn't exist yet or the request died, the
+            // per-environment path still works, so startup degrades to what
+            // it loaded before `myCloudAgents`: the environments a keypress
+            // would immediately need.
+            Err(err) => {
+                // These are fresh requests; a stop left over from an earlier
+                // 429 would strand them as spinners that never resolve.
+                stop_fetching.store(false, std::sync::atomic::Ordering::Relaxed);
+                let sweep = app.initial_environments();
+                if sweep.is_empty() {
+                    // No target and no default project means nothing loads
+                    // lazily either — without this line an expired login
+                    // looks like an account with no agents anywhere.
+                    app.status = format!("Couldn't load agents: {err}");
+                } else {
+                    spawn_sweep(sweep, tx, client, backboard, stop_fetching.clone());
+                }
+                None
+            }
+        },
+        Message::SessionsLoaded {
+            path,
+            agent_id,
+            result,
+        } => {
+            app.sessions_loaded(path, &agent_id, result);
             None
         }
         Message::LaunchStep(text) => {
@@ -1031,7 +1071,73 @@ fn spawn_session_fetch(
                 Err(err.to_string())
             }
         };
-        let _ = tx.send(Message::SessionsLoaded { path, result });
+        let _ = tx.send(Message::SessionsLoaded {
+            path,
+            agent_id,
+            result,
+        });
+    });
+}
+
+/// Fetch a batch of agents' sessions, a few at a time.
+///
+/// Same discipline as [`spawn_sweep`]: the account-wide settle can name every
+/// running agent at once, and firing one request per agent simultaneously is
+/// the burst this TUI exists to avoid. The first 429 abandons the rest.
+fn spawn_session_prefetch(
+    effects: Vec<Effect>,
+    tx: &mpsc::UnboundedSender<Message>,
+    client: &reqwest::Client,
+    backboard: &str,
+    stop: StopFlag,
+) {
+    use std::sync::atomic::Ordering;
+
+    let tx = tx.clone();
+    let client = client.clone();
+    let backboard = backboard.to_string();
+    tokio::spawn(async move {
+        let permits = std::sync::Arc::new(tokio::sync::Semaphore::new(SWEEP_CONCURRENCY));
+        for effect in effects {
+            let Effect::LoadSessions { agent_id, path } = effect else {
+                continue;
+            };
+            if stop.load(Ordering::Relaxed) {
+                return;
+            }
+            let Ok(permit) = permits.clone().acquire_owned().await else {
+                return;
+            };
+            let tx = tx.clone();
+            let client = client.clone();
+            let backboard = backboard.clone();
+            let stop = stop.clone();
+            tokio::spawn(async move {
+                match fetch_sessions(&client, &backboard, &agent_id).await {
+                    Ok(sessions) => {
+                        let _ = tx.send(Message::SessionsLoaded {
+                            path,
+                            agent_id,
+                            result: Ok(sessions),
+                        });
+                    }
+                    Err(err) => match rate_limit_from(&err) {
+                        Some(retry_after_secs) => {
+                            stop.store(true, Ordering::Relaxed);
+                            let _ = tx.send(Message::RateLimited { retry_after_secs });
+                        }
+                        None => {
+                            let _ = tx.send(Message::SessionsLoaded {
+                                path,
+                                agent_id,
+                                result: Err(err.to_string()),
+                            });
+                        }
+                    },
+                }
+                drop(permit);
+            });
+        }
     });
 }
 

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -187,6 +187,12 @@ enum Message {
         path: (usize, usize, usize),
         result: Result<Vec<Agent>, String>,
     },
+    /// The whole account's agents in one request, keyed by environment — or
+    /// why that wasn't possible, in which case startup degrades to the
+    /// per-environment path.
+    MyAgentsLoaded {
+        result: Result<Vec<(String, Agent)>, String>,
+    },
     /// A background fetch was refused for rate limiting. The rest of its batch
     /// is abandoned; see [`spawn_sweep`].
     RateLimited {
@@ -307,6 +313,71 @@ async fn fetch_agents(
         .collect())
 }
 
+/// Every agent the caller owns, keyed by environment, in one request.
+///
+/// `myCloudAgents` answers for the whole account what the startup sweep used
+/// to ask environment by environment. A backboard that predates the field
+/// reports it as unqueryable, which is the caller's cue to fall back to that
+/// sweep.
+async fn fetch_my_agents(
+    client: &reqwest::Client,
+    backboard: &str,
+) -> Result<Vec<(String, Agent)>> {
+    let res = post_graphql::<queries::MyCloudAgents, _>(
+        client,
+        backboard,
+        queries::my_cloud_agents::Variables {},
+    )
+    .await?;
+    Ok(res
+        .my_cloud_agents
+        .into_iter()
+        .map(|a| {
+            (
+                a.environment_id,
+                Agent {
+                    id: a.id,
+                    name: a.name,
+                    status: format!("{:?}", a.status).to_lowercase(),
+                    sessions: LoadSessions::NotLoaded,
+                    expanded: false,
+                },
+            )
+        })
+        .collect())
+}
+
+/// Ask for the whole account's agents in the background, once, at startup.
+fn spawn_my_agents_fetch(
+    tx: &mpsc::UnboundedSender<Message>,
+    client: &reqwest::Client,
+    backboard: &str,
+) {
+    let tx = tx.clone();
+    let client = client.clone();
+    let backboard = backboard.to_string();
+    tokio::spawn(async move {
+        match fetch_my_agents(&client, &backboard).await {
+            Ok(agents) => {
+                let _ = tx.send(Message::MyAgentsLoaded { result: Ok(agents) });
+            }
+            // A rate limit is worth its own message — the toast with the
+            // Retry-After — rather than being folded into the fallback, which
+            // would immediately spend more requests against a refusal.
+            Err(err) => match rate_limit_from(&err) {
+                Some(retry_after_secs) => {
+                    let _ = tx.send(Message::RateLimited { retry_after_secs });
+                }
+                None => {
+                    let _ = tx.send(Message::MyAgentsLoaded {
+                        result: Err(err.to_string()),
+                    });
+                }
+            },
+        }
+    });
+}
+
 /// The reattachable shell and exec sessions on one agent's VM.
 ///
 /// These are the platform's own record of what is running in there, so they
@@ -364,14 +435,11 @@ pub async fn run(
         start_launch(app, req, &tx);
     }
 
-    // Load the environments a keypress would immediately need, in the
-    // background. Everything else waits to be expanded: one request per
-    // environment across a whole account is hundreds on a large one.
+    // Ask for every agent the caller owns, in one request. If the platform
+    // predates `myCloudAgents`, the reply says so and startup degrades to
+    // loading just the environments a keypress would immediately need.
     let stop_fetching: StopFlag = Default::default();
-    let sweep = app.initial_environments();
-    if !sweep.is_empty() {
-        spawn_sweep(sweep, &tx, &client, &backboard, stop_fetching.clone());
-    }
+    spawn_my_agents_fetch(&tx, &client, &backboard);
 
     loop {
         let mut rects = app.panes;
@@ -390,7 +458,7 @@ pub async fn run(
         let effect = tokio::select! {
             // Background work first: draining it keeps the tree and the session
             // honest even while keys arrive faster than frames.
-            Some(message) = rx.recv() => handle_message(app, message, &tx, &client, &backboard),
+            Some(message) = rx.recv() => handle_message(app, message, &tx, &client, &backboard, &stop_fetching),
             // Animate the loading screen. Only armed while it is showing, so an
             // idle TUI still blocks rather than spinning on a timer.
             // The wizard borrows the same tick for its "creating…" spinner.
@@ -654,6 +722,7 @@ fn handle_message(
     tx: &mpsc::UnboundedSender<Message>,
     client: &reqwest::Client,
     backboard: &str,
+    stop_fetching: &StopFlag,
 ) -> Option<Effect> {
     match message {
         Message::RateLimited { retry_after_secs } => {
@@ -672,6 +741,29 @@ fn handle_message(
             // A launch that just created an agent asked for it to be opened;
             // its row only exists now.
             app.expand_pending()
+        }
+        Message::MyAgentsLoaded { result } => {
+            match result {
+                Ok(agents) => {
+                    app.my_agents_loaded(agents);
+                    for effect in app.sessions_to_prefetch() {
+                        if let Effect::LoadSessions { agent_id, path } = effect {
+                            spawn_session_fetch(agent_id, path, tx, client, backboard);
+                        }
+                    }
+                }
+                // Whether the field doesn't exist yet or the request died,
+                // the per-environment path still works, so startup degrades
+                // to what it loaded before `myCloudAgents`: the environments
+                // a keypress would immediately need.
+                Err(_) => {
+                    let sweep = app.initial_environments();
+                    if !sweep.is_empty() {
+                        spawn_sweep(sweep, tx, client, backboard, stop_fetching.clone());
+                    }
+                }
+            }
+            None
         }
         Message::SessionsLoaded { path, result } => {
             app.sessions_loaded(path, result);

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -356,6 +356,15 @@ pub struct CloudAgents;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/MyCloudAgents.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq",
+    skip_serializing_none
+)]
+pub struct MyCloudAgents;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/CloudAgentConsoleSessions.graphql",
     response_derives = "Debug, Serialize, Clone, PartialEq",
     skip_serializing_none

--- a/src/gql/queries/strings/MyCloudAgents.graphql
+++ b/src/gql/queries/strings/MyCloudAgents.graphql
@@ -1,0 +1,10 @@
+query MyCloudAgents {
+  myCloudAgents {
+    id
+    name
+    status
+    projectId
+    environmentId
+    createdAt
+  }
+}

--- a/src/gql/schema.json
+++ b/src/gql/schema.json
@@ -37160,6 +37160,30 @@
               "deprecationReason": null
             },
             {
+              "name": "myCloudAgents",
+              "description": "Cloud agents you own, across every project and environment you can reach. Answers \"where are my agents\" in one request; `cloudAgents` needs one call per environment. Machine fields (`status`, `domain`, `domains`) read the last observed state in batched queries, so selecting them across many environments is fine.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CloudAgent",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "networkFlowLogs",
               "description": "Fetch individual network flow logs for an environment",
               "args": [


### PR DESCRIPTION
Stacked on #1056; lands after it and after railwayapp/mono#34876 deploys.

#1056 stopped the startup fan-out by loading less — the price was that a project's agent count only appeared when you opened it, with `shift+r` as the whole-account escape hatch. This restores full visibility at startup without the fan-out: one `myCloudAgents` request returns every agent the caller owns, and the tree settles entirely from that answer. Agents land in their environments; an environment absent from the reply is loaded as empty, since absence from a complete answer means "none of yours here" rather than "unknown". An environment that already answered (a launch just filled the target) keeps what it has, which may carry session state the account-wide reply doesn't.

The fallback is the code #1056 shipped, unchanged. Against a backboard that predates the field, the request fails with an unqueryable-field error and startup degrades to the keypress-driven loads, the `shift+r` sweep, and the 429 handling. A rate limit on the new request itself surfaces the same Retry-After toast rather than silently falling back, which would spend more requests against a refusal. `schema.json` was regenerated from the mono working tree with `dump-public-introspection.ts` so this could be written before the backboard change deploys; the CLI must still release after backboard, or every launch takes the fallback path.

`shift+r` stays for the fallback path. On a current backboard it reports every project as already loaded, which at startup is now simply true.

## Verification

873 tests, fmt and clippy clean. New tests: one `myCloudAgents` reply settles every environment (agents placed by environment, absent environments loaded as empty, unknown environments ignored), and environments that already answered keep their contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

An adversarial review pass then hardened the path (second fix commit): session prefetch is bounded by the same five-permit discipline as the sweep, sessions replies resolve by agent id instead of positional index, the settle no longer overwrites in-flight environments, a stale rate-limit stop can't strand the fallback as permanent spinners, user-driven loads classify 429s like background ones, and re-entry skips the request a settled tree would discard.
