### PR TITLE
feat(ca): flat lifecycle commands — list, create, ssh, wake, sleep, delete

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -444,8 +444,12 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
     let result = ca::sleep(client, &backboard, &agent.id).await;
     spinner.finish_and_clear();
     result?;
+    // Present tense, not "is asleep": the mutation returns before the agent has
+    // finished transitioning, so a `railway ca list` run straight afterwards
+    // still reports it running. Claiming a state the next command contradicts is
+    // worse than describing the action taken.
     println!(
-        "✓ Agent {} is asleep — its disk is kept, compute is not billed.",
+        "✓ Sleeping agent {} — its disk is kept, compute stops billing.",
         agent.name.cyan()
     );
     Ok(())
@@ -509,8 +513,8 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
     // Never creates. The caller named a machine — or has exactly one — and
     // silently minting a second billed VM because a name was mistyped is not a
     // thing a connect command should be able to do.
-    let spinner = (!matches!(agent.status, ca::Status::Running))
-        .then(|| create_spinner(format!("Waking agent {}", agent.name)));
+    let was_running = matches!(agent.status, ca::Status::Running);
+    let spinner = (!was_running).then(|| create_spinner(format!("Waking agent {}", agent.name)));
     let ready = ca::ensure_running(client, &backboard, &agent).await;
     if let Some(spinner) = spinner {
         spinner.finish_and_clear();
@@ -518,10 +522,25 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
     let agent = ready?;
     ca::remember(configs, &agent)?;
 
-    let exit_code = if !args.command.is_empty() {
-        run_command(&agent, &args.command).await?
+    let connected = if !args.command.is_empty() {
+        run_command(&agent, &args.command).await
     } else {
-        attach(client, &backboard, &agent, args.session.as_deref()).await?
+        attach(client, &backboard, &agent, args.session.as_deref()).await
+    };
+
+    // A connection that never happened still woke a machine with no idle
+    // timeout, so put back what this run changed — but only that. An agent
+    // found already running was someone's deliberate state (possibly a session
+    // open in another terminal), and a failed connect here is no reason to
+    // suspend it.
+    let exit_code = match connected {
+        Ok(code) => code,
+        Err(e) => {
+            if !was_running && !args.keep_awake {
+                let _ = ca::sleep(client, &backboard, &agent.id).await;
+            }
+            return Err(e);
+        }
     };
 
     if args.keep_awake {
@@ -535,7 +554,7 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
         let slept = ca::sleep(client, &backboard, &agent.id).await;
         spinner.finish_and_clear();
         match slept {
-            Ok(()) => println!("\nDisconnected — agent {} is asleep.", agent.name.cyan()),
+            Ok(()) => println!("\nDisconnected — sleeping agent {}.", agent.name.cyan()),
             Err(e) => eprintln!(
                 "{}",
                 format!(

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -7,6 +7,7 @@
 //! billed VM.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use anyhow::{Result, bail};
 use clap::Parser;
@@ -14,6 +15,7 @@ use colored::Colorize;
 use is_terminal::IsTerminal;
 
 use crate::client::GQLClient;
+use crate::commands::cloud_agent::telemetry;
 use crate::commands::cloud_agent::tui::session;
 use crate::commands::code::{self, LaunchArgs, Progress};
 use crate::commands::sandbox::{resolve_project_and_env, variables_to_input};
@@ -411,6 +413,7 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
             println!("No running agents to sleep.");
             return Ok(());
         }
+        telemetry::track_lifecycle("sleep_all", Duration::ZERO, None).await;
         let spinner = create_spinner(format!("Sleeping {} agents", awake.len()));
         // Concurrently: each sleep now flushes the agent's disk over ssh first,
         // and run in sequence that would make the cost-control command take a
@@ -511,6 +514,22 @@ pub async fn delete(args: DeleteArgs) -> Result<()> {
 }
 
 pub async fn ssh(args: SshArgs) -> Result<()> {
+    let started = std::time::Instant::now();
+    let result = ssh_connect(args).await;
+    let message = result.as_ref().err().map(|e| format!("{e:#}"));
+    telemetry::track_lifecycle("ssh", started.elapsed(), message.as_deref()).await;
+
+    // A non-zero remote exit is the command's result, not a failure of ours, so
+    // it is reported as a success above and only then propagated as our own exit
+    // status — `exit` never returns, and reporting after it would never happen.
+    match result? {
+        0 => Ok(()),
+        code => std::process::exit(code),
+    }
+}
+
+/// Connect, and hand back what the remote side exited with.
+async fn ssh_connect(args: SshArgs) -> Result<i32> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let (configs, client) = (&mut configs, &client);
@@ -533,6 +552,7 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
     ca::remember(configs, &agent)?;
 
     let connected = if !args.command.is_empty() {
+        telemetry::track_lifecycle("ssh_command", Duration::ZERO, None).await;
         run_command(&agent, &args.command).await
     } else {
         attach(client, &backboard, &agent, args.session.as_deref()).await
@@ -576,10 +596,7 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
         }
     }
 
-    if exit_code != 0 {
-        std::process::exit(exit_code);
-    }
-    Ok(())
+    Ok(exit_code)
 }
 
 /// Run one command on the agent instead of attaching. This is ssh's ordinary
@@ -629,7 +646,10 @@ async fn attach(
             name.to_string()
         }
         None => match running.len() {
-            0 => return start_session(agent).await,
+            0 => {
+                telemetry::track_lifecycle("ssh_new_session", Duration::ZERO, None).await;
+                return start_session(agent).await;
+            }
             1 => running[0].name.clone(),
             _ => bail!(
                 "Agent {} has {} running sessions. Pick one with --session:{}",
@@ -640,6 +660,7 @@ async fn attach(
         },
     };
 
+    telemetry::track_lifecycle("ssh_attach", Duration::ZERO, None).await;
     println!(
         "{}",
         format!("Attaching to {} · {}", agent.name, session_name).dimmed()

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -412,12 +412,22 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
             return Ok(());
         }
         let spinner = create_spinner(format!("Sleeping {} agents", awake.len()));
-        let mut failed = Vec::new();
-        for agent in &awake {
-            if let Err(e) = ca::sleep(client, &backboard, &agent.id).await {
-                failed.push(format!("  {} — {e}", agent.name));
+        // Concurrently: each sleep now flushes the agent's disk over ssh first,
+        // and run in sequence that would make the cost-control command take a
+        // second per agent — slow enough that people stop reaching for it.
+        let failed: Vec<String> = futures::future::join_all(awake.iter().map(|agent| {
+            let backboard = backboard.clone();
+            async move {
+                ca::sleep(client, &backboard, &agent.environment_id, &agent.id)
+                    .await
+                    .err()
+                    .map(|e| format!("  {} — {e}", agent.name))
             }
-        }
+        }))
+        .await
+        .into_iter()
+        .flatten()
+        .collect();
         spinner.finish_and_clear();
         println!("✓ Slept {} agents.", awake.len() - failed.len());
         if !failed.is_empty() {
@@ -441,7 +451,7 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
     }
 
     let spinner = create_spinner(format!("Sleeping agent {}", agent.name));
-    let result = ca::sleep(client, &backboard, &agent.id).await;
+    let result = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
     spinner.finish_and_clear();
     result?;
     // Present tense, not "is asleep": the mutation returns before the agent has
@@ -537,7 +547,7 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
         Ok(code) => code,
         Err(e) => {
             if !was_running && !args.keep_awake {
-                let _ = ca::sleep(client, &backboard, &agent.id).await;
+                let _ = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
             }
             return Err(e);
         }
@@ -551,7 +561,7 @@ pub async fn ssh(args: SshArgs) -> Result<()> {
     } else {
         // Agents have no idle timeout, so nothing else will ever do this.
         let spinner = create_spinner("Sleeping the agent".to_string());
-        let slept = ca::sleep(client, &backboard, &agent.id).await;
+        let slept = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
         spinner.finish_and_clear();
         match slept {
             Ok(()) => println!("\nDisconnected — sleeping agent {}.", agent.name.cyan()),

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -1,0 +1,763 @@
+//! The flat `railway ca` verbs: list, create, ssh, wake, sleep, delete.
+//!
+//! Each addresses an agent that already exists, by name or id. Only `create`
+//! makes one — `ssh` connects to what is there and errors otherwise, and
+//! `railway ca start` remains the create-and-launch path. That line is the
+//! point of the split: a mistyped agent name should be an error, not a second
+//! billed VM.
+
+use std::collections::HashMap;
+
+use anyhow::{Result, bail};
+use clap::Parser;
+use colored::Colorize;
+use is_terminal::IsTerminal;
+
+use crate::client::GQLClient;
+use crate::commands::cloud_agent::tui::session;
+use crate::commands::code::{self, LaunchArgs, Progress};
+use crate::commands::sandbox::{resolve_project_and_env, variables_to_input};
+use crate::commands::ssh::native;
+use crate::config::Configs;
+use crate::controllers::cloud_agent as ca;
+use crate::util::progress::create_spinner;
+use crate::util::prompt::prompt_confirm_with_default;
+
+/// Where to look. Flattened into each subcommand rather than made global on
+/// `railway ca`, whose own flattened launch flags already own `-p`/`-e`.
+#[derive(Parser)]
+pub struct TargetArgs {
+    /// Environment name or ID (defaults to the linked environment)
+    #[clap(long, short)]
+    environment: Option<String>,
+
+    /// Project ID (defaults to the linked project)
+    #[clap(long, short)]
+    project: Option<String>,
+}
+
+#[derive(Parser)]
+pub struct ListArgs {
+    /// Include agents belonging to other members of the environment. Requires
+    /// --environment, since "everyone's agents" is only a question about a
+    /// place
+    #[clap(long)]
+    all: bool,
+
+    /// Output as JSON
+    #[clap(long)]
+    json: bool,
+
+    #[clap(flatten)]
+    target: TargetArgs,
+}
+
+#[derive(Parser)]
+pub struct CreateArgs {
+    /// Name for the agent (defaults to a generated one)
+    #[clap(value_name = "NAME")]
+    name: Option<String>,
+
+    /// Set a variable on the agent (repeatable, comma-separable). Values may
+    /// reference other variables — `DB_URL=postgres.DATABASE_URL` or the full
+    /// `${{postgres.DATABASE_URL}}` form — resolved server-side at create time
+    #[clap(long = "variable", value_name = "KEY=VALUE[,KEY=VALUE...]")]
+    variables: Vec<String>,
+
+    /// Load variables from a .env file (repeatable). `--variable` flags
+    /// override file entries with the same key
+    #[clap(long = "env-file", value_name = "PATH")]
+    env_files: Vec<std::path::PathBuf>,
+
+    /// Return as soon as the agent is requested, without waiting for it to
+    /// finish booting
+    #[clap(long)]
+    no_wait: bool,
+
+    /// Output as JSON
+    #[clap(long)]
+    json: bool,
+
+    #[clap(flatten)]
+    target: TargetArgs,
+}
+
+#[derive(Parser)]
+pub struct WakeArgs {
+    /// Agent name or ID (defaults to this directory's, or your only one)
+    #[clap(value_name = "AGENT")]
+    agent: Option<String>,
+
+    /// Return as soon as the wake is requested, without waiting for the agent
+    /// to come up
+    #[clap(long)]
+    no_wait: bool,
+
+    #[clap(flatten)]
+    target: TargetArgs,
+}
+
+#[derive(Parser)]
+pub struct SleepArgs {
+    /// Agent name or ID (defaults to this directory's, or your only one)
+    #[clap(value_name = "AGENT")]
+    agent: Option<String>,
+
+    /// Sleep every running agent you own (narrowed by --environment when given)
+    #[clap(long, conflicts_with = "agent")]
+    all: bool,
+
+    #[clap(flatten)]
+    target: TargetArgs,
+}
+
+#[derive(Parser)]
+pub struct SshArgs {
+    /// Agent name or ID (defaults to this directory's, or your only one)
+    #[clap(value_name = "AGENT")]
+    agent: Option<String>,
+
+    /// Attach to this durable session by name, rather than the agent's only one
+    #[clap(long, value_name = "NAME")]
+    session: Option<String>,
+
+    /// Leave the agent running on disconnect instead of putting it to sleep.
+    /// A running agent keeps billing for compute
+    #[clap(long)]
+    keep_awake: bool,
+
+    #[clap(flatten)]
+    target: TargetArgs,
+
+    /// Run this command instead of attaching to a session (`-- bash` for a
+    /// plain shell)
+    #[clap(trailing_var_arg = true)]
+    command: Vec<String>,
+}
+
+#[derive(Parser)]
+pub struct DeleteArgs {
+    /// Agent name or ID (defaults to this directory's, or your only one)
+    #[clap(value_name = "AGENT")]
+    agent: Option<String>,
+
+    /// Skip the confirmation prompt
+    #[clap(long, short = 'y')]
+    yes: bool,
+
+    #[clap(flatten)]
+    target: TargetArgs,
+}
+
+/// Resolve the environment the caller narrowed to, if they narrowed at all.
+///
+/// Only runs when a flag was passed: the lifecycle verbs address agents by name
+/// across the whole account, so resolving an environment unprompted would add a
+/// request — and, in an unlinked directory, a picker — to commands that do not
+/// need one.
+async fn scope(
+    configs: &mut Configs,
+    client: &reqwest::Client,
+    project: Option<String>,
+    environment: Option<String>,
+) -> Result<Option<String>> {
+    if project.is_none() && environment.is_none() {
+        return Ok(None);
+    }
+    let (_, environment_id) =
+        resolve_project_and_env(configs, client, project, environment).await?;
+    Ok(Some(environment_id))
+}
+
+pub async fn list(args: ListArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
+    let scoped = scope(configs, client, project, environment).await?;
+    if args.all && scoped.is_none() {
+        bail!(
+            "--all lists everyone's agents in one environment. Add --environment (and --project if this directory isn't linked)."
+        );
+    }
+
+    let backboard = configs.get_backboard();
+    let mut agents = match &scoped {
+        Some(environment_id) => {
+            ca::list_in_environment(client, &backboard, environment_id, !args.all).await?
+        }
+        None => ca::list_mine(client, &backboard).await?,
+    };
+
+    if agents.is_empty() {
+        if args.json {
+            println!("[]");
+        } else if scoped.is_some() {
+            println!("No cloud agents in this environment.");
+        } else {
+            println!(
+                "No cloud agents. Create one with {}.",
+                "railway ca create".cyan()
+            );
+        }
+        return Ok(());
+    }
+
+    let names = place_names(client, configs).await;
+    agents.sort_by(|a, b| {
+        let place = |agent: &ca::Agent| names.get(&agent.project_id).cloned().unwrap_or_default();
+        place(a).cmp(&place(b)).then_with(|| a.name.cmp(&b.name))
+    });
+
+    if args.json {
+        let out: Vec<_> = agents
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "id": a.id,
+                    "name": a.name,
+                    "status": a.status.label(),
+                    "projectId": a.project_id,
+                    "project": names.get(&a.project_id),
+                    "environmentId": a.environment_id,
+                    "environment": names.get(&a.environment_id),
+                    "createdAt": a.created_at.to_rfc3339(),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    println!(
+        "  {:<24}  {:<9}  {:<22}  {:<14}  {}",
+        "NAME".dimmed(),
+        "STATUS".dimmed(),
+        "PROJECT".dimmed(),
+        "ENVIRONMENT".dimmed(),
+        "AGE".dimmed()
+    );
+    let mut marked = false;
+    for agent in &agents {
+        let current = configs.get_code_agent(&agent.environment_id).as_deref() == Some(&agent.id);
+        marked |= current;
+        let place = |id: &String| names.get(id).cloned().unwrap_or_else(|| truncate(id, 22));
+        println!(
+            "{} {:<24}  {:<9}  {:<22}  {:<14}  {}",
+            if current { "*" } else { " " },
+            truncate(&agent.name, 24),
+            colorize_status(&agent.status),
+            truncate(&place(&agent.project_id), 22),
+            truncate(&place(&agent.environment_id), 14),
+            ca::humanize_age(agent.created_at)
+        );
+    }
+    if marked {
+        println!("\n{}", "* this directory's agent".dimmed());
+    }
+    Ok(())
+}
+
+pub async fn create(args: CreateArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
+    let (_, environment_id) =
+        resolve_project_and_env(configs, client, project, environment).await?;
+    let variables = variables_to_input(&args.env_files, &args.variables)?
+        .map(serde_json::to_value)
+        .transpose()?;
+
+    let backboard = configs.get_backboard();
+    let spinner = (!args.json).then(|| create_spinner("Creating a cloud agent".to_string()));
+    let agent = match ca::create(
+        client,
+        &backboard,
+        &environment_id,
+        args.name.clone(),
+        variables,
+    )
+    .await
+    {
+        Ok(agent) => agent,
+        Err(e) => {
+            if let Some(spinner) = spinner {
+                spinner.finish_and_clear();
+            }
+            return Err(e);
+        }
+    };
+
+    // Remembered before the box is up: a create that succeeds and then times
+    // out waiting has still spent a VM, and the pointer is the only handle the
+    // next command has on it.
+    ca::remember(configs, &agent)?;
+
+    let agent = if args.no_wait {
+        agent
+    } else {
+        match ca::wait_until_running(client, &backboard, &environment_id, &agent.id).await {
+            Ok(running) => running,
+            Err(e) => {
+                if let Some(spinner) = spinner {
+                    spinner.finish_and_clear();
+                }
+                return Err(e);
+            }
+        }
+    };
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": agent.id,
+                "name": agent.name,
+                "status": agent.status.label(),
+                "projectId": agent.project_id,
+                "environmentId": agent.environment_id,
+                "createdAt": agent.created_at.to_rfc3339(),
+            }))?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "✓ Created agent {} ({})",
+        agent.name.cyan(),
+        agent.status.label()
+    );
+    println!(
+        "\nIt has no coding agent on it yet — {} installs one and drops you in.",
+        format!("railway ca ssh {}", agent.name).cyan()
+    );
+    println!(
+        "{}",
+        format!(
+            "Agents have no idle timeout: `railway ca sleep {}` stops the compute bill, `railway ca delete {}` takes the disk with it.",
+            agent.name, agent.name
+        )
+        .dimmed()
+    );
+    Ok(())
+}
+
+pub async fn wake(args: WakeArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
+    let scoped = scope(configs, client, project, environment).await?;
+    let (agent, _) = ca::resolve(configs, client, args.agent.as_deref(), scoped.as_deref()).await?;
+    let backboard = configs.get_backboard();
+
+    match agent.status {
+        ca::Status::Running => {
+            println!("Agent {} is already awake.", agent.name.cyan());
+            ca::remember(configs, &agent)?;
+            return Ok(());
+        }
+        ca::Status::Sleeping => ca::wake(client, &backboard, &agent.id).await?,
+        // Something else is already booting it; a second wake would be noise.
+        ca::Status::Starting => {}
+        _ => bail!(
+            "Agent {} is {} and cannot be woken.",
+            agent.name,
+            agent.status.label()
+        ),
+    }
+    ca::remember(configs, &agent)?;
+
+    if args.no_wait {
+        println!("Waking agent {}…", agent.name.cyan());
+        return Ok(());
+    }
+
+    let spinner = create_spinner(format!("Waking agent {}", agent.name));
+    let result = ca::wait_until_running(client, &backboard, &agent.environment_id, &agent.id).await;
+    spinner.finish_and_clear();
+    result?;
+    println!(
+        "✓ Agent {} is running — your work is on its disk.",
+        agent.name.cyan()
+    );
+    Ok(())
+}
+
+pub async fn sleep(args: SleepArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
+    let scoped = scope(configs, client, project, environment).await?;
+    let backboard = configs.get_backboard();
+
+    if args.all {
+        let agents = match &scoped {
+            Some(environment_id) => {
+                ca::list_in_environment(client, &backboard, environment_id, true).await?
+            }
+            None => ca::list_mine(client, &backboard).await?,
+        };
+        let awake: Vec<_> = agents
+            .into_iter()
+            .filter(|a| matches!(a.status, ca::Status::Running | ca::Status::Starting))
+            .collect();
+        if awake.is_empty() {
+            println!("No running agents to sleep.");
+            return Ok(());
+        }
+        let spinner = create_spinner(format!("Sleeping {} agents", awake.len()));
+        let mut failed = Vec::new();
+        for agent in &awake {
+            if let Err(e) = ca::sleep(client, &backboard, &agent.id).await {
+                failed.push(format!("  {} — {e}", agent.name));
+            }
+        }
+        spinner.finish_and_clear();
+        println!("✓ Slept {} agents.", awake.len() - failed.len());
+        if !failed.is_empty() {
+            bail!("Some agents are still running:\n{}", failed.join("\n"));
+        }
+        return Ok(());
+    }
+
+    let (agent, _) = ca::resolve(configs, client, args.agent.as_deref(), scoped.as_deref()).await?;
+    match agent.status {
+        ca::Status::Sleeping => {
+            println!("Agent {} is already asleep.", agent.name.cyan());
+            return Ok(());
+        }
+        ca::Status::Running | ca::Status::Starting => {}
+        _ => bail!(
+            "Agent {} is {} — there is nothing running to sleep.",
+            agent.name,
+            agent.status.label()
+        ),
+    }
+
+    let spinner = create_spinner(format!("Sleeping agent {}", agent.name));
+    let result = ca::sleep(client, &backboard, &agent.id).await;
+    spinner.finish_and_clear();
+    result?;
+    println!(
+        "✓ Agent {} is asleep — its disk is kept, compute is not billed.",
+        agent.name.cyan()
+    );
+    Ok(())
+}
+
+pub async fn delete(args: DeleteArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
+    let scoped = scope(configs, client, project, environment).await?;
+    let (agent, _) = ca::resolve(configs, client, args.agent.as_deref(), scoped.as_deref()).await?;
+
+    if !args.yes {
+        // Deleting takes the disk with it, and there is no undo. A pipe cannot
+        // answer the prompt, so it is told what to pass instead of hanging on a
+        // read nobody will satisfy.
+        if !(std::io::stdin().is_terminal() && std::io::stdout().is_terminal()) {
+            bail!(
+                "Refusing to delete agent {} without confirmation. Pass --yes.",
+                agent.name
+            );
+        }
+        let confirmed = prompt_confirm_with_default(
+            &format!(
+                "Delete agent {} and everything on its disk?",
+                agent.name.cyan()
+            ),
+            false,
+        )?;
+        if !confirmed {
+            println!("Left agent {} alone.", agent.name);
+            return Ok(());
+        }
+    }
+
+    let backboard = configs.get_backboard();
+    let spinner = create_spinner(format!("Deleting agent {}", agent.name));
+    let result = ca::delete(client, &backboard, &agent.id).await;
+    spinner.finish_and_clear();
+
+    // Forget the pointer whether or not the mutation reported success: a delete
+    // that fails on an already-gone agent must not leave the CLI reaching for
+    // it forever.
+    ca::forget(configs, &agent.environment_id)?;
+    result?;
+    println!("✓ Deleted agent {}", agent.name.cyan());
+    Ok(())
+}
+
+pub async fn ssh(args: SshArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
+
+    let scoped = scope(configs, client, project, environment).await?;
+    let (agent, _) = ca::resolve(configs, client, args.agent.as_deref(), scoped.as_deref()).await?;
+    let backboard = configs.get_backboard();
+
+    // Never creates. The caller named a machine — or has exactly one — and
+    // silently minting a second billed VM because a name was mistyped is not a
+    // thing a connect command should be able to do.
+    let spinner = (!matches!(agent.status, ca::Status::Running))
+        .then(|| create_spinner(format!("Waking agent {}", agent.name)));
+    let ready = ca::ensure_running(client, &backboard, &agent).await;
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+    let agent = ready?;
+    ca::remember(configs, &agent)?;
+
+    let exit_code = if !args.command.is_empty() {
+        run_command(&agent, &args.command).await?
+    } else {
+        attach(client, &backboard, &agent, args.session.as_deref()).await?
+    };
+
+    if args.keep_awake {
+        println!(
+            "\nDisconnected — agent {} is still running (--keep-awake).",
+            agent.name.cyan()
+        );
+    } else {
+        // Agents have no idle timeout, so nothing else will ever do this.
+        let spinner = create_spinner("Sleeping the agent".to_string());
+        let slept = ca::sleep(client, &backboard, &agent.id).await;
+        spinner.finish_and_clear();
+        match slept {
+            Ok(()) => println!("\nDisconnected — agent {} is asleep.", agent.name.cyan()),
+            Err(e) => eprintln!(
+                "{}",
+                format!(
+                    "Agent {} is still running and billing compute. `railway ca sleep {}` to stop it. ({e})",
+                    agent.name, agent.name
+                )
+                .yellow()
+            ),
+        }
+    }
+
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+/// Run one command on the agent instead of attaching. This is ssh's ordinary
+/// trailing-command behaviour, and `railway ca ssh -- bash` is how you get a
+/// plain shell on a box whose default is a coding agent.
+async fn run_command(agent: &ca::Agent, command: &[String]) -> Result<i32> {
+    let info = code::connect_info(&agent.environment_id, &agent.id).await?;
+    let command = command.to_vec();
+    let code = tokio::task::spawn_blocking(move || {
+        native::run_native_ssh_with_opts(
+            &info.ssh_target,
+            Some(&command),
+            info.identity.as_deref(),
+            None,
+            &info.relay_opts,
+        )
+    })
+    .await??;
+    native::clear_mouse_tracking();
+    Ok(code)
+}
+
+/// Attach to a durable session, or start one when the agent has none.
+///
+/// Attaching deliberately skips provisioning: the credential, the skills and
+/// the harness were settled when the session was started, and walking that
+/// pipeline again to arrive at a box that was ready the whole time is the
+/// difference between a reattach that is instant and one that is not.
+async fn attach(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent: &ca::Agent,
+    requested: Option<&str>,
+) -> Result<i32> {
+    let sessions = ca::list_sessions(client, backboard, &agent.id).await?;
+    let running: Vec<_> = sessions.into_iter().filter(|s| s.running).collect();
+
+    let session_name = match requested {
+        Some(name) => {
+            if !running.iter().any(|s| s.name == name) {
+                bail!(
+                    "Agent {} has no running session named {name:?}.{}",
+                    agent.name,
+                    describe_sessions(&running)
+                );
+            }
+            name.to_string()
+        }
+        None => match running.len() {
+            0 => return start_session(agent).await,
+            1 => running[0].name.clone(),
+            _ => bail!(
+                "Agent {} has {} running sessions. Pick one with --session:{}",
+                agent.name,
+                running.len(),
+                describe_sessions(&running)
+            ),
+        },
+    };
+
+    println!(
+        "{}",
+        format!("Attaching to {} · {}", agent.name, session_name).dimmed()
+    );
+    let info = code::connect_info(&agent.environment_id, &agent.id).await?;
+    let code = tokio::task::spawn_blocking(move || {
+        native::run_native_ssh_with_opts(
+            &info.ssh_target,
+            None,
+            info.identity.as_deref(),
+            Some(native::DurableResume {
+                session_name: &session_name,
+                resume_from_last_read: false,
+            }),
+            &info.relay_opts,
+        )
+    })
+    .await??;
+    native::clear_mouse_tracking();
+    Ok(code)
+}
+
+/// Start the agent's first session: install and configure the harness, then run
+/// it under a *named* durable session so the platform tracks it, it survives
+/// this ssh dying, and the next `railway ca ssh` reattaches instead of starting
+/// a second copy.
+async fn start_session(agent: &ca::Agent) -> Result<i32> {
+    let harness = code::default_harness()?;
+    let launch = LaunchArgs::for_target(
+        agent.project_id.clone(),
+        agent.environment_id.clone(),
+        harness,
+        false,
+        None,
+        Some(agent.id.clone()),
+    );
+
+    println!(
+        "{}",
+        format!("No session on {} yet — starting {harness}.", agent.name).dimmed()
+    );
+    let progress = code::CliProgress::default();
+    let prepared = code::prepare(&launch, &progress).await?;
+    progress.finish();
+
+    let session_name = session::durable_name(prepared.harness);
+    let remote = vec![prepared.remote_cmd.clone()];
+    let target = prepared.ssh_target.clone();
+    let identity = prepared.identity.clone();
+    let opts = prepared.relay_opts.clone();
+    let code = tokio::task::spawn_blocking(move || {
+        native::run_native_ssh_with_opts(
+            &target,
+            Some(&remote),
+            identity.as_deref(),
+            Some(native::DurableResume {
+                session_name: &session_name,
+                resume_from_last_read: false,
+            }),
+            &opts,
+        )
+    })
+    .await??;
+    native::clear_mouse_tracking();
+    Ok(code)
+}
+
+/// The running sessions, for an error that has to be actionable — the name is
+/// what `--session` takes, so the name is what this leads with.
+fn describe_sessions(sessions: &[ca::ConsoleSession]) -> String {
+    if sessions.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n");
+    for session in sessions {
+        out.push_str(&format!(
+            "  {}{}  {}\n",
+            session.name,
+            if session.attached { " (attached)" } else { "" },
+            session.command.dimmed()
+        ));
+    }
+    out
+}
+
+/// Project and environment names, keyed by id, for display.
+///
+/// Best-effort: the workspace listing is a second request, and a list that
+/// prints ids because it failed is better than a list that errors.
+async fn place_names(client: &reqwest::Client, configs: &Configs) -> HashMap<String, String> {
+    let mut names = HashMap::new();
+    let Ok(workspaces) = crate::workspace::workspaces_with_client(client, configs).await else {
+        return names;
+    };
+    for workspace in workspaces {
+        for project in workspace.projects() {
+            names.insert(project.id().to_string(), project.name().to_string());
+            for environment in project.environments() {
+                names.insert(environment.id, environment.name);
+            }
+        }
+    }
+    names
+}
+
+fn colorize_status(status: &ca::Status) -> colored::ColoredString {
+    let label = status.label();
+    match status {
+        ca::Status::Running => label.green(),
+        ca::Status::Sleeping => label.dimmed(),
+        ca::Status::Starting => label.yellow(),
+        _ => label.red(),
+    }
+}
+
+/// Keep a column a column. Padding with `{:<width$}` widens on long values,
+/// which turns one long project name into a table with no columns at all.
+fn truncate(value: &str, width: usize) -> String {
+    if value.chars().count() <= width {
+        return value.to_string();
+    }
+    let kept: String = value.chars().take(width.saturating_sub(1)).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_leaves_short_values_alone() {
+        assert_eq!(truncate("prod", 10), "prod");
+        assert_eq!(truncate("exactly-10", 10), "exactly-10");
+    }
+
+    #[test]
+    fn truncate_marks_elision_within_the_column() {
+        let out = truncate("a-very-long-project-name", 10);
+        assert_eq!(out.chars().count(), 10);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_counts_characters_not_bytes() {
+        // A byte-based truncate would both mis-measure this and risk slicing a
+        // multi-byte char in half.
+        assert_eq!(truncate("ünïcödé", 10), "ünïcödé");
+        assert_eq!(truncate("ünïcödé-project", 8).chars().count(), 8);
+    }
+}

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -5,6 +5,7 @@
 //! read the same preferences file, so the choice between them is only whether
 //! you want to browse first.
 
+pub mod lifecycle;
 pub mod prefs;
 pub mod setup;
 pub mod skills_sync;
@@ -26,7 +27,7 @@ use tui::{App, Outcome};
 #[derive(Parser)]
 #[clap(
     args_conflicts_with_subcommands = true,
-    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -45,12 +46,40 @@ enum Command {
 
     /// Launch a coding agent on a cloud agent VM, without the TUI
     Start(LaunchArgs),
+
+    /// List your cloud agents
+    #[clap(visible_alias = "ls")]
+    List(lifecycle::ListArgs),
+
+    /// Create a cloud agent VM, without connecting to it
+    #[clap(visible_alias = "new")]
+    Create(lifecycle::CreateArgs),
+
+    /// Connect to an existing cloud agent over SSH
+    #[clap(visible_alias = "connect")]
+    Ssh(lifecycle::SshArgs),
+
+    /// Wake a sleeping agent
+    Wake(lifecycle::WakeArgs),
+
+    /// Put an agent to sleep, keeping its disk and stopping the compute bill
+    Sleep(lifecycle::SleepArgs),
+
+    /// Delete an agent and everything on its disk
+    #[clap(visible_alias = "rm")]
+    Delete(lifecycle::DeleteArgs),
 }
 
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
         Some(Command::Setup(a)) => setup::command(a).await,
         Some(Command::Start(a)) => crate::commands::code::launch(a).await,
+        Some(Command::List(a)) => lifecycle::list(a).await,
+        Some(Command::Create(a)) => lifecycle::create(a).await,
+        Some(Command::Ssh(a)) => lifecycle::ssh(a).await,
+        Some(Command::Wake(a)) => lifecycle::wake(a).await,
+        Some(Command::Sleep(a)) => lifecycle::sleep(a).await,
+        Some(Command::Delete(a)) => lifecycle::delete(a).await,
         None if args.launch.is_bare() && is_stdout_terminal() => browse().await,
         // Flags given, or no terminal to draw on: behave like `railway code`.
         // A TUI in a pipe would be gibberish, and erroring instead would break

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -12,6 +12,8 @@ pub mod skills_sync;
 pub mod telemetry;
 pub mod tui;
 
+use std::future::Future;
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use colored::Colorize;
@@ -71,16 +73,31 @@ enum Command {
     Delete(lifecycle::DeleteArgs),
 }
 
+/// Time one lifecycle verb and report its outcome, passing the result through
+/// unchanged.
+///
+/// At the dispatch rather than inside each verb because the shape is identical
+/// for all of them. `ssh` is the exception and tracks itself: it ends in
+/// `std::process::exit` to propagate a remote exit status, which would skip
+/// anything wrapped around it.
+async fn tracked(kind: &'static str, run: impl Future<Output = Result<()>>) -> Result<()> {
+    let started = std::time::Instant::now();
+    let result = run.await;
+    let message = result.as_ref().err().map(|e| format!("{e:#}"));
+    telemetry::track_lifecycle(kind, started.elapsed(), message.as_deref()).await;
+    result
+}
+
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
         Some(Command::Setup(a)) => setup::command(a).await,
         Some(Command::Start(a)) => crate::commands::code::launch(a).await,
-        Some(Command::List(a)) => lifecycle::list(a).await,
-        Some(Command::Create(a)) => lifecycle::create(a).await,
+        Some(Command::List(a)) => tracked("list", lifecycle::list(a)).await,
+        Some(Command::Create(a)) => tracked("create", lifecycle::create(a)).await,
         Some(Command::Ssh(a)) => lifecycle::ssh(a).await,
-        Some(Command::Wake(a)) => lifecycle::wake(a).await,
-        Some(Command::Sleep(a)) => lifecycle::sleep(a).await,
-        Some(Command::Delete(a)) => lifecycle::delete(a).await,
+        Some(Command::Wake(a)) => tracked("wake", lifecycle::wake(a)).await,
+        Some(Command::Sleep(a)) => tracked("sleep", lifecycle::sleep(a)).await,
+        Some(Command::Delete(a)) => tracked("delete", lifecycle::delete(a)).await,
         None if args.launch.is_bare() && is_stdout_terminal() => browse().await,
         // Flags given, or no terminal to draw on: behave like `railway code`.
         // A TUI in a pipe would be gibberish, and erroring instead would break

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -99,6 +99,39 @@ pub async fn track_agent_op(op: AgentOp, error: Option<&str>) {
     .await;
 }
 
+/// One `railway ca` lifecycle verb run from the command line — list, create,
+/// ssh, wake, sleep, delete — fired once per attempt so volume and failure rate
+/// are visible per verb.
+///
+/// Its own `cli_` prefix rather than sharing [`track_agent_op`]'s slugs: those
+/// are the same mutations reached from the TUI's manage screen, and rolling the
+/// two together would hide which surface people actually reach for. The generic
+/// per-dispatch event only says `command="cloud_agent"`, which cannot answer
+/// that either.
+///
+/// `kind` is a fixed slug — never a name, id, or anything the caller typed.
+/// Detail slugs (`ssh_attach`, `sleep_all`) pass [`Duration::ZERO`]: they record
+/// which path was taken, and the verb's own event already carries the timing.
+pub async fn track_lifecycle(kind: &str, duration: Duration, error: Option<&str>) {
+    telemetry::send(event(
+        "cloud_agent",
+        lifecycle_sub_command(kind, error.is_some()),
+        duration.as_millis() as u64,
+        error.is_none(),
+        error.map(truncate),
+    ))
+    .await;
+}
+
+/// The slug a lifecycle verb reports under. Split out so the shape dashboards
+/// group on is pinned by a test rather than by reading the call sites.
+fn lifecycle_sub_command(kind: &str, failed: bool) -> String {
+    match failed {
+        true => format!("cli_{kind}_failed"),
+        false => format!("cli_{kind}"),
+    }
+}
+
 /// A named session action outside the main launch pipeline — reattaching to
 /// an existing durable session, killing one by name, opening the ssh pane on
 /// a freshly prepared agent, or the auto-sleep-on-quit that keeps a
@@ -189,6 +222,22 @@ pub async fn track_setup_failed(entry: &str, error: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn lifecycle_slugs_are_prefixed_and_marked() {
+        assert_eq!(lifecycle_sub_command("create", false), "cli_create");
+        assert_eq!(lifecycle_sub_command("create", true), "cli_create_failed");
+    }
+
+    #[test]
+    fn lifecycle_slugs_do_not_collide_with_the_tui_ops() {
+        // Same three mutations, two surfaces. `agent_sleep` is the manage
+        // screen's; `cli_sleep` is the command line's. Merging them would hide
+        // which one people actually use.
+        for kind in ["sleep", "wake", "delete"] {
+            assert_ne!(lifecycle_sub_command(kind, false), format!("agent_{kind}"));
+        }
+    }
 
     #[test]
     fn truncate_caps_long_messages() {

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -1202,14 +1202,8 @@ async fn run_agent_op(
     let backboard = backboard.to_string();
     match op {
         AgentOp::Sleep => {
-            post_graphql::<mutations::CloudAgentSleep, _>(
-                client,
-                backboard,
-                mutations::cloud_agent_sleep::Variables {
-                    id: agent_id.to_string(),
-                },
-            )
-            .await?;
+            crate::controllers::cloud_agent::sleep(client, &backboard, environment_id, agent_id)
+                .await?;
         }
         AgentOp::Wake => {
             post_graphql::<mutations::CloudAgentWake, _>(
@@ -1255,15 +1249,24 @@ async fn close_and_sleep(app: &mut App, index: usize, client: &reqwest::Client, 
         return;
     };
     let agent_id = session.agent_id.clone();
+    let environment_id = session.environment_id().map(str::to_string);
     session.detach();
     drop(session);
 
-    let _ = post_graphql::<mutations::CloudAgentSleep, _>(
-        client,
-        backboard.to_string(),
-        mutations::cloud_agent_sleep::Variables { id: agent_id },
-    )
-    .await;
+    // Without the environment there is no relay target to flush through, so the
+    // disk cannot be quiesced first. Sleeping anyway is still right: an agent
+    // left awake with nothing watching it bills until someone notices.
+    let Some(environment_id) = environment_id else {
+        let _ = post_graphql::<mutations::CloudAgentSleep, _>(
+            client,
+            backboard.to_string(),
+            mutations::cloud_agent_sleep::Variables { id: agent_id },
+        )
+        .await;
+        return;
+    };
+    let _ =
+        crate::controllers::cloud_agent::sleep(client, backboard, &environment_id, &agent_id).await;
 }
 
 /// Keep the emulator the same shape as the pane it is drawn into — done after a

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -41,6 +41,20 @@ pub fn durable_name(harness: &str) -> String {
     format!("{harness}-{suffix}")
 }
 
+/// Read the environment back out of a relay target (`agent:<env>:<agent>`).
+///
+/// Returns `None` for anything else rather than guessing: the caller uses this
+/// to pick a machine to flush and suspend, and a target shape we don't
+/// recognise is not one to act on.
+fn environment_from_target(target: &str) -> Option<&str> {
+    match *target.split(':').collect::<Vec<_>>().as_slice() {
+        ["agent", environment, agent] if !environment.is_empty() && !agent.is_empty() => {
+            Some(environment)
+        }
+        _ => None,
+    }
+}
+
 /// A running `ssh` under a pty, plus the emulator that makes sense of it.
 pub struct Session {
     pub agent_id: String,
@@ -70,6 +84,13 @@ pub struct Session {
 }
 
 impl Session {
+    /// The environment this session's agent lives in. The relay target is the
+    /// only place the pane carries it, and sleeping the agent needs it to flush
+    /// the disk first.
+    pub fn environment_id(&self) -> Option<&str> {
+        environment_from_target(&self.ssh_target)
+    }
+
     /// Spawn `ssh` under a pty and start reading it.
     ///
     /// `notify` fires whenever new output has been folded into the emulator, so
@@ -1146,5 +1167,24 @@ mod tests {
         let screen = parser.screen();
         assert_eq!(screen.contents().lines().next().unwrap().trim(), "hello");
         assert!(screen.contents().contains("world"));
+    }
+
+    #[test]
+    fn environment_is_read_out_of_a_relay_target() {
+        assert_eq!(
+            environment_from_target("agent:env-123:agent-456"),
+            Some("env-123")
+        );
+    }
+
+    #[test]
+    fn other_target_shapes_are_not_guessed_at() {
+        // A sandbox target has the same arity, and sleeping a machine picked
+        // out of one would suspend the wrong thing entirely.
+        assert_eq!(environment_from_target("sbx:env-123:sandbox-456"), None);
+        assert_eq!(environment_from_target("agent:env-123"), None);
+        assert_eq!(environment_from_target("agent::agent-456"), None);
+        assert_eq!(environment_from_target("agent:env-123:"), None);
+        assert_eq!(environment_from_target("some-service-instance"), None);
     }
 }

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1676,12 +1676,11 @@ pub async fn sleep_agent(
     progress: &dyn Progress,
 ) -> Result<()> {
     progress.step("Sleeping the agent");
-    post_graphql::<mutations::CloudAgentSleep, _>(
+    crate::controllers::cloud_agent::sleep(
         client,
-        configs.get_backboard(),
-        mutations::cloud_agent_sleep::Variables {
-            id: prepared.agent_id.clone(),
-        },
+        &configs.get_backboard(),
+        &prepared.environment_id,
+        &prepared.agent_id,
     )
     .await?;
     progress.finish();
@@ -1912,6 +1911,52 @@ pub async fn connect_info(environment_id: &str, agent_id: &str) -> Result<Connec
         identity,
         relay_opts: relay.opts,
     })
+}
+
+/// How long the pre-sleep flush may take before we sleep the agent anyway.
+const FLUSH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Flush the agent's filesystem so sleeping it cannot discard recent work.
+///
+/// `cloudAgentSleep` snapshots the disk without quiescing the guest, so pages
+/// still dirty in its page cache are absent from the image the next wake
+/// restores. Measured on a scratch agent: a file written a second before a
+/// sleep was gone after waking, while the same write followed by `sync`
+/// survived — including when the sleep was issued immediately on disconnect.
+/// So the variable is the flush, not the timing.
+///
+/// A side connection is enough because `sync(2)` flushes the whole filesystem
+/// regardless of which process dirtied it: this covers whatever the durable
+/// session was writing without reaching into it.
+///
+/// Best-effort by design. Failing to reach the agent must not stop us sleeping
+/// it — agents have no idle timeout, so the alternative to an imperfect sleep is
+/// a machine that bills until someone remembers it.
+pub async fn flush_disk(environment_id: &str, agent_id: &str) {
+    // Deliberately not `ssh_plumbing`: its ~20s retry budget exists to cross the
+    // gap while a woken agent becomes attachable. Spending it here would make
+    // every disconnect slow whenever the relay is having a bad minute, to
+    // protect writes on a box we have already failed to reach twice.
+    let flush = async {
+        let info = connect_info(environment_id, agent_id).await.ok()?;
+        let mut opts = info.relay_opts;
+        opts.push("-o".to_string());
+        opts.push(format!("ConnectTimeout={}", FLUSH_TIMEOUT.as_secs()));
+        tokio::task::spawn_blocking(move || {
+            run_native_ssh_captured(
+                &info.ssh_target,
+                "sync",
+                info.identity.as_deref(),
+                None,
+                &opts,
+            )
+        })
+        .await
+        .ok()
+    };
+    // On timeout the blocking ssh is left to finish on its own: it is a `sync`,
+    // it harms nothing, and waiting on it is the thing we just declined to do.
+    let _ = tokio::time::timeout(FLUSH_TIMEOUT, flush).await;
 }
 
 /// End a durable session on an agent.

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -115,7 +115,9 @@ pub struct LaunchArgs {
     #[clap(long)]
     keep_awake: bool,
 
-    /// Destroy this environment's agent and exit. Its disk goes with it
+    /// Destroy this environment's agent and exit. Its disk goes with it.
+    /// Superseded by `railway ca delete`, which can name any agent and asks
+    /// before it destroys one
     #[clap(long)]
     rm: bool,
 
@@ -998,17 +1000,6 @@ fn ssh_plumbing(
     bail!("SSH to the agent failed after {attempts} attempts (exit {code}):\n{reason}")
 }
 
-/// The literal `ssh` command for a relay target, for the disconnect hint. The
-/// relay is the same one this command connected through, so whatever worked here
-/// works when pasted — including the dev relay's non-default port.
-fn raw_ssh_hint(target: &str) -> String {
-    let (host, port) = Configs::get_ssh_relay();
-    match port {
-        Some(p) if p != 22 => format!("ssh -p {p} {target}@{host}"),
-        _ => format!("ssh {target}@{host}"),
-    }
-}
-
 /// One cloud agent, reduced to what this command steers on.
 #[derive(Clone)]
 struct CodeAgent {
@@ -1386,11 +1377,21 @@ fn warn_ignored_variables(args: &LaunchArgs) {
 }
 
 /// `railway code --rm`: destroy this environment's agent, disk and all.
+///
+/// Kept working for anyone with it in a script, but `railway ca delete` is the
+/// command now: it can name any agent rather than only this environment's, and
+/// it confirms before taking a disk away.
 async fn destroy_agent(
     configs: &mut Configs,
     client: &reqwest::Client,
     environment_id: &str,
 ) -> Result<()> {
+    use colored::Colorize;
+    eprintln!(
+        "{}",
+        "Note: `railway ca delete` supersedes --rm — it names any agent and confirms first."
+            .dimmed()
+    );
     let backboard = configs.get_backboard();
     let Some(id) = configs.get_code_agent(environment_id) else {
         println!("No agent recorded for this environment.");
@@ -1416,6 +1417,19 @@ async fn destroy_agent(
         None => println!("Agent {id} is already gone."),
     }
     Ok(())
+}
+
+/// The harness a launch would use right now: the saved default, or
+/// `RAILWAY_CA_AGENT`, or — on a terminal — one prompt whose answer is saved.
+///
+/// Public so `railway ca ssh` can start a session on an agent without
+/// duplicating that precedence. It takes no flags because the lifecycle verbs
+/// have none: choosing a harness per-invocation is what `railway ca start` and
+/// `railway code` are for.
+pub fn default_harness() -> Result<&'static str> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to get home directory"))?;
+    let mut prefs = AgentPrefs::load_in(&home).unwrap_or_default();
+    Ok(resolve_agent_choice(&LaunchArgs::default(), &mut prefs, &home)?.name())
 }
 
 /// Environment override for the saved default — one run, no file write. For
@@ -1545,7 +1559,6 @@ pub struct Prepared {
     pub relay_opts: Vec<String>,
     pub agent_id: String,
     pub agent_name: String,
-    pub project_id: String,
     pub environment_id: String,
     pub harness: &'static str,
     /// True when this run created the agent, which only affects messaging.
@@ -1619,18 +1632,19 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
         "  railway code --{}   # wakes it and drops back into {}",
         prepared.harness, prepared.harness
     );
-    // `railway ssh` addresses services and deployments, not agents, so the
-    // plain-shell route is ssh itself against the relay. Only useful while the
-    // agent is awake — hence second, after the command that wakes it.
     println!(
-        "  {}   # plain shell (once awake)",
-        raw_ssh_hint(&prepared.ssh_target)
+        "  railway ca ssh {}   # same, by name — and reattaches your session",
+        prepared.agent_name
+    );
+    // The relay speaks plain ssh too, and `railway ca ssh -- bash` is that
+    // without having to hold the target format. Only useful while the agent is
+    // awake — hence after the commands that wake it.
+    println!(
+        "  railway ca ssh {} -- bash   # plain shell",
+        prepared.agent_name
     );
     println!("Destroy it:");
-    println!(
-        "  railway code --rm -p {} -e {}",
-        prepared.project_id, prepared.environment_id
-    );
+    println!("  railway ca delete {}", prepared.agent_name);
 
     if exit_code != 0 {
         std::process::exit(exit_code);
@@ -1724,7 +1738,7 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
     // --- Resolve where the agent lives.
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let (project_id, environment_id) =
+    let (_project_id, environment_id) =
         resolve_target(&mut configs, &client, args, &mut prefs, &home).await?;
 
     let (cloud_agent, created) =
@@ -1868,7 +1882,6 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
         relay_opts: relay.opts,
         agent_id: cloud_agent.id,
         agent_name: cloud_agent.name,
-        project_id,
         environment_id,
         harness: agent.name(),
         created,

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -1,0 +1,575 @@
+//! Cloud agent lifecycle, shared by `railway ca` and `railway code`.
+//!
+//! The launcher grew these operations as flags on a command whose job is
+//! something else (`--new` creates, `--rm` destroys, `--keep-awake` declines to
+//! sleep). Pulling them here gives the flat `railway ca` verbs one
+//! implementation to call, and — more importantly — one place where the local
+//! agent pointer is kept honest. A delete that forgets to clear the pointer
+//! leaves `railway code` waking a corpse.
+
+use anyhow::{Result, bail};
+use chrono::{DateTime, Utc};
+
+use crate::client::post_graphql;
+use crate::config::Configs;
+use crate::gql::{mutations, queries};
+
+/// How long to wait for a created or woken agent to reach RUNNING.
+///
+/// Matches the launcher's budget: a cold create boots a microVM and publishes
+/// routes, a wake restores a checkpoint and is much quicker.
+const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// Gap between readiness polls.
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// An agent's lifecycle state, normalised across the four generated enums that
+/// describe the same thing.
+///
+/// Worth the conversion boilerplate: without it every caller matches on a
+/// per-operation enum, and the "is this thing usable" question gets answered
+/// slightly differently in each place it is asked.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Status {
+    Running,
+    Sleeping,
+    Starting,
+    Crashed,
+    Failed,
+    Deleting,
+    /// A state this CLI predates. Treated as terminal — refusing to act on a
+    /// state we cannot reason about beats guessing.
+    Unknown(String),
+}
+
+impl Status {
+    /// Lowercase label for tables and messages.
+    pub fn label(&self) -> String {
+        match self {
+            Status::Running => "running".into(),
+            Status::Sleeping => "sleeping".into(),
+            Status::Starting => "starting".into(),
+            Status::Crashed => "crashed".into(),
+            Status::Failed => "failed".into(),
+            Status::Deleting => "deleting".into(),
+            Status::Unknown(s) => s.to_lowercase(),
+        }
+    }
+
+    /// The agent exists and can be brought back: it is worth listing, waking,
+    /// sleeping or connecting to.
+    pub fn is_live(&self) -> bool {
+        matches!(self, Status::Running | Status::Sleeping | Status::Starting)
+    }
+}
+
+/// Generate `From` impls for the per-operation status enums, which are
+/// structurally identical and separately generated.
+macro_rules! status_from {
+    ($($path:path),+ $(,)?) => {
+        $(
+            impl From<$path> for Status {
+                fn from(status: $path) -> Self {
+                    use $path as S;
+                    match status {
+                        S::RUNNING => Status::Running,
+                        S::SLEEPING => Status::Sleeping,
+                        S::STARTING => Status::Starting,
+                        S::CRASHED => Status::Crashed,
+                        S::FAILED => Status::Failed,
+                        S::DELETING => Status::Deleting,
+                        S::Other(other) => Status::Unknown(other),
+                    }
+                }
+            }
+        )+
+    };
+}
+
+status_from!(
+    queries::cloud_agent::CloudAgentStatus,
+    queries::cloud_agents::CloudAgentStatus,
+    queries::my_cloud_agents::CloudAgentStatus,
+    mutations::cloud_agent_create::CloudAgentStatus,
+);
+
+/// One cloud agent, as every `railway ca` verb sees it.
+#[derive(Clone, Debug)]
+pub struct Agent {
+    pub id: String,
+    pub name: String,
+    pub status: Status,
+    pub project_id: String,
+    pub environment_id: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Read one agent by id, scoped to its environment. `None` means it is gone —
+/// deleted, or it belongs to another environment — which is the caller's cue to
+/// forget the stored pointer rather than to fail.
+pub async fn get(
+    client: &reqwest::Client,
+    backboard: &str,
+    environment_id: &str,
+    id: &str,
+) -> Result<Option<Agent>> {
+    let res = post_graphql::<queries::CloudAgent, _>(
+        client,
+        backboard,
+        queries::cloud_agent::Variables {
+            id: id.to_owned(),
+            environment_id: environment_id.to_owned(),
+        },
+    )
+    .await?;
+    Ok(res.cloud_agent.map(|a| Agent {
+        id: a.id,
+        name: a.name,
+        status: a.status.into(),
+        project_id: a.project_id,
+        environment_id: a.environment_id,
+        created_at: a.created_at,
+    }))
+}
+
+/// Every agent the caller owns, across the whole account, in one request.
+///
+/// This is what makes the flat verbs work without a linked directory: agents
+/// are addressed by name, and the name has to be looked up somewhere.
+pub async fn list_mine(client: &reqwest::Client, backboard: &str) -> Result<Vec<Agent>> {
+    let res = post_graphql::<queries::MyCloudAgents, _>(
+        client,
+        backboard,
+        queries::my_cloud_agents::Variables {},
+    )
+    .await?;
+    Ok(res
+        .my_cloud_agents
+        .into_iter()
+        .map(|a| Agent {
+            id: a.id,
+            name: a.name,
+            status: a.status.into(),
+            project_id: a.project_id,
+            environment_id: a.environment_id,
+            created_at: a.created_at,
+        })
+        .collect())
+}
+
+/// Agents in one environment. `mine` is load-bearing rather than tidiness:
+/// agents authorize per environment, so an unfiltered list includes teammates'
+/// — and connecting to one would put this user's credentials on a box someone
+/// else is working in.
+pub async fn list_in_environment(
+    client: &reqwest::Client,
+    backboard: &str,
+    environment_id: &str,
+    mine: bool,
+) -> Result<Vec<Agent>> {
+    let res = post_graphql::<queries::CloudAgents, _>(
+        client,
+        backboard,
+        queries::cloud_agents::Variables {
+            environment_id: environment_id.to_owned(),
+            mine: Some(mine),
+        },
+    )
+    .await?;
+    Ok(res
+        .cloud_agents
+        .into_iter()
+        .map(|a| Agent {
+            id: a.id,
+            name: a.name,
+            status: a.status.into(),
+            project_id: a.project_id,
+            environment_id: a.environment_id,
+            created_at: a.created_at,
+        })
+        .collect())
+}
+
+/// Create an agent. The VM only — no harness, no credential, no session.
+/// Provisioning belongs to whatever opens a session on it, so an agent created
+/// here works with any of them.
+pub async fn create(
+    client: &reqwest::Client,
+    backboard: &str,
+    environment_id: &str,
+    name: Option<String>,
+    variables: Option<serde_json::Value>,
+) -> Result<Agent> {
+    let res = post_graphql::<mutations::CloudAgentCreate, _>(
+        client,
+        backboard,
+        mutations::cloud_agent_create::Variables {
+            input: mutations::cloud_agent_create::CloudAgentCreateInput {
+                environment_id: environment_id.to_owned(),
+                name,
+                variables,
+            },
+        },
+    )
+    .await?
+    .cloud_agent_create;
+    Ok(Agent {
+        id: res.id,
+        name: res.name,
+        status: res.status.into(),
+        project_id: res.project_id,
+        environment_id: res.environment_id,
+        created_at: res.created_at,
+    })
+}
+
+pub async fn wake(client: &reqwest::Client, backboard: &str, id: &str) -> Result<()> {
+    post_graphql::<mutations::CloudAgentWake, _>(
+        client,
+        backboard,
+        mutations::cloud_agent_wake::Variables { id: id.to_owned() },
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn sleep(client: &reqwest::Client, backboard: &str, id: &str) -> Result<()> {
+    post_graphql::<mutations::CloudAgentSleep, _>(
+        client,
+        backboard,
+        mutations::cloud_agent_sleep::Variables { id: id.to_owned() },
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn delete(client: &reqwest::Client, backboard: &str, id: &str) -> Result<()> {
+    post_graphql::<mutations::CloudAgentDelete, _>(
+        client,
+        backboard,
+        mutations::cloud_agent_delete::Variables { id: id.to_owned() },
+    )
+    .await?;
+    Ok(())
+}
+
+/// Poll until the agent is RUNNING. A terminal state is reported immediately
+/// rather than burning the whole timeout on a box that will never come up.
+pub async fn wait_until_running(
+    client: &reqwest::Client,
+    backboard: &str,
+    environment_id: &str,
+    id: &str,
+) -> Result<Agent> {
+    let deadline = std::time::Instant::now() + READY_TIMEOUT;
+    loop {
+        let agent = match get(client, backboard, environment_id, id).await? {
+            Some(agent) => agent,
+            None => bail!("Agent {id} disappeared while starting."),
+        };
+        match agent.status {
+            Status::Running => return Ok(agent),
+            Status::Starting | Status::Sleeping => {}
+            Status::Crashed => bail!("Agent {} crashed while starting.", agent.name),
+            Status::Failed => bail!("Agent {} failed to start.", agent.name),
+            Status::Deleting => bail!("Agent {} is being deleted.", agent.name),
+            Status::Unknown(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
+        }
+        if std::time::Instant::now() >= deadline {
+            bail!(
+                "Agent {} did not reach running within {}s (last state: {}).",
+                agent.name,
+                READY_TIMEOUT.as_secs(),
+                agent.status.label()
+            );
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+/// Bring an existing agent up to RUNNING, waking it if it is asleep.
+///
+/// Deliberately unlike the launcher's [`crate::commands::code`] path, which
+/// treats a crashed agent as a cue to create a fresh one. That is a reasonable
+/// answer to "get me coding" and a terrible answer to "wake this agent": the
+/// caller named a machine, and silently handing back a different, empty one
+/// while the original's disk sits there is not a thing to do quietly.
+pub async fn ensure_running(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent: &Agent,
+) -> Result<Agent> {
+    match agent.status {
+        Status::Running => Ok(agent.clone()),
+        // STARTING means something else is already booting it, so this waits
+        // rather than issuing a second wake.
+        Status::Starting => {
+            wait_until_running(client, backboard, &agent.environment_id, &agent.id).await
+        }
+        Status::Sleeping => {
+            wake(client, backboard, &agent.id).await?;
+            wait_until_running(client, backboard, &agent.environment_id, &agent.id).await
+        }
+        _ => bail!(
+            "Agent {} is {} — it cannot be connected to. `railway ca delete {}` and create a new one.",
+            agent.name,
+            agent.status.label(),
+            agent.name
+        ),
+    }
+}
+
+/// A durable console session on an agent.
+///
+/// Sessions outlive the ssh that started them — that is the point of them — so
+/// reconnecting means finding the session by name rather than starting a second
+/// copy of the work alongside the first.
+pub struct ConsoleSession {
+    pub name: String,
+    pub command: String,
+    pub running: bool,
+    pub attached: bool,
+}
+
+pub async fn list_sessions(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent_id: &str,
+) -> Result<Vec<ConsoleSession>> {
+    let res = post_graphql::<queries::CloudAgentConsoleSessions, _>(
+        client,
+        backboard,
+        queries::cloud_agent_console_sessions::Variables {
+            cloud_agent_id: agent_id.to_owned(),
+        },
+    )
+    .await?;
+    Ok(res
+        .cloud_agent_console_sessions
+        .map(|conn| {
+            conn.edges
+                .into_iter()
+                .map(|edge| ConsoleSession {
+                    name: edge.node.name,
+                    command: edge.node.command,
+                    running: edge.node.run_state.running,
+                    attached: edge.node.attached,
+                })
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// How an agent was picked, so callers can say so.
+pub enum Resolution {
+    /// The caller named it.
+    Named,
+    /// It is the agent this machine last used in its environment.
+    Remembered,
+    /// It is the caller's only live agent in scope.
+    Sole,
+}
+
+/// Find the agent a command should act on.
+///
+/// One order for every verb, and no interactive prompt anywhere in it — a
+/// lifecycle command that stops to ask which agent it meant is unusable in a
+/// script, and the ambiguous case has a better answer anyway: print the
+/// candidates and let the next invocation name one.
+///
+/// Scope is the whole account unless `--project`/`--environment` narrows it,
+/// because agents are cross-project and the directory you happen to be in is
+/// about deploys.
+pub async fn resolve(
+    configs: &Configs,
+    client: &reqwest::Client,
+    selector: Option<&str>,
+    environment_id: Option<&str>,
+) -> Result<(Agent, Resolution)> {
+    let backboard = configs.get_backboard();
+    let candidates = match environment_id {
+        Some(env) => list_in_environment(client, &backboard, env, true).await?,
+        None => list_mine(client, &backboard).await?,
+    };
+
+    if let Some(selector) = selector {
+        return match_selector(candidates, selector).map(|agent| (agent, Resolution::Named));
+    }
+
+    let live: Vec<Agent> = candidates
+        .into_iter()
+        .filter(|a| a.status.is_live())
+        .collect();
+
+    // The pointer is what makes bare `railway ca ssh` mean "the agent I was
+    // just working in" rather than "whichever one sorts first".
+    let mut remembered: Vec<Agent> = live
+        .iter()
+        .filter(|a| configs.get_code_agent(&a.environment_id).as_deref() == Some(a.id.as_str()))
+        .cloned()
+        .collect();
+    if remembered.len() == 1 {
+        return Ok((remembered.remove(0), Resolution::Remembered));
+    }
+
+    match live.len() {
+        0 => bail!(
+            "You have no cloud agents{}. Create one with `railway ca create`.",
+            match environment_id {
+                Some(_) => " in this environment",
+                None => "",
+            }
+        ),
+        1 => Ok((
+            live.into_iter().next().expect("len checked"),
+            Resolution::Sole,
+        )),
+        _ => bail!(
+            "You have {} cloud agents and none is this directory's. Name one:\n{}",
+            live.len(),
+            describe(&live)
+        ),
+    }
+}
+
+/// Match a user-supplied selector against candidates: an exact id first, then
+/// an exact name. Ambiguity is reported rather than broken by picking one —
+/// names are not unique across projects, and guessing here would act on the
+/// wrong machine.
+fn match_selector(candidates: Vec<Agent>, selector: &str) -> Result<Agent> {
+    if let Some(agent) = candidates.iter().find(|a| a.id == selector) {
+        return Ok(agent.clone());
+    }
+    let mut by_name: Vec<Agent> = candidates
+        .into_iter()
+        .filter(|a| a.name == selector)
+        .collect();
+    match by_name.len() {
+        0 => bail!("No cloud agent named {selector:?}. `railway ca list` shows yours."),
+        1 => Ok(by_name.remove(0)),
+        _ => bail!(
+            "{} cloud agents are named {selector:?}. Use an id:\n{}",
+            by_name.len(),
+            describe(&by_name)
+        ),
+    }
+}
+
+/// Candidate list for an ambiguity error: the id is what disambiguates, so it
+/// is what this prints.
+fn describe(agents: &[Agent]) -> String {
+    agents
+        .iter()
+        .map(|a| format!("  {} ({}) — {}", a.name, a.status.label(), a.id))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Remember this agent as the environment's, and persist.
+pub fn remember(configs: &mut Configs, agent: &Agent) -> Result<()> {
+    configs.set_code_agent(&agent.environment_id, &agent.id);
+    configs.write()
+}
+
+/// Forget an environment's agent pointer, and persist.
+///
+/// Called on delete whether or not the delete reported success: a mutation that
+/// fails on an already-gone agent must not leave the CLI reaching for it
+/// forever.
+pub fn forget(configs: &mut Configs, environment_id: &str) -> Result<()> {
+    configs.remove_code_agent(environment_id);
+    configs.write()
+}
+
+/// Compact age for list output — the column answers "is this one stale", which
+/// needs one unit, not a timestamp.
+pub fn humanize_age(created_at: DateTime<Utc>) -> String {
+    let seconds = Utc::now().signed_duration_since(created_at).num_seconds();
+    if seconds < 0 {
+        return "just now".into();
+    }
+    match seconds {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s if s < 86_400 => format!("{}h", s / 3600),
+        s => format!("{}d", s / 86_400),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(id: &str, name: &str, status: Status) -> Agent {
+        Agent {
+            id: id.into(),
+            name: name.into(),
+            status,
+            project_id: "project".into(),
+            environment_id: "env".into(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn selector_matches_id_before_name() {
+        // A name that happens to equal another agent's id must not win over the
+        // agent that actually has that id.
+        let candidates = vec![
+            agent("abc", "first", Status::Running),
+            agent("def", "abc", Status::Running),
+        ];
+        let found = match_selector(candidates, "abc").unwrap();
+        assert_eq!(found.name, "first");
+    }
+
+    #[test]
+    fn selector_matches_name() {
+        let candidates = vec![agent("abc", "sunny-cloud", Status::Sleeping)];
+        assert_eq!(match_selector(candidates, "sunny-cloud").unwrap().id, "abc");
+    }
+
+    #[test]
+    fn duplicate_names_are_ambiguous_rather_than_guessed() {
+        let candidates = vec![
+            agent("abc", "dev", Status::Running),
+            agent("def", "dev", Status::Running),
+        ];
+        let err = match_selector(candidates, "dev").unwrap_err().to_string();
+        assert!(err.contains("abc"), "error should list ids: {err}");
+        assert!(err.contains("def"), "error should list ids: {err}");
+    }
+
+    #[test]
+    fn unknown_selector_points_at_list() {
+        let err = match_selector(vec![agent("abc", "dev", Status::Running)], "nope")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("railway ca list"), "{err}");
+    }
+
+    #[test]
+    fn terminal_states_are_not_live() {
+        assert!(Status::Running.is_live());
+        assert!(Status::Sleeping.is_live());
+        assert!(Status::Starting.is_live());
+        assert!(!Status::Crashed.is_live());
+        assert!(!Status::Failed.is_live());
+        assert!(!Status::Deleting.is_live());
+        assert!(!Status::Unknown("wat".into()).is_live());
+    }
+
+    #[test]
+    fn age_uses_one_unit() {
+        assert_eq!(
+            humanize_age(Utc::now() - chrono::Duration::seconds(30)),
+            "30s"
+        );
+        assert_eq!(
+            humanize_age(Utc::now() - chrono::Duration::minutes(5)),
+            "5m"
+        );
+        assert_eq!(humanize_age(Utc::now() - chrono::Duration::hours(3)), "3h");
+        assert_eq!(humanize_age(Utc::now() - chrono::Duration::days(9)), "9d");
+    }
+}

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -233,7 +233,24 @@ pub async fn wake(client: &reqwest::Client, backboard: &str, id: &str) -> Result
     Ok(())
 }
 
-pub async fn sleep(client: &reqwest::Client, backboard: &str, id: &str) -> Result<()> {
+/// Sleep an agent, flushing its filesystem first.
+///
+/// The flush is paired with the mutation here, rather than left to each caller,
+/// because forgetting it loses the user's most recent work silently — see
+/// [`crate::commands::code::flush_disk`]. Every path that suspends an agent goes
+/// through this function for that reason; there is deliberately no way to reach
+/// the bare mutation from outside this module.
+pub async fn sleep(
+    client: &reqwest::Client,
+    backboard: &str,
+    environment_id: &str,
+    id: &str,
+) -> Result<()> {
+    crate::commands::code::flush_disk(environment_id, id).await;
+    sleep_without_flush(client, backboard, id).await
+}
+
+async fn sleep_without_flush(client: &reqwest::Client, backboard: &str, id: &str) -> Result<()> {
     post_graphql::<mutations::CloudAgentSleep, _>(
         client,
         backboard,

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat;
+pub mod cloud_agent;
 pub mod cluster_scale;
 pub mod config;
 pub mod database;


### PR DESCRIPTION
Adds six flat lifecycle subcommands to `railway ca`.

| Command | Enables |
|---|---|
| `ca list` (`ls`) | Every agent you own, across all projects. `-e` narrows, `--all` includes teammates', `--json` for scripts |
| `ca create` (`new`) | An agent VM without connecting to it. `--variable`, `--env-file`, `--no-wait`, `--json` |
| `ca ssh` (`connect`) | Attach to an agent's durable session. `-- bash` for a plain shell, `--session` to pick one, `--keep-awake` to skip sleep-on-disconnect |
| `ca wake` | Wake a sleeping agent, waiting for RUNNING |
| `ca sleep` | Stop the compute bill, keep the disk. `--all` for every running agent you own |
| `ca delete` (`rm`) | Destroy an agent and its disk, with confirmation (`-y` to skip) |

Agents are addressed by name or id. With neither, commands use this directory's agent, then your only live one, then list the candidates.

## Structure

- `src/controllers/cloud_agent.rs` — agent model normalised across the generated query types, the operations, the shared resolver, and config pointer bookkeeping.
- `src/commands/cloud_agent/lifecycle.rs` — the six verbs.
- `ca create` makes a VM only; `ca ssh` never creates. `ca start` and `railway code` remain the create-and-launch path.
- `list` is account-wide via `myCloudAgents`, so it works in an unlinked directory.
- `railway code --rm`, `--keep-awake` and `--new` keep working; `--rm` points at `ca delete`.

## Telemetry

Extends #1063's `cloud_agent::telemetry` to the new verbs, which otherwise had only the generic per-dispatch event that can't say which verb ran.

- One event per verb: `cli_list`, `cli_create`, `cli_ssh`, `cli_wake`, `cli_sleep`, `cli_delete`, with `_failed` variants and real duration.
- Detail slugs: `cli_ssh_attach` / `cli_ssh_new_session` / `cli_ssh_command`, and `cli_sleep_all`.
- The `cli_` prefix keeps these separate from the TUI's `agent_sleep`/`agent_wake`/`agent_delete` — same mutations, different surface. A test pins the separation.
- Fixed slugs only, no free text.

## Fixes

- **Sleeping an agent could lose recent work.** `cloudAgentSleep` snapshots the disk without quiescing the guest, so pages still dirty in its page cache were absent after a wake. Sleep now runs `sync` over a side ssh first, paired inside `controllers::cloud_agent::sleep` so none of the four suspend paths can skip it. Best-effort, 5s cap; `sleep --all` flushes concurrently. Adds ~1s to a disconnect.
- **A failed connect left an agent it woke awake and billing.** Now rolled back, and only when this run did the waking.
- **`ca sleep` reported "asleep" before the transition finished**, contradicting a following `ca list`.

## Testing

957 unit tests, clippy clean. Full `create → ssh → wake → sleep → delete` run against live agents: create RUNNING in 7.3s, remote command in 1s, auto-wake in 12s, delete clears the local pointer. Error paths checked (unknown name, `--all` without `-e`, `delete` over a pipe, `wake` on a running agent). Disk-loss case re-run after the fix and confirmed resolved.

## Not included

`forward`, `exec`, and `fork`/`checkpoint`/`template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
