### PR TITLE
Add upgrade CTA to new-version-available banner

### DIFF
--- a/src/commands/check_updates.rs
+++ b/src/commands/check_updates.rs
@@ -35,9 +35,10 @@ pub async fn command(args: Args) -> Result<()> {
     }
 
     println!(
-        "{} v{} visit {} for more info",
+        "{} v{} run {} to update ({} for more info)",
         "New version available:".green().bold(),
         latest_version.yellow(),
+        "railway upgrade".cyan(),
         "https://docs.railway.com/guides/cli".purple(),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,9 +333,10 @@ async fn main() -> Result<()> {
                 )
             {
                 eprintln!(
-                    "{} v{} visit {} for more info",
+                    "{} v{} run {} to update ({} for more info)",
                     "New version available:".green().bold(),
                     latest_version.yellow(),
+                    "railway upgrade".cyan(),
                     "https://docs.railway.com/guides/cli".purple(),
                 );
             }


### PR DESCRIPTION
Noticed that we would tell you that there is a new version availible but we wouldn't tell you how to update. This fixes that.

## Summary
- The "New version available" banner (printed on every TTY command run, and from `railway check_updates`) told users a new version existed but never said how to install it — just a docs link.
- The neighboring "Railway skills update available" banner already has a CTA (`run railway skills update to update`); this brings the version banner in line.
- Now reads: `New version available: v{version} run railway upgrade to update ({docs url} for more info)`
