### PR TITLE
Cloud agents: prefer linked project over saved default

### DIFF
--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -32,7 +32,7 @@ use tui::{App, Outcome};
 #[derive(Parser)]
 #[clap(
     args_conflicts_with_subcommands = true,
-    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run. A\ndirectory linked with `railway link` wins over the saved default project too\n— new agents land there instead.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -198,28 +198,32 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
     let stored = AgentPrefs::load_in(&home);
     let first_run = stored.is_none();
     let saved = stored.unwrap_or_default();
-    // The configured default wins: it is the answer to "where do agents go",
-    // and a linked directory is about deploys, not agents. A linked project is
-    // still the fallback when no default has been set.
-    let target = saved
-        .default_project
-        .as_ref()
-        .map(|project| tui::Target {
+    // A linked directory wins: `railway link` (or a linked service checkout) is
+    // an explicit, per-directory statement of "this is the project I'm working
+    // in", which outranks a person-wide preference chosen once from wherever
+    // the terminal happened to be. The configured default is still the
+    // fallback when this directory has no link.
+    let linked = linked_target(&mut configs, &client, &tree).await;
+    let target = linked.clone().or_else(|| {
+        saved.default_project.as_ref().map(|project| tui::Target {
             project_id: project.project_id.clone(),
             project_name: project.project_name.clone(),
             environment_id: project.environment_id.clone(),
             environment_name: project.environment_name.clone(),
         })
-        .or(linked_target(&mut configs, &client, &tree).await);
+    });
+    // Same order for the "(default)" label in the tree: a linked project shows
+    // as the default over whatever is in the preferences file.
+    let default_project_id = linked
+        .as_ref()
+        .map(|t| t.project_id.clone())
+        .or_else(|| saved.default_project.as_ref().map(|p| p.project_id.clone()));
     let mut app = App::new(
         tree,
         target,
         saved.agent.as_deref(),
         saved.theme.as_deref(),
-        saved
-            .default_project
-            .as_ref()
-            .map(|project| project.project_id.clone()),
+        default_project_id,
         !first_run,
     );
 

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -721,8 +721,9 @@ pub struct LaunchRequest {
 }
 
 pub struct App {
-    /// The project new agents go to, from preferences. Sorted to the top of the
-    /// tree and separated from the rest.
+    /// The project new agents go to: the linked directory's project, or the
+    /// preferences file when this directory has no link. Sorted to the top of
+    /// the tree and separated from the rest.
     pub default_project: Option<String>,
     /// Whether preferences exist yet. Decides whether the menu carries a Setup
     /// card or leaves changing things to the ⌥s settings card.

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1332,9 +1332,12 @@ async fn sole_owned_agent_id(
 /// forever, which is worth one extra lookup to avoid.
 /// Where a launch lands, in the order `railway ca` uses.
 ///
-/// The configured default project is the answer to "where do agents go", so it
-/// beats the linked directory — a link is about deploys, and running
-/// `railway code` inside some service's checkout should not put an agent there.
+/// A linked directory beats the configured default: `railway link` (or a
+/// linked service checkout) is an explicit, per-directory statement of "this
+/// is the project I'm working in", and that outranks a person-wide preference
+/// that was chosen once, possibly a long time ago, from wherever the terminal
+/// happened to be. The configured default is still the answer when there is no
+/// link — most `railway code` invocations are not inside a linked directory.
 /// Flags still win over both: they are the caller saying it outright.
 ///
 /// With nothing to go on, this runs `railway ca setup` rather than the
@@ -1416,16 +1419,16 @@ fn choose_target(
     if args.project.is_some() || args.environment.is_some() {
         return TargetSource::Flags;
     }
+    // A linked directory is an explicit, per-directory statement of intent, so
+    // it outranks the person-wide configured default.
+    if let Some((project_id, environment_id)) = linked {
+        return TargetSource::Linked(project_id, environment_id);
+    }
     if let Some(default) = configured {
         return TargetSource::Configured(
             default.project_id.clone(),
             default.environment_id.clone(),
         );
-    }
-    // A linked directory is a worse answer than a configured default but a
-    // better one than a question, and plenty of people rely on it.
-    if let Some((project_id, environment_id)) = linked {
-        return TargetSource::Linked(project_id, environment_id);
     }
     // Only offer setup when there is someone to answer it. The TUI always
     // passes an explicit target, so this cannot fire underneath a frame, and a
@@ -2546,7 +2549,7 @@ mod tests {
     /// The order `railway ca` uses, so a launch lands in the same place from
     /// either command.
     #[test]
-    fn the_configured_default_beats_the_linked_directory() {
+    fn the_linked_directory_beats_the_configured_default() {
         let linked = || Some(("proj_linked".to_string(), "env_linked".to_string()));
 
         // Flags win outright — the caller said it.
@@ -2568,17 +2571,18 @@ mod tests {
             TargetSource::Flags
         );
 
-        // A configured default beats a linked directory: the default answers
-        // "where do agents go", a link answers "what do I deploy".
+        // A linked directory beats a configured default: the link is an
+        // explicit statement of "this is the project I'm working in", a
+        // default is a person-wide preference chosen once.
         assert_eq!(
             choose_target(&LaunchArgs::default(), Some(&default_project()), linked()),
-            TargetSource::Configured("proj_default".into(), "env_default".into())
+            TargetSource::Linked("proj_linked".into(), "env_linked".into())
         );
 
-        // With no default, the link is still better than a question.
+        // With no link, the configured default is still better than a question.
         assert_eq!(
-            choose_target(&LaunchArgs::default(), None, linked()),
-            TargetSource::Linked("proj_linked".into(), "env_linked".into())
+            choose_target(&LaunchArgs::default(), Some(&default_project()), None),
+            TargetSource::Configured("proj_default".into(), "env_default".into())
         );
     }
 


### PR DESCRIPTION
## Changes
- `choose_target` (code.rs): linked project now wins over `agent-prefs.json` default_project
- `browse_into` (cloud_agent/mod.rs): TUI target and "(default)" label follow the same order
- No change needed for session reuse — `code_agents` is already keyed by environment_id

## Behavior
- Linked directory (`railway link`) present → new agents/sessions go there
- No linked directory → falls back to `agent-prefs.json` default_project
- `-p`/`-e` flags still win over both

## Test plan
- [x] `cargo test` (unit tests for `choose_target` updated and passing)
- [x] `cargo fmt` / `cargo clippy` clean on changed files