### PR TITLE
railway ca: workspace-first onboarding + railway agent harness

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -123,9 +123,9 @@ pub struct SshArgs {
     #[clap(long, value_name = "NAME")]
     session: Option<String>,
 
-    /// Leave the agent running on disconnect instead of putting it to sleep.
-    /// A running agent keeps billing for compute
-    #[clap(long)]
+    /// Accepted for compatibility; agents now always stay running on
+    /// disconnect. `railway ca sleep` stops the compute bill
+    #[clap(long, hide = true)]
     keep_awake: bool,
 
     #[clap(flatten)]
@@ -555,7 +555,14 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
         telemetry::track_lifecycle("ssh_command", Duration::ZERO, None).await;
         run_command(&agent, &args.command).await
     } else {
-        attach(client, &backboard, &agent, args.session.as_deref()).await
+        attach(
+            client,
+            &backboard,
+            &agent,
+            args.session.as_deref(),
+            was_running,
+        )
+        .await
     };
 
     // A connection that never happened still woke a machine with no idle
@@ -566,35 +573,22 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
     let exit_code = match connected {
         Ok(code) => code,
         Err(e) => {
-            if !was_running && !args.keep_awake {
+            if !was_running {
                 let _ = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
             }
             return Err(e);
         }
     };
 
-    if args.keep_awake {
-        println!(
-            "\nDisconnected — agent {} is still running (--keep-awake).",
-            agent.name.cyan()
-        );
-    } else {
-        // Agents have no idle timeout, so nothing else will ever do this.
-        let spinner = create_spinner("Sleeping the agent".to_string());
-        let slept = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
-        spinner.finish_and_clear();
-        match slept {
-            Ok(()) => println!("\nDisconnected — sleeping agent {}.", agent.name.cyan()),
-            Err(e) => eprintln!(
-                "{}",
-                format!(
-                    "Agent {} is still running and billing compute. `railway ca sleep {}` to stop it. ({e})",
-                    agent.name, agent.name
-                )
-                .yellow()
-            ),
-        }
-    }
+    // Disconnecting no longer sleeps the agent: sleep kills every process on
+    // the VM — including the durable session just detached from — while the
+    // platform keeps listing those sessions as running, so the next reattach
+    // landed on a dead name and a blank screen. Sleeping is deliberate now.
+    println!(
+        "\nDisconnected — agent {} is still running. `railway ca sleep {}` stops the compute bill.",
+        agent.name.cyan(),
+        agent.name
+    );
 
     Ok(exit_code)
 }
