### PR TITLE
Add telemetry for railway ca launches, lifecycle ops, and setup

### DIFF
--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -8,6 +8,7 @@
 pub mod prefs;
 pub mod setup;
 pub mod skills_sync;
+pub mod telemetry;
 pub mod tui;
 
 use anyhow::{Context, Result};

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -129,7 +129,13 @@ pub async fn command(args: Args) -> Result<()> {
         prompt(&home, existing).await?
     };
 
-    prefs.save_in(&home)?;
+    match prefs.save_in(&home) {
+        Ok(()) => super::telemetry::track_setup_saved("cli", &prefs).await,
+        Err(err) => {
+            super::telemetry::track_setup_failed("cli", &format!("{err:#}")).await;
+            return Err(err);
+        }
+    }
     print_summary(&home, &prefs)?;
     Ok(())
 }

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -1,0 +1,203 @@
+//! Additive telemetry for `railway ca` — detail events layered on top of the
+//! generic per-dispatch event the `commands!` macro already fires for
+//! `command="cloud_agent"` (and, for the shared launch pipeline, for
+//! `command="code"` too).
+//!
+//! Same role as [`crate::commands::ssh::tel`]: never replaces `?`
+//! propagation, only reports alongside it. Reused here rather than
+//! generalized there because the shapes differ enough (a kind dimension
+//! flattened into `sub_command`, not just a failing stage) to want their own
+//! small mapping functions per call site.
+//!
+//! Nothing here logs free text: no prompts, no session/agent/project names,
+//! no repo-shaped values. Only IDs (already attached by
+//! [`crate::telemetry::send`]'s ambient context), fixed slugs (harness,
+//! theme, skills source), and truncated error messages.
+
+use std::time::Duration;
+
+use super::prefs::AgentPrefs;
+use super::tui::app::AgentOp;
+use crate::config::Configs;
+use crate::telemetry::{self, CliTrackEvent};
+
+const TRUNCATE_AT: usize = 256;
+
+fn truncate(message: &str) -> String {
+    if message.len() > TRUNCATE_AT {
+        message[..TRUNCATE_AT].to_string()
+    } else {
+        message.to_string()
+    }
+}
+
+fn event(
+    command: &str,
+    sub_command: String,
+    duration_ms: u64,
+    success: bool,
+    error_message: Option<String>,
+) -> CliTrackEvent {
+    CliTrackEvent {
+        command: command.to_string(),
+        sub_command: Some(sub_command),
+        duration_ms,
+        success,
+        error_message,
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        cli_version: env!("CARGO_PKG_VERSION"),
+        is_ci: Configs::env_is_ci(),
+    }
+}
+
+/// Outcome of the shared `code::prepare()` launch pipeline — fired once per
+/// attempt regardless of which command reached it (`railway code`,
+/// `railway ca start`, or the TUI's `start_launch`), since none of those
+/// three would otherwise see the others' outcomes.
+///
+/// Its own pseudo-command (`cloud_agent_launch`) rather than `"cloud_agent"`
+/// because it isn't 1:1 with a single top-level dispatch — same reasoning as
+/// the `"mcp"` pseudo-command for MCP tool calls.
+pub async fn track_launch_outcome(
+    harness: &'static str,
+    created: Option<bool>,
+    duration: Duration,
+    error: Option<&str>,
+) {
+    let sub_command = match (error, created) {
+        (Some(_), _) => format!("{harness}_failed"),
+        (None, Some(true)) => format!("{harness}_created"),
+        (None, _) => format!("{harness}_reused"),
+    };
+    telemetry::send(event(
+        "cloud_agent_launch",
+        sub_command,
+        duration.as_millis() as u64,
+        error.is_none(),
+        error.map(truncate),
+    ))
+    .await;
+}
+
+/// One lifecycle mutation on an agent (sleep/wake/delete) from the manage
+/// screen, fired once per attempt so both volume and failure rate are
+/// visible per op kind.
+pub async fn track_agent_op(op: AgentOp, error: Option<&str>) {
+    let kind = match op {
+        AgentOp::Sleep => "sleep",
+        AgentOp::Wake => "wake",
+        AgentOp::Delete => "delete",
+    };
+    telemetry::send(event(
+        "cloud_agent",
+        format!("agent_{kind}"),
+        0,
+        error.is_none(),
+        error.map(truncate),
+    ))
+    .await;
+}
+
+/// A named session action outside the main launch pipeline — reattaching to
+/// an existing durable session, killing one by name, opening the ssh pane on
+/// a freshly prepared agent, or the auto-sleep-on-quit that keeps a
+/// disconnected agent from billing unattended. `kind` is a fixed label, not
+/// user input.
+pub async fn track_session_event(kind: &str, error: Option<&str>) {
+    telemetry::send(event(
+        "cloud_agent",
+        kind.to_string(),
+        0,
+        error.is_none(),
+        error.map(truncate),
+    ))
+    .await;
+}
+
+/// `railway ca setup` or the TUI wizard saved preferences. `entry` is
+/// `"cli"` or `"wizard"` — the two call sites share this mapping so both
+/// land in the same shape.
+///
+/// One flat event per dimension (agent / theme / project / skills), mirror
+/// of `commands/service.rs`'s `track_service_source`, rather than one event
+/// with all four combined: keeps `sub_command` cardinality small and each
+/// fact independently queryable.
+pub async fn track_setup_saved(entry: &str, prefs: &AgentPrefs) {
+    let harness = prefs.agent.as_deref().unwrap_or("none");
+    telemetry::send(event(
+        "cloud_agent",
+        format!("setup_{entry}_agent_{harness}"),
+        0,
+        true,
+        None,
+    ))
+    .await;
+
+    let theme = prefs.theme.as_deref().unwrap_or("default");
+    telemetry::send(event(
+        "cloud_agent",
+        format!("setup_{entry}_theme_{theme}"),
+        0,
+        true,
+        None,
+    ))
+    .await;
+
+    let project_state = if prefs.default_project.is_some() {
+        "set"
+    } else {
+        "unset"
+    };
+    telemetry::send(event(
+        "cloud_agent",
+        format!("setup_{entry}_project_{project_state}"),
+        0,
+        true,
+        None,
+    ))
+    .await;
+
+    let skills_state = if !prefs.skills.enabled {
+        "off"
+    } else {
+        prefs.skills.source.as_deref().unwrap_or("unknown")
+    };
+    telemetry::send(event(
+        "cloud_agent",
+        format!("setup_{entry}_skills_{skills_state}"),
+        0,
+        true,
+        None,
+    ))
+    .await;
+}
+
+/// `entry`'s setup flow failed to save preferences (disk error, etc.) — the
+/// prompts themselves succeeded, so this is a write failure, not a decline.
+pub async fn track_setup_failed(entry: &str, error: &str) {
+    telemetry::send(event(
+        "cloud_agent",
+        format!("setup_{entry}_failed"),
+        0,
+        false,
+        Some(truncate(error)),
+    ))
+    .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_caps_long_messages() {
+        let long = "x".repeat(300);
+        assert_eq!(truncate(&long).len(), TRUNCATE_AT);
+    }
+
+    #[test]
+    fn truncate_leaves_short_messages_alone() {
+        assert_eq!(truncate("boom"), "boom");
+    }
+}

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -9,10 +9,16 @@
 //! flattened into `sub_command`, not just a failing stage) to want their own
 //! small mapping functions per call site.
 //!
