### PR TITLE
Ask which workspace the wizard's new project lands in

### DIFF
--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -73,7 +73,9 @@ async fn browse() -> Result<()> {
     let tree = tui::load_tree(&client, &configs).await;
     spinner.finish_and_clear();
     let tree = tree?;
-    if tree.is_empty() {
+    // Workspaces alone are not enough to browse — the listing now keeps the
+    // empty ones, for setup to create a project in — so ask about projects.
+    if tree.iter().all(|ws| ws.projects.is_empty()) {
         println!(
             "No projects with environments you can use. Create one with {} first.",
             "railway init".cyan()

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -775,6 +775,10 @@ pub struct App {
     pub harness: usize,
     pub target: Option<Target>,
     pub tree: Vec<WorkspaceNode>,
+    /// Every workspace the account can see, empty ones included — where setup
+    /// can put a new project, as opposed to `tree`, which is what can be
+    /// browsed. See [`App::new`].
+    pub workspaces: Vec<super::wizard::WorkspaceOption>,
     pub cursor: usize,
     /// Transient one-line message shown in the header.
     pub status: String,
@@ -792,7 +796,25 @@ impl App {
         let harness = harness
             .and_then(|h| HARNESSES.iter().position(|x| *x == h))
             .unwrap_or(0);
+        // Two views of the same listing. The tree shows what can be browsed, so
+        // a workspace holding nothing is dropped from it — an empty row that
+        // expands to nothing. Setup wants the full list: a workspace with no
+        // projects yet is still somewhere a project can be created, and for a
+        // team someone just joined it is often the one they mean.
+        let workspaces = tree
+            .iter()
+            .map(|ws| super::wizard::WorkspaceOption {
+                id: ws.id.clone(),
+                name: ws.name.clone(),
+                projects: ws.projects.len(),
+            })
+            .collect();
+        let tree = tree
+            .into_iter()
+            .filter(|ws| !ws.projects.is_empty())
+            .collect();
         let mut app = Self {
+            workspaces,
             default_project,
             configured,
             known_environments: Vec::new(),
@@ -1037,6 +1059,7 @@ impl App {
     pub fn start_wizard(&mut self, ask_first: bool) {
         let mut wizard = super::wizard::Wizard::new(
             &self.tree,
+            self.workspaces.clone(),
             Some(self.harness_name()),
             self.theme,
             self.skills_source.clone(),

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -227,6 +227,10 @@ pub struct ProjectNode {
 
 #[derive(Clone, Debug)]
 pub struct WorkspaceNode {
+    /// Carried for the wizard, which creates a project in one of these and so
+    /// needs to name a workspace the API will accept. The tree itself groups by
+    /// display name.
+    pub id: String,
     pub name: String,
     pub expanded: bool,
     pub projects: Vec<ProjectNode>,
@@ -646,8 +650,11 @@ pub enum Effect {
         environment_id: String,
         session_name: String,
     },
-    /// Create the default project the wizard asked for.
-    CreateDefaultProject,
+    /// Create the default project the wizard asked for, in the workspace it
+    /// picked (`None` when there was only one to pick from).
+    CreateDefaultProject {
+        workspace_id: Option<String>,
+    },
     /// Persist what first-run setup collected.
     SaveSetup(Box<super::wizard::Outcome>),
     /// Remember the default project chosen from the target card.
@@ -1686,7 +1693,9 @@ impl App {
             .unwrap_or(self.theme);
         match action {
             Action::None | Action::Redraw => None,
-            Action::CreateProject => Some(Effect::CreateDefaultProject),
+            Action::CreateProject(workspace_id) => {
+                Some(Effect::CreateDefaultProject { workspace_id })
+            }
             Action::Cancel => {
                 self.end_wizard();
                 None
@@ -3333,6 +3342,7 @@ mod tests {
 
     fn tree() -> Vec<WorkspaceNode> {
         vec![WorkspaceNode {
+            id: "ws1".into(),
             name: "Railway".into(),
             expanded: false,
             projects: vec![ProjectNode {
@@ -3376,6 +3386,7 @@ mod tests {
             envs: vec![env(&format!("{id}-prod"), "production")],
         };
         let tree = vec![WorkspaceNode {
+            id: "ws1".into(),
             name: "Railway".into(),
             expanded: true,
             projects: vec![

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -268,6 +268,10 @@ impl Progress for ChannelProgress {
 /// Build the tree from the workspace listing. Deleted projects are dropped, and
 /// so are environments the caller cannot access — an agent can't be listed or
 /// created in either, so showing them would only offer dead ends.
+///
+/// Workspaces with nothing left in them stay: they are dropped from the browse
+/// tree by [`App::new`], but setup still offers them as somewhere to create the
+/// default project, which is the whole point of an empty workspace.
 pub async fn load_tree(client: &reqwest::Client, configs: &Configs) -> Result<Vec<WorkspaceNode>> {
     let workspaces = crate::workspace::workspaces_with_client(client, configs).await?;
     Ok(workspaces
@@ -299,7 +303,6 @@ pub async fn load_tree(client: &reqwest::Client, configs: &Configs) -> Result<Ve
                 .filter(|p| !p.envs.is_empty())
                 .collect(),
         })
-        .filter(|ws| !ws.projects.is_empty())
         .collect())
 }
 

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -50,21 +50,34 @@ use crate::commands::code::{self, LaunchArgs, Prepared, Progress};
 use crate::config::Configs;
 use crate::gql::{mutations, queries};
 
-/// Create the project first-run setup offers to make.
+/// Create the project first-run setup offers to make, in the workspace the
+/// wizard asked for.
+///
+/// `workspace_id` is `None` only when there was one workspace to choose from,
+/// so falling back to the first is the same answer the user would have given.
+/// An id that no longer resolves is an error rather than a silent fallback:
+/// creating the project somewhere other than where they pointed is how one ends
+/// up lost.
 async fn create_default_project(
     client: &reqwest::Client,
     backboard: &str,
+    workspace_id: Option<String>,
 ) -> Result<wizard::ProjectOption> {
     use crate::gql::mutations;
 
     let configs = Configs::new()?;
     let workspaces = crate::workspace::workspaces_with_client(client, &configs).await?;
-    // No prompt here: the TUI owns the screen. The first workspace is the only
-    // one most accounts have, and setup can be re-run to move it.
-    let workspace = workspaces
-        .first()
-        .map(|ws| ws.id().to_string())
-        .ok_or_else(|| anyhow::anyhow!("no workspace to create a project in"))?;
+    let workspace = match workspace_id {
+        Some(id) => workspaces
+            .iter()
+            .find(|ws| ws.id() == id)
+            .map(|ws| ws.id().to_string())
+            .ok_or_else(|| anyhow::anyhow!("that workspace is no longer available"))?,
+        None => workspaces
+            .first()
+            .map(|ws| ws.id().to_string())
+            .ok_or_else(|| anyhow::anyhow!("no workspace to create a project in"))?,
+    };
 
     let created = post_graphql::<mutations::ProjectCreate, _>(
         client,
@@ -260,6 +273,7 @@ pub async fn load_tree(client: &reqwest::Client, configs: &Configs) -> Result<Ve
     Ok(workspaces
         .into_iter()
         .map(|ws| WorkspaceNode {
+            id: ws.id().to_string(),
             name: ws.name().to_string(),
             expanded: false,
             projects: ws
@@ -577,12 +591,12 @@ pub async fn run(
                     let _ = tx.send(message);
                 });
             }
-            Some(Effect::CreateDefaultProject) => {
+            Some(Effect::CreateDefaultProject { workspace_id }) => {
                 let tx = tx.clone();
                 let client = client.clone();
                 let backboard = backboard.clone();
                 tokio::spawn(async move {
-                    let result = create_default_project(&client, &backboard)
+                    let result = create_default_project(&client, &backboard, workspace_id)
                         .await
                         .map_err(|e| format!("{e:#}"));
                     let _ = tx.send(Message::ProjectCreated(result));
@@ -903,6 +917,17 @@ fn handle_message(
         }
         Message::ProjectCreated(result) => {
             if let Some(w) = app.wizard.as_mut() {
+                // Say where it went. The wizard moves straight on to the next
+                // question, so without this the only record of which workspace
+                // now holds a "Cloud Agents" project is the dashboard.
+                if let Ok(project) = &result {
+                    app.status = match &w.created_in {
+                        Some(workspace) => {
+                            format!("Created {} in {workspace}", project.project_name)
+                        }
+                        None => format!("Created {}", project.project_name),
+                    };
+                }
                 w.project_created(result);
             }
             None

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -2761,12 +2761,13 @@ mod tests {
     #[test]
     fn the_workspace_card_and_its_result_are_both_on_screen() {
         let mut app = app_with_tree();
-        app.tree.push(WorkspaceNode {
-            id: "ws2".into(),
-            name: "Acme".into(),
-            expanded: false,
-            projects: Vec::new(),
-        });
+        // An empty workspace: never in the browse tree, always in the picker.
+        app.workspaces
+            .push(crate::commands::cloud_agent::tui::wizard::WorkspaceOption {
+                id: "ws2".into(),
+                name: "Acme".into(),
+                projects: 0,
+            });
         app.start_wizard(false);
         if let Some(w) = app.wizard.as_mut() {
             w.step = crate::commands::cloud_agent::tui::wizard::Step::WorkspacePick;
@@ -2774,6 +2775,7 @@ mod tests {
         let out = draw(&app, 100, 30);
         assert!(out.contains("Which workspace?"), "{out}");
         assert!(out.contains("Acme"), "{out}");
+        assert!(out.contains("no projects yet"), "{out}");
 
         app.status = "Created Cloud Agents in Acme".into();
         let out = draw(&app, 100, 30);

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1818,6 +1818,7 @@ mod tests {
 
     pub(super) fn app_with_tree() -> App {
         let tree = vec![WorkspaceNode {
+            id: "ws1".into(),
             name: "Railway".into(),
             expanded: true,
             projects: vec![ProjectNode {
@@ -2752,6 +2753,31 @@ mod tests {
             lines[first + 1].contains("mono (staging)"),
             "rows should be adjacent:\n{out}"
         );
+    }
+
+    /// The workspace card, and the line saying where the project went — both
+    /// have to survive the wizard being drawn over the menu, which is where
+    /// the status lives.
+    #[test]
+    fn the_workspace_card_and_its_result_are_both_on_screen() {
+        let mut app = app_with_tree();
+        app.tree.push(WorkspaceNode {
+            id: "ws2".into(),
+            name: "Acme".into(),
+            expanded: false,
+            projects: Vec::new(),
+        });
+        app.start_wizard(false);
+        if let Some(w) = app.wizard.as_mut() {
+            w.step = crate::commands::cloud_agent::tui::wizard::Step::WorkspacePick;
+        }
+        let out = draw(&app, 100, 30);
+        assert!(out.contains("Which workspace?"), "{out}");
+        assert!(out.contains("Acme"), "{out}");
+
+        app.status = "Created Cloud Agents in Acme".into();
+        let out = draw(&app, 100, 30);
+        assert!(out.contains("Created Cloud Agents in Acme"), "{out}");
     }
 
     /// A tree with nothing in it must not panic the renderer.

--- a/src/commands/cloud_agent/tui/wizard.rs
+++ b/src/commands/cloud_agent/tui/wizard.rs
@@ -95,8 +95,13 @@ pub enum Action {
 
 impl Wizard {
     /// Build the flow, taking the project list from the loaded tree.
+    ///
+    /// `workspaces` is passed in rather than derived from `tree` because the
+    /// two differ: the tree carries only workspaces with something to browse,
+    /// and a new project can go in any of them.
     pub fn new(
         tree: &[WorkspaceNode],
+        workspaces: Vec<WorkspaceOption>,
         harness: Option<&str>,
         theme: &Theme,
         skills_source: Option<String>,
@@ -112,14 +117,6 @@ impl Wizard {
                     environment_id: env.id.clone(),
                     environment_name: env.name.clone(),
                 })
-            })
-            .collect();
-        let workspaces = tree
-            .iter()
-            .map(|ws| WorkspaceOption {
-                id: ws.id.clone(),
-                name: ws.name.clone(),
-                projects: ws.projects.len(),
             })
             .collect();
         Self {
@@ -189,6 +186,9 @@ impl Wizard {
                 .iter()
                 .map(|ws| {
                     let what = match ws.projects {
+                        // A workspace with nothing in it is a fine home for
+                        // agents and the row should not read like a warning.
+                        0 => "no projects yet".to_string(),
                         1 => "1 project".to_string(),
                         n => format!("{n} projects"),
                     };
@@ -453,8 +453,27 @@ mod tests {
         }]
     }
 
+    /// The workspace list the app derives from the same listing the tree came
+    /// from — see [`super::app::App::new`].
+    fn workspaces(tree: &[WorkspaceNode]) -> Vec<WorkspaceOption> {
+        tree.iter()
+            .map(|ws| WorkspaceOption {
+                id: ws.id.clone(),
+                name: ws.name.clone(),
+                projects: ws.projects.len(),
+            })
+            .collect()
+    }
+
     fn wizard() -> Wizard {
-        Wizard::new(&tree(), Some("codex"), Theme::default_theme(), None)
+        let tree = tree();
+        Wizard::new(
+            &tree,
+            workspaces(&tree),
+            Some("codex"),
+            Theme::default_theme(),
+            None,
+        )
     }
 
     #[test]
@@ -600,7 +619,13 @@ mod tests {
                 }],
             }],
         });
-        let mut w = Wizard::new(&tree, Some("codex"), Theme::default_theme(), None);
+        let mut w = Wizard::new(
+            &tree,
+            workspaces(&tree),
+            Some("codex"),
+            Theme::default_theme(),
+            None,
+        );
         w.select(); // set up now
         assert_eq!(w.select(), Action::Redraw, "create asks first");
         assert_eq!(w.step, Step::WorkspacePick);
@@ -627,6 +652,29 @@ mod tests {
         assert_eq!(w.step, Step::Project);
     }
 
+    /// A workspace with nothing in it never reaches the browse tree, but it is
+    /// still somewhere a project can go — often the point of a team workspace
+    /// someone has just joined.
+    #[test]
+    fn an_empty_workspace_is_offered_as_a_home() {
+        let tree = tree();
+        let mut workspaces = workspaces(&tree);
+        workspaces.push(WorkspaceOption {
+            id: "ws2".into(),
+            name: "Acme".into(),
+            projects: 0,
+        });
+        let mut w = Wizard::new(&tree, workspaces, None, Theme::default_theme(), None);
+        w.select(); // set up now
+        w.select(); // create → which workspace?
+        assert_eq!(w.step, Step::WorkspacePick);
+        assert_eq!(w.options()[1], ("Acme".into(), "no projects yet".into()));
+
+        w.down();
+        assert_eq!(w.select(), Action::CreateProject(Some("ws2".into())));
+        assert_eq!(w.busy.as_deref(), Some("Creating Cloud Agents in Acme…"));
+    }
+
     /// The workspace question is part of "where should agents live?", not a
     /// fifth step — the progress dots must not move because of it.
     #[test]
@@ -640,7 +688,7 @@ mod tests {
     /// offered at all.
     #[test]
     fn the_pick_option_is_hidden_without_projects() {
-        let mut w = Wizard::new(&[], None, Theme::default_theme(), None);
+        let mut w = Wizard::new(&[], Vec::new(), None, Theme::default_theme(), None);
         w.select();
         let labels: Vec<String> = w.options().into_iter().map(|(label, _)| label).collect();
         assert_eq!(labels, vec!["Create a project", "Decide later"]);

--- a/src/commands/cloud_agent/tui/wizard.rs
+++ b/src/commands/cloud_agent/tui/wizard.rs
@@ -21,6 +21,9 @@ pub enum Step {
     Project,
     /// Only when "use an existing project" was chosen.
     ProjectPick,
+    /// Only when "create a project" was chosen and there is more than one
+    /// workspace it could land in.
+    WorkspacePick,
     Agent,
     Skills,
     Theme,
@@ -33,6 +36,16 @@ pub struct ProjectOption {
     pub project_name: String,
     pub environment_id: String,
     pub environment_name: String,
+}
+
+/// A workspace the new project could be created in.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceOption {
+    pub id: String,
+    pub name: String,
+    /// How many projects it already holds — the one fact that tells a personal
+    /// workspace from a team one at a glance.
+    pub projects: usize,
 }
 
 /// What the wizard asks for when it finishes.
@@ -54,6 +67,10 @@ pub struct Wizard {
     pub error: Option<String>,
     pub project: Option<ProjectOption>,
     pub projects: Vec<ProjectOption>,
+    pub workspaces: Vec<WorkspaceOption>,
+    /// The workspace the create in flight is going to, for the line that
+    /// reports where it landed.
+    pub created_in: Option<String>,
     pub agent: usize,
     pub skills: bool,
     pub skills_source: Option<String>,
@@ -66,8 +83,10 @@ pub enum Action {
     None,
     /// Redraw only; the theme step previews as the cursor moves.
     Redraw,
-    /// Create the default project, then call [`Wizard::project_created`].
-    CreateProject,
+    /// Create the default project in this workspace, then call
+    /// [`Wizard::project_created`]. `None` when the account has exactly one
+    /// workspace and there was nothing to ask.
+    CreateProject(Option<String>),
     /// The user finished; save these.
     Finish(Box<Outcome>),
     /// The user declined or backed out of the first question.
@@ -95,6 +114,14 @@ impl Wizard {
                 })
             })
             .collect();
+        let workspaces = tree
+            .iter()
+            .map(|ws| WorkspaceOption {
+                id: ws.id.clone(),
+                name: ws.name.clone(),
+                projects: ws.projects.len(),
+            })
+            .collect();
         Self {
             step: Step::Intro,
             cursor: 0,
@@ -102,6 +129,8 @@ impl Wizard {
             error: None,
             project: None,
             projects,
+            workspaces,
+            created_in: None,
             agent: harness
                 .and_then(|h| super::app::HARNESSES.iter().position(|x| *x == h))
                 .unwrap_or(0),
@@ -155,6 +184,17 @@ impl Wizard {
                     )
                 })
                 .collect(),
+            Step::WorkspacePick => self
+                .workspaces
+                .iter()
+                .map(|ws| {
+                    let what = match ws.projects {
+                        1 => "1 project".to_string(),
+                        n => format!("{n} projects"),
+                    };
+                    (ws.name.clone(), what)
+                })
+                .collect(),
             Step::Agent => super::app::HARNESSES
                 .iter()
                 .map(|slug| {
@@ -197,6 +237,7 @@ impl Wizard {
             Step::Intro => "Set up cloud agents?",
             Step::Project => "Where should agents live?",
             Step::ProjectPick => "Which project?",
+            Step::WorkspacePick => "Which workspace?",
             Step::Agent => "Which coding agent?",
             Step::Skills => "Bring your skills?",
             Step::Theme => "Pick a theme",
@@ -208,7 +249,9 @@ impl Wizard {
     pub fn position(&self) -> Option<(usize, usize)> {
         let index = match self.step {
             Step::Intro => return None,
-            Step::Project | Step::ProjectPick => 0,
+            // All three answer the same question — where agents live — so they
+            // share a dot rather than making the flow look longer than it is.
+            Step::Project | Step::ProjectPick | Step::WorkspacePick => 0,
             Step::Agent => 1,
             Step::Skills => 2,
             Step::Theme => 3,
@@ -252,9 +295,17 @@ impl Wizard {
             Step::Project => {
                 let has_existing = !self.projects.is_empty();
                 match (self.cursor, has_existing) {
+                    // More than one workspace: ask which, rather than picking
+                    // one for them. A project made in the wrong workspace is
+                    // invisible to everyone who cannot see that workspace, and
+                    // nothing in the flow would have said where it went.
+                    (0, _) if self.workspaces.len() > 1 => {
+                        self.go(Step::WorkspacePick);
+                        Action::Redraw
+                    }
                     (0, _) => {
-                        self.busy = Some("Creating Cloud Agents…".into());
-                        Action::CreateProject
+                        let only = self.workspaces.first().cloned();
+                        self.create_in(only)
                     }
                     (1, true) => {
                         self.go(Step::ProjectPick);
@@ -271,6 +322,12 @@ impl Wizard {
                 self.project = self.projects.get(self.cursor).cloned();
                 self.go(Step::Agent);
                 Action::Redraw
+            }
+            Step::WorkspacePick => {
+                let Some(workspace) = self.workspaces.get(self.cursor).cloned() else {
+                    return Action::None;
+                };
+                self.create_in(Some(workspace))
             }
             Step::Agent => {
                 self.agent = self.cursor.min(super::app::HARNESSES.len() - 1);
@@ -304,7 +361,7 @@ impl Wizard {
                 self.go(Step::Intro);
                 Action::Redraw
             }
-            Step::ProjectPick => {
+            Step::ProjectPick | Step::WorkspacePick => {
                 self.go(Step::Project);
                 Action::Redraw
             }
@@ -321,6 +378,20 @@ impl Wizard {
                 Action::Redraw
             }
         }
+    }
+
+    /// Hand the create off to the loop, with the workspace it answered for.
+    /// The workspace is named in the busy line whenever it was a choice, so
+    /// where the project is going is on screen while it goes there.
+    fn create_in(&mut self, workspace: Option<WorkspaceOption>) -> Action {
+        self.busy = Some(match &workspace {
+            Some(ws) if self.workspaces.len() > 1 => {
+                format!("Creating Cloud Agents in {}…", ws.name)
+            }
+            _ => "Creating Cloud Agents…".into(),
+        });
+        self.created_in = workspace.as_ref().map(|ws| ws.name.clone());
+        Action::CreateProject(workspace.map(|ws| ws.id))
     }
 
     fn go(&mut self, step: Step) {
@@ -352,6 +423,7 @@ mod tests {
 
     fn tree() -> Vec<WorkspaceNode> {
         vec![WorkspaceNode {
+            id: "ws1".into(),
             name: "Railway".into(),
             expanded: true,
             projects: vec![
@@ -433,7 +505,8 @@ mod tests {
     fn a_failed_create_keeps_the_step() {
         let mut w = wizard();
         w.select();
-        assert_eq!(w.select(), Action::CreateProject);
+        // One workspace, so the create goes straight through with it.
+        assert_eq!(w.select(), Action::CreateProject(Some("ws1".into())));
         assert!(w.busy.is_some());
 
         w.project_created(Err("no permission".into()));
@@ -504,6 +577,63 @@ mod tests {
         // flow is still walkable in both directions.
         assert_eq!(w.back(), Action::Redraw);
         assert_eq!(w.step, Step::Intro);
+    }
+
+    /// A second workspace means the create has a question to answer first:
+    /// which one it lands in. Nothing else about the flow changes.
+    #[test]
+    fn creating_with_several_workspaces_asks_which_one() {
+        let mut tree = tree();
+        tree.push(WorkspaceNode {
+            id: "ws2".into(),
+            name: "Acme".into(),
+            expanded: false,
+            projects: vec![ProjectNode {
+                id: "p3".into(),
+                name: "acme-api".into(),
+                expanded: false,
+                envs: vec![EnvNode {
+                    id: "e3".into(),
+                    name: "production".into(),
+                    expanded: false,
+                    agents: Load::NotLoaded,
+                }],
+            }],
+        });
+        let mut w = Wizard::new(&tree, Some("codex"), Theme::default_theme(), None);
+        w.select(); // set up now
+        assert_eq!(w.select(), Action::Redraw, "create asks first");
+        assert_eq!(w.step, Step::WorkspacePick);
+        assert!(w.busy.is_none(), "nothing is created until they answer");
+
+        let labels: Vec<String> = w.options().into_iter().map(|(label, _)| label).collect();
+        assert_eq!(labels, vec!["Railway", "Acme"]);
+        // The row says how big each workspace is; a name alone is not always
+        // enough to tell yours from your team's.
+        assert_eq!(w.options()[1].1, "1 project");
+
+        w.down();
+        assert_eq!(w.select(), Action::CreateProject(Some("ws2".into())));
+        assert!(w.busy.is_some());
+
+        // The step is still the picker, so a failure lands where the choice was
+        // made and another workspace can be tried.
+        w.project_created(Err("no permission".into()));
+        assert_eq!(w.step, Step::WorkspacePick);
+        assert_eq!(w.error.as_deref(), Some("no permission"));
+
+        // And escape from the picker goes back to the project question.
+        assert_eq!(w.back(), Action::Redraw);
+        assert_eq!(w.step, Step::Project);
+    }
+
+    /// The workspace question is part of "where should agents live?", not a
+    /// fifth step — the progress dots must not move because of it.
+    #[test]
+    fn the_workspace_question_shares_the_project_step() {
+        let mut w = wizard();
+        w.step = Step::WorkspacePick;
+        assert_eq!(w.position(), Some((0, 4)));
     }
 
     /// With no projects loaded there is nothing to pick, so the option is not


### PR DESCRIPTION
First-run setup's "Create a project" made "Cloud Agents" in
`workspaces.first()` and said nothing about it. On an account with more
than one workspace that is a coin flip, and the project is then invisible
to anyone who cannot see the workspace it guessed — with nothing in the
flow to say which one that was. The CLI's own `railway ca setup` has
always prompted here (`pick_workspace`); only the TUI wizard guessed.

Add the question it was missing: choosing "Create a project" with more
than one workspace now goes to a picker first, listing each workspace and
how many projects it holds. One workspace still creates straight away —
there is nothing to ask. The workspace rides through the create effect,
and an id that no longer resolves is an error rather than a quiet
fallback to the first, which is the same bug wearing a different hat.

Where it went is now said twice over: the busy line names the workspace
while the project is being created, and the status line reports it
afterwards. The workspace question shares the project step's progress
dot, since it is the same question — where agents live.

WorkspaceNode carries its id for this; the tree grouped by name alone.
