### PR TITLE
Send logged-out `railway ca` through login, then carry on

### DIFF
--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -21,6 +21,7 @@ use colored::Colorize;
 use crate::client::GQLClient;
 use crate::commands::code::LaunchArgs;
 use crate::config::Configs;
+use crate::errors::RailwayError;
 use crate::macros::is_stdout_terminal;
 use crate::util::progress::create_spinner;
 use prefs::AgentPrefs;
@@ -89,6 +90,15 @@ async fn tracked(kind: &'static str, run: impl Future<Output = Result<()>>) -> R
 }
 
 pub async fn command(args: Args) -> Result<()> {
+    // `railway ca` is often the first Railway command someone runs, so a logged
+    // out user gets the login flow inline instead of an error telling them to
+    // run `railway login` and type this again. The command they asked for then
+    // continues on the credential that flow just wrote.
+    let interactive = is_stdout_terminal();
+    if needs_credential(args.command.as_ref(), interactive) {
+        ensure_logged_in(interactive).await?;
+    }
+
     match args.command {
         Some(Command::Setup(a)) => setup::command(a).await,
         Some(Command::Start(a)) => crate::commands::code::launch(a).await,
@@ -104,6 +114,43 @@ pub async fn command(args: Args) -> Result<()> {
         // scripted callers that reasonably expect the launcher.
         None => crate::commands::code::launch(args.launch).await,
     }
+}
+
+/// Whether this invocation will talk to the API, and so needs a credential
+/// before it starts. Only `setup` can get by without one — everything else
+/// (the TUI, `start`, a bare launch flag) opens with a query.
+fn needs_credential(command: Option<&Command>, interactive: bool) -> bool {
+    match command {
+        Some(Command::Setup(a)) => a.needs_credential(interactive),
+        _ => true,
+    }
+}
+
+/// Run the login flow in place when there is no credential to work with.
+///
+/// Any credential counts, including a project token: those callers are already
+/// authenticated as far as this command is concerned, and `railway login`
+/// short-circuits on `RAILWAY_TOKEN` anyway, so sending them there would be a
+/// detour to nowhere. An expired login is not a case to handle here — `main`
+/// refreshes and clears dead credentials before dispatch, so it reaches this
+/// check as no credential at all.
+async fn ensure_logged_in(interactive: bool) -> Result<()> {
+    if Configs::new()?.has_auth_credentials() {
+        return Ok(());
+    }
+    // Piped or scripted: the login flow would sit on a device code nobody is
+    // watching. Fail the way every other command does instead.
+    if !interactive {
+        return Err(RailwayError::Unauthorized.into());
+    }
+
+    println!("{}", "Log in to Railway to continue.".bold());
+    let result = crate::commands::login::prompt_login().await;
+    telemetry::track_login_forwarded(result.as_ref().err().map(|e| format!("{e:#}")).as_deref())
+        .await;
+    result?;
+    println!();
+    Ok(())
 }
 
 /// The TUI loop. `run` gives the terminal back whenever something needs the
@@ -274,4 +321,39 @@ async fn linked_target(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn setup_args(argv: &[&str]) -> Command {
+        Command::Setup(setup::Args::parse_from(
+            std::iter::once("setup").chain(argv.iter().copied()),
+        ))
+    }
+
+    #[test]
+    fn launch_paths_need_a_credential() {
+        assert!(needs_credential(None, true));
+        assert!(needs_credential(None, false));
+        assert!(needs_credential(
+            Some(&Command::Start(LaunchArgs::parse_from(["start"]))),
+            true
+        ));
+    }
+
+    #[test]
+    fn local_setup_runs_logged_out() {
+        assert!(!needs_credential(Some(&setup_args(&["--show"])), true));
+        assert!(!needs_credential(Some(&setup_args(&["-y"])), true));
+        // Piped setup takes the same non-interactive path as `-y`.
+        assert!(!needs_credential(Some(&setup_args(&[])), false));
+    }
+
+    #[test]
+    fn interactive_setup_needs_a_credential_for_the_project_picker() {
+        assert!(needs_credential(Some(&setup_args(&[])), true));
+    }
 }

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -114,6 +114,16 @@ impl fmt::Display for SourceChoice {
     }
 }
 
+impl Args {
+    /// Whether this run needs a Railway credential. `--show` only prints what
+    /// is already on disk, and the non-interactive path picks a harness from
+    /// what it can see locally; only the prompts reach the API, to ask which
+    /// project agents should land in.
+    pub fn needs_credential(&self, interactive: bool) -> bool {
+        !self.show && !self.yes && interactive
+    }
+}
+
 pub async fn command(args: Args) -> Result<()> {
     let home = dirs::home_dir().context("Unable to get home directory")?;
     let existing = AgentPrefs::load_in(&home);

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -148,6 +148,22 @@ pub async fn track_session_event(kind: &str, error: Option<&str>) {
     .await;
 }
 
+/// `railway ca` was run with no credential and sent the user through the login
+/// flow before doing what they asked. Fired once per forwarded run, so the
+/// share of `ca` invocations that are somebody's first Railway command — and
+/// how often that hand-off fails — is visible without inferring it from the
+/// gap between a `login` event and a `cloud_agent` one.
+pub async fn track_login_forwarded(error: Option<&str>) {
+    telemetry::send(event(
+        "cloud_agent",
+        "login_forwarded".to_string(),
+        0,
+        error.is_none(),
+        error.map(truncate),
+    ))
+    .await;
+}
+
 /// `railway ca setup` or the TUI wizard saved preferences. `entry` is
 /// `"cli"` or `"wizard"` — the two call sites share this mapping so both
 /// land in the same shape.


### PR DESCRIPTION
`railway ca` is often the first Railway command someone runs, and logged
out it failed with "Unauthorized. Please login with `railway login`" —
leaving them to run that themselves and retype the command.

Preflight the credential in the `ca` front door instead: with none, run
the login flow in place and continue into what they asked for once it
writes one. Same pattern `railway config` already uses, gated the same
way — piped or scripted callers keep the plain error rather than sitting
on a device code nobody is watching.

`setup --show` and non-interactive `setup` stay logged-out-friendly:
neither leaves the machine. Any credential counts, project tokens
included, since `railway login` short-circuits on RAILWAY_TOKEN anyway.