-//! Nothing here logs free text: no prompts, no session/agent/project names,
-//! no repo-shaped values. Only IDs (already attached by
-//! [`crate::telemetry::send`]'s ambient context), fixed slugs (harness,
-//! theme, skills source), and truncated error messages.
+//! None of the structured fields carry free text: no prompts, no
+//! session/agent/project names, no repo-shaped values — only IDs (already
+//! attached by [`crate::telemetry::send`]'s ambient context) and fixed slugs
+//! (harness, theme, skills source). `error_message` is the one exception:
+//! like every other failure event in this CLI (the generic dispatch event,
+//! `commands/ssh/tel.rs`), it carries the underlying error's `Display`
+//! text truncated to 256 bytes, which can include a user-supplied
+//! identifier when the error type formats one in (an unknown environment or
+//! service name, for instance) — this module doesn't scrub that, it just
+//! doesn't add any of its own.
 
 use std::time::Duration;
 
@@ -21,14 +27,8 @@ use super::tui::app::AgentOp;
 use crate::config::Configs;
 use crate::telemetry::{self, CliTrackEvent};
 
-const TRUNCATE_AT: usize = 256;
-
 fn truncate(message: &str) -> String {
-    if message.len() > TRUNCATE_AT {
-        message[..TRUNCATE_AT].to_string()
-    } else {
-        message.to_string()
-    }
+    telemetry::truncate_message(message)
 }
 
 fn event(
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn truncate_caps_long_messages() {
         let long = "x".repeat(300);
-        assert_eq!(truncate(&long).len(), TRUNCATE_AT);
+        assert_eq!(truncate(&long).len(), 256);
     }
 
     #[test]

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -883,9 +883,7 @@ fn handle_message(
             ) {
                 Ok(session) => {
                     app.attach_session(session, agent_id);
-                    tokio::spawn(async move {
-                        super::telemetry::track_session_event("reattach", None).await;
-                    });
+                    tokio::spawn(super::telemetry::track_session_event("reattach", None));
                     None
                 }
                 Err(err) => {

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -92,7 +92,10 @@ async fn create_default_project(
 }
 
 /// Write what first-run setup collected.
-fn save_setup(app: &App, outcome: &wizard::Outcome) -> Result<()> {
+fn save_setup(
+    app: &App,
+    outcome: &wizard::Outcome,
+) -> Result<crate::commands::cloud_agent::prefs::AgentPrefs> {
     use crate::commands::cloud_agent::prefs::{AgentPrefs, DefaultProject, SkillsPrefs};
 
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home directory"))?;
@@ -113,7 +116,8 @@ fn save_setup(app: &App, outcome: &wizard::Outcome) -> Result<()> {
         theme: Some(outcome.theme.clone()),
     };
     let _ = app;
-    prefs.save_in(&home)
+    prefs.save_in(&home)?;
+    Ok(prefs)
 }
 
 /// Shorten a string for a toast, keeping the front — the host and the start of
@@ -560,7 +564,15 @@ pub async fn run(
                             session_name,
                             info: Box::new(info),
                         },
-                        Err(err) => Message::LaunchFailed(format!("{err:#}")),
+                        Err(err) => {
+                            let message = format!("{err:#}");
+                            super::telemetry::track_session_event(
+                                "reattach_connect_failed",
+                                Some(message.as_str()),
+                            )
+                            .await;
+                            Message::LaunchFailed(message)
+                        }
                     };
                     let _ = tx.send(message);
                 });
@@ -578,8 +590,21 @@ pub async fn run(
             }
             Some(Effect::SaveSetup(outcome)) => {
                 app.status = match save_setup(app, &outcome) {
-                    Ok(()) => "Saved — Setup again to change it".into(),
-                    Err(err) => format!("Couldn't save your setup: {err:#}"),
+                    Ok(prefs) => {
+                        tokio::spawn(async move {
+                            super::telemetry::track_setup_saved("wizard", &prefs).await;
+                        });
+                        "Saved — Setup again to change it".into()
+                    }
+                    Err(err) => {
+                        let message = format!("{err:#}");
+                        let telemetry_message = message.clone();
+                        tokio::spawn(async move {
+                            super::telemetry::track_setup_failed("wizard", &telemetry_message)
+                                .await;
+                        });
+                        format!("Couldn't save your setup: {message}")
+                    }
                 };
                 // Apply it to the session that just chose it, or the prompt
                 // would still offer the harness they replaced.
@@ -685,6 +710,7 @@ pub async fn run(
                         .await
                         .err()
                         .map(|e| format!("{e:#}"));
+                    super::telemetry::track_agent_op(op, error.as_deref()).await;
                     let _ = tx.send(Message::AgentOpDone {
                         agent_id,
                         environment_id,
@@ -857,10 +883,22 @@ fn handle_message(
             ) {
                 Ok(session) => {
                     app.attach_session(session, agent_id);
+                    tokio::spawn(async move {
+                        super::telemetry::track_session_event("reattach", None).await;
+                    });
                     None
                 }
                 Err(err) => {
-                    app.launch_failed(format!("couldn't reattach: {err}"));
+                    let message = format!("couldn't reattach: {err}");
+                    let telemetry_message = message.clone();
+                    tokio::spawn(async move {
+                        super::telemetry::track_session_event(
+                            "reattach_open_failed",
+                            Some(telemetry_message.as_str()),
+                        )
+                        .await;
+                    });
+                    app.launch_failed(message);
                     None
                 }
             }
@@ -876,6 +914,11 @@ fn handle_message(
             session_name,
             error,
         } => {
+            let telemetry_error = error.clone();
+            tokio::spawn(async move {
+                super::telemetry::track_session_event("kill_session", telemetry_error.as_deref())
+                    .await;
+            });
             app.session_killed(&session_name, error);
             // The list is the proof: refetch so the row goes, rather than
             // asserting it did.
@@ -943,7 +986,16 @@ fn open_session(
             app.reveal_environment(&prepared.environment_id)
         }
         Err(err) => {
-            app.launch_failed(format!("couldn't open the session: {err}"));
+            let message = format!("couldn't open the session: {err}");
+            let telemetry_message = message.clone();
+            tokio::spawn(async move {
+                super::telemetry::track_session_event(
+                    "launch_open_failed",
+                    Some(telemetry_message.as_str()),
+                )
+                .await;
+            });
+            app.launch_failed(message);
             None
         }
     }
@@ -1258,12 +1310,19 @@ async fn close_and_sleep(app: &mut App, index: usize, client: &reqwest::Client, 
     session.detach();
     drop(session);
 
-    let _ = post_graphql::<mutations::CloudAgentSleep, _>(
+    let result = post_graphql::<mutations::CloudAgentSleep, _>(
         client,
         backboard.to_string(),
         mutations::cloud_agent_sleep::Variables { id: agent_id },
     )
     .await;
+    // Worth its own event, not just a silent `let _ =`: a failure here is an
+    // agent left running and billing compute with nothing attached to it —
+    // exactly the case sleep-on-quit exists to prevent.
+    if let Err(err) = result {
+        let message = format!("{err:#}");
+        super::telemetry::track_session_event("quit_sleep_failed", Some(message.as_str())).await;
+    }
 }
 
 /// Keep the emulator the same shape as the pane it is drawn into — done after a

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1686,6 +1686,29 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
     let mut prefs = AgentPrefs::load_in(&home).unwrap_or_default();
     let agent = resolve_agent_choice(args, &mut prefs, &home)?;
 
+    // Timed and reported separately from `prepare_inner` so every caller
+    // (`railway code`, `railway ca start`, and the TUI's `start_launch`) gets
+    // the same outcome event without duplicating it at each call site — none
+    // of the three otherwise see the others' launch attempts at all.
+    let start = std::time::Instant::now();
+    let result = prepare_inner(args, progress, agent, prefs, &home).await;
+    crate::commands::cloud_agent::telemetry::track_launch_outcome(
+        agent.name(),
+        result.as_ref().ok().map(|p| p.created),
+        start.elapsed(),
+        result.as_ref().err().map(|e| format!("{e:#}")).as_deref(),
+    )
+    .await;
+    result
+}
+
+async fn prepare_inner(
+    args: &LaunchArgs,
+    progress: &dyn Progress,
+    agent: Agent,
+    mut prefs: AgentPrefs,
+    home: &Path,
+) -> Result<Prepared> {
     // --- Resolve the local credential (client-side only, announced).
     //
     // Only the cheap sources run here. Codex and Grok read a local file, so a
@@ -1712,7 +1735,7 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
     // Pack the user's skills before spending a VM: a skills directory that has
     // grown into something unshippable should fail here, not after a create.
     // The upload itself is decided later, against the hash the agent reports.
-    let packed_skills = skills_sync::pack(&prefs, &home)?;
+    let packed_skills = skills_sync::pack(&prefs, home)?;
     if let Some(packed) = &packed_skills {
         progress.note(&format!(
             "Including {} of your skills ({})",
@@ -1725,7 +1748,7 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let (project_id, environment_id) =
-        resolve_target(&mut configs, &client, args, &mut prefs, &home).await?;
+        resolve_target(&mut configs, &client, args, &mut prefs, home).await?;
 
     let (cloud_agent, created) =
         resolve_agent(&mut configs, &client, args, &environment_id, progress).await?;

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -9,6 +9,7 @@ use crate::client::{GQLClient, post_graphql};
 use crate::commands::cloud_agent::prefs::{AgentPrefs, DefaultProject};
 use crate::commands::cloud_agent::skills_sync;
 use crate::commands::sandbox::{resolve_project_and_env, variables_to_input};
+use crate::commands::ssh::tel as ssh_tel;
 use crate::commands::ssh::{
     ensure_ssh_key_quiet, run_native_ssh_captured, run_native_ssh_with_opts,
 };
@@ -1682,15 +1683,31 @@ pub async fn sleep_agent(
 /// mint — see [`ensure_claude_credential_cached`], which a TUI caller runs
 /// before it takes the screen.
 pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepared> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to get home directory"))?;
-    let mut prefs = AgentPrefs::load_in(&home).unwrap_or_default();
-    let agent = resolve_agent_choice(args, &mut prefs, &home)?;
-
     // Timed and reported separately from `prepare_inner` so every caller
     // (`railway code`, `railway ca start`, and the TUI's `start_launch`) gets
     // the same outcome event without duplicating it at each call site — none
-    // of the three otherwise see the others' launch attempts at all.
+    // of the three otherwise see the others' launch attempts at all. Started
+    // before the harness is even resolved so a bad `--codex --claude`
+    // combination or a non-interactive run with no default agent — a real
+    // failure someone hits — still reports, rather than silently dropping
+    // out of the funnel before there's a harness to tag it with.
     let start = std::time::Instant::now();
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to get home directory"))?;
+    let mut prefs = AgentPrefs::load_in(&home).unwrap_or_default();
+    let agent = match resolve_agent_choice(args, &mut prefs, &home) {
+        Ok(agent) => agent,
+        Err(err) => {
+            crate::commands::cloud_agent::telemetry::track_launch_outcome(
+                "unresolved",
+                None,
+                start.elapsed(),
+                Some(&format!("{err:#}")),
+            )
+            .await;
+            return Err(err);
+        }
+    };
+
     let result = prepare_inner(args, progress, agent, prefs, &home).await;
     crate::commands::cloud_agent::telemetry::track_launch_outcome(
         agent.name(),
@@ -1717,14 +1734,23 @@ async fn prepare_inner(
     // already holds a credential from a previous run — see `PendingAuth`.
     let pending = match agent {
         Agent::Codex => {
-            let (line, source) = codex_credentials()?;
+            let (line, source) =
+                ssh_tel::track_for("cloud_agent_launch", "credential", codex_credentials()).await?;
             PendingAuth::Ready { line, source }
         }
         Agent::Grok => {
-            let (line, source) = grok_credentials()?;
+            let (line, source) =
+                ssh_tel::track_for("cloud_agent_launch", "credential", grok_credentials()).await?;
             PendingAuth::Ready { line, source }
         }
-        Agent::Claude => claude_credentials_cheap()?,
+        Agent::Claude => {
+            ssh_tel::track_for(
+                "cloud_agent_launch",
+                "credential",
+                claude_credentials_cheap(),
+            )
+            .await?
+        }
     };
     if let PendingAuth::Ready { ref source, .. } = pending {
         progress.note(&format!(
@@ -1735,7 +1761,12 @@ async fn prepare_inner(
     // Pack the user's skills before spending a VM: a skills directory that has
     // grown into something unshippable should fail here, not after a create.
     // The upload itself is decided later, against the hash the agent reports.
-    let packed_skills = skills_sync::pack(&prefs, home)?;
+    let packed_skills = ssh_tel::track_for(
+        "cloud_agent_launch",
+        "skills_pack",
+        skills_sync::pack(&prefs, home),
+    )
+    .await?;
     if let Some(packed) = &packed_skills {
         progress.note(&format!(
             "Including {} of your skills ({})",
@@ -1747,20 +1778,33 @@ async fn prepare_inner(
     // --- Resolve where the agent lives.
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let (project_id, environment_id) =
-        resolve_target(&mut configs, &client, args, &mut prefs, home).await?;
+    let (project_id, environment_id) = ssh_tel::track_for(
+        "cloud_agent_launch",
+        "resolve_target",
+        resolve_target(&mut configs, &client, args, &mut prefs, home).await,
+    )
+    .await?;
 
-    let (cloud_agent, created) =
-        resolve_agent(&mut configs, &client, args, &environment_id, progress).await?;
+    let (cloud_agent, created) = ssh_tel::track_for(
+        "cloud_agent_launch",
+        "resolve_agent",
+        resolve_agent(&mut configs, &client, args, &environment_id, progress).await,
+    )
+    .await?;
     configs.set_code_agent(&environment_id, &cloud_agent.id);
     configs.write()?;
 
-    let identity = ensure_ssh_key_quiet(&client, &configs).await?;
+    let identity = ssh_tel::track_for(
+        "cloud_agent_launch",
+        "ssh_key",
+        ensure_ssh_key_quiet(&client, &configs).await,
+    )
+    .await?;
     // The relay's cloud-agent grammar; by id rather than name because names are
     // not unique within an environment.
     let target = format!("agent:{environment_id}:{}", cloud_agent.id);
 
-    let relay = relay_ssh()?;
+    let relay = ssh_tel::track_for("cloud_agent_launch", "relay", relay_ssh()).await?;
 
     // --- Deferred Claude mint. A setup-token lasts a year and the agent's disk
     // survives sleep, so a reused agent is normally still authenticated; minting
@@ -1771,23 +1815,36 @@ async fn prepare_inner(
         PendingAuth::MintClaude => {
             // A fresh agent has nothing to inherit, and --refresh-auth is an
             // explicit request to replace whatever is there; neither needs a probe.
-            let inherit = !created
-                && !args.refresh_auth
-                && String::from_utf8_lossy(&ssh_plumbing(
-                    &target,
-                    CLAUDE_CREDENTIAL_PROBE,
-                    identity.as_deref(),
-                    None,
-                    &relay,
-                )?)
-                .contains("CRED-PRESENT");
+            let needs_probe = !created && !args.refresh_auth;
+            let inherit = if needs_probe {
+                let probe = ssh_tel::track_for(
+                    "cloud_agent_launch",
+                    "claude_probe",
+                    ssh_plumbing(
+                        &target,
+                        CLAUDE_CREDENTIAL_PROBE,
+                        identity.as_deref(),
+                        None,
+                        &relay,
+                    ),
+                )
+                .await?;
+                String::from_utf8_lossy(&probe).contains("CRED-PRESENT")
+            } else {
+                false
+            };
             if inherit {
                 progress.note(
                     "Reusing the Claude credential already on this agent (--refresh-auth to replace it)",
                 );
                 None
             } else {
-                let (line, source) = mint_claude_credentials()?;
+                let (line, source) = ssh_tel::track_for(
+                    "cloud_agent_launch",
+                    "claude_mint",
+                    mint_claude_credentials(),
+                )
+                .await?;
                 progress.note(&format!(
                     "Using your Claude Code credential ({source}) on the agent"
                 ));
@@ -1872,7 +1929,7 @@ async fn prepare_inner(
         }
         result
     };
-    provision?;
+    ssh_tel::track_for("cloud_agent_launch", "provision", provision).await?;
 
     let env_prefix = format!(
         "{HARNESS_PATH}; [ -f ~/.gh-token ] && export GH_TOKEN=\"$(cat ~/.gh-token)\"; [ -f ~/.claude-code-env ] && set -a && . ~/.claude-code-env && set +a; "

--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -2015,14 +2015,10 @@ impl ServerHandler for RailwayMcp {
             tool_name,
             duration_ms,
             result.is_ok(),
-            result.as_ref().err().map(|e| {
-                let msg = format!("{e}");
-                if msg.len() > 256 {
-                    msg[..256].to_string()
-                } else {
-                    msg
-                }
-            }),
+            result
+                .as_ref()
+                .err()
+                .map(|e| telemetry::truncate_message(&format!("{e}"))),
             mcp_client,
         )
         .await;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -148,15 +148,10 @@ async fn agent_setup(args: AgentArgs) -> Result<()> {
             Ok(())
         }
         Err(err) => {
-            let message = err.to_string();
             telemetry::send_setup_agent(SetupAgentTrackEvent {
                 phase: SetupAgentPhase::Finish,
                 success: Some(false),
-                error_message: Some(if message.len() > 256 {
-                    message[..256].to_string()
-                } else {
-                    message
-                }),
+                error_message: Some(telemetry::truncate_message(&err.to_string())),
                 configured_clients: None,
             })
             .await;

--- a/src/commands/ssh/tel.rs
+++ b/src/commands/ssh/tel.rs
@@ -15,10 +15,7 @@ pub async fn report_failure(stage: &str, message: &str) {
 /// SSH-backed commands (e.g. `sandbox ssh`) land in the same stage-failure
 /// dashboards with their own command tag.
 pub async fn report_failure_for(command: &str, stage: &str, message: &str) {
-    let mut truncated = message.to_string();
-    if truncated.len() > 256 {
-        truncated.truncate(256);
-    }
+    let truncated = telemetry::truncate_message(message);
 
     telemetry::send(CliTrackEvent {
         command: command.to_string(),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -93,10 +93,10 @@ macro_rules! commands {
                                 command: command_name.to_string(),
                                 sub_command: subcommand_name,
                                 success: result.is_ok(),
-                                error_message: result.as_ref().err().map(|e| {
-                                    let msg = format!("{e}");
-                                    if msg.len() > 256 { msg[..256].to_string() } else { msg }
-                                }),
+                                error_message: result
+                                    .as_ref()
+                                    .err()
+                                    .map(|e| $crate::telemetry::truncate_message(&format!("{e}"))),
                                 duration_ms: duration.as_millis() as u64,
                                 cli_version: env!("CARGO_PKG_VERSION"),
                                 os: ::std::env::consts::OS,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -153,6 +153,30 @@ fn env_var_is_truthy(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Cap an error message at 256 bytes for the `error_message` field, shared by
+/// every call site that truncates a `{err}`/`{err:#}` string before sending
+/// it (the generic dispatch event, `commands/ssh/tel.rs`,
+/// `commands/cloud_agent/telemetry.rs`).
+///
+/// A raw byte-length check (`s.len() > 256`) followed by slicing or
+/// `String::truncate` panics whenever the cut point lands mid-character —
+/// any error message with a non-ASCII byte near the boundary (a path with an
+/// accented/CJK/emoji character, a non-English GraphQL error) — and this
+/// crate builds with `panic = "abort"`, so that panic takes down the whole
+/// process instead of just failing to log. Walking back to the nearest char
+/// boundary first avoids that.
+pub(crate) fn truncate_message(message: &str) -> String {
+    const MAX_LEN: usize = 256;
+    if message.len() <= MAX_LEN {
+        return message.to_string();
+    }
+    let mut end = MAX_LEN;
+    while !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    message[..end].to_string()
+}
+
 fn safe_telemetry_value(value: &str) -> Option<String> {
     if value.is_empty() || value.len() > 256 {
         return None;
@@ -2139,9 +2163,32 @@ mod tests {
     use super::{
         ProcessNode, STRONG_AGENT_ENV, agent_ancestor_pid, agent_from_strong_env,
         caller_from_mcp_client_name, caller_from_process_name, is_agent_caller, is_agent_harness,
-        new_session_uuid, parent_kind_from_command, residue_from_command, walk_ancestors,
+        new_session_uuid, parent_kind_from_command, residue_from_command, truncate_message,
+        walk_ancestors,
     };
     use std::collections::HashMap;
+
+    #[test]
+    fn truncate_message_leaves_short_messages_alone() {
+        assert_eq!(truncate_message("boom"), "boom");
+    }
+
+    #[test]
+    fn truncate_message_caps_long_ascii_messages() {
+        let long = "x".repeat(300);
+        assert_eq!(truncate_message(&long).len(), 256);
+    }
+
+    /// Regression test for the panic this function exists to avoid: a raw
+    /// byte-length cut (`s[..256]` or `String::truncate(256)`) panics here
+    /// because a multi-byte character straddles the 256-byte boundary.
+    #[test]
+    fn truncate_message_does_not_split_a_multibyte_character() {
+        let long = "x".repeat(255) + "💥" + &"y".repeat(50);
+        let truncated = truncate_message(&long);
+        assert!(truncated.len() <= 256);
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
 
     fn node(ppid: u32, command: &str) -> ProcessNode {
         ProcessNode {


### PR DESCRIPTION
## Summary

`railway ca` had essentially no bespoke telemetry. The only signal was the generic per-dispatch event the `commands!` macro fires for every top-level command (`command="cloud_agent"`, `sub_command` in `{None, "setup", "start"}`, `success` = the top-level `Result`).

That's close to useless for the most common path: bare `railway ca` runs a TUI event loop that swallows internal errors (SSH attach failures, credential-mint failures, launch failures) into toast text and keeps looping, so `command()` almost never returns `Err` — every bare `railway ca` invocation reported `success: true` regardless of what actually happened. There was also no visibility into which agent got launched, whether a VM was created vs. reused, agent lifecycle actions (sleep/wake/delete), session reattach/kill, or setup/wizard choices.

This adds a small `commands/cloud_agent/telemetry.rs` module and wires it in at the natural convergence points, following the CLI's existing conventions (additive `CliTrackEvent` detail events, same shape as the per-tool MCP and per-stage SSH events in `commands/ssh/tel.rs` and `commands/service.rs`'s `track_service_source`). No new GraphQL mutations — everything reuses the existing `cliEventTrack` event, already gated by `DO_NOT_TRACK` / `RAILWAY_NO_TELEMETRY` / the local telemetry preference.

- **Launch outcome** (`cloud_agent_launch`): harness, created-vs-reused, real duration, fired from inside `code::prepare()` itself — so it fires for `railway code`, `railway ca start`, and the TUI's `start_launch` alike, and survives the TUI catching the error afterward.
- **Agent lifecycle ops**: sleep/wake/delete from the manage screen.
- **Session events**: reattach (connect + open), kill, opening a freshly prepared session, and the auto-sleep-on-quit whose result was previously discarded with `let _ =` (a failure there means an agent is left running and billing compute unattended).
- **Setup/wizard**: one flat event per choice (agent/theme/project/skills) on save, from both `railway ca setup` and the TUI's first-run wizard.

No user-visible behavior changes; no free text is ever logged (no prompts, no session/agent/project names — only IDs, fixed slugs, and truncated error messages).

## Test plan
- [x] `cargo build`
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets` — no new warnings in changed files
- [x] `cargo test --bin railway` — 945 passed; the 3 `auth_sim` failures are pre-existing on `master` too, unrelated to this change
- [ ] Manual smoke test against a real account (launch, reattach, sleep/wake/delete, quit with a session open, `ca setup`) to confirm events post with the expected `command`/`sub_command`/`success`