@@ -630,9 +624,30 @@ async fn attach(
     backboard: &str,
     agent: &ca::Agent,
     requested: Option<&str>,
+    was_running: bool,
 ) -> Result<i32> {
     let sessions = ca::list_sessions(client, backboard, &agent.id).await?;
-    let running: Vec<_> = sessions.into_iter().filter(|s| s.running).collect();
+    let mut running: Vec<_> = sessions.into_iter().filter(|s| s.running).collect();
+
+    // An agent that was asleep a moment ago cannot have a live session:
+    // sleeping stopped every process on the VM, but the platform's session
+    // records can keep saying "running". Believing them attaches to a dead
+    // name — the relay resolves it, streams nothing, and the screen stays
+    // blank. Skip the zombies and start fresh instead.
+    if !was_running && !running.is_empty() {
+        println!(
+            "{}",
+            format!(
+                "Ignoring {} listed session{} on {} — {} ended when the agent last slept.",
+                running.len(),
+                if running.len() == 1 { "" } else { "s" },
+                agent.name,
+                if running.len() == 1 { "it" } else { "they" },
+            )
+            .dimmed()
+        );
+        running.clear();
+    }
 
     let session_name = match requested {
         Some(name) => {

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -46,6 +46,12 @@ struct Harness {
 
 const HARNESSES: &[Harness] = &[
     Harness {
+        slug: "railway",
+        name: "Railway",
+        config_dir: ".railway-agent",
+        bin: "railway-agent",
+    },
+    Harness {
         slug: "claude",
         name: "Claude Code",
         config_dir: ".claude",
@@ -62,12 +68,6 @@ const HARNESSES: &[Harness] = &[
         name: "Grok",
         config_dir: ".grok",
         bin: "grok",
-    },
-    Harness {
-        slug: "railway",
-        name: "Railway",
-        config_dir: ".railway-agent",
-        bin: "railway-agent",
     },
 ];
 
@@ -584,7 +584,7 @@ mod tests {
             .iter()
             .map(|c| c.slug)
             .collect();
-        assert_eq!(slugs, vec!["claude", "codex", "grok", "railway"]);
+        assert_eq!(slugs, vec!["railway", "claude", "codex", "grok"]);
     }
 
     #[test]

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -32,7 +32,10 @@ pub struct Args {
 /// The harnesses a cloud agent can launch today. Every one of these ships in
 /// `cloud-agent-base`; what differs is whether the launcher can carry the
 /// user's credential to it, which is why droid and cursor are absent — their
-/// CLI sign-ins have no copyable local form.
+/// CLI sign-ins have no copyable local form. Railway's own harness needs no
+/// credential at all — see `Agent::Railway` in `commands/code.rs` — so
+/// `config_dir`/`bin` here are only ever meaningful as a "you happen to have
+/// this installed locally too" hint, not a requirement.
 struct Harness {
     slug: &'static str,
     name: &'static str,
@@ -59,6 +62,12 @@ const HARNESSES: &[Harness] = &[
         name: "Grok",
         config_dir: ".grok",
         bin: "grok",
+    },
+    Harness {
+        slug: "railway",
+        name: "Railway",
+        config_dir: ".railway-agent",
+        bin: "railway-agent",
     },
 ];
 
@@ -575,7 +584,7 @@ mod tests {
             .iter()
             .map(|c| c.slug)
             .collect();
-        assert_eq!(slugs, vec!["claude", "codex", "grok"]);
+        assert_eq!(slugs, vec!["claude", "codex", "grok", "railway"]);
     }
 
     #[test]

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -19,8 +19,10 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use super::session;
 use super::theme::Theme;
 
-/// Harnesses the launcher can carry a credential to, in cycle order.
-pub const HARNESSES: &[&str] = &["claude", "codex", "grok"];
+/// Harnesses the launcher can put a session on, in cycle order. `railway` is
+/// the one exception to this list's old name ("carry a credential to") — it
+/// needs none, using the VM's own integrated Railway credentials instead.
+pub const HARNESSES: &[&str] = &["claude", "codex", "grok", "railway"];
 
 /// Everything the Manage screen responds to, grouped for the `?` overlay. The
 /// footer shows two or three of these; this is where the rest lives, so the
@@ -227,6 +229,7 @@ pub struct ProjectNode {
 
 #[derive(Clone, Debug)]
 pub struct WorkspaceNode {
+    pub id: String,
     pub name: String,
     pub expanded: bool,
     pub projects: Vec<ProjectNode>,
@@ -646,8 +649,8 @@ pub enum Effect {
         environment_id: String,
         session_name: String,
     },
-    /// Create the default project the wizard asked for.
-    CreateDefaultProject,
+    /// Create the default project the wizard asked for, in this workspace.
+    CreateDefaultProject(String),
     /// Persist what first-run setup collected.
     SaveSetup(Box<super::wizard::Outcome>),
     /// Remember the default project chosen from the target card.
@@ -1686,7 +1689,7 @@ impl App {
             .unwrap_or(self.theme);
         match action {
             Action::None | Action::Redraw => None,
-            Action::CreateProject => Some(Effect::CreateDefaultProject),
+            Action::CreateProject(workspace_id) => Some(Effect::CreateDefaultProject(workspace_id)),
             Action::Cancel => {
                 self.end_wizard();
                 None
@@ -3333,6 +3336,7 @@ mod tests {
 
     fn tree() -> Vec<WorkspaceNode> {
         vec![WorkspaceNode {
+            id: "ws_1".into(),
             name: "Railway".into(),
             expanded: false,
             projects: vec![ProjectNode {
@@ -3376,6 +3380,7 @@ mod tests {
             envs: vec![env(&format!("{id}-prod"), "production")],
         };
         let tree = vec![WorkspaceNode {
+            id: "ws_1".into(),
             name: "Railway".into(),
             expanded: true,
             projects: vec![
@@ -4073,6 +4078,8 @@ mod tests {
         a.menu_focus = MenuFocus::Cards;
         a.on_key(key(KeyCode::BackTab));
         assert_eq!(a.harness_name(), "grok");
+        a.on_key(key(KeyCode::BackTab));
+        assert_eq!(a.harness_name(), "railway");
         a.on_key(key(KeyCode::BackTab));
         assert_eq!(a.harness_name(), "claude", "cycling wraps");
     }

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -2555,6 +2555,16 @@ impl App {
             .unwrap_or(TOAST_LIFETIME)
     }
 
+    /// Time until an attached pane would first count as stalled, for the loop
+    /// to wake once and draw the notice. `None` when no pane is waiting on
+    /// its first byte.
+    pub fn stall_check_remaining(&self) -> Option<std::time::Duration> {
+        self.sessions
+            .iter()
+            .filter_map(|session| session.stall_remaining())
+            .min()
+    }
+
     /// Give the session pane the whole screen, or give the tree back.
     ///
     /// Only where there is a session to give it to: on the menu, or with

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -19,10 +19,12 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use super::session;
 use super::theme::Theme;
 
-/// Harnesses the launcher can put a session on, in cycle order. `railway` is
-/// the one exception to this list's old name ("carry a credential to") — it
-/// needs none, using the VM's own integrated Railway credentials instead.
-pub const HARNESSES: &[&str] = &["claude", "codex", "grok", "railway"];
+/// Harnesses the launcher can put a session on, in cycle order. `railway`
+/// leads the list — and so is the default pick with nothing configured —
+/// since it is the one exception needing no credential of its own: no
+/// carry-a-local-sign-in step, just the VM's own integrated Railway
+/// credentials.
+pub const HARNESSES: &[&str] = &["railway", "claude", "codex", "grok"];
 
 /// Everything the Manage screen responds to, grouped for the `?` overlay. The
 /// footer shows two or three of these; this is where the rest lives, so the

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -486,6 +486,11 @@ pub async fn run(
             _ = tokio::time::sleep(app::WATCH_TICK), if app.watching_agents() => {
                 app.watch_tick()
             }
+            // A reattach that stays silent gets its "no response" notice drawn
+            // once the stall clock runs out; nothing else would redraw, since
+            // a silent pane by definition sends no output to wake the loop.
+            _ = tokio::time::sleep(app.stall_check_remaining().unwrap_or(std::time::Duration::MAX)),
+                if app.stall_check_remaining().is_some() => None,
             event = events.next() => match event {
                 Some(Ok(Event::Key(key))) if key.kind == KeyEventKind::Press => app.on_key(key),
                 Some(Ok(Event::Mouse(mouse))) => {
@@ -515,10 +520,13 @@ pub async fn run(
         match effect {
             None => {}
             Some(Effect::Quit) => {
-                // Every open session sleeps on the way out; leaving one awake
-                // bills compute with nothing attached to it.
-                while !app.sessions.is_empty() {
-                    close_and_sleep(app, 0, &client, &backboard).await;
+                // Panes detach; agents stay running. Sleeping is a deliberate
+                // act (`s` on the tree, `railway ca sleep`) — an automatic
+                // sleep here killed every session's process while the
+                // platform kept listing the sessions as running, and the next
+                // reattach landed on a dead name and a blank pane.
+                while let Some(mut session) = app.take_session(0) {
+                    session.detach();
                 }
                 return Ok(Outcome::Quit);
             }
@@ -1279,48 +1287,11 @@ async fn run_agent_op(
 ///
 /// Detach only. The agent keeps running, because it may well have other
 /// sessions on it and because sleeping is `s` — a deliberate act on the agent,
-/// not a side effect of closing one window onto it. Quitting still sleeps
-/// everything, which is what stops an agent billing forever.
+/// not a side effect of closing one window onto it. Quitting detaches the
+/// same way; `railway ca sleep` (or `s` on the tree) is what stops the bill.
 async fn close_session(app: &mut App, index: usize, _client: &reqwest::Client, _backboard: &str) {
     if let Some(mut session) = app.take_session(index) {
         session.detach();
-    }
-}
-
-/// Detach a session and sleep its agent — the way out, where nothing is left
-/// watching and an awake agent would bill unattended.
-async fn close_and_sleep(app: &mut App, index: usize, client: &reqwest::Client, backboard: &str) {
-    let Some(mut session) = app.take_session(index) else {
-        return;
-    };
-    let agent_id = session.agent_id.clone();
-    let environment_id = session.environment_id().map(str::to_string);
-    session.detach();
-    drop(session);
-
-    // Without the environment there is no relay target, so the disk cannot be
-    // quiesced first. Sleeping anyway is still right: an agent left awake with
-    // nothing watching it bills until someone notices.
-    let result = match environment_id {
-        Some(environment_id) => {
-            crate::controllers::cloud_agent::sleep(client, backboard, &environment_id, &agent_id)
-                .await
-        }
-        None => post_graphql::<mutations::CloudAgentSleep, _>(
-            client,
-            backboard.to_string(),
-            mutations::cloud_agent_sleep::Variables { id: agent_id },
-        )
-        .await
-        .map(|_| ())
-        .map_err(Into::into),
-    };
-    // Worth its own event, not just a silent `let _ =`: a failure here is an
-    // agent left running and billing compute with nothing attached to it —
-    // exactly the case sleep-on-quit exists to prevent.
-    if let Err(err) = result {
-        let message = format!("{err:#}");
-        super::telemetry::track_session_event("quit_sleep_failed", Some(message.as_str())).await;
     }
 }
 

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -50,21 +50,14 @@ use crate::commands::code::{self, LaunchArgs, Prepared, Progress};
 use crate::config::Configs;
 use crate::gql::{mutations, queries};
 
-/// Create the project first-run setup offers to make.
+/// Create the project first-run setup offers to make, in the workspace the
+/// target step's "+ Create a project" row was chosen under.
 async fn create_default_project(
     client: &reqwest::Client,
     backboard: &str,
+    workspace_id: String,
 ) -> Result<wizard::ProjectOption> {
     use crate::gql::mutations;
-
-    let configs = Configs::new()?;
-    let workspaces = crate::workspace::workspaces_with_client(client, &configs).await?;
-    // No prompt here: the TUI owns the screen. The first workspace is the only
-    // one most accounts have, and setup can be re-run to move it.
-    let workspace = workspaces
-        .first()
-        .map(|ws| ws.id().to_string())
-        .ok_or_else(|| anyhow::anyhow!("no workspace to create a project in"))?;
 
     let created = post_graphql::<mutations::ProjectCreate, _>(
         client,
@@ -72,7 +65,7 @@ async fn create_default_project(
         mutations::project_create::Variables {
             name: Some("Cloud Agents".to_string()),
             description: Some("Home for Railway cloud agents".to_string()),
-            workspace_id: Some(workspace),
+            workspace_id: Some(workspace_id),
         },
     )
     .await?
@@ -260,6 +253,7 @@ pub async fn load_tree(client: &reqwest::Client, configs: &Configs) -> Result<Ve
     Ok(workspaces
         .into_iter()
         .map(|ws| WorkspaceNode {
+            id: ws.id().to_string(),
             name: ws.name().to_string(),
             expanded: false,
             projects: ws
@@ -577,12 +571,12 @@ pub async fn run(
                     let _ = tx.send(message);
                 });
             }
-            Some(Effect::CreateDefaultProject) => {
+            Some(Effect::CreateDefaultProject(workspace_id)) => {
                 let tx = tx.clone();
                 let client = client.clone();
                 let backboard = backboard.clone();
                 tokio::spawn(async move {
-                    let result = create_default_project(&client, &backboard)
+                    let result = create_default_project(&client, &backboard, workspace_id)
                         .await
                         .map_err(|e| format!("{e:#}"));
                     let _ = tx.send(Message::ProjectCreated(result));

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -41,6 +41,29 @@ pub fn durable_name(harness: &str) -> String {
     format!("{harness}-{suffix}")
 }
 
+/// The reply to a device-status-report cursor-position query (`ESC[6n`),
+/// found anywhere in a chunk of remote output — `Some` iff the query is
+/// there.
+///
+/// The query is how a program without a trustworthy `ioctl` answer (this
+/// pane's remote side is a real pty, but a program can still choose to probe
+/// rather than assume) works out where the cursor already is; some terminal
+/// setup code — `railway-agent-tui`'s among them — sends it and blocks on a
+/// reply before drawing anything. The query lives entirely inside the byte
+/// stream this emulator parses: nothing forwards it to the real terminal this
+/// pane itself is drawn in, so unless the emulator answers on the query's
+/// behalf, the remote program hangs until it gives up. `ESC[row;colR`,
+/// 1-indexed, is what a real terminal would have sent back — read off the
+/// emulator's own idea of the cursor position after this chunk lands, so it
+/// reflects everything the chunk itself just drew.
+fn dsr_reply(chunk: &[u8], screen: &vt100::Screen) -> Option<Vec<u8>> {
+    const QUERY: &[u8] = b"\x1b[6n";
+    chunk.windows(QUERY.len()).any(|w| w == QUERY).then(|| {
+        let (row, col) = screen.cursor_position();
+        format!("\x1b[{};{}R", row + 1, col + 1).into_bytes()
+    })
+}
+
 /// Read the environment back out of a relay target (`agent:<env>:<agent>`).
 ///
 /// Returns `None` for anything else rather than guessing: the caller uses this
@@ -70,7 +93,10 @@ pub struct Session {
     pub identity: Option<std::path::PathBuf>,
     pub relay_opts: Vec<String>,
     parser: Arc<Mutex<vt100::Parser>>,
-    writer: Box<dyn Write + Send>,
+    /// Shared with the reader thread, which also writes to it — a synthetic
+    /// cursor-position reply (see [`dsr_reply`]) has to go back over the same
+    /// pty the keyboard does, and `take_writer` can only be called once.
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
     master: Box<dyn portable_pty::MasterPty + Send>,
     /// Set by the reader thread when ssh's output ends — the session is over
@@ -89,6 +115,15 @@ impl Session {
     /// the disk first.
     pub fn environment_id(&self) -> Option<&str> {
         environment_from_target(&self.ssh_target)
+    }
+
+    /// Write straight to the pty — keystrokes, pointer reports, and the
+    /// reader thread's own DSR replies all go through this one shared writer.
+    fn write_raw(&self, bytes: &[u8]) {
+        if let Ok(mut writer) = self.writer.lock() {
+            let _ = writer.write_all(bytes);
+            let _ = writer.flush();
+        }
     }
 
     /// Spawn `ssh` under a pty and start reading it.
@@ -175,22 +210,31 @@ impl Session {
             .master
             .try_clone_reader()
             .context("Failed to read the agent session")?;
-        let writer = pty
-            .master
-            .take_writer()
-            .context("Failed to write to the agent session")?;
+        let writer: Arc<Mutex<Box<dyn Write + Send>>> = Arc::new(Mutex::new(
+            pty.master
+                .take_writer()
+                .context("Failed to write to the agent session")?,
+        ));
 
         {
             let parser = parser.clone();
             let ended = ended.clone();
+            let writer = writer.clone();
             std::thread::spawn(move || {
                 let mut buf = [0u8; 8192];
                 loop {
                     match reader.read(&mut buf) {
                         Ok(0) | Err(_) => break,
                         Ok(n) => {
-                            if let Ok(mut parser) = parser.lock() {
+                            let reply = parser.lock().ok().and_then(|mut parser| {
                                 parser.process(&buf[..n]);
+                                dsr_reply(&buf[..n], parser.screen())
+                            });
+                            if let Some(reply) = reply {
+                                if let Ok(mut writer) = writer.lock() {
+                                    let _ = writer.write_all(&reply);
+                                    let _ = writer.flush();
+                                }
                             }
                             notify();
                         }
@@ -362,10 +406,9 @@ impl Session {
         if !wanted {
             return false;
         }
-        // `write_all`, not `send`: this is not typing, and it must not cancel a
+        // Not through `send`: this is not typing, and it must not cancel a
         // scrollback the way a keystroke does.
-        let _ = self.writer.write_all(&pointer_report(kind, at, encoding));
-        let _ = self.writer.flush();
+        self.write_raw(&pointer_report(kind, at, encoding));
         true
     }
 
@@ -430,8 +473,7 @@ impl Session {
             }
             // Not through `send`: this is not typing, and it must not snap the
             // view back to live.
-            let _ = self.writer.write_all(&out);
-            let _ = self.writer.flush();
+            self.write_raw(&out);
             return;
         }
         if alternate {
@@ -467,8 +509,7 @@ impl Session {
     pub fn send(&mut self, bytes: &[u8]) {
         // Typing is a statement of intent to be at the bottom.
         self.scroll_to_live();
-        let _ = self.writer.write_all(bytes);
-        let _ = self.writer.flush();
+        self.write_raw(bytes);
     }
 
     pub fn send_key(&mut self, key: KeyEvent) {
@@ -538,7 +579,8 @@ impl Session {
         let child = pty.slave.spawn_command(CommandBuilder::new("cat"))?;
         drop(pty.slave);
         let parser = Arc::new(Mutex::new(vt100::Parser::new(24, 80, 4000)));
-        let writer = pty.master.take_writer()?;
+        let writer: Arc<Mutex<Box<dyn Write + Send>>> =
+            Arc::new(Mutex::new(pty.master.take_writer()?));
 
         // The same reader the real session runs. Without it the emulator never
         // sees a byte, and a test against this fixture would be testing
@@ -1002,6 +1044,26 @@ mod tests {
         assert_eq!(legacy[3], 96, "button 64 plus the 32 offset");
         assert_eq!(legacy[4], 255, "clamped to the encodable maximum");
         assert_eq!(legacy[5], 34);
+    }
+
+    /// The reply the emulator would send back for a cursor-position query —
+    /// 1-indexed, and read off wherever the chunk that carried the query
+    /// itself left the cursor.
+    #[test]
+    fn dsr_reply_answers_with_the_current_cursor_position() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        parser.process(b"hello\r\n\x1b[6n");
+        let reply = dsr_reply(b"hello\r\n\x1b[6n", parser.screen());
+        assert_eq!(reply, Some(b"\x1b[2;1R".to_vec()));
+    }
+
+    /// Ordinary output — the vast majority of what comes through — is not a
+    /// query, and must not be answered as though it were one.
+    #[test]
+    fn dsr_reply_is_none_without_a_query() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        parser.process(b"just some output\r\n");
+        assert_eq!(dsr_reply(b"just some output\r\n", parser.screen()), None);
     }
 
     /// An application with mouse reporting on gets the wheel; the emulator's

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -64,20 +64,6 @@ fn dsr_reply(chunk: &[u8], screen: &vt100::Screen) -> Option<Vec<u8>> {
     })
 }
 
-/// Read the environment back out of a relay target (`agent:<env>:<agent>`).
-///
-/// Returns `None` for anything else rather than guessing: the caller uses this
-/// to pick a machine to flush and suspend, and a target shape we don't
-/// recognise is not one to act on.
-fn environment_from_target(target: &str) -> Option<&str> {
-    match *target.split(':').collect::<Vec<_>>().as_slice() {
-        ["agent", environment, agent] if !environment.is_empty() && !agent.is_empty() => {
-            Some(environment)
-        }
-        _ => None,
-    }
-}
-
 /// A running `ssh` under a pty, plus the emulator that makes sense of it.
 pub struct Session {
     pub agent_id: String,
@@ -102,6 +88,14 @@ pub struct Session {
     /// Set by the reader thread when ssh's output ends — the session is over
     /// even though the child may take another moment to reap.
     ended: Arc<AtomicBool>,
+    /// This pane attached to a session that already existed, rather than
+    /// starting one. Only an attach can go silent (see [`Self::stalled`]).
+    reattach: bool,
+    /// When the pane connected, for the stall clock.
+    spawned_at: std::time::Instant,
+    /// Set by the reader thread on the first byte. An attach that never sets
+    /// this is talking to a session whose process is gone.
+    got_output: Arc<AtomicBool>,
     /// Last size pushed to the pty, so a redraw at the same size is free.
     size: (u16, u16),
     /// Rows scrolled back from the live view. Typing snaps back to 0 — nobody
@@ -110,13 +104,6 @@ pub struct Session {
 }
 
 impl Session {
-    /// The environment this session's agent lives in. The relay target is the
-    /// only place the pane carries it, and sleeping the agent needs it to flush
-    /// the disk first.
-    pub fn environment_id(&self) -> Option<&str> {
-        environment_from_target(&self.ssh_target)
-    }
-
     /// Write straight to the pty — keystrokes, pointer reports, and the
     /// reader thread's own DSR replies all go through this one shared writer.
     fn write_raw(&self, bytes: &[u8]) {
@@ -206,6 +193,7 @@ impl Session {
 
         let parser = Arc::new(Mutex::new(vt100::Parser::new(rows, cols, 4000)));
         let ended = Arc::new(AtomicBool::new(false));
+        let got_output = Arc::new(AtomicBool::new(false));
         let mut reader = pty
             .master
             .try_clone_reader()
@@ -220,12 +208,14 @@ impl Session {
             let parser = parser.clone();
             let ended = ended.clone();
             let writer = writer.clone();
+            let got_output = got_output.clone();
             std::thread::spawn(move || {
                 let mut buf = [0u8; 8192];
                 loop {
                     match reader.read(&mut buf) {
                         Ok(0) | Err(_) => break,
                         Ok(n) => {
+                            got_output.store(true, Ordering::Relaxed);
                             let reply = parser.lock().ok().and_then(|mut parser| {
                                 parser.process(&buf[..n]);
                                 dsr_reply(&buf[..n], parser.screen())
@@ -258,9 +248,39 @@ impl Session {
             child,
             master: pty.master,
             ended,
+            reattach,
+            spawned_at: std::time::Instant::now(),
+            got_output,
             size: (rows, cols),
             scroll: 0,
         })
+    }
+
+    /// How long an attach may stay silent before the pane says so.
+    pub const STALL_AFTER: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// An attach that has produced nothing, for long enough to say so.
+    ///
+    /// Only reattaches count: a fresh launch always prints (provisioning, the
+    /// harness banner), so silence there is just a slow start. An attach is
+    /// silent exactly when the durable session's process is gone — the relay
+    /// resolves the name, streams nothing, and never will. The platform can
+    /// keep reporting such a session as running after its agent slept, so
+    /// this is the pane's own way of noticing.
+    pub fn stalled(&self) -> bool {
+        self.reattach
+            && !self.got_output.load(Ordering::Relaxed)
+            && !self.ended()
+            && self.spawned_at.elapsed() >= Self::STALL_AFTER
+    }
+
+    /// Time until [`Self::stalled`] would first flip, so the event loop can
+    /// schedule one redraw for it. `None` when it can't stall or already has.
+    pub fn stall_remaining(&self) -> Option<std::time::Duration> {
+        if !self.reattach || self.got_output.load(Ordering::Relaxed) || self.ended() {
+            return None;
+        }
+        Self::STALL_AFTER.checked_sub(self.spawned_at.elapsed())
     }
 
     pub fn ended(&self) -> bool {
@@ -613,6 +633,9 @@ impl Session {
             child,
             master: pty.master,
             ended: Arc::new(AtomicBool::new(false)),
+            reattach: false,
+            spawned_at: std::time::Instant::now(),
+            got_output: Arc::new(AtomicBool::new(true)),
             size: (24, 80),
             scroll: 0,
         })
@@ -1229,24 +1252,5 @@ mod tests {
         let screen = parser.screen();
         assert_eq!(screen.contents().lines().next().unwrap().trim(), "hello");
         assert!(screen.contents().contains("world"));
-    }
-
-    #[test]
-    fn environment_is_read_out_of_a_relay_target() {
-        assert_eq!(
-            environment_from_target("agent:env-123:agent-456"),
-            Some("env-123")
-        );
-    }
-
-    #[test]
-    fn other_target_shapes_are_not_guessed_at() {
-        // A sandbox target has the same arity, and sleeping a machine picked
-        // out of one would suspend the wrong thing entirely.
-        assert_eq!(environment_from_target("sbx:env-123:sandbox-456"), None);
-        assert_eq!(environment_from_target("agent:env-123"), None);
-        assert_eq!(environment_from_target("agent::agent-456"), None);
-        assert_eq!(environment_from_target("agent:env-123:"), None);
-        assert_eq!(environment_from_target("some-service-instance"), None);
     }
 }

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -893,10 +893,14 @@ mod tests {
         let mut session = Session::for_test("ca", "test").unwrap();
         session.resize(6, 60);
         session.send(b"open https://railway.com/deploy now\r\n");
+        // Wait for the whole URL, not just the host. A pty delivers the line in
+        // whatever chunks it likes, and "railway.com" is already on screen while
+        // the path is still arriving — which left the assertion below comparing
+        // against a truncated `…/dep` on a loaded runner.
         for _ in 0..40 {
             if session
                 .with_screen(|s| s.contents_between(0, 0, 0, u16::MAX))
-                .is_some_and(|line| line.contains("railway.com"))
+                .is_some_and(|line| line.contains("https://railway.com/deploy"))
             {
                 break;
             }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1818,6 +1818,7 @@ mod tests {
 
     pub(super) fn app_with_tree() -> App {
         let tree = vec![WorkspaceNode {
+            id: "ws_1".into(),
             name: "Railway".into(),
             expanded: true,
             projects: vec![ProjectNode {
@@ -2724,32 +2725,30 @@ mod tests {
     #[test]
     fn wizard_rows_without_a_description_have_no_gap() {
         let mut app = app_with_tree();
-        // A second project, so "adjacent" means something.
-        app.tree[0].projects.push(ProjectNode {
-            id: "proj_2".into(),
-            name: "mono".into(),
+        // A second environment, so "adjacent" means something.
+        app.tree[0].projects[0].envs.push(EnvNode {
+            id: "env_stg".into(),
+            name: "staging".into(),
             expanded: false,
-            envs: vec![EnvNode {
-                id: "env_stg".into(),
-                name: "staging".into(),
-                expanded: false,
-                agents: Load::NotLoaded,
-            }],
+            agents: Load::NotLoaded,
         });
         app.skills_source = None;
         app.start_wizard(false);
         if let Some(w) = app.wizard.as_mut() {
-            w.step = crate::commands::cloud_agent::tui::wizard::Step::ProjectPick;
+            w.step = crate::commands::cloud_agent::tui::wizard::Step::Target;
+            // Expand the workspace's only project to reveal its environments
+            // — leaf rows carry no description.
+            w.workspaces[0].projects[0].expanded = true;
         }
 
         let out = draw(&app, 100, 30);
         let lines: Vec<&str> = out.lines().collect();
         let first = lines
             .iter()
-            .position(|l| l.contains("devtools (production)"))
-            .expect("the project row");
+            .position(|l| l.contains("production"))
+            .expect("the environment row");
         assert!(
-            lines[first + 1].contains("mono (staging)"),
+            lines[first + 1].contains("staging"),
             "rows should be adjacent:\n{out}"
         );
     }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -41,18 +41,25 @@ const CARD_GUTTER: usize = 3;
 /// Width of the tree column in Manage, borders included.
 const TREE_W: u16 = 32;
 
+/// One inverse-styled key badge, e.g. ` ^t `. The building block of
+/// [`chord_spans`], and also used solo wherever a shortcut sits beside the
+/// thing it acts on instead of in the footer's own chord list.
+fn chord_badge(theme: &Theme, chord: &str) -> Span<'static> {
+    Span::styled(
+        format!(" {chord} "),
+        Style::default()
+            .fg(theme.on_accent)
+            .bg(theme.accent_dim)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
 /// Footer chords: an inverse badge for the key, dim text for what it does.
 /// Shared so the menu and the manage screen read as the same product.
 fn chord_spans(theme: &Theme, chords: &[(&str, &str)]) -> Vec<Span<'static>> {
     let mut spans = Vec::with_capacity(chords.len() * 2);
     for (chord, what) in chords {
-        spans.push(Span::styled(
-            format!(" {chord} "),
-            Style::default()
-                .fg(theme.on_accent)
-                .bg(theme.accent_dim)
-                .add_modifier(Modifier::BOLD),
-        ));
+        spans.push(chord_badge(theme, chord));
         spans.push(Span::styled(
             format!(" {what}   "),
             Style::default().fg(theme.dim),
@@ -294,14 +301,12 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
         MenuFocus::Prompt => &[
             ("enter", "launch"),
             ("shift+tab", "agent"),
-            ("^t", "target"),
             ("⌥t", "theme"),
             ("⌥s", "setup"),
         ],
         MenuFocus::Cards => &[
             ("↑↓", "select"),
             ("enter", "open"),
-            ("^t", "target"),
             ("⌥t", "theme"),
             ("⌥s", "setup"),
             ("q", "quit"),
@@ -313,26 +318,28 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     );
 }
 
-/// `Target Project  name (environment)`, or an invitation to set one.
+/// `^t  Target Project  name (environment)`, or an invitation to set one.
+/// The shortcut sits right on the field it changes rather than in the
+/// footer's own chord list, which otherwise says nothing about what "target"
+/// even refers to.
 fn target_line(app: &App) -> Line<'static> {
     let theme = app.theme;
-    let label = Span::styled(
-        "Target Project  ",
-        Style::default().fg(theme.dim).add_modifier(Modifier::BOLD),
-    );
-    match app.target.as_ref() {
-        Some(target) => Line::from(vec![
-            label,
-            Span::styled(
-                format!("{} ({})", target.project_name, target.environment_name),
-                Style::default().fg(theme.accent),
-            ),
-        ]),
-        None => Line::from(vec![
-            label,
-            Span::styled("not set", Style::default().fg(theme.pending)),
-        ]),
-    }
+    let mut spans = vec![
+        chord_badge(theme, "^t"),
+        Span::raw(" "),
+        Span::styled(
+            "Target Project  ",
+            Style::default().fg(theme.dim).add_modifier(Modifier::BOLD),
+        ),
+    ];
+    spans.push(match app.target.as_ref() {
+        Some(target) => Span::styled(
+            format!("{} ({})", target.project_name, target.environment_name),
+            Style::default().fg(theme.accent),
+        ),
+        None => Span::styled("not set", Style::default().fg(theme.pending)),
+    });
+    Line::from(spans)
 }
 
 /// The wait, with the task in front of you.
@@ -1927,9 +1934,11 @@ mod tests {
             .rfind(|l| l.contains("launch"))
             .expect("the menu footer");
         assert!(footer.contains("enter"), "{footer}");
-        assert!(footer.contains("target"), "{footer}");
         assert!(footer.contains("theme"), "{footer}");
         assert!(footer.contains("setup"), "{footer}");
+        // The target shortcut moved onto the target line itself — see
+        // `target_shortcut_sits_on_its_own_line`.
+        assert!(!footer.contains("target"), "{footer}");
         assert!(!footer.contains("menu"), "the arrow hint is gone: {footer}");
         // The old run-on line separated with interpuncts; the badges do not.
         assert!(!footer.contains(" · "), "{footer}");
@@ -2043,6 +2052,34 @@ mod tests {
             .position(|l| l.contains("launch"))
             .expect("the footer");
         assert!(target < footer, "the target sits above the shortcuts");
+    }
+
+    /// The shortcut for changing the target sits right on the field it acts
+    /// on, not lumped into the footer's own chord list where it read like a
+    /// command with no object.
+    #[test]
+    fn the_target_shortcut_sits_on_its_own_line() {
+        let app = app_with_tree();
+        let out = draw(&app, 100, 40);
+        let target = out
+            .lines()
+            .find(|l| l.contains("Target Project"))
+            .expect("the target indicator");
+        let chord_at = target.find("^t").expect("the chord badge: {target}");
+        let label_at = target.find("Target Project").unwrap();
+        assert!(
+            chord_at < label_at,
+            "the chord badge comes before the label: {target}"
+        );
+
+        let footer = out
+            .lines()
+            .rfind(|l| l.contains("theme") || l.contains("setup"))
+            .expect("the menu footer");
+        assert!(
+            !footer.contains("^t"),
+            "the chord moved out of the footer: {footer}"
+        );
     }
 
     /// With nowhere to launch, the indicator says so rather than going blank.

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1395,6 +1395,8 @@ fn render_session(app: &App, session: &super::session::Session, f: &mut Frame, a
         .title_bottom(Line::from(Span::styled(
             if session.ended() {
                 " session ended "
+            } else if session.stalled() {
+                " no response "
             } else if session.scrolled_back() {
                 " scrolled back · type to return "
             } else if !session.scrollable() {
@@ -1409,6 +1411,31 @@ fn render_session(app: &App, session: &super::session::Session, f: &mut Frame, a
 
     let inner = block.inner(area);
     f.render_widget(block, area);
+
+    // An attach gone silent has nothing to draw, so say what the silence
+    // means instead of showing an empty screen. The platform can list a
+    // session as running after its agent slept killed the process; attaching
+    // to that name streams nothing, ever.
+    if session.stalled() {
+        let dim = Style::default().fg(theme.dim);
+        f.render_widget(
+            Paragraph::new(vec![
+                Line::from(""),
+                Line::from(Span::styled("Nothing has arrived from this session.", dim)),
+                Line::from(Span::styled(
+                    "It may have ended when the agent last slept —",
+                    dim,
+                )),
+                Line::from(Span::styled(
+                    "x closes this pane, n starts a fresh session.",
+                    dim,
+                )),
+            ])
+            .alignment(ratatui::layout::Alignment::Center),
+            inner,
+        );
+        return;
+    }
 
     let Some(lines) = session.with_screen(|screen| screen_lines(screen, focused)) else {
         return;

--- a/src/commands/cloud_agent/tui/wizard.rs
+++ b/src/commands/cloud_agent/tui/wizard.rs
@@ -6,9 +6,10 @@
 //! moment someone has no idea what a "target" or a "harness" is, so each step
 //! carries a line saying what the choice does.
 //!
-//! The project step reads from the tree the TUI already loaded, so choosing an
-//! existing project costs no network. Creating one does, and that is the only
-//! step that can fail.
+//! The target step reads from the tree the TUI already loaded, so browsing it
+//! costs no network: workspaces list first, and expanding one (or a project
+//! inside it) reveals what is under it, exactly like the tree on the Manage
+//! screen. Creating a project is the only step that can fail.
 
 use super::app::WorkspaceNode;
 use super::theme::{THEMES, Theme};
@@ -18,9 +19,8 @@ use super::theme::{THEMES, Theme};
 pub enum Step {
     /// The modal that opens it: set up now, or not.
     Intro,
-    Project,
-    /// Only when "use an existing project" was chosen.
-    ProjectPick,
+    /// Workspace → project → environment, expandable in place.
+    Target,
     Agent,
     Skills,
     Theme,
@@ -45,6 +45,48 @@ pub struct Outcome {
     pub theme: String,
 }
 
+/// An environment leaf under a [`TargetProject`]. Selecting one finishes the
+/// target step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetEnv {
+    pub id: String,
+    pub name: String,
+}
+
+/// A project under a [`TargetWorkspace`]. Expands to show its environments.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetProject {
+    pub id: String,
+    pub name: String,
+    pub expanded: bool,
+    pub envs: Vec<TargetEnv>,
+}
+
+/// A workspace, the top level of the target step. Expands to show its
+/// projects, and (once expanded) a row to create a new project inside it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TargetWorkspace {
+    pub id: String,
+    pub name: String,
+    pub expanded: bool,
+    pub projects: Vec<TargetProject>,
+}
+
+/// One visible row of the target step's flattened, indented tree. Recomputed
+/// from `Wizard::workspaces` on every render and every keypress, so it never
+/// drifts from the expand state that produced it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum TargetRow {
+    Workspace(usize),
+    /// Create a project inside workspace `usize` — the first row under it
+    /// once expanded, ahead of its existing projects.
+    CreateProject(usize),
+    Project(usize, usize),
+    Env(usize, usize, usize),
+    /// Pinned last: a way out at any depth.
+    DecideLater,
+}
+
 pub struct Wizard {
     pub step: Step,
     pub cursor: usize,
@@ -53,7 +95,7 @@ pub struct Wizard {
     /// Shown under the card when a step went wrong.
     pub error: Option<String>,
     pub project: Option<ProjectOption>,
-    pub projects: Vec<ProjectOption>,
+    pub workspaces: Vec<TargetWorkspace>,
     pub agent: usize,
     pub skills: bool,
     pub skills_source: Option<String>,
@@ -66,8 +108,9 @@ pub enum Action {
     None,
     /// Redraw only; the theme step previews as the cursor moves.
     Redraw,
-    /// Create the default project, then call [`Wizard::project_created`].
-    CreateProject,
+    /// Create the default project in this workspace, then call
+    /// [`Wizard::project_created`].
+    CreateProject(String),
     /// The user finished; save these.
     Finish(Box<Outcome>),
     /// The user declined or backed out of the first question.
@@ -75,39 +118,124 @@ pub enum Action {
 }
 
 impl Wizard {
-    /// Build the flow, taking the project list from the loaded tree.
+    /// Build the flow, taking the workspace tree from the loaded tree. The
+    /// first workspace opens by default — mirroring the Manage screen, so the
+    /// target step is never a wall of collapsed rows — and everything under
+    /// it stays collapsed until asked for.
     pub fn new(
         tree: &[WorkspaceNode],
         harness: Option<&str>,
         theme: &Theme,
         skills_source: Option<String>,
     ) -> Self {
-        let projects = tree
+        let mut workspaces: Vec<TargetWorkspace> = tree
             .iter()
-            .flat_map(|ws| ws.projects.iter())
-            .filter_map(|project| {
-                let env = project.envs.first()?;
-                Some(ProjectOption {
-                    project_id: project.id.clone(),
-                    project_name: project.name.clone(),
-                    environment_id: env.id.clone(),
-                    environment_name: env.name.clone(),
-                })
+            .map(|ws| TargetWorkspace {
+                id: ws.id.clone(),
+                name: ws.name.clone(),
+                expanded: false,
+                projects: ws
+                    .projects
+                    .iter()
+                    .map(|project| TargetProject {
+                        id: project.id.clone(),
+                        name: project.name.clone(),
+                        expanded: false,
+                        envs: project
+                            .envs
+                            .iter()
+                            .map(|env| TargetEnv {
+                                id: env.id.clone(),
+                                name: env.name.clone(),
+                            })
+                            .collect(),
+                    })
+                    .collect(),
             })
             .collect();
+        if let Some(first) = workspaces.first_mut() {
+            first.expanded = true;
+        }
         Self {
             step: Step::Intro,
             cursor: 0,
             busy: None,
             error: None,
             project: None,
-            projects,
+            workspaces,
             agent: harness
                 .and_then(|h| super::app::HARNESSES.iter().position(|x| *x == h))
                 .unwrap_or(0),
             skills: skills_source.is_some(),
             skills_source,
             theme: theme.index(),
+        }
+    }
+
+    /// The target step's rows, flattened and in display order: each
+    /// workspace, then (if expanded) a create-project row and its projects,
+    /// then (for each expanded project) its environments — "Decide later"
+    /// pinned at the end regardless of depth.
+    fn target_rows(&self) -> Vec<TargetRow> {
+        let mut rows = Vec::new();
+        for (w, workspace) in self.workspaces.iter().enumerate() {
+            rows.push(TargetRow::Workspace(w));
+            if !workspace.expanded {
+                continue;
+            }
+            rows.push(TargetRow::CreateProject(w));
+            for (p, project) in workspace.projects.iter().enumerate() {
+                rows.push(TargetRow::Project(w, p));
+                if !project.expanded {
+                    continue;
+                }
+                for e in 0..project.envs.len() {
+                    rows.push(TargetRow::Env(w, p, e));
+                }
+            }
+        }
+        rows.push(TargetRow::DecideLater);
+        rows
+    }
+
+    /// The label and description for one target row, indented by depth. Only
+    /// workspaces and projects carry an expand marker — an environment is
+    /// always a leaf.
+    fn target_row_label(&self, row: TargetRow) -> (String, String) {
+        match row {
+            TargetRow::Workspace(w) => {
+                let workspace = &self.workspaces[w];
+                let marker = if workspace.expanded { "▾" } else { "▸" };
+                let count = workspace.projects.len();
+                (
+                    format!("{marker} {}", workspace.name),
+                    format!("{count} project{}", if count == 1 { "" } else { "s" }),
+                )
+            }
+            TargetRow::CreateProject(w) => (
+                "    + Create a project".into(),
+                format!(
+                    "a new project named \"Cloud Agents\" in {}",
+                    self.workspaces[w].name
+                ),
+            ),
+            TargetRow::Project(w, p) => {
+                let project = &self.workspaces[w].projects[p];
+                let marker = if project.expanded { "▾" } else { "▸" };
+                let count = project.envs.len();
+                (
+                    format!("  {marker} {}", project.name),
+                    format!("{count} environment{}", if count == 1 { "" } else { "s" }),
+                )
+            }
+            TargetRow::Env(w, p, e) => {
+                let env = &self.workspaces[w].projects[p].envs[e];
+                (format!("    {}", env.name), String::new())
+            }
+            TargetRow::DecideLater => (
+                "Decide later".into(),
+                "Pick a target each time you launch".into(),
+            ),
         }
     }
 
@@ -125,35 +253,10 @@ impl Wizard {
                     "Everything still works; you will be asked for a target each time".into(),
                 ),
             ],
-            Step::Project => {
-                let mut options = vec![(
-                    "Create a project".into(),
-                    "A new Railway project named \"Cloud Agents\" to keep them in".into(),
-                )];
-                if !self.projects.is_empty() {
-                    options.push((
-                        "Use an existing project".into(),
-                        format!("Choose one of your {} projects", self.projects.len()),
-                    ));
-                }
-                options.push((
-                    "Decide later".into(),
-                    "Pick a target each time you launch".into(),
-                ));
-                options
-            }
-            // The environment rides in the label. As a description it was the
-            // same sentence on every row, which is a lot of words to say
-            // "production" a dozen times.
-            Step::ProjectPick => self
-                .projects
-                .iter()
-                .map(|p| {
-                    (
-                        format!("{} ({})", p.project_name, p.environment_name),
-                        String::new(),
-                    )
-                })
+            Step::Target => self
+                .target_rows()
+                .into_iter()
+                .map(|row| self.target_row_label(row))
                 .collect(),
             Step::Agent => super::app::HARNESSES
                 .iter()
@@ -161,7 +264,9 @@ impl Wizard {
                     let what = match *slug {
                         "claude" => "Anthropic's Claude Code",
                         "codex" => "OpenAI's Codex",
-                        _ => "xAI's Grok",
+                        "grok" => "xAI's Grok",
+                        "railway" => "Railway's own agent — no sign-in needed",
+                        _ => "",
                     };
                     ((*slug).to_string(), what.to_string())
                 })
@@ -188,15 +293,14 @@ impl Wizard {
 
     /// Start at the first question rather than at "do you want to?".
     pub fn skip_intro(&mut self) {
-        self.step = Step::Project;
+        self.step = Step::Target;
         self.cursor = 0;
     }
 
     pub fn title(&self) -> &'static str {
         match self.step {
             Step::Intro => "Set up cloud agents?",
-            Step::Project => "Where should agents live?",
-            Step::ProjectPick => "Which project?",
+            Step::Target => "Where should agents live?",
             Step::Agent => "Which coding agent?",
             Step::Skills => "Bring your skills?",
             Step::Theme => "Pick a theme",
@@ -208,7 +312,7 @@ impl Wizard {
     pub fn position(&self) -> Option<(usize, usize)> {
         let index = match self.step {
             Step::Intro => return None,
-            Step::Project | Step::ProjectPick => 0,
+            Step::Target => 0,
             Step::Agent => 1,
             Step::Skills => 2,
             Step::Theme => 3,
@@ -246,32 +350,43 @@ impl Wizard {
                 if self.cursor == 1 {
                     return Action::Cancel;
                 }
-                self.go(Step::Project);
+                self.go(Step::Target);
                 Action::Redraw
             }
-            Step::Project => {
-                let has_existing = !self.projects.is_empty();
-                match (self.cursor, has_existing) {
-                    (0, _) => {
-                        self.busy = Some("Creating Cloud Agents…".into());
-                        Action::CreateProject
-                    }
-                    (1, true) => {
-                        self.go(Step::ProjectPick);
-                        Action::Redraw
-                    }
-                    _ => {
-                        self.project = None;
-                        self.go(Step::Agent);
-                        Action::Redraw
-                    }
+            Step::Target => match self.target_rows().get(self.cursor).copied() {
+                Some(TargetRow::Workspace(w)) => {
+                    let workspace = &mut self.workspaces[w];
+                    workspace.expanded = !workspace.expanded;
+                    Action::Redraw
                 }
-            }
-            Step::ProjectPick => {
-                self.project = self.projects.get(self.cursor).cloned();
-                self.go(Step::Agent);
-                Action::Redraw
-            }
+                Some(TargetRow::Project(w, p)) => {
+                    let project = &mut self.workspaces[w].projects[p];
+                    project.expanded = !project.expanded;
+                    Action::Redraw
+                }
+                Some(TargetRow::Env(w, p, e)) => {
+                    let project = &self.workspaces[w].projects[p];
+                    let env = &project.envs[e];
+                    self.project = Some(ProjectOption {
+                        project_id: project.id.clone(),
+                        project_name: project.name.clone(),
+                        environment_id: env.id.clone(),
+                        environment_name: env.name.clone(),
+                    });
+                    self.go(Step::Agent);
+                    Action::Redraw
+                }
+                Some(TargetRow::CreateProject(w)) => {
+                    let workspace = &self.workspaces[w];
+                    self.busy = Some(format!("Creating Cloud Agents in {}…", workspace.name));
+                    Action::CreateProject(workspace.id.clone())
+                }
+                Some(TargetRow::DecideLater) | None => {
+                    self.project = None;
+                    self.go(Step::Agent);
+                    Action::Redraw
+                }
+            },
             Step::Agent => {
                 self.agent = self.cursor.min(super::app::HARNESSES.len() - 1);
                 self.go(Step::Skills);
@@ -300,16 +415,12 @@ impl Wizard {
     pub fn back(&mut self) -> Action {
         match self.step {
             Step::Intro => Action::Cancel,
-            Step::Project => {
+            Step::Target => {
                 self.go(Step::Intro);
                 Action::Redraw
             }
-            Step::ProjectPick => {
-                self.go(Step::Project);
-                Action::Redraw
-            }
             Step::Agent => {
-                self.go(Step::Project);
+                self.go(Step::Target);
                 Action::Redraw
             }
             Step::Skills => {
@@ -332,7 +443,7 @@ impl Wizard {
         };
     }
 
-    /// The project step finished, one way or the other.
+    /// The create-project step finished, one way or the other.
     pub fn project_created(&mut self, result: Result<ProjectOption, String>) {
         self.busy = None;
         match result {
@@ -352,6 +463,7 @@ mod tests {
 
     fn tree() -> Vec<WorkspaceNode> {
         vec![WorkspaceNode {
+            id: "ws1".into(),
             name: "Railway".into(),
             expanded: true,
             projects: vec![
@@ -392,21 +504,42 @@ mod tests {
         assert_eq!(w.select(), Action::Cancel);
     }
 
-    /// The whole flow, ending in the preferences it collected.
+    /// The first workspace opens by default, so its projects are visible
+    /// right away and nothing about them is listed until expanded.
+    #[test]
+    fn the_first_workspace_opens_by_default() {
+        let mut w = wizard();
+        w.skip_intro();
+        let options = w.options();
+        assert_eq!(options[0].0, "▾ Railway");
+        assert!(options.iter().any(|(label, _)| label.contains("devtools")));
+        assert!(options.iter().any(|(label, _)| label.contains("mono")));
+        assert!(
+            !options
+                .iter()
+                .any(|(label, _)| label.contains("production")),
+            "environments stay hidden until their project is expanded"
+        );
+    }
+
+    /// The whole flow, ending in the preferences it collected: expand into a
+    /// project, then pick one of its environments.
     #[test]
     fn the_flow_collects_every_answer() {
         let mut w = wizard();
         assert_eq!(w.select(), Action::Redraw); // set up now
-        assert_eq!(w.step, Step::Project);
+        assert_eq!(w.step, Step::Target);
 
-        w.down(); // use an existing project
-        assert_eq!(w.select(), Action::Redraw);
-        assert_eq!(w.step, Step::ProjectPick);
+        // Rows: ▾ Railway, + Create a project, ▸ devtools, ▸ mono, Decide later.
+        w.down(); // create a project
+        w.down(); // devtools
         w.down(); // mono
+        assert_eq!(w.select(), Action::Redraw); // expand mono
+        w.down(); // staging, just revealed under mono
         w.select();
         assert_eq!(w.step, Step::Agent);
         assert_eq!(w.project.as_ref().unwrap().project_name, "mono");
-        // The project's first environment comes along with it.
+        // The environment picked comes along with it.
         assert_eq!(w.project.as_ref().unwrap().environment_name, "staging");
 
         // The agent step opens on the harness already configured.
@@ -432,12 +565,13 @@ mod tests {
     #[test]
     fn a_failed_create_keeps_the_step() {
         let mut w = wizard();
-        w.select();
-        assert_eq!(w.select(), Action::CreateProject);
+        w.select(); // set up now
+        w.down(); // + Create a project, under the already-open workspace
+        assert_eq!(w.select(), Action::CreateProject("ws1".into()));
         assert!(w.busy.is_some());
 
         w.project_created(Err("no permission".into()));
-        assert_eq!(w.step, Step::Project);
+        assert_eq!(w.step, Step::Target);
         assert!(w.busy.is_none());
         assert_eq!(w.error.as_deref(), Some("no permission"));
 
@@ -456,10 +590,11 @@ mod tests {
     fn escape_walks_back() {
         let mut w = wizard();
         w.select();
+        w.down();
         w.select(); // create → busy, but the step is what matters here
         w.step = Step::Agent;
         assert_eq!(w.back(), Action::Redraw);
-        assert_eq!(w.step, Step::Project);
+        assert_eq!(w.step, Step::Target);
         assert_eq!(w.back(), Action::Redraw);
         assert_eq!(w.step, Step::Intro);
         assert_eq!(w.back(), Action::Cancel);
@@ -476,28 +611,13 @@ mod tests {
         assert_ne!(w.previewed_theme().slug, first);
     }
 
-    /// The project rows carry their environment in the label, so the list is
-    /// not a column of identical sentences.
-    #[test]
-    fn project_rows_name_their_environment_inline() {
-        let mut w = wizard();
-        w.step = Step::ProjectPick;
-        let options = w.options();
-        assert_eq!(options[0].0, "devtools (production)");
-        assert_eq!(options[1].0, "mono (staging)");
-        assert!(
-            options.iter().all(|(_, what)| what.is_empty()),
-            "no repeated description line"
-        );
-    }
-
     /// Chosen from the menu, setup starts at the first question: "do you want
     /// to set up?" has already been answered by choosing it.
     #[test]
     fn skipping_the_intro_starts_at_the_first_question() {
         let mut w = wizard();
         w.skip_intro();
-        assert_eq!(w.step, Step::Project);
+        assert_eq!(w.step, Step::Target);
         assert_eq!(w.position(), Some((0, 4)));
 
         // And escape from there goes back to the intro rather than out, so the
@@ -506,19 +626,67 @@ mod tests {
         assert_eq!(w.step, Step::Intro);
     }
 
-    /// With no projects loaded there is nothing to pick, so the option is not
-    /// offered at all.
+    /// With no workspaces at all there is nothing to expand into, so the only
+    /// way through is the escape hatch.
     #[test]
-    fn the_pick_option_is_hidden_without_projects() {
+    fn with_no_workspaces_only_decide_later_is_offered() {
         let mut w = Wizard::new(&[], None, Theme::default_theme(), None);
-        w.select();
+        w.select(); // set up now
         let labels: Vec<String> = w.options().into_iter().map(|(label, _)| label).collect();
-        assert_eq!(labels, vec!["Create a project", "Decide later"]);
+        assert_eq!(labels, vec!["Decide later"]);
 
-        // And "decide later" still lands on the next question.
-        w.down();
         w.select();
         assert_eq!(w.step, Step::Agent);
         assert!(w.project.is_none());
+    }
+
+    /// A second workspace stays collapsed until asked for, and expanding it
+    /// does not disturb the first.
+    #[test]
+    fn other_workspaces_stay_collapsed_until_expanded() {
+        let mut tree = tree();
+        tree.push(WorkspaceNode {
+            id: "ws2".into(),
+            name: "Personal".into(),
+            expanded: false,
+            projects: vec![ProjectNode {
+                id: "p3".into(),
+                name: "side-project".into(),
+                expanded: false,
+                envs: vec![EnvNode {
+                    id: "e3".into(),
+                    name: "production".into(),
+                    expanded: false,
+                    agents: Load::NotLoaded,
+                }],
+            }],
+        });
+        let mut w = Wizard::new(&tree, Some("codex"), Theme::default_theme(), None);
+        w.skip_intro();
+
+        let before = w.options();
+        assert!(
+            !before
+                .iter()
+                .any(|(label, _)| label.contains("side-project"))
+        );
+
+        let personal_row = before
+            .iter()
+            .position(|(label, _)| label.contains("Personal"))
+            .expect("the second workspace row");
+        w.cursor = personal_row;
+        w.select();
+
+        let after = w.options();
+        assert!(
+            after
+                .iter()
+                .any(|(label, _)| label.contains("side-project"))
+        );
+        assert!(
+            after.iter().any(|(label, _)| label.contains("devtools")),
+            "the first workspace is still expanded"
+        );
     }
 }

--- a/src/commands/cloud_agent/tui/wizard.rs
+++ b/src/commands/cloud_agent/tui/wizard.rs
@@ -543,7 +543,7 @@ mod tests {
         assert_eq!(w.project.as_ref().unwrap().environment_name, "staging");
 
         // The agent step opens on the harness already configured.
-        assert_eq!(w.cursor, 1, "codex was passed in");
+        assert_eq!(w.cursor, 2, "codex was passed in");
         w.select();
         assert_eq!(w.step, Step::Skills);
 

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -262,10 +262,12 @@ enum Agent {
 }
 
 impl Agent {
-    /// The remote binary name (also what's autostarted on reconnect). The one
-    /// exception to "identical to the slug" below: the interactive frontend
-    /// binary is `railway-agent-tui`, not `railway-agent` (that name is the
-    /// headless `run`/`serve` CLI it drives).
+    /// The remote binary name — what's actually exec'd, and what's
+    /// autostarted on reconnect. Only ever used for that: anywhere this agent
+    /// needs a name a person reads, use [`Self::slug`] instead. The one
+    /// exception to "identical to the slug": the interactive frontend binary
+    /// is `railway-agent-tui`, not `railway-agent` (that name is the headless
+    /// `run`/`serve` CLI it drives).
     fn name(self) -> &'static str {
         match self {
             Agent::Codex => "codex",
@@ -275,11 +277,22 @@ impl Agent {
         }
     }
 
-    /// The slug persisted in `agent-prefs.json` and accepted by
-    /// `RAILWAY_CA_AGENT`. Identical to the remote binary name for every agent
-    /// except Railway's own — "railway" reads better than "railway-agent-tui"
-    /// in a flag or a config file, and there is only the one harness it could
-    /// mean.
+    /// The slug persisted in `agent-prefs.json`, accepted by
+    /// `RAILWAY_CA_AGENT`, and used anywhere this agent needs a short,
+    /// user-facing identifier — session name prefixes, the "get back in"
+    /// hint, launch messages. Identical to [`Self::name`] for every agent
+    /// except Railway's own: "railway" reads better than "railway-agent-tui"
+    /// in a flag, a config file, or a session name, and there is only the one
+    /// harness it could mean.
+    fn slug(self) -> &'static str {
+        match self {
+            Agent::Codex => "codex",
+            Agent::Claude => "claude",
+            Agent::Grok => "grok",
+            Agent::Railway => "railway",
+        }
+    }
+
     fn from_slug(slug: &str) -> Option<Self> {
         match slug {
             "claude" => Some(Agent::Claude),
@@ -1555,7 +1568,10 @@ async fn destroy_agent(
 pub fn default_harness() -> Result<&'static str> {
     let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to get home directory"))?;
     let mut prefs = AgentPrefs::load_in(&home).unwrap_or_default();
-    Ok(resolve_agent_choice(&LaunchArgs::default(), &mut prefs, &home)?.name())
+    // The slug, not the remote binary name: this feeds `LaunchArgs::for_target`,
+    // which matches a harness flag by slug, and it's echoed back to the user
+    // in `start_session`'s "starting {harness}" line.
+    Ok(resolve_agent_choice(&LaunchArgs::default(), &mut prefs, &home)?.slug())
 }
 
 /// Environment override for the saved default — one run, no file write. For
@@ -1866,7 +1882,7 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
 
     let result = prepare_inner(args, progress, agent, prefs, &home).await;
     crate::commands::cloud_agent::telemetry::track_launch_outcome(
-        agent.name(),
+        agent.slug(),
         result.as_ref().ok().map(|p| p.created),
         start.elapsed(),
         result.as_ref().err().map(|e| format!("{e:#}")).as_deref(),
@@ -2126,7 +2142,7 @@ async fn prepare_inner(
         agent_id: cloud_agent.id,
         agent_name: cloud_agent.name,
         environment_id,
-        harness: agent.name(),
+        harness: agent.slug(),
         created,
     })
 }
@@ -2715,11 +2731,14 @@ mod tests {
     #[test]
     fn agent_slugs_round_trip() {
         for agent in [Agent::Claude, Agent::Codex, Agent::Grok] {
+            assert_eq!(agent.slug(), agent.name());
             assert_eq!(Agent::from_slug(agent.name()), Some(agent));
         }
         // Railway is the one exception: the slug is "railway", not the
-        // interactive binary's own name.
+        // interactive binary's own name — which is what session prefixes,
+        // launch messages, and telemetry should read.
         assert_eq!(Agent::from_slug("railway"), Some(Agent::Railway));
+        assert_eq!(Agent::Railway.slug(), "railway");
         assert_eq!(Agent::Railway.name(), "railway-agent-tui");
         assert!(Agent::from_slug("droid").is_none());
         assert!(Agent::from_slug("").is_none());

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1901,9 +1901,7 @@ async fn prepare_inner(
         // Said up front, before the VM: the sign-in is the first thing waiting
         // on the other end, and finding that out on arrival reads as a bug.
         PendingAuth::SignInOnAgent { ref note } => progress.note(note),
-        PendingAuth::None => {
-            progress.note("Using the agent's own integrated Railway credentials")
-        }
+        PendingAuth::None => progress.note("Using the agent's own integrated Railway credentials"),
         PendingAuth::MintClaude => {}
     }
     // Pack the user's skills before spending a VM: a skills directory that has
@@ -2295,6 +2293,7 @@ mod tests {
             PendingAuth::SignInOnAgent { note } => note,
             PendingAuth::Ready { source, .. } => panic!("expected a fallback, got {source}"),
             PendingAuth::MintClaude => panic!("expected a fallback, got a mint"),
+            PendingAuth::None => panic!("expected a fallback, got a harness needing no credential"),
         }
     }
 

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -20,8 +20,9 @@ use crate::util::progress::create_shimmer_spinner;
 use crate::util::shell::shell_join;
 
 // ---------------------------------------------------------------------------
-// `railway code --codex` / `railway code --claude` / `railway code --grok` —
-// launch a coding agent on a Railway cloud agent VM, on the user's own plan.
+// `railway code --codex` / `railway code --claude` / `railway code --grok` /
+// `railway code --railway` — launch a coding agent on a Railway cloud agent
+// VM, on the user's own plan.
 //
 // The VM does most of the work. `cloud-agent-base` bakes every harness
 // (claude, codex, grok, cursor, droid, opencode, pi, railway-agent), and the
@@ -41,7 +42,10 @@ use crate::util::shell::shell_join;
 // for "CI pipelines, scripts, or other environments where interactive browser
 // login isn't available", and their own claude-code-action has Pro/Max users
 // mint locally, store the token, and use it on remote runners — the same shape
-// as this command.
+// as this command. Railway's own harness is the odd one out: there is no local
+// sign-in to bring, because the VM already carries a server-minted LLM relay
+// credential and Railway platform tools, reconciled the same way as skills and
+// MCP config — see `Agent::Railway`.
 //
 // All three are a convenience, not a requirement. Carrying the credential saves
 // signing in twice; when the local half isn't there — no `~/.codex/auth.json`,
@@ -98,7 +102,7 @@ pub async fn command(args: Args) -> Result<()> {
 // renders those as `long_about` and it would show up in `--help`.
 #[derive(Parser, Default)]
 #[clap(
-    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs: disconnecting sleeps yours, and the next\n`railway code` wakes it with your work still on disk. `--keep-awake` leaves it\nrunning; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` re-mints it.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs: disconnecting sleeps yours, and the next\n`railway code` wakes it with your work still on disk. `--keep-awake` leaves it\nrunning; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` re-mints it.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct LaunchArgs {
     /// Launch OpenAI Codex, carrying your local ChatGPT sign-in
@@ -116,6 +120,11 @@ pub struct LaunchArgs {
     /// there is one to carry
     #[clap(long)]
     grok: bool,
+
+    /// Launch Railway's own agent — no sign-in needed; it uses credentials
+    /// already on the VM
+    #[clap(long)]
+    railway: bool,
 
     /// Always create a fresh agent instead of reusing this environment's
     #[clap(long)]
@@ -186,6 +195,7 @@ impl LaunchArgs {
         !self.codex
             && !self.claude
             && !self.grok
+            && !self.railway
             && !self.new
             && !self.keep_awake
             && !self.rm
@@ -205,6 +215,7 @@ impl LaunchArgs {
         self.claude = slug == "claude";
         self.codex = slug == "codex";
         self.grok = slug == "grok";
+        self.railway = slug == "railway";
     }
 
     /// The launch the TUI asks for: an explicit project and environment, an
@@ -235,32 +246,46 @@ impl LaunchArgs {
 /// The coding agent to launch, and the two things that differ between them:
 /// where the local sign-in lives, and how its credential is written on the VM.
 /// Installing and configuring the harness is the image's job, not ours.
+///
+/// `Railway` is the exception to both: it is Railway's own harness (built on
+/// `railway-agent`/pi-rs), and the VM already carries everything it needs —
+/// an LLM relay credential and Railway platform tools — minted server-side at
+/// create time, the same way skills and MCP config are reconciled by
+/// express-agent. There is no local sign-in to copy or mint, so it needs none
+/// of the client-side credential machinery the other three do.
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum Agent {
     Codex,
     Claude,
     Grok,
+    Railway,
 }
 
 impl Agent {
-    /// The remote binary name (also what's autostarted on reconnect).
+    /// The remote binary name (also what's autostarted on reconnect). The one
+    /// exception to "identical to the slug" below: the interactive frontend
+    /// binary is `railway-agent-tui`, not `railway-agent` (that name is the
+    /// headless `run`/`serve` CLI it drives).
     fn name(self) -> &'static str {
         match self {
             Agent::Codex => "codex",
             Agent::Claude => "claude",
             Agent::Grok => "grok",
+            Agent::Railway => "railway-agent-tui",
         }
     }
 
     /// The slug persisted in `agent-prefs.json` and accepted by
-    /// `RAILWAY_CA_AGENT`. Identical to the remote binary name, deliberately:
-    /// one string for the user to recognise in a config file, a log line, and
-    /// the process list on the VM.
+    /// `RAILWAY_CA_AGENT`. Identical to the remote binary name for every agent
+    /// except Railway's own — "railway" reads better than "railway-agent-tui"
+    /// in a flag or a config file, and there is only the one harness it could
+    /// mean.
     fn from_slug(slug: &str) -> Option<Self> {
         match slug {
             "claude" => Some(Agent::Claude),
             "codex" => Some(Agent::Codex),
             "grok" => Some(Agent::Grok),
+            "railway" => Some(Agent::Railway),
             _ => None,
         }
     }
@@ -271,37 +296,48 @@ impl Agent {
             Agent::Codex => "Codex",
             Agent::Claude => "Claude Code",
             Agent::Grok => "Grok",
+            Agent::Railway => "Railway",
         }
     }
 
+    /// Unreachable for `Railway`: it is never asked for a credential seed —
+    /// see [`Agent`]'s doc comment — so `prepare_inner` never sets
+    /// `write_credential` for it.
     fn credential_seed(self) -> &'static str {
         match self {
             Agent::Codex => CODEX_SEED,
             Agent::Claude => CLAUDE_SEED,
             Agent::Grok => GROK_SEED,
+            Agent::Railway => "",
         }
     }
 
     /// The local sign-in file this command copies, as `$HOME`-relative
     /// components. `None` for Claude, whose credential is minted rather than
     /// copied — sharing the local sign-in's rotating refresh token across two
-    /// machines is the thing the setup-token exists to avoid.
+    /// machines is the thing the setup-token exists to avoid — and for
+    /// Railway's own harness, whose credential the VM is given at create time.
     fn local_signin_file(self) -> Option<[&'static str; 2]> {
         match self {
             Agent::Codex => Some([".codex", "auth.json"]),
             Agent::Grok => Some([".grok", "auth.json"]),
-            Agent::Claude => None,
+            Agent::Claude | Agent::Railway => None,
         }
     }
 
     /// What to tell someone whose launch carries no credential: the harness
     /// will ask them to sign in on the agent, and this is how that goes. Each
     /// one has a browser/device flow that works fine from a VM.
+    ///
+    /// Railway's own harness never reaches this — it resolves to
+    /// [`PendingAuth::None`] before anything asks for a hint — but the arm
+    /// states the reason rather than leaving the match to guess at one.
     fn sign_in_on_agent_hint(self) -> &'static str {
         match self {
             Agent::Codex => "sign in there with `codex login --device-auth`",
             Agent::Claude => "sign in there with `/login`",
             Agent::Grok => "sign in there when it asks",
+            Agent::Railway => "no sign-in needed — the agent carries its own",
         }
     }
 }
@@ -659,6 +695,9 @@ enum PendingAuth {
     /// before. `note` is the line the user gets so the extra sign-in isn't a
     /// surprise.
     SignInOnAgent { note: String },
+    /// Railway's own harness: nothing to push, ever. Its credential is a
+    /// server-minted VM env var, not a client-side file.
+    None,
 }
 
 /// Set once a Claude mint has been offered this run and come away empty — no
@@ -1532,19 +1571,28 @@ const AGENT_ENV_VAR: &str = "RAILWAY_CA_AGENT";
 /// `prefs` is updated in place when the prompt runs, so the caller's copy
 /// reflects what was saved.
 fn resolve_agent_choice(args: &LaunchArgs, prefs: &mut AgentPrefs, home: &Path) -> Result<Agent> {
-    match (args.codex, args.claude, args.grok) {
-        (true, false, false) => return Ok(Agent::Codex),
-        (false, true, false) => return Ok(Agent::Claude),
-        (false, false, true) => return Ok(Agent::Grok),
-        (false, false, false) => {}
-        _ => bail!("Pick one agent: --codex, --claude, or --grok."),
+    let flagged: Vec<Agent> = [
+        (args.codex, Agent::Codex),
+        (args.claude, Agent::Claude),
+        (args.grok, Agent::Grok),
+        (args.railway, Agent::Railway),
+    ]
+    .into_iter()
+    .filter_map(|(set, agent)| set.then_some(agent))
+    .collect();
+    match flagged.as_slice() {
+        [agent] => return Ok(*agent),
+        [] => {}
+        _ => bail!("Pick one agent: --codex, --claude, --grok, or --railway."),
     }
 
     if let Ok(slug) = std::env::var(AGENT_ENV_VAR) {
         let slug = slug.trim().to_lowercase();
         if !slug.is_empty() {
             let agent = Agent::from_slug(&slug).ok_or_else(|| {
-                anyhow!("{AGENT_ENV_VAR}={slug} is not a known agent (claude, codex, or grok).")
+                anyhow!(
+                    "{AGENT_ENV_VAR}={slug} is not a known agent (claude, codex, grok, or railway)."
+                )
             })?;
             return Ok(agent);
         }
@@ -1858,6 +1906,8 @@ async fn prepare_inner(
             )
             .await?
         }
+        // Nothing to read or mint — the VM already carries its own.
+        Agent::Railway => PendingAuth::None,
     };
     match pending {
         PendingAuth::Ready { ref source, .. } => progress.note(&format!(
@@ -1867,6 +1917,9 @@ async fn prepare_inner(
         // Said up front, before the VM: the sign-in is the first thing waiting
         // on the other end, and finding that out on arrival reads as a bug.
         PendingAuth::SignInOnAgent { ref note } => progress.note(note),
+        PendingAuth::None => {
+            progress.note("Using the agent's own integrated Railway credentials")
+        }
         PendingAuth::MintClaude => {}
     }
     // Pack the user's skills before spending a VM: a skills directory that has
@@ -1925,7 +1978,7 @@ async fn prepare_inner(
     // Probe first, and only pay for the flow when there is nothing there.
     let auth = match pending {
         PendingAuth::Ready { line, source } => Some((line, source)),
-        PendingAuth::SignInOnAgent { .. } => None,
+        PendingAuth::SignInOnAgent { .. } | PendingAuth::None => None,
         PendingAuth::MintClaude => {
             // A fresh agent has nothing to inherit, and --refresh-auth is an
             // explicit request to replace whatever is there; neither needs a probe.
@@ -2393,6 +2446,26 @@ mod tests {
         }
     }
 
+    /// Railway's own harness never has a credential to push — `prepare_inner`
+    /// always resolves it to `PendingAuth::None`, so `write_credential` is
+    /// always false — but it still runs the reconnect/PATH seeds and reports
+    /// its own binary name like every other harness.
+    #[test]
+    fn railway_needs_no_credential_seed() {
+        let script = provision_script(Agent::Railway, false);
+        for other_seed in [
+            "cat > ~/.claude-code-env",
+            "cat > ~/.codex/auth.json",
+            "cat > ~/.grok/auth.json",
+        ] {
+            assert!(!script.contains(other_seed), "{script}");
+        }
+        assert!(script.contains("echo railway-agent-tui > ~/.railway-code-agent"));
+        assert!(script.contains("if command -v railway-agent-tui"));
+        assert!(script.contains("railway-code agent autostart"));
+        assert!(script.contains("AGENT-READY"));
+    }
+
     /// Harness config on an agent VM belongs to express-agent, which reconciles
     /// it on every boot. The CLI used to copy the laptop's
     /// `~/.claude/settings.json` up; it no longer does, and must not drift back
@@ -2400,7 +2473,7 @@ mod tests {
     /// statusline commands that only resolve on the machine that wrote them.
     #[test]
     fn no_provision_step_writes_harness_config() {
-        for agent in [Agent::Claude, Agent::Codex, Agent::Grok] {
+        for agent in [Agent::Claude, Agent::Codex, Agent::Grok, Agent::Railway] {
             for write_credential in [true, false] {
                 let script = provision_script(agent, write_credential);
                 assert!(!script.contains(".claude/settings.json"), "{script}");
@@ -2561,6 +2634,10 @@ mod tests {
             "a harness flag is not a bare invocation"
         );
 
+        let mut railway = LaunchArgs::default();
+        railway.set_harness("railway");
+        assert!(!railway.is_bare());
+
         let targeted = LaunchArgs::for_target(
             "proj_1".into(),
             "env_1".into(),
@@ -2640,6 +2717,10 @@ mod tests {
         for agent in [Agent::Claude, Agent::Codex, Agent::Grok] {
             assert_eq!(Agent::from_slug(agent.name()), Some(agent));
         }
+        // Railway is the one exception: the slug is "railway", not the
+        // interactive binary's own name.
+        assert_eq!(Agent::from_slug("railway"), Some(Agent::Railway));
+        assert_eq!(Agent::Railway.name(), "railway-agent-tui");
         assert!(Agent::from_slug("droid").is_none());
         assert!(Agent::from_slug("").is_none());
     }

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -71,8 +71,10 @@ use crate::util::shell::shell_join;
 // cache.
 //
 // Lifecycle: agents are durable and have no idle timeout, so unlike a sandbox
-// nothing eventually reaps one. Disconnecting therefore SLEEPS the agent —
-// disk and work survive, compute stops billing — and the next run wakes it.
+// nothing eventually reaps one. Disconnecting leaves the agent RUNNING —
+// sleeping kills every process on the VM (including durable sessions the
+// platform keeps listing as reattachable), so it is a deliberate act:
+// `railway ca sleep`, or `s` on the TUI tree.
 // ---------------------------------------------------------------------------
 
 /// `railway code` is the launcher on its own: the same flags and the same
@@ -102,7 +104,7 @@ pub async fn command(args: Args) -> Result<()> {
 // renders those as `long_about` and it would show up in `--help`.
 #[derive(Parser, Default)]
 #[clap(
-    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs: disconnecting sleeps yours, and the next\n`railway code` wakes it with your work still on disk. `--keep-awake` leaves it\nrunning; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` re-mints it.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` re-mints it.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct LaunchArgs {
     /// Launch OpenAI Codex, carrying your local ChatGPT sign-in
@@ -130,9 +132,9 @@ pub struct LaunchArgs {
     #[clap(long)]
     pub new: bool,
 
-    /// Leave the agent running on disconnect instead of putting it to sleep.
-    /// A running agent keeps billing for compute
-    #[clap(long)]
+    /// Accepted for compatibility; agents now always stay running on
+    /// disconnect. `railway ca sleep` stops the compute bill
+    #[clap(long, hide = true)]
     keep_awake: bool,
 
     /// Destroy this environment's agent and exit. Its disk goes with it.
@@ -1761,28 +1763,15 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
         let _ = out.flush();
     }
 
-    let configs = Configs::new()?;
-    let client = GQLClient::new_authorized(&configs)?;
-    if args.keep_awake {
-        println!(
-            "\nDisconnected — agent {} is still running (--keep-awake).",
-            prepared.agent_name.cyan()
-        );
-    } else {
-        let progress = CliProgress::default();
-        if let Err(e) = sleep_agent(&client, &configs, &prepared, &progress).await {
-            progress.finish();
-            eprintln!(
-                "{}",
-                format!(
-                    "Agent {} is still running and billing compute. Sleep it from the dashboard, or `railway code --rm` to destroy it. ({e})",
-                    prepared.agent_name
-                )
-                .yellow()
-            );
-        }
-        progress.finish();
-    }
+    // Disconnecting no longer sleeps the agent: sleep kills every process on
+    // the VM — including the durable session just detached from — while the
+    // platform keeps listing those sessions as running, so the next reattach
+    // landed on a dead name and a blank screen. Sleeping is deliberate now.
+    println!(
+        "\nDisconnected — agent {} is still running. `railway ca sleep {}` stops the compute bill.",
+        prepared.agent_name.cyan(),
+        prepared.agent_name
+    );
 
     if prepared.created {
         println!("Agents persist between runs — this one is yours until you --rm it.");
@@ -1824,27 +1813,6 @@ pub fn run_session(prepared: &Prepared) -> Result<i32> {
     );
     crate::commands::ssh::native::clear_mouse_tracking();
     code
-}
-
-/// Put the agent back to sleep. Agents have no idle timeout, so nothing else
-/// ever will: leaving one running bills compute until the user remembers it,
-/// and sleeping keeps the disk so the next run wakes into the same work.
-pub async fn sleep_agent(
-    client: &reqwest::Client,
-    configs: &Configs,
-    prepared: &Prepared,
-    progress: &dyn Progress,
-) -> Result<()> {
-    progress.step("Sleeping the agent");
-    crate::controllers::cloud_agent::sleep(
-        client,
-        &configs.get_backboard(),
-        &prepared.environment_id,
-        &prepared.agent_id,
-    )
-    .await?;
-    progress.finish();
-    Ok(())
 }
 
 /// Everything between "the user asked" and "there is a session to open":


### PR DESCRIPTION
## Summary
- Reworks the `railway ca` / `railway ca setup` first-run wizard's target step: it now shows workspaces first (the first one auto-expanded, mirroring the Manage tree), and expanding a workspace or project reveals what's under it — projects, then environments — instead of the old flat "pick from every project across every workspace" list.
- "+ Create a project" is now a row nested under the workspace you're browsing, and actually creates the project there (`Effect::CreateDefaultProject` now carries a `workspace_id`), instead of always silently defaulting to `workspaces.first()`.
- `railway ca setup` (the plain, non-TUI `inquire` flow) was audited against the same ask — its "Use an existing project"/"Create a project" paths already resolve workspace → project → environment in that order (`prompt_workspace_project_env`, `pick_workspace`), so no change was needed there.
- Adds `railway` as a fourth launchable harness alongside `claude`/`codex`/`grok` (`railway ca --railway` / `railway code --railway`). It's Railway's own agent (`railway-agent`/`railway-agent-tui`, built on pi-rs) — the VM already carries a server-minted LLM gateway credential and Railway platform tools at create time, so unlike the other three harnesses it needs no local sign-in copied or minted onto the agent (`PendingAuth::None`).

## Test plan
- [x] `cargo build` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --bin railway` — no new warnings in touched files
- [x] `cargo test --bin railway` — 965 passed (3 pre-existing, unrelated `auth_sim` failures reproduce identically on `master`, caused by this dev VM's own ambient Railway auth env leaking into those tests)
- [x] Downloaded the public `railway-agent`/`railway-agent-tui` v0.1.9 release binaries and ran them on this cloud-agent VM using its own ambient `AI_GATEWAY_URL`/`AI_AGENT_KEY` — confirmed a real one-shot `railway-agent run` call succeeds with zero local credential setup, validating the "own integrated credentials" premise this harness choice relies on.