### PR TITLE
Add railway ca manage, fix --refresh-auth cache, add setup reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +303,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,9 +325,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -377,6 +410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,12 +448,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -455,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -623,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -653,7 +686,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -666,7 +699,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -771,6 +804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crokey"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +908,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "futures-core",
  "libc",
@@ -882,27 +921,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.1",
- "crossterm_winapi",
- "mio 1.0.3",
- "parking_lot",
- "rustix 0.38.42",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -976,6 +999,16 @@ dependencies = [
  "crypto-bigint",
  "libm",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -1200,6 +1233,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1248,12 @@ dependencies = [
  "pem-rfc7468 1.0.0",
  "zeroize",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive-new"
@@ -1337,7 +1382,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1490,6 +1535,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1562,16 @@ checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -1581,6 +1645,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1690,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1998,9 +2080,29 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2413,7 +2515,7 @@ checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console 0.16.1",
  "portable-atomic",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -2430,7 +2532,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -2470,12 +2572,12 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crossterm 0.29.0",
  "dyn-clone",
  "fuzzy-matcher",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2594,18 +2696,18 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -2629,6 +2731,17 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2670,6 +2783,12 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy-regex"
@@ -2727,9 +2846,18 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2774,11 +2902,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2786,6 +2914,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "md5"
@@ -2800,10 +2938,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -2816,6 +2969,12 @@ checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2904,7 +3063,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 
@@ -2914,10 +3073,11 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2926,7 +3086,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2938,10 +3098,20 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2950,7 +3120,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2996,6 +3166,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,6 +3222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3049,7 +3245,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -3061,7 +3257,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -3072,7 +3268,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3091,7 +3287,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3102,7 +3298,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3141,6 +3337,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "p256"
@@ -3203,6 +3408,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3241,12 +3479,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -3309,6 +3541,100 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -3387,7 +3713,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -3430,9 +3756,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-pty"
@@ -3454,6 +3780,12 @@ dependencies = [
  "winapi",
  "winreg",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3757,23 +4089,103 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
- "bitflags 2.11.1",
- "cassowary",
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.1",
  "compact_str",
- "crossterm 0.28.1",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
- "strum 0.26.3",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum 0.28.0",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3782,7 +4194,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3993,7 +4405,7 @@ dependencies = [
  "aes 0.8.4",
  "aes 0.9.0",
  "aes-gcm 0.11.0-rc.3",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block-padding 0.3.3",
  "byteorder",
  "bytes 1.11.1",
@@ -4083,7 +4495,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c826d40e310bbcb377fd8f6c5873c12eaf54da30569d8e8da56914fdac9773cd"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes 1.11.1",
  "chrono",
  "dashmap",
@@ -4151,7 +4563,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -4164,7 +4576,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -4346,7 +4758,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4528,7 +4940,7 @@ dependencies = [
  "ioctl-rs",
  "libc",
  "serial-core",
- "termios",
+ "termios 0.2.2",
 ]
 
 [[package]]
@@ -4669,6 +5081,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4834,6 +5252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4851,6 +5278,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4953,12 +5392,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.1",
+ "parking_lot",
+ "rustix 1.1.2",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "termios"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios 0.3.3",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -5035,6 +5550,27 @@ dependencies = [
  "weezl",
  "zune-jpeg",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -5187,7 +5723,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes 1.11.1",
  "futures-util",
  "http 1.2.0",
@@ -5272,6 +5808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5291,13 +5833,13 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5308,9 +5850,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5392,6 +5934,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "venial"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5409,35 +5963,32 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vt100"
-version = "0.15.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
 dependencies = [
  "itoa",
- "log",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.2",
  "vte",
 ]
 
 [[package]]
 name = "vte"
-version = "0.11.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
+ "memchr",
 ]
 
 [[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
+name = "vtparse"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
- "proc-macro2",
- "quote",
+ "utf8parse",
 ]
 
 [[package]]
@@ -5579,7 +6130,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
@@ -5619,6 +6170,78 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
 
 [[package]]
 name = "which"
@@ -6101,7 +6724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ derive_more = { version = "2.1.1", features = ["display"] }
 nix = { version = "0.30.1", features = ["signal"] }
 fs2 = "0.4.3"
 async-trait = "0.1.89"
-ratatui = "0.29"
+ratatui = "0.30"
 scopeguard = "1.2"
 schemars = "0.8"
 rmcp = { version = "1.4", features = ["transport-io"] }
@@ -117,7 +117,7 @@ russh = { version = "0.60.2", default-features = false, features = [
 ] }
 tempfile = "3.23.0"
 portable-pty = "0.8"
-vt100 = "0.15"
+vt100 = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 pageant = "0.2.0"

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -32,7 +32,7 @@ use tui::{App, Outcome};
 #[derive(Parser)]
 #[clap(
     args_conflicts_with_subcommands = true,
-    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -48,6 +48,9 @@ pub struct Args {
 enum Command {
     /// Configure how cloud agents are launched (default agent, skills)
     Setup(setup::Args),
+
+    /// Open the TUI directly on the manage screen, skipping the menu
+    Manage,
 
     /// Launch a coding agent on a cloud agent VM, without the TUI
     Start(LaunchArgs),
@@ -102,6 +105,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     match args.command {
         Some(Command::Setup(a)) => setup::command(a).await,
+        Some(Command::Manage) => browse_into(Some(tui::Screen::Manage)).await,
         Some(Command::Start(a)) => crate::commands::code::launch(a).await,
         Some(Command::List(a)) => tracked("list", lifecycle::list(a)).await,
         Some(Command::Create(a)) => tracked("create", lifecycle::create(a)).await,
@@ -159,6 +163,15 @@ async fn ensure_logged_in(interactive: bool) -> Result<()> {
 /// is what makes connecting feel like stepping into a session and back out
 /// rather than restarting the command.
 async fn browse() -> Result<()> {
+    browse_into(None).await
+}
+
+/// Like [`browse`], but opens straight on `initial_screen` instead of the menu
+/// when one is given. `railway ca manage` uses this to land on the manage
+/// screen without a detour through the menu — an explicit ask, so it also
+/// skips the first-run "set up cloud agents?" nudge that a bare `railway ca`
+/// would show.
+async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
@@ -226,8 +239,11 @@ async fn browse() -> Result<()> {
     // No preferences yet: ask whether to set them up, rather than dropping
     // someone in front of a prompt whose target, agent and skills are all
     // unanswered. Choosing Setup from the menu skips that question — they have
-    // already answered it by choosing it.
-    if first_run {
+    // already answered it by choosing it. An explicit initial screen is its
+    // own answer to "what should I see first" and skips the nudge too.
+    if let Some(screen) = initial_screen {
+        app.screen = screen;
+    } else if first_run {
         app.start_wizard(true);
     }
 

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -27,6 +27,12 @@ pub struct Args {
     /// Print the current preferences and exit
     #[clap(long)]
     show: bool,
+
+    /// Clear saved preferences and any cached Claude auth token, then exit
+    /// without prompting. The same as choosing "Reset to default" from the
+    /// interactive prompts, for a script or a machine with no terminal
+    #[clap(long)]
+    reset: bool,
 }
 
 /// The harnesses a cloud agent can launch today. Every one of these ships in
@@ -141,6 +147,10 @@ pub async fn command(args: Args) -> Result<()> {
         return show(&home, existing.as_ref());
     }
 
+    if args.reset {
+        return reset(&home);
+    }
+
     let non_interactive = args.yes || !is_stdout_terminal();
     let prefs = if non_interactive {
         non_interactive_prefs(&home, existing)
@@ -156,6 +166,25 @@ pub async fn command(args: Args) -> Result<()> {
         }
     }
     print_summary(&home, &prefs)?;
+    Ok(())
+}
+
+/// Clear saved preferences and the cached Claude setup-token, back to a clean
+/// slate.
+///
+/// Preferences alone would leave a stale credential behind for the next setup
+/// to silently pick back up — the same reason `railway logout` drops it too.
+/// Best-effort on the token cache, same as everywhere else it is cleared: a
+/// preferences reset should not fail over a file that was already gone.
+fn reset(home: &Path) -> Result<()> {
+    let path = AgentPrefs::path_in(home);
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .with_context(|| format!("Failed to remove {}", path.display()))?;
+    }
+    crate::commands::code::clear_claude_token_cache();
+    println!("Cleared cloud agent preferences and cached tokens.");
+    println!("Run {} to configure again.", "railway ca setup".cyan());
     Ok(())
 }
 
@@ -192,6 +221,13 @@ fn non_interactive_prefs(home: &Path, existing: Option<AgentPrefs>) -> AgentPref
 async fn prompt(home: &Path, existing: Option<AgentPrefs>) -> Result<AgentPrefs> {
     println!("\n{}\n", "Railway Cloud Agent Setup".bold().cyan());
 
+    // Only worth asking when there is something to reset — a first run has no
+    // preferences and no cached token either.
+    if existing.is_some() && prompt_reset_to_default()? {
+        reset(home)?;
+        return Ok(AgentPrefs::default());
+    }
+
     let previous = existing.clone().unwrap_or_default();
     let default_project = prompt_default_project(previous.default_project.clone()).await?;
     let agent = prompt_agent(home, previous.agent.as_deref())?;
@@ -206,6 +242,40 @@ async fn prompt(home: &Path, existing: Option<AgentPrefs>) -> Result<AgentPrefs>
         default_project,
         theme: Some(theme),
     })
+}
+
+/// What to do about preferences that are already there.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SetupMode {
+    Edit,
+    Reset,
+}
+
+impl fmt::Display for SetupMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SetupMode::Edit => write!(f, "Continue — review and update my preferences"),
+            SetupMode::Reset => write!(
+                f,
+                "Reset to default  {}",
+                "— clear preferences and cached tokens".dimmed()
+            ),
+        }
+    }
+}
+
+/// Asked only when there are existing preferences to do something about.
+/// `true` means the caller should reset and stop, rather than walk the rest
+/// of the questions.
+fn prompt_reset_to_default() -> Result<bool> {
+    let choice = inquire::Select::new(
+        "Existing cloud agent preferences found:",
+        vec![SetupMode::Edit, SetupMode::Reset],
+    )
+    .with_render_config(Configs::get_render_config())
+    .prompt()
+    .context("Failed to prompt for the setup mode")?;
+    Ok(choice == SetupMode::Reset)
 }
 
 /// The agent picker on its own, so a launch with no configured default can ask
@@ -564,6 +634,28 @@ fn display_path(home: &Path, path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reset_removes_the_preferences_file() {
+        let home = tempfile::tempdir().unwrap();
+        AgentPrefs {
+            agent: Some("claude".into()),
+            ..Default::default()
+        }
+        .save_in(home.path())
+        .unwrap();
+        assert!(AgentPrefs::path_in(home.path()).exists());
+
+        reset(home.path()).unwrap();
+        assert!(!AgentPrefs::path_in(home.path()).exists());
+    }
+
+    /// No preferences file yet — resetting is a no-op, not an error.
+    #[test]
+    fn reset_without_a_preferences_file_is_fine() {
+        let home = tempfile::tempdir().unwrap();
+        reset(home.path()).unwrap();
+    }
 
     #[test]
     fn detects_a_harness_by_its_config_directory() {

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -1646,14 +1646,15 @@ impl App {
                 self.focus = ManageFocus::Tree;
                 return None;
             }
-            // Two chords are taken from the agent, both because the moment you
-            // want them is while you are using it: ⌥f for room, ⌥] to move on
-            // to the next pane. ⌥f costs Meta-f (forward-word) in a shell;
-            // readline leaves Meta-] unbound, and `^]` (character-search) is
-            // untouched because only the Meta form is claimed. Nothing else is
-            // intercepted — ⌥s still reaches the agent from here.
+            // Three chords are taken from the agent, all because the moment
+            // you want them is while you are using it: ⌥f for room, ⌥] and ⌥[
+            // to move between panes. ⌥f costs Meta-f (forward-word) in a
+            // shell; readline leaves Meta-] and Meta-[ unbound, and `^]`
+            // (character-search) is untouched because only the Meta forms are
+            // claimed. Nothing else is intercepted — ⌥s still reaches the
+            // agent from here.
             if let Some(chord) = alt_chord(&key)
-                && matches!(chord, 'f' | ']')
+                && matches!(chord, 'f' | ']' | '[')
             {
                 return self.alt_action(chord);
             }
@@ -2553,19 +2554,21 @@ impl App {
                 self.toggle_maximized();
                 None
             }
-            ']' => self.cycle_session(),
+            ']' => self.cycle_session(true),
+            '[' => self.cycle_session(false),
             _ => None,
         }
     }
 
-    /// Move the pane to the next open session, wrapping at the end.
+    /// Move the pane to the next or previous open session, wrapping.
     ///
     /// Scoped to panes that are already open rather than every session in the
     /// tree, and that is the whole design: waking a sleeping agent is a cold
     /// boot — seconds of wall clock and a VM that starts billing — so holding
-    /// `⌥]` must never fan out wakes across agents you were only passing
-    /// through. Opening something new stays the deliberate `enter` on a row.
-    fn cycle_session(&mut self) -> Option<Effect> {
+    /// `⌥]` or `⌥[` must never fan out wakes across agents you were only
+    /// passing through. Opening something new stays the deliberate `enter` on
+    /// a row.
+    fn cycle_session(&mut self, forward: bool) -> Option<Effect> {
         match self.sessions.len() {
             0 => {
                 self.status = "No open sessions".to_string();
@@ -2579,7 +2582,13 @@ impl App {
             _ => {}
         }
         let count = self.sessions.len();
-        let next = self.active.map_or(0, |i| (i + 1) % count);
+        let next = match (self.active, forward) {
+            (Some(i), true) => (i + 1) % count,
+            (Some(i), false) => (i + count - 1) % count,
+            // No pane yet: forward starts at the front, back at the end.
+            (None, true) => 0,
+            (None, false) => count - 1,
+        };
         self.active = Some(next);
         self.select_row_for_active();
         if let Some(name) = self.active_session().map(|s| s.agent_name.clone()) {
@@ -3391,13 +3400,18 @@ fn project_count_note(project: &ProjectNode) -> String {
 /// is unreachable without Meta, which is why every card also keeps its bare
 /// letter while the cards have focus.
 ///
-/// `]` is the one non-letter, and it has no `[` twin on purpose: under Meta,
-/// Option+`[` is the two bytes `ESC [` — byte-identical to the CSI prefix that
-/// starts every arrow key and escape sequence — so it can never be told apart
-/// from a cursor key. `ESC ]` is OSC, which terminals effectively never send,
-/// so the forward direction is safe on its own.
+/// The brackets are the non-letters, and they are not equals. `ESC ]` is OSC,
+/// which terminals effectively never send, so under Meta ⌥] is safe
+/// everywhere. ⌥[ under Meta is the two bytes `ESC [` — byte-identical to the
+/// CSI prefix that starts every arrow key — so a legacy terminal can never
+/// deliver it; the parser eats the bytes as an unfinished escape sequence and
+/// no key event exists to match. `[` is still in the table for the terminals
+/// that can say it unambiguously: under the kitty keyboard protocol (pushed at
+/// startup) it arrives as a genuine ALT+`[` event, and composed-mode macOS
+/// sends it as a curly double quote. Everywhere else the reverse chord is
+/// simply absent — it can go dead, but never misfire.
 fn alt_chord(key: &KeyEvent) -> Option<char> {
-    const ACTIONS: &[char] = &['f', 's', ']'];
+    const ACTIONS: &[char] = &['f', 's', ']', '['];
     if key.modifiers.contains(KeyModifiers::ALT) {
         if let KeyCode::Char(c) = key.code {
             let c = c.to_ascii_lowercase();
@@ -3409,10 +3423,12 @@ fn alt_chord(key: &KeyEvent) -> Option<char> {
     match key.code {
         KeyCode::Char('ƒ') => Some('f'),
         KeyCode::Char('ß') => Some('s'),
-        // Option+] composes to a left curly quote, Option+shift+] to the right
-        // one. Both are the same chord as far as anyone pressing it is
-        // concerned, matching how the letters fold their shifted forms.
+        // Option+] composes to a left curly single quote, Option+shift+] to
+        // the right one; Option+[ does the same with the double quotes. Each
+        // pair is one chord as far as anyone pressing it is concerned,
+        // matching how the letters fold their shifted forms.
         KeyCode::Char('\u{2018}') | KeyCode::Char('\u{2019}') => Some(']'),
+        KeyCode::Char('\u{201C}') | KeyCode::Char('\u{201D}') => Some('['),
         _ => None,
     }
 }
@@ -3971,8 +3987,7 @@ mod tests {
         a
     }
 
-    /// ⌥] walks the open panes and wraps, so a single key reaches every
-    /// session without needing a reverse chord.
+    /// ⌥] walks the open panes and wraps, and ⌥[ walks them the other way.
     #[test]
     fn alt_bracket_cycles_forward_through_open_sessions_and_wraps() {
         let mut a = with_sessions(&["ca_1", "ca_2", "ca_3"]);
@@ -3986,6 +4001,20 @@ mod tests {
         assert_eq!(a.active, Some(2), "back where it started");
     }
 
+    /// The reverse chord retraces the forward one exactly, wrap included.
+    #[test]
+    fn alt_left_bracket_cycles_backward_and_wraps() {
+        let mut a = with_sessions(&["ca_1", "ca_2", "ca_3"]);
+        assert_eq!(a.active, Some(2), "the newest attach is active");
+
+        assert_eq!(a.on_key(alt('[')), None);
+        assert_eq!(a.active, Some(1));
+        assert_eq!(a.on_key(alt('[')), None);
+        assert_eq!(a.active, Some(0));
+        assert_eq!(a.on_key(alt('[')), None);
+        assert_eq!(a.active, Some(2), "wraps past the front");
+    }
+
     /// The chord has to work from inside the pane — that is where you are when
     /// you want the next one. ⌥s must still fall through to the agent.
     #[test]
@@ -3997,7 +4026,13 @@ mod tests {
         assert_eq!(a.active, Some(0));
         assert_eq!(a.focus, ManageFocus::Session, "cycling does not detach");
 
-        // Still only ⌥f and ⌥] are taken from the agent.
+        // ⌥[ is taken from the agent too — going back is the same moment as
+        // going forward.
+        assert_eq!(a.on_key(alt('[')), None);
+        assert_eq!(a.active, Some(1), "retraces the forward step");
+        assert_eq!(a.focus, ManageFocus::Session, "cycling does not detach");
+
+        // Still only ⌥f, ⌥] and ⌥[ are taken from the agent.
         let screen = a.screen;
         a.on_key(alt('s'));
         assert_eq!(a.screen, screen, "⌥s belongs to whatever is running");
@@ -4018,11 +4053,18 @@ mod tests {
         assert!(b.status.contains("Only one session"), "{}", b.status);
     }
 
-    /// Without Option-as-Meta macOS composes ⌥] into a curly quote; both the
-    /// plain and shifted forms are the same chord.
+    /// Without Option-as-Meta macOS composes the bracket chords into curly
+    /// quotes — singles for ⌥], doubles for ⌥[ — and each pair folds its
+    /// shifted form into the same chord.
     #[test]
-    fn option_composed_curly_quotes_are_the_bracket_chord() {
+    fn option_composed_curly_quotes_are_the_bracket_chords() {
         for composed in ['\u{2018}', '\u{2019}'] {
+            let mut a = with_sessions(&["ca_1", "ca_2"]);
+            assert_eq!(a.on_key(key(KeyCode::Char(composed))), None);
+            assert_eq!(a.active, Some(0), "composed {composed:?} should cycle");
+            assert!(a.prompt.is_empty(), "a chord is not text");
+        }
+        for composed in ['\u{201C}', '\u{201D}'] {
             let mut a = with_sessions(&["ca_1", "ca_2"]);
             assert_eq!(a.on_key(key(KeyCode::Char(composed))), None);
             assert_eq!(a.active, Some(0), "composed {composed:?} should cycle");
@@ -4030,16 +4072,17 @@ mod tests {
         }
     }
 
-    /// There is deliberately no ⌥[ twin: under Meta it is the two bytes
-    /// `ESC [`, which is the CSI prefix every arrow key starts with, so it
-    /// cannot be told apart from a cursor key. Guard the omission.
+    /// ⌥[ only exists where the terminal can say it unambiguously — as a real
+    /// ALT event under the kitty protocol, or as macOS's composed quote. In a
+    /// legacy Meta terminal it is the CSI prefix `ESC [` and never reaches the
+    /// key handler at all, so recognizing the clean forms risks nothing.
     #[test]
-    fn there_is_no_alt_left_bracket_chord() {
-        assert_eq!(alt_chord(&alt('[')), None);
+    fn alt_left_bracket_is_the_reverse_chord() {
+        assert_eq!(alt_chord(&alt('[')), Some('['));
         assert_eq!(
             alt_chord(&key(KeyCode::Char('\u{201C}'))),
-            None,
-            "the composed ⌥[ quote is not a chord either"
+            Some('['),
+            "the composed ⌥[ quote is the same chord"
         );
     }
 

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -57,7 +57,7 @@ pub const KEY_HELP: &[(&str, &[(&str, &str)])] = &[
     (
         "agents",
         &[
-            ("n", "new agent (on a project or environment)"),
+            ("n", "new agent (on a group, project, or environment)"),
             ("s", "sleep"),
             ("w", "wake"),
             ("d", "delete, with a confirmation"),
@@ -521,12 +521,21 @@ pub enum RowKind {
     Workspace(usize),
     Project(usize, usize),
     Environment(usize, usize, usize),
+    /// An environment that has agents, promoted to a top-level heading. The
+    /// tree leads with these — the screen is about agents, so the containers
+    /// read as context on the way to them, not as levels to open.
+    Group(usize, usize, usize),
     Agent(usize, usize, usize, usize),
     /// A reattachable session on an agent's VM.
     Session(usize, usize, usize, usize, usize),
     /// A non-selectable line under an environment: loading, empty, or failed.
     Note(usize, usize, usize),
-    /// A rule between the default project and the rest.
+    /// The collapsible tail of projects with no agents — where `n` goes to
+    /// start somewhere new.
+    OtherProjects,
+    /// A non-selectable line that belongs to no environment: the empty state.
+    Hint,
+    /// A rule between the agent groups and the projects tail.
     Separator,
 }
 
@@ -546,7 +555,10 @@ pub struct Row {
 
 impl Row {
     pub fn selectable(&self) -> bool {
-        !matches!(self.kind, RowKind::Note(..) | RowKind::Separator)
+        !matches!(
+            self.kind,
+            RowKind::Note(..) | RowKind::Hint | RowKind::Separator
+        )
     }
 }
 
@@ -785,6 +797,10 @@ pub struct App {
     pub target: Option<Target>,
     pub tree: Vec<WorkspaceNode>,
     pub cursor: usize,
+    /// Whether the projects tail is open. `None` decides automatically: open
+    /// while there are no agents to show — the tail is the whole tree then —
+    /// and folded away once agent groups exist to lead with.
+    pub others_expanded: Option<bool>,
     /// Transient one-line message shown in the header.
     pub status: String,
 }
@@ -839,13 +855,20 @@ impl App {
             target,
             tree,
             cursor: 0,
+            others_expanded: None,
             status: String::new(),
         };
-        // Open the first workspace so Manage is never a wall of collapsed rows.
+        // Open the first workspace so the projects tail is never a wall of
+        // collapsed rows on a multi-workspace account.
         if let Some(ws) = app.tree.first_mut() {
             ws.expanded = true;
         }
         app.clamp_cursor();
+        // The tree can lead with an unselectable hint; the cursor belongs on
+        // the first row a key can act on.
+        if app.selected_row().is_some_and(|row| !row.selectable()) {
+            app.move_cursor_inner(1);
+        }
         app
     }
 
@@ -1108,66 +1131,258 @@ impl App {
         HARNESSES[self.harness.min(HARNESSES.len() - 1)]
     }
 
-    /// The flattened, currently-visible tree.
+    /// The flattened, currently-visible tree: agent groups first, then the
+    /// projects tail.
+    ///
+    /// Agents are what this screen is about, so every environment that has
+    /// any is promoted to a top-level group — always open, never a level to
+    /// expand. The containers survive as context rather than navigation: the
+    /// group is labelled with its project (and environment, when that adds
+    /// something), and projects with nothing in them wait in a collapsible
+    /// tail at the bottom, which is where `n` goes to start an agent
+    /// somewhere new.
     pub fn rows(&self) -> Vec<Row> {
         let mut rows = Vec::new();
-        for (w, ws) in self.tree.iter().enumerate() {
+        let groups = self.agent_groups();
+        for &(w, p, e) in &groups {
+            let proj = &self.tree[w].projects[p];
             rows.push(Row {
                 depth: 0,
-                kind: RowKind::Workspace(w),
-                label: ws.name.clone(),
-                note: "workspace".into(),
+                kind: RowKind::Group(w, p, e),
+                label: group_label(proj, e),
+                note: self.group_note(w, p),
                 status: None,
-                expanded: Some(ws.expanded),
+                // Always open: collapsing the thing the screen exists to show
+                // would only manufacture a place to lose it.
+                expanded: Some(true),
                 dimmed: false,
             });
-            if !ws.expanded {
+            self.push_agent_rows(&mut rows, w, p, e);
+        }
+        if groups.is_empty() {
+            // "None yet" is a definitive claim, so it waits until every
+            // environment has actually answered; anything still on its way
+            // reads as searching, and a failure says so rather than passing
+            // itself off as an empty account.
+            let mut envs = self
+                .tree
+                .iter()
+                .flat_map(|ws| ws.projects.iter())
+                .flat_map(|project| project.envs.iter());
+            let searching = envs
+                .clone()
+                .any(|env| matches!(env.agents, Load::NotLoaded | Load::Loading));
+            let failed = envs.any(|env| matches!(env.agents, Load::Failed(_)));
+            rows.push(Row {
+                depth: 0,
+                kind: RowKind::Hint,
+                label: if searching {
+                    "looking for cloud agents…".into()
+                } else if failed {
+                    "couldn't check every environment — r retries".into()
+                } else {
+                    "no cloud agents yet — n creates one".into()
+                },
+                note: String::new(),
+                status: None,
+                expanded: None,
+                dimmed: false,
+            });
+        }
+        self.push_project_tail(&mut rows, &groups);
+        rows
+    }
+
+    /// One group's agents, sessions still nested beneath them.
+    fn push_agent_rows(&self, rows: &mut Vec<Row>, w: usize, p: usize, e: usize) {
+        let env = &self.tree[w].projects[p].envs[e];
+        let agents = env.agents_vec();
+        for a in sorted_agents(agents) {
+            let agent = &agents[a];
+            let pending = self.ops.get(agent.id.as_str()).copied();
+            rows.push(Row {
+                depth: 1,
+                kind: RowKind::Agent(w, p, e, a),
+                label: agent.name.clone(),
+                note: match pending {
+                    Some(op) => op.to_string(),
+                    None => agent_note(agent, &self.ending),
+                },
+                status: Some(
+                    pending
+                        .map(str::to_string)
+                        .unwrap_or_else(|| agent.status.clone()),
+                ),
+                expanded: Some(agent.expanded),
+                dimmed: false,
+            });
+            if !agent.expanded {
                 continue;
             }
-            let order = sorted_projects(ws, self.default_project.as_deref());
-            for (position, p) in order.iter().copied().enumerate() {
-                let proj = &ws.projects[p];
-                let is_default = Some(proj.id.as_str()) == self.default_project.as_deref();
+            // The agent's own sessions: what the platform says is running in
+            // there, which outlives our connections and can be rejoined by
+            // name.
+            match &agent.sessions {
+                LoadSessions::Loaded(sessions)
+                    if !sessions.iter().any(|session| {
+                        session.is_interesting() && !self.ending.contains(&session.name)
+                    }) =>
+                {
+                    rows.push(note_row(w, p, e, 2, "no sessions on this agent"));
+                }
+                LoadSessions::Loaded(sessions) => {
+                    for (i, session) in sessions.iter().enumerate() {
+                        if !session.is_interesting() || self.ending.contains(&session.name) {
+                            continue;
+                        }
+                        // Every listed session is running, so the only state
+                        // worth showing is whether this UI is attached to it.
+                        // The platform's own `attached` flag counts other
+                        // clients too, which is why it flickered.
+                        let connected = self.pane_for(&session.name).is_some();
+                        rows.push(Row {
+                            depth: 2,
+                            kind: RowKind::Session(w, p, e, a, i),
+                            label: session.label(),
+                            note: String::new(),
+                            status: connected.then(|| "connected".to_string()),
+                            expanded: None,
+                            dimmed: false,
+                        });
+                    }
+                }
+                LoadSessions::Loading => {
+                    rows.push(note_row(w, p, e, 2, "loading sessions…"));
+                }
+                LoadSessions::Failed(err) => {
+                    rows.push(note_row(
+                        w,
+                        p,
+                        e,
+                        2,
+                        &format!("couldn't load sessions: {err}"),
+                    ));
+                }
+                LoadSessions::NotLoaded => {}
+            }
+        }
+    }
+
+    /// The projects with agent-less environments, folded under one heading at
+    /// the bottom.
+    ///
+    /// This is the browse-to-create surface the groups can't be: selecting a
+    /// project or environment here and pressing `n` is how the first agent
+    /// gets somewhere new. A project appears whenever it has an environment
+    /// that is not a group above — usually because it has no agents at all,
+    /// but also when its staging sits empty next to an occupied production;
+    /// every environment stays reachable for `n`, `t`, and `r`. Workspaces
+    /// appear as a level only when there is more than one to tell apart.
+    fn push_project_tail(&self, rows: &mut Vec<Row>, groups: &[(usize, usize, usize)]) {
+        let default_project = self.default_project.as_deref();
+        let tails: Vec<(usize, Vec<usize>)> = self
+            .tree
+            .iter()
+            .enumerate()
+            .map(|(w, ws)| {
+                let order = sorted_projects(ws, default_project)
+                    .into_iter()
+                    .filter(|&p| {
+                        ws.projects[p]
+                            .envs
+                            .iter()
+                            .any(|env| env.agents_vec().is_empty())
+                    })
+                    .collect();
+                (w, order)
+            })
+            .collect();
+        let total: usize = tails.iter().map(|(_, order)| order.len()).sum();
+        if total == 0 {
+            return;
+        }
+        if !groups.is_empty() {
+            rows.push(separator_row());
+        }
+        let open = self.others_expanded.unwrap_or(groups.is_empty());
+        rows.push(Row {
+            depth: 0,
+            kind: RowKind::OtherProjects,
+            // "Other" is relative to the groups; without any there is nothing
+            // for these to be other than.
+            label: if groups.is_empty() {
+                "projects".into()
+            } else {
+                "other projects".into()
+            },
+            note: format!("({total})"),
+            status: None,
+            expanded: Some(open),
+            dimmed: false,
+        });
+        if !open {
+            return;
+        }
+        let multi_workspace = self.tree.len() > 1;
+        for (w, order) in tails {
+            if order.is_empty() {
+                continue;
+            }
+            let ws = &self.tree[w];
+            let base = if multi_workspace {
                 rows.push(Row {
                     depth: 1,
+                    kind: RowKind::Workspace(w),
+                    label: ws.name.clone(),
+                    note: "workspace".into(),
+                    status: None,
+                    expanded: Some(ws.expanded),
+                    dimmed: false,
+                });
+                if !ws.expanded {
+                    continue;
+                }
+                2
+            } else {
+                1
+            };
+            for p in order {
+                let proj = &ws.projects[p];
+                let is_default = Some(proj.id.as_str()) == default_project;
+                rows.push(Row {
+                    depth: base,
                     kind: RowKind::Project(w, p),
                     label: proj.name.clone(),
                     note: if is_default {
-                        match project_agent_count(proj) {
-                            0 => "(default)".to_string(),
-                            n => format!("(default · {n})"),
-                        }
+                        "(default)".to_string()
                     } else {
-                        project_count_note(proj)
+                        String::new()
                     },
                     status: None,
                     expanded: Some(proj.expanded),
-                    // Nothing provisioned here yet, so it recedes — still
-                    // selectable, and `n` promotes it into the group above.
-                    // The default never recedes: it is where agents go, so it
-                    // has to be findable even while empty.
-                    dimmed: !is_default && project_agent_count(proj) == 0,
+                    // Everything here is empty, so everything recedes — except
+                    // the default, which is where agents go and has to be
+                    // findable even while empty.
+                    dimmed: !is_default,
                 });
-                let separate_after = is_default && position + 1 < order.len();
                 if !proj.expanded {
-                    if separate_after {
-                        rows.push(separator_row());
-                    }
                     continue;
                 }
                 for (e, env) in proj.envs.iter().enumerate() {
+                    // An environment with agents is a group above; repeating
+                    // it down here would be the same thing twice.
+                    if !env.agents_vec().is_empty() {
+                        continue;
+                    }
                     let note = match &env.agents {
-                        // Nothing at all when there is nothing here: a marker
-                        // against every empty environment is noise, and the
-                        // count exists to make the ones with agents stand out.
-                        Load::Loaded(agents) if agents.is_empty() => String::new(),
-                        Load::Loaded(agents) => format!("({})", agents.len()),
                         Load::Loading => "…".into(),
                         Load::Failed(_) => "!".into(),
-                        Load::NotLoaded => String::new(),
+                        // Everything left here is empty, and a marker against
+                        // every empty environment would be noise.
+                        _ => String::new(),
                     };
                     rows.push(Row {
-                        depth: 2,
+                        depth: base + 1,
                         kind: RowKind::Environment(w, p, e),
                         label: env.name.clone(),
                         note,
@@ -1179,116 +1394,76 @@ impl App {
                         continue;
                     }
                     match &env.agents {
-                        Load::Loaded(agents) if agents.is_empty() => rows.push(Row {
-                            depth: 3,
-                            kind: RowKind::Note(w, p, e),
-                            label: "no agents here".into(),
-                            note: String::new(),
-                            status: None,
-                            expanded: None,
-                            dimmed: false,
-                        }),
-                        Load::Loaded(agents) => {
-                            for (a, agent) in agents.iter().enumerate() {
-                                let pending = self.ops.get(agent.id.as_str()).copied();
-                                rows.push(Row {
-                                    depth: 3,
-                                    kind: RowKind::Agent(w, p, e, a),
-                                    label: agent.name.clone(),
-                                    note: match pending {
-                                        Some(op) => op.to_string(),
-                                        None => agent_note(agent, &self.ending),
-                                    },
-                                    status: Some(
-                                        pending
-                                            .map(str::to_string)
-                                            .unwrap_or_else(|| agent.status.clone()),
-                                    ),
-                                    expanded: Some(agent.expanded),
-                                    dimmed: false,
-                                });
-                                if !agent.expanded {
-                                    continue;
-                                }
-                                // The agent's own sessions: what the platform
-                                // says is running in there, which outlives our
-                                // connections and can be rejoined by name.
-                                match &agent.sessions {
-                                    LoadSessions::Loaded(sessions)
-                                        if !sessions.iter().any(|session| {
-                                            session.is_interesting()
-                                                && !self.ending.contains(&session.name)
-                                        }) =>
-                                    {
-                                        rows.push(note_row(w, p, e, "no sessions on this agent"));
-                                    }
-                                    LoadSessions::Loaded(sessions) => {
-                                        for (i, session) in sessions.iter().enumerate() {
-                                            if !session.is_interesting()
-                                                || self.ending.contains(&session.name)
-                                            {
-                                                continue;
-                                            }
-                                            // Every listed session is running,
-                                            // so the only state worth showing
-                                            // is whether this UI is attached to
-                                            // it. The platform's own `attached`
-                                            // flag counts other clients too,
-                                            // which is why it flickered.
-                                            let connected = self.pane_for(&session.name).is_some();
-                                            rows.push(Row {
-                                                depth: 4,
-                                                kind: RowKind::Session(w, p, e, a, i),
-                                                label: session.label(),
-                                                note: String::new(),
-                                                status: connected.then(|| "connected".to_string()),
-                                                expanded: None,
-                                                dimmed: false,
-                                            });
-                                        }
-                                    }
-                                    LoadSessions::Loading => {
-                                        rows.push(note_row(w, p, e, "loading sessions…"));
-                                    }
-                                    LoadSessions::Failed(err) => {
-                                        rows.push(note_row(
-                                            w,
-                                            p,
-                                            e,
-                                            &format!("couldn't load sessions: {err}"),
-                                        ));
-                                    }
-                                    LoadSessions::NotLoaded => {}
-                                }
-                            }
+                        Load::Loaded(agents) if agents.is_empty() => {
+                            rows.push(note_row(w, p, e, base + 2, "no agents here"));
                         }
-                        Load::Loading => rows.push(Row {
-                            depth: 3,
-                            kind: RowKind::Note(w, p, e),
-                            label: "loading…".into(),
-                            note: String::new(),
-                            status: None,
-                            expanded: None,
-                            dimmed: false,
-                        }),
-                        Load::Failed(err) => rows.push(Row {
-                            depth: 3,
-                            kind: RowKind::Note(w, p, e),
-                            label: format!("couldn't load: {err}"),
-                            note: String::new(),
-                            status: None,
-                            expanded: None,
-                            dimmed: false,
-                        }),
-                        Load::NotLoaded => {}
+                        Load::Loading => rows.push(note_row(w, p, e, base + 2, "loading…")),
+                        Load::Failed(err) => {
+                            rows.push(note_row(
+                                w,
+                                p,
+                                e,
+                                base + 2,
+                                &format!("couldn't load: {err}"),
+                            ));
+                        }
+                        // Loaded and non-empty lives in the groups; nothing to
+                        // add under it here.
+                        Load::Loaded(_) | Load::NotLoaded => {}
                     }
-                }
-                if separate_after {
-                    rows.push(separator_row());
                 }
             }
         }
-        rows
+    }
+
+    /// Every environment with agents, as `(workspace, project, environment)`
+    /// paths in display order: the groups with something running first, then
+    /// the default project, then by name.
+    ///
+    /// Indices rather than references, so `RowKind` keeps pointing at the same
+    /// environment as statuses change and the order shifts under it — the
+    /// cursor is restored by identity, not by position.
+    fn agent_groups(&self) -> Vec<(usize, usize, usize)> {
+        let mut groups = Vec::new();
+        for (w, ws) in self.tree.iter().enumerate() {
+            for (p, proj) in ws.projects.iter().enumerate() {
+                for (e, env) in proj.envs.iter().enumerate() {
+                    if !env.agents_vec().is_empty() {
+                        groups.push((w, p, e));
+                    }
+                }
+            }
+        }
+        let default = self.default_project.as_deref();
+        let running = |(w, p, e): &(usize, usize, usize)| {
+            self.tree[*w].projects[*p].envs[*e]
+                .agents_vec()
+                .iter()
+                .any(|agent| agent.status == "running")
+        };
+        groups.sort_by(|a, b| {
+            let (pa, pb) = (&self.tree[a.0].projects[a.1], &self.tree[b.0].projects[b.1]);
+            let is_default = |p: &ProjectNode| Some(p.id.as_str()) == default;
+            running(b)
+                .cmp(&running(a))
+                .then_with(|| is_default(pb).cmp(&is_default(pa)))
+                .then_with(|| pa.name.to_lowercase().cmp(&pb.name.to_lowercase()))
+                .then_with(|| a.2.cmp(&b.2))
+        });
+        groups
+    }
+
+    /// What sits to the right of a group header: the default marker, and the
+    /// workspace when there is more than one for the project to belong to.
+    fn group_note(&self, w: usize, p: usize) -> String {
+        let mut parts = Vec::new();
+        if Some(self.tree[w].projects[p].id.as_str()) == self.default_project.as_deref() {
+            parts.push("(default)".to_string());
+        }
+        if self.tree.len() > 1 {
+            parts.push(self.tree[w].name.clone());
+        }
+        parts.join(" · ")
     }
 
     pub fn selected_row(&self) -> Option<Row> {
@@ -1299,9 +1474,10 @@ impl App {
     /// and `n` work with the cursor on an agent, not just on its environment.
     fn env_of(&self, kind: RowKind) -> Option<(usize, usize, usize)> {
         match kind {
-            RowKind::Environment(w, p, e) | RowKind::Agent(w, p, e, _) | RowKind::Note(w, p, e) => {
-                Some((w, p, e))
-            }
+            RowKind::Environment(w, p, e)
+            | RowKind::Group(w, p, e)
+            | RowKind::Agent(w, p, e, _)
+            | RowKind::Note(w, p, e) => Some((w, p, e)),
             _ => None,
         }
     }
@@ -1394,16 +1570,27 @@ impl App {
         // moves up — so the cursor is put back by row identity rather than
         // left on whatever index it was.
         let anchor = self.selected_row().map(|row| row.kind);
+        let mut refresh_failed = None;
         if let Some(env) = self
             .tree
             .get_mut(w)
             .and_then(|ws| ws.projects.get_mut(p))
             .and_then(|proj| proj.envs.get_mut(e))
         {
-            env.agents = match result {
-                Ok(agents) => Load::Loaded(agents),
-                Err(err) => Load::Failed(err),
+            let previous = std::mem::replace(&mut env.agents, Load::NotLoaded);
+            env.agents = match (result, previous) {
+                (Ok(agents), _) => Load::Loaded(agents),
+                // A refresh that fails must not take the agents with it:
+                // stale beats gone, and the status line carries the reason.
+                (Err(err), Load::Loaded(agents)) => {
+                    refresh_failed = Some(err);
+                    Load::Loaded(agents)
+                }
+                (Err(err), _) => Load::Failed(err),
             };
+        }
+        if let Some(err) = refresh_failed {
+            self.status = format!("Couldn't refresh: {err}");
         }
         self.collapse_if_empty(w, p);
         self.settle_watched_agents();
@@ -1483,13 +1670,32 @@ impl App {
     }
 
     /// Put the cursor back on the row it was on, wherever that row now sits.
+    ///
+    /// A load can promote the environment under the cursor into a group — or
+    /// demote it back into the tail — and it is the same place under either
+    /// name, so the cursor follows it. A row can also be gone entirely — a
+    /// load can fold the projects tail the cursor was in — and then the
+    /// nearest selectable row is the best that can be done.
     fn restore_cursor(&mut self, anchor: Option<RowKind>) {
-        if let Some(kind) = anchor
-            && let Some(index) = self.rows().iter().position(|row| row.kind == kind)
-        {
-            self.cursor = index;
+        if let Some(kind) = anchor {
+            let rows = self.rows();
+            let position = |kind: RowKind| rows.iter().position(|row| row.kind == kind);
+            let index = position(kind).or_else(|| match kind {
+                RowKind::Environment(w, p, e) => position(RowKind::Group(w, p, e)),
+                RowKind::Group(w, p, e) => position(RowKind::Environment(w, p, e)),
+                _ => None,
+            });
+            if let Some(index) = index {
+                self.cursor = index;
+            }
         }
         self.clamp_cursor();
+        if self.selected_row().is_some_and(|row| !row.selectable()) {
+            self.move_cursor_inner(1);
+        }
+        if self.selected_row().is_some_and(|row| !row.selectable()) {
+            self.move_cursor_inner(-1);
+        }
     }
 
     /// Expand or collapse an agent, fetching its sessions the first time.
@@ -2421,8 +2627,8 @@ impl App {
     ///
     /// Only where the answer is needed immediately: the prompt's target, which
     /// New Session reads to decide whether it has an agent to work on, and the
-    /// default project, which the tree leads with. Everything else loads when
-    /// its row is expanded.
+    /// default project, whose agents the tree wants to lead with. Everything
+    /// else loads when its row is expanded.
     ///
     /// This used to be every environment in every project in every workspace,
     /// which is one request each. That is fine on a small account and hundreds
@@ -2435,8 +2641,8 @@ impl App {
         if let Some(target) = self.target.as_ref() {
             wanted.push(target.environment_id.clone());
         }
-        // The default project's environments, which is where the tree opens and
-        // where a launch with no target lands.
+        // The default project's environments, whose agents the tree leads
+        // with and where a launch with no target lands.
         if let Some(project_id) = self.default_project.clone() {
             for ws in &self.tree {
                 for project in &ws.projects {
@@ -2526,9 +2732,14 @@ impl App {
                     self.tree[w].expanded = true;
                     self.tree[w].projects[p].expanded = true;
                     // Always refetch: the launch may have just created the
-                    // agent we are about to select.
+                    // agent we are about to select. What is already loaded
+                    // stays on screen while the reply is on its way — blanking
+                    // it would fold the group mid-poll and shove every row
+                    // (and the cursor) somewhere else.
                     self.tree[w].projects[p].envs[e].expanded = true;
-                    self.tree[w].projects[p].envs[e].agents = Load::Loading;
+                    if !matches!(self.tree[w].projects[p].envs[e].agents, Load::Loaded(_)) {
+                        self.tree[w].projects[p].envs[e].agents = Load::Loading;
+                    }
                     return Some(Effect::LoadAgents {
                         environment_id: environment_id.to_string(),
                         path: (w, p, e),
@@ -2924,7 +3135,11 @@ impl App {
             KeyCode::Char('r') => {
                 let (w, p, e) = self.env_of(row?.kind)?;
                 let env = self.tree.get_mut(w)?.projects.get_mut(p)?.envs.get_mut(e)?;
-                env.agents = Load::Loading;
+                // What is already loaded stays put while the reply is on its
+                // way: blanking it would fold the group and move every row.
+                if !matches!(env.agents, Load::Loaded(_)) {
+                    env.agents = Load::Loading;
+                }
                 Some(Effect::LoadAgents {
                     environment_id: env.id.clone(),
                     path: (w, p, e),
@@ -2944,12 +3159,15 @@ impl App {
     ///
     /// On an agent (or one of its sessions) another session on that same
     /// agent — the agent is already there, and a second one would be a second
-    /// VM nobody asked for. On a project or an environment, a whole new agent,
-    /// because that is the only thing "new" can mean there.
+    /// VM nobody asked for. On a project, an environment, or a group, a whole
+    /// new agent, because that is the only thing "new" can mean there.
+    /// Anywhere else — the tail header, an empty tree — it falls back to the
+    /// target, the same place the menu's New Cloud Agent goes: the empty
+    /// state advertises `n`, so `n` has to work from where the cursor starts.
     fn new_here(&mut self) -> Option<Effect> {
-        let row = self.selected_row()?;
-        match row.kind {
-            RowKind::Agent(w, p, e, a) | RowKind::Session(w, p, e, a, _) => {
+        let kind = self.selected_row().map(|row| row.kind);
+        match kind {
+            Some(RowKind::Agent(w, p, e, a)) | Some(RowKind::Session(w, p, e, a, _)) => {
                 let (agent_id, agent_name) = self.agent_at(w, p, e, a)?;
                 self.target = self.target_at((w, p, e));
                 let target = self.target.clone()?;
@@ -2965,11 +3183,11 @@ impl App {
                     label: format!("{agent_name} · new session"),
                 }))
             }
-            RowKind::Environment(w, p, e) => {
+            Some(RowKind::Environment(w, p, e)) | Some(RowKind::Group(w, p, e)) => {
                 self.target = self.target_at((w, p, e));
                 self.launch(None, true)
             }
-            RowKind::Project(w, p) => {
+            Some(RowKind::Project(w, p)) => {
                 // A project is not a place an agent can live; its first
                 // environment is the only unambiguous reading, and the status
                 // line says which one it picked.
@@ -2979,8 +3197,10 @@ impl App {
                 self.status = format!("New agent in {name}");
                 self.launch(None, true)
             }
+            _ if self.target.is_some() => self.launch(None, true),
             _ => {
-                self.status = "Select a project, an environment, or an agent".into();
+                self.start_target_pick();
+                self.status = "Pick where this should run".into();
                 None
             }
         }
@@ -3219,6 +3439,13 @@ impl App {
 
     fn set_expanded(&mut self, kind: RowKind, open: bool) -> Option<Effect> {
         match kind {
+            // A group is always open; there is nothing to do in either
+            // direction, and quietly folding agents away would be the old
+            // tree's problem reintroduced on purpose.
+            RowKind::Group(..) => {}
+            RowKind::OtherProjects => {
+                self.others_expanded = Some(open);
+            }
             RowKind::Workspace(w) => {
                 self.tree.get_mut(w)?.expanded = open;
             }
@@ -3273,20 +3500,14 @@ impl App {
                 self.clamp_cursor();
                 return None;
             }
-            // Collapsing from a child row closes the environment above it,
-            // which is where the cursor should land too.
-            RowKind::Agent(w, p, e, _) | RowKind::Note(w, p, e) if !open => {
-                self.tree
-                    .get_mut(w)?
-                    .projects
-                    .get_mut(p)?
-                    .envs
-                    .get_mut(e)?
-                    .expanded = false;
+            // Collapsing a closed agent walks the cursor up to its group
+            // header. The group itself never folds, so this is as far out as
+            // `h` can go.
+            RowKind::Agent(w, p, e, _) if !open => {
                 if let Some(i) = self
                     .rows()
                     .iter()
-                    .position(|r| r.kind == RowKind::Environment(w, p, e))
+                    .position(|r| r.kind == RowKind::Group(w, p, e))
                 {
                     self.cursor = i;
                 }
@@ -3298,8 +3519,8 @@ impl App {
     }
 }
 
-/// A rule under the default project, so it reads as its own group rather than
-/// as the first of a list.
+/// A rule between the agent groups and the projects tail, so the tail reads
+/// as its own section rather than as one more group.
 fn separator_row() -> Row {
     Row {
         depth: 0,
@@ -3312,9 +3533,9 @@ fn separator_row() -> Row {
     }
 }
 
-fn note_row(w: usize, p: usize, e: usize, text: &str) -> Row {
+fn note_row(w: usize, p: usize, e: usize, depth: usize, text: &str) -> Row {
     Row {
-        depth: 4,
+        depth,
         kind: RowKind::Note(w, p, e),
         label: text.to_string(),
         note: String::new(),
@@ -3322,6 +3543,38 @@ fn note_row(w: usize, p: usize, e: usize, text: &str) -> Row {
         expanded: None,
         dimmed: false,
     }
+}
+
+/// What a group header says: the project, and the environment only when it
+/// adds something. Most projects have a single `production`, and repeating
+/// that against every group would be the same noise the environment level was
+/// as a row of its own.
+fn group_label(project: &ProjectNode, e: usize) -> String {
+    let env = &project.envs[e];
+    if project.envs.len() > 1 && env.name != "production" {
+        return format!("{}/{}", project.name, env.name);
+    }
+    project.name.clone()
+}
+
+/// Display order for a group's agents: running first, waking next, sleeping
+/// last, then by name. Indices for the same reason as [`App::agent_groups`].
+fn sorted_agents(agents: &[Agent]) -> Vec<usize> {
+    let rank = |agent: &Agent| match agent.status.as_str() {
+        "running" => 0,
+        "starting" => 1,
+        _ => 2,
+    };
+    let mut order: Vec<usize> = (0..agents.len()).collect();
+    order.sort_by(|&a, &b| {
+        rank(&agents[a]).cmp(&rank(&agents[b])).then_with(|| {
+            agents[a]
+                .name
+                .to_lowercase()
+                .cmp(&agents[b].name.to_lowercase())
+        })
+    });
+    order
 }
 
 /// What sits to the right of an agent: its status, plus how many sessions are
@@ -3372,22 +3625,6 @@ fn project_agent_count(project: &ProjectNode) -> usize {
             _ => None,
         })
         .sum()
-}
-
-/// The agent count shown beside a project, as `(3)`.
-///
-/// Counts only environments whose agents have arrived — the startup sweep fills
-/// these in within a second or two, and a number that grows as they land is
-/// better than a placeholder that has to be explained.
-fn project_count_note(project: &ProjectNode) -> String {
-    let total = project_agent_count(project);
-    // Nothing at all when there is nothing to find: a marker against every
-    // empty project is noise, and the count exists to make the projects that
-    // *do* have agents stand out.
-    if total == 0 {
-        return String::new();
-    }
-    format!("({total})")
 }
 
 /// Map a keystroke to an Alt-chord action letter.
@@ -3520,24 +3757,28 @@ mod tests {
             .collect()
     }
 
-    /// A target-less app: the first workspace opens so Manage has something in
-    /// it, but nothing below it is expanded yet.
+    /// A target-less app with nothing loaded yet: no agents to lead with, so
+    /// the projects tail is the whole tree, open, behind the search hint.
     #[test]
-    fn opens_with_the_first_workspace_expanded() {
+    fn opens_with_the_projects_tail_open() {
         let a = app();
         let rows = a.rows();
-        assert_eq!(rows.len(), 2, "{rows:#?}");
-        assert_eq!(rows[0].label, "Railway");
-        assert_eq!(rows[1].label, "devtools");
+        assert_eq!(rows.len(), 3, "{rows:#?}");
+        assert_eq!(rows[0].label, "looking for cloud agents…");
+        assert!(!rows[0].selectable());
+        assert_eq!(rows[1].label, "projects");
+        assert_eq!(rows[2].label, "devtools");
+        // The cursor starts on a row a key can act on, not on the hint.
+        assert_eq!(a.cursor, 1);
     }
 
     #[test]
     fn expanding_an_environment_requests_its_agents_once() {
         let mut a = app();
         a.screen = Screen::Manage;
-        a.cursor = 1; // devtools
+        a.cursor = 2; // devtools
         assert_eq!(a.on_key(key(KeyCode::Right)), None);
-        a.cursor = 2; // production
+        a.cursor = 3; // production
         let effect = a.on_key(key(KeyCode::Right)).unwrap();
         assert_eq!(
             effect,
@@ -3555,9 +3796,9 @@ mod tests {
     fn a_loading_environment_shows_a_note_that_cannot_be_selected() {
         let mut a = app();
         a.screen = Screen::Manage;
-        a.cursor = 1;
+        a.cursor = 2; // devtools
         a.on_key(key(KeyCode::Right));
-        a.cursor = 2;
+        a.cursor = 3; // production
         a.on_key(key(KeyCode::Right));
         let rows = a.rows();
         let note = rows.iter().find(|r| r.label == "loading…").unwrap();
@@ -4842,7 +5083,7 @@ mod tests {
         a.cursor = a
             .rows()
             .iter()
-            .position(|r| r.label == "production")
+            .position(|r| matches!(r.kind, RowKind::Group(..)))
             .unwrap();
         assert_eq!(a.on_key(key(KeyCode::Char('d'))), None);
         assert!(a.confirm.is_none());
@@ -5066,44 +5307,79 @@ mod tests {
         assert!(req.new_session, "must not reuse the open pane");
         assert!(req.wants_new_session());
 
-        // On an environment: a whole new agent.
+        // On a group header — the environment's stand-in: a whole new agent.
         a.cursor = a
             .rows()
             .iter()
-            .position(|r| r.label == "production")
+            .position(|r| matches!(r.kind, RowKind::Group(..)))
             .unwrap();
         let Some(Effect::Launch(req)) = a.on_key(key(KeyCode::Char('n'))) else {
             panic!("expected a launch");
         };
         assert!(req.force_new);
         assert_eq!(req.agent_id, None);
+        assert_eq!(req.environment_id, "env_prod");
 
-        // On a project: a new agent in its first environment, and it says so.
-        a.cursor = a.rows().iter().position(|r| r.label == "devtools").unwrap();
-        let Some(Effect::Launch(req)) = a.on_key(key(KeyCode::Char('n'))) else {
+        // On a project in the tail: a new agent in its first environment, and
+        // it says so.
+        let mut b = ordering_app();
+        b.screen = Screen::Manage;
+        b.cursor = b.rows().iter().position(|r| r.label == "Alpha").unwrap();
+        let Some(Effect::Launch(req)) = b.on_key(key(KeyCode::Char('n'))) else {
             panic!("expected a launch");
         };
         assert!(req.force_new);
-        assert_eq!(req.environment_id, "env_prod");
-        assert!(a.status.contains("production"), "{}", a.status);
+        assert_eq!(req.environment_id, "p2-prod");
+        assert!(b.status.contains("production"), "{}", b.status);
     }
 
     /// Clicking a row with children opens it, and clicking again closes it —
     /// the one gesture every tree has.
     #[test]
     fn clicking_a_collapsible_row_toggles_it() {
-        let mut a = loaded_app();
+        let mut a = ordering_app();
+        a.screen = Screen::Manage;
         a.panes = panes_fixture();
-        let devtools = a.rows().iter().position(|r| r.label == "devtools").unwrap();
+        let alpha = a.rows().iter().position(|r| r.label == "Alpha").unwrap();
 
-        // Open in the fixture; a click closes it.
-        a.on_mouse(MouseAction::Down, 5, 3 + devtools as u16);
-        assert!(!a.tree[0].projects[0].expanded);
-        assert!(!a.rows().iter().any(|r| r.label == "production"));
+        // Closed in the fixture; a click opens it and shows its environment.
+        a.on_mouse(MouseAction::Down, 5, 3 + alpha as u16);
+        assert!(a.tree[0].projects[1].expanded);
+        assert!(a.rows().iter().any(|r| r.label == "production"));
 
-        // And a second click opens it again.
-        a.on_mouse(MouseAction::Down, 5, 3 + devtools as u16);
-        assert!(a.tree[0].projects[0].expanded);
+        // And a second click closes it again.
+        a.on_mouse(MouseAction::Down, 5, 3 + alpha as u16);
+        assert!(!a.tree[0].projects[1].expanded);
+    }
+
+    /// The projects tail folds and unfolds like any other branch, and its
+    /// state sticks once it has been touched.
+    #[test]
+    fn clicking_the_tail_header_toggles_it() {
+        let mut a = ordering_app();
+        a.screen = Screen::Manage;
+        a.panes = panes_fixture();
+        let header = a
+            .rows()
+            .iter()
+            .position(|r| matches!(r.kind, RowKind::OtherProjects))
+            .unwrap();
+
+        // Open (nothing else to show); a click folds every project away.
+        a.on_mouse(MouseAction::Down, 5, 3 + header as u16);
+        assert!(
+            !a.rows()
+                .iter()
+                .any(|r| matches!(r.kind, RowKind::Project(..)))
+        );
+
+        // And a second click brings them back.
+        a.on_mouse(MouseAction::Down, 5, 3 + header as u16);
+        assert!(
+            a.rows()
+                .iter()
+                .any(|r| matches!(r.kind, RowKind::Project(..)))
+        );
     }
 
     /// Clicking a collapsed environment has to fetch its agents, the same as
@@ -5216,10 +5492,11 @@ mod tests {
         );
     }
 
-    /// An empty environment carries no marker at all — the count is there to
-    /// pick out the ones with agents.
+    /// An environment in the tail carries no marker at all unless it is
+    /// mid-load or failed — everything down there is empty, so a count would
+    /// say nothing.
     #[test]
-    fn environment_counts_have_no_empty_marker() {
+    fn tail_environments_have_no_empty_marker() {
         let mut a = app();
         let note =
             |a: &App, name: &str| a.rows().into_iter().find(|r| r.label == name).unwrap().note;
@@ -5229,8 +5506,8 @@ mod tests {
         a.agents_loaded((0, 0, 0), Ok(Vec::new()));
         assert_eq!(note(&a, "production"), "", "loaded and empty");
 
-        a.agents_loaded((0, 0, 1), Ok(vec![agent("ca_1", "one", "running")]));
-        assert_eq!(note(&a, "staging"), "(1)");
+        a.tree[0].projects[0].envs[1].agents = Load::Loading;
+        assert_eq!(note(&a, "staging"), "…");
     }
 
     /// The dot next to a session means "open in this UI", nothing else. The
@@ -5751,45 +6028,50 @@ mod tests {
         assert!(a.tree[0].projects[0].expanded);
     }
 
-    /// The default project leads the list, separated from the rest — it is
-    /// where agents go, so it is not just another row.
+    /// The default project leads the tail and is never dimmed — it is where
+    /// agents go, so it has to be findable even while empty.
     #[test]
-    fn the_default_project_sorts_first_with_a_rule_under_it() {
+    fn the_default_project_leads_the_tail() {
         let mut a = ordering_app();
-        // `zebra` has agents, so it would otherwise lead.
-        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "running")]));
-        assert_eq!(project_order(&a)[0], "zebra");
-
-        // `mono` is the default and takes the top regardless.
         a.default_project = Some("p3".into());
-        assert_eq!(project_order(&a), ["mono", "zebra", "Alpha", "beta"]);
+        assert_eq!(project_order(&a), ["mono", "Alpha", "beta", "zebra"]);
 
         let rows = a.rows();
         let mono = rows.iter().position(|r| r.label == "mono").unwrap();
-        assert!(
-            matches!(rows[mono + 1].kind, RowKind::Separator),
-            "a rule should follow the default project"
-        );
-        assert!(!rows[mono + 1].selectable(), "the rule is not a stop");
         assert_eq!(rows[mono].note, "(default)", "marked, and not dimmed");
         assert!(!rows[mono].dimmed, "the default is always findable");
-
-        // With agents it carries the count alongside the marker.
-        a.agents_loaded((0, 2, 0), Ok(vec![agent("ca_2", "two", "running")]));
-        let rows = a.rows();
-        let mono = rows.iter().position(|r| r.label == "mono").unwrap();
-        assert_eq!(rows[mono].note, "(default · 1)");
-
-        // Moving down skips the rule rather than landing on it.
-        a.screen = Screen::Manage;
-        a.cursor = mono;
-        a.on_key(key(KeyCode::Down));
-        assert_eq!(a.selected_row().unwrap().label, "zebra");
     }
 
-    /// With no default, nothing is separated and the old order stands.
+    /// The rule sits between the agent groups and the projects tail, and
+    /// moving down skips it rather than landing on it.
     #[test]
-    fn no_default_project_means_no_rule() {
+    fn a_rule_separates_the_groups_from_the_tail() {
+        let mut a = ordering_app();
+        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "running")]));
+        let rows = a.rows();
+        let sep = rows
+            .iter()
+            .position(|r| matches!(r.kind, RowKind::Separator))
+            .expect("a rule under the groups");
+        assert!(
+            matches!(rows[sep - 1].kind, RowKind::Agent(..)),
+            "{rows:#?}"
+        );
+        assert!(matches!(rows[sep + 1].kind, RowKind::OtherProjects));
+        assert!(!rows[sep].selectable(), "the rule is not a stop");
+
+        a.screen = Screen::Manage;
+        a.cursor = sep - 1;
+        a.on_key(key(KeyCode::Down));
+        assert!(matches!(
+            a.selected_row().unwrap().kind,
+            RowKind::OtherProjects
+        ));
+    }
+
+    /// With no agents there are no groups, so there is nothing to rule off.
+    #[test]
+    fn no_groups_means_no_rule() {
         let a = ordering_app();
         assert!(
             !a.rows()
@@ -5806,19 +6088,50 @@ mod tests {
         assert_eq!(project_order(&a), ["Alpha", "beta", "mono", "zebra"]);
     }
 
-    /// Projects with agents come first, and stay alphabetical within their
-    /// group — that is the whole point of the ordering.
+    /// A project that gains agents leaves the tail and leads the tree as a
+    /// group — groups with something running first.
     #[test]
-    fn projects_with_agents_sort_to_the_top() {
+    fn projects_with_agents_become_groups() {
         let mut a = ordering_app();
-        // `mono` (index 2) and `zebra` (index 0) gain agents.
-        a.agents_loaded((0, 2, 0), Ok(vec![agent("ca_1", "one", "running")]));
-        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_2", "two", "running")]));
-        assert_eq!(project_order(&a), ["mono", "zebra", "Alpha", "beta"]);
+        // `zebra` gains a sleeping agent, `mono` a running one.
+        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "sleeping")]));
+        a.agents_loaded((0, 2, 0), Ok(vec![agent("ca_2", "two", "running")]));
+        let groups: Vec<String> = a
+            .rows()
+            .iter()
+            .filter(|r| matches!(r.kind, RowKind::Group(..)))
+            .map(|r| r.label.clone())
+            .collect();
+        assert_eq!(groups, ["mono", "zebra"], "running leads");
+
+        // Groups exist now, so the untouched tail folded itself away…
+        assert_eq!(project_order(&a), Vec::<String>::new());
+        // …and holds the rest once opened.
+        a.others_expanded = Some(true);
+        assert_eq!(project_order(&a), ["Alpha", "beta"]);
 
         // An environment that answers with nothing does not promote anyone.
         a.agents_loaded((0, 1, 0), Ok(Vec::new()));
-        assert_eq!(project_order(&a), ["mono", "zebra", "Alpha", "beta"]);
+        assert_eq!(project_order(&a), ["Alpha", "beta"]);
+    }
+
+    /// A group names its project, and its environment only when that says
+    /// something — not `production`, and not the only environment there is.
+    #[test]
+    fn group_labels_fold_the_environment_in_only_when_it_matters() {
+        let mut a = app();
+        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "running")]));
+        let group_labels = |a: &App| -> Vec<String> {
+            a.rows()
+                .iter()
+                .filter(|r| matches!(r.kind, RowKind::Group(..)))
+                .map(|r| r.label.clone())
+                .collect()
+        };
+        assert_eq!(group_labels(&a), ["devtools"], "production says nothing");
+
+        a.agents_loaded((0, 0, 1), Ok(vec![agent("ca_2", "two", "running")]));
+        assert_eq!(group_labels(&a), ["devtools", "devtools/staging"]);
     }
 
     /// Empty projects are de-emphasised, and stop being so the moment they
@@ -5838,49 +6151,37 @@ mod tests {
         assert!(!mono.dimmed);
     }
 
-    /// Re-ordering must not move the selection to a different project: the
-    /// cursor is an index, and the row under it would otherwise change.
+    /// Re-ordering must not move the selection to a different row: the cursor
+    /// is an index, and the row under it would otherwise change.
     #[test]
     fn the_cursor_stays_on_its_row_when_the_order_changes() {
         let mut a = ordering_app();
-        let beta = a.rows().iter().position(|r| r.label == "beta").unwrap();
-        a.cursor = beta;
+        // `zebra` has a sleeping agent, and the cursor is on it.
+        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "sleeping")]));
+        a.cursor = a.rows().iter().position(|r| r.label == "one").unwrap();
 
-        // `zebra` gains an agent and jumps to the top, shifting `beta` down.
-        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "running")]));
-        assert_eq!(a.selected_row().unwrap().label, "beta");
+        // `mono` gains a running agent and its group jumps above zebra's.
+        a.agents_loaded((0, 2, 0), Ok(vec![agent("ca_2", "two", "running")]));
+        assert_eq!(a.selected_row().unwrap().label, "one");
     }
 
-    /// `(N)` beside a project, and nothing at all when there is nothing to
-    /// find — a marker against every empty project is noise.
+    /// The tail header counts the projects folded under it, and says what
+    /// they are other than once there are groups to be other than.
     #[test]
-    fn project_counts_read_as_n_in_parentheses() {
-        let mut a = app();
-        let project_note = |a: &App| {
+    fn the_tail_header_counts_its_projects() {
+        let mut a = ordering_app();
+        let header = |a: &App| {
             a.rows()
                 .into_iter()
-                .find(|r| r.label == "devtools")
+                .find(|r| matches!(r.kind, RowKind::OtherProjects))
                 .unwrap()
-                .note
         };
-        assert_eq!(project_note(&a), "", "nothing fetched yet");
+        assert_eq!(header(&a).label, "projects");
+        assert_eq!(header(&a).note, "(4)");
 
         a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "running")]));
-        assert_eq!(project_note(&a), "(1)");
-
-        a.agents_loaded(
-            (0, 0, 1),
-            Ok(vec![
-                agent("ca_2", "two", "sleeping"),
-                agent("ca_3", "three", "running"),
-            ]),
-        );
-        assert_eq!(project_note(&a), "(3)", "summed across environments");
-
-        let mut empty = app();
-        empty.agents_loaded((0, 0, 0), Ok(vec![]));
-        empty.agents_loaded((0, 0, 1), Ok(vec![]));
-        assert_eq!(project_note(&empty), "", "no marker on an empty project");
+        assert_eq!(header(&a).label, "other projects");
+        assert_eq!(header(&a).note, "(3)");
     }
 
     /// Expanding an agent asks the platform what is running on it, every time:
@@ -6520,9 +6821,10 @@ mod tests {
     #[test]
     fn a_stale_load_result_is_ignored() {
         let mut a = app();
+        let before = a.rows();
         a.agents_loaded((9, 9, 9), Ok(vec![]));
         a.agents_loaded((0, 0, 5), Err("boom".into()));
-        assert_eq!(a.rows().len(), 2);
+        assert_eq!(a.rows(), before);
     }
 
     #[test]
@@ -6534,5 +6836,137 @@ mod tests {
         let rows = a.rows();
         assert!(rows.iter().any(|r| r.label.contains("502 from backboard")));
         assert!(!rows.iter().any(|r| r.label == "no agents here"));
+    }
+
+    /// `r` refetches without blanking what is on screen: a group that
+    /// vanished for every refresh would shove the rows — and the cursor —
+    /// somewhere else once every poll tick during a wake.
+    #[test]
+    fn refreshing_a_group_keeps_it_on_screen() {
+        let mut a = loaded_app();
+        a.cursor = a
+            .rows()
+            .iter()
+            .position(|r| r.label == "nimble-otter")
+            .unwrap();
+        let effect = a.on_key(key(KeyCode::Char('r')));
+        assert_eq!(
+            effect,
+            Some(Effect::LoadAgents {
+                environment_id: "env_prod".into(),
+                path: (0, 0, 0)
+            })
+        );
+        assert!(a.rows().iter().any(|r| r.label == "nimble-otter"));
+        assert_eq!(a.selected_row().unwrap().label, "nimble-otter");
+
+        // The same when a watch polls the environment behind the scenes.
+        a.reveal_environment("env_prod");
+        assert!(a.rows().iter().any(|r| r.label == "nimble-otter"));
+    }
+
+    /// A refresh that fails keeps the stale list — stale beats gone — and
+    /// says why in the status line.
+    #[test]
+    fn a_failed_refresh_keeps_the_agents_and_reports() {
+        let mut a = loaded_app();
+        a.agents_loaded((0, 0, 0), Err("502 from backboard".into()));
+        assert!(a.rows().iter().any(|r| r.label == "nimble-otter"));
+        assert!(a.status.contains("502 from backboard"), "{}", a.status);
+    }
+
+    /// A project with agents in one environment still shows its empty ones in
+    /// the tail — they have to stay reachable for `n`, `t`, and `r`.
+    #[test]
+    fn empty_environments_of_a_grouped_project_stay_reachable() {
+        let mut a = loaded_app();
+        a.others_expanded = Some(true);
+        let rows = a.rows();
+        assert!(
+            rows.iter()
+                .any(|r| r.kind == RowKind::Environment(0, 0, 1) && r.label == "staging"),
+            "{rows:#?}"
+        );
+        // The occupied environment is a group above, not a tail row too.
+        assert!(!rows.iter().any(|r| r.kind == RowKind::Environment(0, 0, 0)));
+
+        // Once every environment has agents the project leaves the tail.
+        a.agents_loaded((0, 0, 1), Ok(vec![agent("ca_9", "niner", "running")]));
+        assert!(
+            !a.rows()
+                .iter()
+                .any(|r| matches!(r.kind, RowKind::Project(..)))
+        );
+    }
+
+    /// The empty state advertises `n`, so `n` must work from where the cursor
+    /// starts: with a target it launches there, without one it asks for one.
+    #[test]
+    fn n_falls_back_to_the_target_from_the_tail_header() {
+        let mut a = app();
+        a.screen = Screen::Manage;
+        assert!(matches!(
+            a.selected_row().unwrap().kind,
+            RowKind::OtherProjects
+        ));
+        a.on_key(key(KeyCode::Char('n')));
+        assert_eq!(a.screen, Screen::TargetPick, "no target: ask for one");
+
+        let mut b = app();
+        b.screen = Screen::Manage;
+        b.target = Some(Target {
+            project_id: "proj_1".into(),
+            project_name: "devtools".into(),
+            environment_id: "env_prod".into(),
+            environment_name: "production".into(),
+        });
+        let Some(Effect::Launch(req)) = b.on_key(key(KeyCode::Char('n'))) else {
+            panic!("expected a launch into the target");
+        };
+        assert!(req.force_new);
+        assert_eq!(req.environment_id, "env_prod");
+    }
+
+    /// Loading an environment from the tail can promote it into a group; the
+    /// cursor follows it up rather than being stranded in the folded tail.
+    #[test]
+    fn the_cursor_follows_an_environment_promoted_to_a_group() {
+        let mut a = app();
+        a.screen = Screen::Manage;
+        a.cursor = a.rows().iter().position(|r| r.label == "devtools").unwrap();
+        a.on_key(key(KeyCode::Right));
+        a.cursor = a
+            .rows()
+            .iter()
+            .position(|r| r.label == "production")
+            .unwrap();
+        a.on_key(key(KeyCode::Right));
+        a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "one", "running")]));
+        assert_eq!(
+            a.selected_row().unwrap().kind,
+            RowKind::Group(0, 0, 0),
+            "{:#?}",
+            a.rows()
+        );
+    }
+
+    /// "None yet" is a definitive claim: the hint searches while anything is
+    /// unanswered, owns up to failures, and only then declares the account
+    /// empty.
+    #[test]
+    fn the_hint_waits_for_answers_before_claiming_empty() {
+        let mut a = app();
+        let hint = |a: &App| a.rows().first().unwrap().label.clone();
+        assert_eq!(hint(&a), "looking for cloud agents…", "not loaded");
+
+        a.tree[0].projects[0].envs[0].agents = Load::Loading;
+        assert_eq!(hint(&a), "looking for cloud agents…", "still in flight");
+
+        a.agents_loaded((0, 0, 0), Ok(Vec::new()));
+        a.agents_loaded((0, 0, 1), Err("boom".into()));
+        assert_eq!(hint(&a), "couldn't check every environment — r retries");
+
+        a.agents_loaded((0, 0, 1), Ok(Vec::new()));
+        assert_eq!(hint(&a), "no cloud agents yet — n creates one");
     }
 }

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -44,7 +44,7 @@ use tokio::sync::mpsc;
 use app::{
     Agent, AgentOp, ConsoleSession, EnvNode, Load, LoadSessions, ProjectNode, WorkspaceNode,
 };
-pub use app::{App, Effect, LaunchRequest, Target};
+pub use app::{App, Effect, LaunchRequest, Screen, Target};
 
 use crate::client::post_graphql;
 use crate::commands::code::{self, LaunchArgs, Prepared, Progress};

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -297,14 +297,11 @@ impl Session {
         }
         self.size = (rows, cols);
         if let Ok(mut parser) = self.parser.lock() {
-            parser.set_size(rows, cols);
-            // A smaller pane means a lower ceiling; an offset held over from a
-            // taller one would underflow inside the emulator.
-            let ceiling = rows.saturating_sub(1) as usize;
-            if self.scroll > ceiling {
-                self.scroll = ceiling;
-                parser.set_scrollback(ceiling);
-            }
+            parser.screen_mut().set_size(rows, cols);
+            // Resizing can reflow rows between the screen and history; read
+            // the offset back so the held position stays whatever the
+            // emulator says the view now is.
+            self.scroll = parser.screen().scrollback();
         }
         let _ = self.master.resize(PtySize {
             rows,
@@ -373,7 +370,7 @@ impl Session {
                         index = Some(text.chars().count());
                     }
                     match screen.cell(r, c).map(|cell| cell.contents()) {
-                        Some(s) if !s.is_empty() => text.push_str(&s),
+                        Some(s) if !s.is_empty() => text.push_str(s),
                         // Empty, or a wide character's second cell: still a
                         // column.
                         _ => text.push(' '),
@@ -434,25 +431,16 @@ impl Session {
 
     /// Scroll back through the emulator's history.
     ///
-    /// Clamped to the screen height, which is a limit of the emulator rather
-    /// than a choice: vt100 0.15 composes the scrolled view as
-    /// `scrollback[len-offset..] ++ rows[..rows_len-offset]`, so an offset past
-    /// the number of screen rows underflows that second subtraction. In debug
-    /// that panics; in release it wraps to a huge `take` and quietly renders
-    /// the live screen — which is what "scrolling does nothing" looked like.
-    ///
-    /// One screenful of history at a time, therefore. Going further back needs
-    /// a newer vt100, which currently conflicts with ratatui's pinned
-    /// `unicode-width`.
+    /// The only ceiling is the history that actually exists: the emulator
+    /// clamps the offset to it, so ask for the position and read back where
+    /// it settled. (vt100 0.15 could not compose a view more than one screen
+    /// deep — a clamp used to sit here working around that.)
     pub fn scroll_by(&mut self, delta: isize) {
         let Ok(mut parser) = self.parser.lock() else {
             return;
         };
-        let ceiling = self.size.0.saturating_sub(1) as isize;
-        let wanted = (self.scroll as isize + delta).clamp(0, ceiling.max(0)) as usize;
-        parser.set_scrollback(wanted);
-        // It also clamps to the history that exists, so read back what it
-        // settled on rather than trusting the request.
+        let wanted = (self.scroll as isize).saturating_add(delta).max(0) as usize;
+        parser.screen_mut().set_scrollback(wanted);
         self.scroll = parser.screen().scrollback();
     }
 
@@ -513,7 +501,7 @@ impl Session {
         }
         self.scroll = 0;
         if let Ok(mut parser) = self.parser.lock() {
-            parser.set_scrollback(0);
+            parser.screen_mut().set_scrollback(0);
         }
     }
 
@@ -1009,6 +997,218 @@ mod tests {
         // Typing returns to the live view.
         session.send(b"x");
         assert!(!session.scrolled_back());
+    }
+
+    /// The whole retained history is reachable, not one screenful. The old
+    /// emulator could not compose a view deeper than the pane is tall, so a
+    /// clamp in `scroll_by` stopped exactly here — this is the regression
+    /// test for its removal.
+    #[test]
+    fn scrolling_reaches_the_whole_history() {
+        let mut session = Session::for_test("ca", "test").unwrap();
+        session.resize(6, 40);
+
+        for i in 0..120 {
+            session.send(format!("line-{i}\r\n").as_bytes());
+        }
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let seen = session
+                .with_screen(|screen| screen.contents().contains("line-119"))
+                .unwrap_or(false);
+            if seen {
+                break;
+            }
+        }
+
+        // Ask for infinitely far back; the emulator clamps to what exists.
+        session.scroll_by(isize::MAX);
+        assert!(
+            session.scroll > 100,
+            "120 lines through a 6-row pane should leave far more than one \
+             screen of history, got offset {}",
+            session.scroll
+        );
+        let top = session.with_screen(|s| s.contents()).unwrap();
+        assert!(
+            top.contains("line-0"),
+            "the very first line should be visible at full depth:\n{top}"
+        );
+
+        // And all the way forward again.
+        session.scroll_by(isize::MIN);
+        assert!(!session.scrolled_back());
+        let live = session.with_screen(|s| s.contents()).unwrap();
+        assert!(live.contains("line-119"), "back to the tail:\n{live}");
+    }
+
+    /// Successive wheel notches keep going past one screenful, through the
+    /// same entry point the mouse uses.
+    #[test]
+    fn scrolling_walks_past_one_screenful() {
+        let mut session = Session::for_test("ca", "test").unwrap();
+        session.resize(6, 40);
+
+        for i in 0..60 {
+            session.send(format!("line-{i}\r\n").as_bytes());
+        }
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let seen = session
+                .with_screen(|screen| screen.contents().contains("line-59"))
+                .unwrap_or(false);
+            if seen {
+                break;
+            }
+        }
+
+        // No mouse reporting and no alternate screen here, so each wheel goes
+        // to the emulator's own scrollback.
+        session.scroll(true, 5, (1, 1));
+        let one = session.scroll;
+        session.scroll(true, 5, (1, 1));
+        let two = session.scroll;
+        session.scroll(true, 5, (1, 1));
+        let three = session.scroll;
+        assert!(one < two && two < three, "each notch must go deeper");
+        assert!(
+            three > 6,
+            "three notches should pass the height of the pane, got {three}"
+        );
+
+        let deep = session.with_screen(|s| s.contents()).unwrap();
+        assert!(
+            !deep.contains("line-59"),
+            "the tail should have scrolled out of view:\n{deep}"
+        );
+    }
+
+    /// A deep offset survives the pane changing shape. Resize used to clamp
+    /// the offset to the new height because the old emulator would underflow
+    /// past it; now the offset just rides along.
+    #[test]
+    fn a_deep_scroll_survives_resize() {
+        let mut session = Session::for_test("ca", "test").unwrap();
+        session.resize(10, 40);
+
+        for i in 0..100 {
+            session.send(format!("line-{i}\r\n").as_bytes());
+        }
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let seen = session
+                .with_screen(|screen| screen.contents().contains("line-99"))
+                .unwrap_or(false);
+            if seen {
+                break;
+            }
+        }
+
+        session.scroll_by(60);
+        assert!(session.scroll > 10, "start well past one screen");
+
+        // Shrink, then grow. Either way the view must keep rendering — in
+        // debug builds an underflow inside the emulator would panic here.
+        session.resize(4, 40);
+        assert!(session.scrolled_back(), "the offset survives shrinking");
+        let shrunk = session.with_screen(|s| s.contents()).unwrap();
+        assert!(!shrunk.is_empty(), "a shrunk pane still renders history");
+
+        session.resize(20, 40);
+        let grown = session.with_screen(|s| s.contents()).unwrap();
+        assert!(!grown.is_empty(), "a grown pane still renders history");
+
+        // Typing is still the way back to live.
+        session.send(b"x");
+        assert!(!session.scrolled_back());
+    }
+
+    /// Scrolling, resizing, and live output all at once. None of these
+    /// operations may wedge the offset, wedge each other, or leave the view
+    /// unable to render — the wheel arrives whenever it arrives, not when the
+    /// pane is conveniently idle.
+    #[test]
+    fn scrollback_survives_churn() {
+        let mut session = Session::for_test("ca", "test").unwrap();
+        session.resize(8, 40);
+
+        // Interleave output with scrolls and reshapes, deterministically.
+        let sizes = [(4u16, 30u16), (12, 60), (6, 40), (24, 80), (8, 40)];
+        for (round, &(rows, cols)) in sizes.iter().enumerate() {
+            for i in 0..40 {
+                session.send(format!("round-{round}-line-{i}\r\n").as_bytes());
+            }
+            session.scroll_by(37);
+            session.resize(rows, cols);
+            session.scroll_by(-13);
+            let held = session.scroll;
+            let history = session
+                .with_screen(|s| s.scrollback())
+                .expect("the emulator stays lockable");
+            assert_eq!(held, history, "the held offset tracks the emulator");
+            assert!(
+                session.with_screen(|s| s.contents()).is_some(),
+                "the view renders mid-churn"
+            );
+        }
+
+        // Wait for the tail so the final checks see settled history.
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let seen = session
+                .with_screen(|screen| screen.contents().contains("round-4-line-39"))
+                .unwrap_or(false);
+            if seen {
+                break;
+            }
+        }
+
+        session.scroll_by(isize::MAX);
+        let top = session.with_screen(|s| s.contents()).unwrap();
+        assert!(
+            top.contains("round-0-line-"),
+            "the first round is still reachable at full depth:\n{top}"
+        );
+        session.send(b"x");
+        assert!(!session.scrolled_back(), "typing still snaps back to live");
+    }
+
+    /// Past the emulator's retention the offset clamps to what is kept, and
+    /// the oldest lines are the ones to go — the view at full depth is the
+    /// start of the *retained* history, never garbage.
+    #[test]
+    fn scrollback_clamps_at_capacity() {
+        let mut session = Session::for_test("ca", "test").unwrap();
+        session.resize(6, 40);
+
+        // More than the 4000 lines the parser retains.
+        for i in 0..4200 {
+            session.send(format!("line-{i}\r\n").as_bytes());
+        }
+        for _ in 0..300 {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let seen = session
+                .with_screen(|screen| screen.contents().contains("line-4199"))
+                .unwrap_or(false);
+            if seen {
+                break;
+            }
+        }
+
+        session.scroll_by(isize::MAX);
+        assert_eq!(
+            session.scroll, 4000,
+            "full depth is the retention limit, no further"
+        );
+        let top = session.with_screen(|s| s.contents()).unwrap();
+        assert!(
+            !top.contains("line-0\r") && !top.contains("line-0\n"),
+            "the very first lines fell out of retention:\n{top}"
+        );
+        assert!(
+            top.contains("line-"),
+            "what is shown is still real history:\n{top}"
+        );
     }
 
     /// An application that asked for mouse reporting gets a real wheel event,

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1552,7 +1552,11 @@ fn screen_lines(screen: &vt100::Screen, focused: bool) -> Vec<Line<'static>> {
                 Some(cell) => (
                     {
                         let c = cell.contents();
-                        if c.is_empty() { " ".to_string() } else { c }
+                        if c.is_empty() {
+                            " ".to_string()
+                        } else {
+                            c.to_string()
+                        }
                     },
                     cell_style(cell),
                 ),
@@ -2277,6 +2281,53 @@ mod tests {
             .position(|l| l.contains("╭ Prompt"))
             .expect("the prompt box");
         assert_eq!(rects.prompt.y as usize, prompt);
+    }
+
+    /// The pane renders history from any depth, not just the last screenful.
+    /// This drives the real draw path — `render_session` → `screen_lines` →
+    /// `Screen::cell` — with the view sitting several screens back, which the
+    /// old emulator could not compose at all.
+    #[test]
+    fn a_deeply_scrolled_pane_draws_old_history() {
+        use crate::commands::cloud_agent::tui::session::Session;
+
+        let mut app = app_with_tree();
+        app.screen = Screen::Manage;
+        app.attach_session(
+            Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+
+        let session = app.sessions.last_mut().expect("just attached");
+        session.resize(6, 40);
+        for i in 0..80 {
+            session.send(format!("line-{i}\r\n").as_bytes());
+        }
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let seen = session
+                .with_screen(|screen| screen.contents().contains("line-79"))
+                .unwrap_or(false);
+            if seen {
+                break;
+            }
+        }
+        session.scroll_by(isize::MAX);
+        assert!(session.scrolled_back());
+
+        let out = draw(&app, 92, 20);
+        assert!(
+            out.contains("line-0"),
+            "the top of history should be on screen:\n{out}"
+        );
+        assert!(
+            !out.contains("line-79"),
+            "the tail should be scrolled out of view:\n{out}"
+        );
+        assert!(
+            out.contains("scrolled back"),
+            "the pane should say where it is:\n{out}"
+        );
     }
 
     /// A drag that reached the clipboard says so in the corner — the only other

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1022,7 +1022,7 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
     // pane the chord is a no-op and the hint would just be a lie.
     let mut hint = hint;
     if app.sessions.len() > 1 {
-        hint.push(("⌥]", "next session"));
+        hint.push(("⌥[ ⌥]", "switch session"));
     }
     let spans = chord_spans(theme, &hint);
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -873,7 +873,10 @@ fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
                     } else {
                         theme.accent_dim
                     }))
-                    .title(Span::styled(" projects ", Style::default().fg(theme.dim))),
+                    .title(Span::styled(
+                        " cloud agents ",
+                        Style::default().fg(theme.dim),
+                    )),
             )
             .highlight_style(
                 Style::default()
@@ -1010,6 +1013,13 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
                     ("s", "sleep")
                 },
                 ("d", "delete agent"),
+            ],
+            // A group is a place, not a thing to open: the keys that matter
+            // are the ones that act on the environment it stands for.
+            Some(RowKind::Group(..)) => vec![
+                ("n", "new agent here"),
+                ("t", "target"),
+                ("shift+r", "find agents"),
             ],
             _ => vec![
                 ("enter", "open"),
@@ -1697,7 +1707,7 @@ fn tree_line(theme: &Theme, row: &Row) -> Line<'static> {
             "─".repeat(TREE_W.saturating_sub(4) as usize),
             Style::default().fg(theme.accent_dim),
         )),
-        (RowKind::Note(..), _) => spans.push(Span::styled(
+        (RowKind::Note(..) | RowKind::Hint, _) => spans.push(Span::styled(
             row.label.clone(),
             Style::default()
                 .fg(theme.dim)
@@ -1719,6 +1729,9 @@ fn tree_line(theme: &Theme, row: &Row) -> Line<'static> {
                 RowKind::Workspace(_) => Style::default()
                     .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),
+                // A group heads its agents the way a workspace used to head
+                // everything: bold, so the sections read at a glance.
+                RowKind::Group(..) => Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
                 _ => Style::default().fg(theme.fg),
             };
             spans.push(Span::styled(row.label.clone(), style));
@@ -1849,7 +1862,7 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
             }
             lines
         }
-        RowKind::Environment(w, p, e) => {
+        RowKind::Environment(w, p, e) | RowKind::Group(w, p, e) => {
             let proj = &app.tree[w].projects[p];
             let env = &proj.envs[e];
             let count = match &env.agents {
@@ -1934,7 +1947,20 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
             )));
             lines
         }
-        RowKind::Separator | RowKind::Note(..) => vec![Line::from("")],
+        RowKind::OtherProjects => vec![
+            Line::from(Span::styled(
+                " projects without agents",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                " open one and press n to start an agent there",
+                Style::default().fg(theme.dim),
+            )),
+        ],
+        RowKind::Separator | RowKind::Note(..) | RowKind::Hint => vec![Line::from("")],
     }
 }
 
@@ -2437,11 +2463,11 @@ mod tests {
             "ca_1".into(),
         );
         let before = draw(&app, 100, 30);
-        assert!(before.contains("projects"), "the tree is there first");
+        assert!(before.contains("cloud agents"), "the tree is there first");
 
         app.maximized = true;
         let out = draw(&app, 100, 30);
-        assert!(!out.contains(" projects "), "the tree is gone:\n{out}");
+        assert!(!out.contains(" cloud agents "), "the tree is gone:\n{out}");
         assert!(!out.contains("devtools"), "no tree rows:\n{out}");
         assert!(out.contains("restore the tree"), "the way back:\n{out}");
 
@@ -2600,7 +2626,8 @@ mod tests {
             .position(|r| r.label == "nimble-otter")
             .unwrap();
         let out = draw(&app, 100, 30);
-        assert!(out.contains("Railway"));
+        // The group header carries the project; the environment shows in the
+        // detail pane rather than as a level of its own.
         assert!(out.contains("devtools"));
         assert!(out.contains("production"));
         assert!(out.contains("nimble-otter"));

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -104,7 +104,7 @@ pub async fn command(args: Args) -> Result<()> {
 // renders those as `long_about` and it would show up in `--help`.
 #[derive(Parser, Default)]
 #[clap(
-    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` re-mints it.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` clears both\ncaches and re-mints.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct LaunchArgs {
     /// Launch OpenAI Codex, carrying your local ChatGPT sign-in
@@ -144,7 +144,8 @@ pub struct LaunchArgs {
     rm: bool,
 
     /// Re-mint the Claude credential even if the agent already has a working
-    /// one. Use after revoking a token, or when auth fails on an existing agent
+    /// one, clearing our local token cache first. Use after revoking a token,
+    /// or when auth fails on an existing agent
     #[clap(long)]
     refresh_auth: bool,
 
@@ -643,7 +644,7 @@ fn local_signin(agent: Agent, home: &Path) -> Result<PendingAuth> {
 /// round-trip for a credential the user already has. Caching it is the shape
 /// Anthropic itself recommends — their `claude-code-action` has Pro/Max users
 /// mint locally, store the result as a repository secret, and use it on remote
-/// runners. Cleared by `railway logout`.
+/// runners. Cleared by `railway logout`, or by `--refresh-auth`.
 fn claude_token_cache_path() -> Option<std::path::PathBuf> {
     Some(dirs::home_dir()?.join(".railway").join("claude-code-token"))
 }
@@ -745,7 +746,13 @@ fn claude_sign_in_on_agent() -> PendingAuth {
 /// unless there is nothing here to mint with, in which case the agent's own
 /// sign-in is the flow, and the user finds that out before a VM is spent
 /// rather than through a browser prompt that never arrives.
-fn claude_credentials_cheap() -> Result<PendingAuth> {
+///
+/// `refresh_auth` is the local half of `--refresh-auth`: it drops our cached
+/// setup-token so a stale or revoked one can't be handed to the agent again,
+/// and forces the mint below to run instead of silently reusing it. An
+/// explicit `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` still wins even
+/// then — that is the user naming a credential for this run, not a cache.
+fn claude_credentials_cheap(refresh_auth: bool) -> Result<PendingAuth> {
     for var in ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"] {
         if let Ok(tok) = std::env::var(var) {
             let tok = tok.trim().to_string();
@@ -758,7 +765,9 @@ fn claude_credentials_cheap() -> Result<PendingAuth> {
             }
         }
     }
-    if let Some(tok) = cached_claude_token() {
+    if refresh_auth {
+        clear_claude_token_cache();
+    } else if let Some(tok) = cached_claude_token() {
         return Ok(PendingAuth::Ready {
             line: format!("CLAUDE_CODE_OAUTH_TOKEN={tok}\n").into_bytes(),
             source: "cached setup-token".to_string(),
@@ -1886,7 +1895,7 @@ async fn prepare_inner(
             ssh_tel::track_for(
                 "cloud_agent_launch",
                 "credential",
-                claude_credentials_cheap(),
+                claude_credentials_cheap(args.refresh_auth),
             )
             .await?
         }
@@ -2254,7 +2263,7 @@ echo "KILLED:$killed""#
 /// of frame where it is readable.
 pub fn claude_needs_local_mint() -> bool {
     !matches!(
-        claude_credentials_cheap(),
+        claude_credentials_cheap(false),
         Ok(PendingAuth::Ready { .. } | PendingAuth::SignInOnAgent { .. })
     )
 }
@@ -2273,7 +2282,7 @@ pub fn ensure_claude_credential_cached(harness: &str) -> Result<()> {
     if harness != "claude" {
         return Ok(());
     }
-    if let PendingAuth::MintClaude = claude_credentials_cheap()? {
+    if let PendingAuth::MintClaude = claude_credentials_cheap(false)? {
         match mint_claude_credentials()? {
             Some((_line, source)) => {
                 eprintln!("Using your Claude Code credential ({source}) on the agent")


### PR DESCRIPTION
## Summary

Three related `railway ca` fixes:

- **`railway ca manage`** — a new subcommand that opens the TUI directly on the manage screen, skipping the front-door menu (`browse_into` generalizes the existing `browse()` to accept an initial screen).
- **`--refresh-auth` cache bug** — previously it only skipped the *remote* reuse check on an existing agent; the local `~/.railway/claude-code-token` cache was still read first in `claude_credentials_cheap`, so a stale/revoked cached token could never actually be replaced. It now clears the local cache before falling through to a fresh mint.
- **`railway ca setup --reset`** — clears saved cloud agent preferences (`~/.railway/agent-prefs.json`) and the cached Claude token together. Also available as a "Reset to default" choice in the interactive prompts when existing preferences are found.

## Test plan

- [x] `cargo test --bin railway commands::cloud_agent` — 235 passed, including new `setup::tests::reset_*` tests
- [x] `cargo test --bin railway commands::code::` — 19 passed
- [x] `cargo fmt` / `cargo clippy --bin railway` clean on touched files
- [x] Manual smoke test: `railway ca setup --reset` against a scratch `$HOME` — removes `agent-prefs.json` and `claude-code-token`, confirmed via `--show` afterward reporting "No cloud agent preferences yet"
- [x] `railway ca --help` lists the new `manage` subcommand