### PR TITLE
Check the CLOUD_AGENTS flag before provisioning anything

### DIFF
--- a/src/commands/cloud_agent/access.rs
+++ b/src/commands/cloud_agent/access.rs
@@ -1,0 +1,89 @@
+//! The `CLOUD_AGENTS` preflight.
+//!
+//! Cloud agents are behind a Priority Boarding flag. Without it the API refuses
+//! the create — but only once the launch has already resolved a credential, a
+//! target and an agent, so what someone without the flag saw was a one-line
+//! rejection at the end of a pipeline that looked like it was working. This
+//! asks first, and answers with the two things that line didn't have: that the
+//! flag is what is missing, and where to turn it on.
+//!
+//! Advisory, not a gate. Only a query that succeeds and comes back without the
+//! flag stops a launch; anything else (a project token, which cannot read `me`,
+//! or a transient failure) proceeds and lets the real call decide. A preflight
+//! that blocks work the API would have allowed is worse than the error it
+//! replaces.
+
+use anyhow::{Result, bail};
+use colored::Colorize;
+
+use crate::client::post_graphql;
+use crate::config::Configs;
+use crate::gql::queries;
+
+/// Stop before provisioning when the account doesn't have `CLOUD_AGENTS`.
+pub async fn ensure_enabled(client: &reqwest::Client, configs: &Configs) -> Result<()> {
+    let flags = match post_graphql::<queries::CloudAgentAccess, _>(
+        client,
+        configs.get_backboard(),
+        queries::cloud_agent_access::Variables {},
+    )
+    .await
+    {
+        Ok(data) => data.me.feature_flags,
+        Err(_) => return Ok(()),
+    };
+    if has_cloud_agents(&flags) {
+        return Ok(());
+    }
+    super::telemetry::track_access_blocked().await;
+    bail!(not_enabled_message(configs.get_host()));
+}
+
+fn has_cloud_agents(flags: &[queries::cloud_agent_access::ActiveFeatureFlag]) -> bool {
+    use queries::cloud_agent_access::ActiveFeatureFlag;
+    flags
+        .iter()
+        .any(|flag| matches!(flag, ActiveFeatureFlag::CLOUD_AGENTS))
+}
+
+/// What to say instead of the API's rejection. Names the flag, says where it
+/// lives, and gives the URL — a flag nobody can find is the same as no flag.
+fn not_enabled_message(host: &str) -> String {
+    format!(
+        "Cloud agents are not enabled for your account yet.\n\n  {} Turn on {} in Priority Boarding:\n    {}\n\nThen run this command again.",
+        "→".cyan(),
+        "Cloud Agents".bold(),
+        format!("https://{host}/account/feature-flags").underline()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use queries::cloud_agent_access::ActiveFeatureFlag;
+
+    #[test]
+    fn the_flag_is_matched_exactly() {
+        assert!(has_cloud_agents(&[
+            ActiveFeatureFlag::PRIORITY_BOARDING,
+            ActiveFeatureFlag::CLOUD_AGENTS,
+        ]));
+        // Priority Boarding on its own is the door, not the room behind it.
+        assert!(!has_cloud_agents(&[ActiveFeatureFlag::PRIORITY_BOARDING]));
+        assert!(!has_cloud_agents(&[]));
+        // An unknown flag from a newer API must not read as a match.
+        assert!(!has_cloud_agents(&[ActiveFeatureFlag::Other(
+            "CLOUD_AGENTS_V2".into()
+        )]));
+    }
+
+    #[test]
+    fn the_message_points_at_the_flag_and_the_page() {
+        let message = not_enabled_message("railway.com");
+        assert!(message.contains("Priority Boarding"), "{message}");
+        assert!(
+            message.contains("https://railway.com/account/feature-flags"),
+            "{message}"
+        );
+    }
+}

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -5,6 +5,7 @@
 //! read the same preferences file, so the choice between them is only whether
 //! you want to browse first.
 
+pub mod access;
 pub mod lifecycle;
 pub mod prefs;
 pub mod setup;
@@ -162,10 +163,16 @@ async fn browse() -> Result<()> {
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
 
+    // Both under one spinner: the flag check is a small query against the same
+    // client, and running it beside the tree load rather than before it keeps
+    // the preflight off the clock for everyone who does have the flag.
     let spinner = create_spinner("Loading your projects".to_string());
-    let tree = tui::load_tree(&client, &configs).await;
+    let loaded = tokio::try_join!(
+        access::ensure_enabled(&client, &configs),
+        tui::load_tree(&client, &configs),
+    );
     spinner.finish_and_clear();
-    let tree = tree?;
+    let (_, tree) = loaded?;
     if tree.is_empty() {
         println!(
             "No projects with environments you can use. Create one with {} first.",

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -164,6 +164,20 @@ pub async fn track_login_forwarded(error: Option<&str>) {
     .await;
 }
 
+/// Someone ran a cloud agent command without the `CLOUD_AGENTS` flag and was
+/// stopped by the preflight. Counts the demand sitting behind the flag, which
+/// the API-side rejection never surfaced as its own event.
+pub async fn track_access_blocked() {
+    telemetry::send(event(
+        "cloud_agent",
+        "flag_missing".to_string(),
+        0,
+        false,
+        None,
+    ))
+    .await;
+}
+
 /// `railway ca setup` or the TUI wizard saved preferences. `entry` is
 /// `"cli"` or `"wizard"` — the two call sites share this mapping so both
 /// land in the same shape.

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1579,6 +1579,15 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
         return destroy_agent(&mut configs, &client, &environment_id).await;
     }
 
+    // Before anything is resolved, minted or provisioned: without the flag the
+    // create at the end of all that is refused, and the work up to it — a
+    // credential, possibly a browser round-trip — is spent for nothing.
+    {
+        let configs = Configs::new()?;
+        let client = GQLClient::new_authorized(&configs)?;
+        crate::commands::cloud_agent::access::ensure_enabled(&client, &configs).await?;
+    }
+
     eprintln!(
         "{}",
         "Warning: Railway cloud agents are experimental and APIs may change or break during testing."

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -48,6 +48,17 @@ impl std::fmt::Display
 pub struct UserMeta;
 pub type RailwayUser = user_meta::UserMetaMe;
 
+/// The account's active feature flags, for the `railway ca` preflight. Its own
+/// query rather than a field on `UserMeta`: that one is on the login path and
+/// has no use for them.
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/CloudAgentAccess.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq"
+)]
+pub struct CloudAgentAccess;
+
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",

--- a/src/gql/queries/strings/CloudAgentAccess.graphql
+++ b/src/gql/queries/strings/CloudAgentAccess.graphql
@@ -1,0 +1,5 @@
+query CloudAgentAccess {
+	me {
+		featureFlags
+	}
+}


### PR DESCRIPTION
Cloud agents sit behind a Priority Boarding flag, and the API enforces it
at the create — the last step of the launch. Someone without the flag
therefore watched the whole pipeline run (resolve a credential, possibly
mint one through a browser, resolve a target, reach for an agent) and
then got a one-line rejection that named neither the flag nor where to
turn it on.

Ask first. `me { featureFlags }` is one small query, run at the top of
`railway code` / `ca start` and alongside the tree load in the TUI — the
try_join keeps it off the clock for the accounts that do have the flag.
Without it, the launch stops before spending anything and says what is
missing and where it lives, with the URL.

Advisory rather than a gate: only a query that succeeds and comes back
without the flag stops a launch. A project token cannot read `me`, and a
transient failure should not stand between someone and a launch the API
would have allowed, so both proceed and let the real call decide.

A `cloud_agent/flag_missing` event counts the demand sitting behind the
flag, which the API-side rejection never surfaced as its own event.

Stacked on #1070 (`railway/ca-login-forward`) — the flag check runs after the login preflight, so the base is that branch rather than master.