### PR TITLE
ca TUI: fix the railway harness launch hang, ⇧esc release, and the shift+enter newline

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -46,7 +46,7 @@ pub const KEY_HELP: &[(&str, &[(&str, &str)])] = &[
             ("⌥f", "give it the whole screen · again to restore"),
             ("⌥enter / f", "leave the TUI and connect full screen"),
             ("c", "copy an ssh command for it"),
-            ("⌥esc / ^]", "stop typing in it"),
+            ("⌥/⇧esc / ^]", "stop typing in it"),
             ("wheel", "scroll its output"),
             ("click a link", "open it in your browser"),
             ("shift+pgup/pgdn", "scroll without the mouse"),
@@ -1868,17 +1868,26 @@ impl App {
         // keyboard is for while it is up, and focus stays on the session
         // underneath so closing the card returns to typing in it.
         if self.focus == ManageFocus::Session && self.screen == Screen::Manage {
-            // Three ways out, because terminals disagree about what they will
-            // report. `^]` is the classic escape chord and works everywhere;
-            // ⌥esc — the ⌥ family's release, matching every other chord here —
-            // needs the enhanced keyboard protocol, without which it arrives
-            // as a bare Escape meant for the agent; `^o` stays for anyone who
-            // learned it.
+            // Four ways out, because terminals disagree about what they will
+            // report. `^]` is the classic escape chord and works everywhere,
+            // and `^o` stays for anyone who learned it. Both modified Escapes
+            // are taken because only one of them can be typed on a stock macOS
+            // terminal: Option is a compose key there unless it is mapped to
+            // Meta, and every other ⌥ chord survives that by arriving as the
+            // character it composes to (⌥f as `ƒ`, ⌥[ as a curly quote — see
+            // `alt_chord`). Escape composes to nothing, so ⌥esc arrives as a
+            // bare Escape that belongs to the agent, with no modifier left to
+            // tell the two apart. Shift is never composed, and the kitty
+            // protocol reports a shifted Escape as `CSI 27;2u`, so ⇧esc is the
+            // one that survives a terminal nobody has configured.
             let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-            let alt_esc = key.code == KeyCode::Esc && key.modifiers.contains(KeyModifiers::ALT);
+            let modified_esc = key.code == KeyCode::Esc
+                && key
+                    .modifiers
+                    .intersects(KeyModifiers::ALT | KeyModifiers::SHIFT);
             let ctrl_bracket = ctrl && key.code == KeyCode::Char(']');
             let ctrl_o = ctrl && matches!(key.code, KeyCode::Char('o') | KeyCode::Char('O'));
-            if alt_esc || ctrl_bracket || ctrl_o {
+            if modified_esc || ctrl_bracket || ctrl_o {
                 self.focus = ManageFocus::Tree;
                 // Releasing means "show me the tree" — a maximized pane has
                 // it folded away, so give it back rather than handing focus
@@ -5754,7 +5763,7 @@ mod tests {
         assert_eq!(a.screen, Screen::Manage);
     }
 
-    /// Releasing a focused session with ⌥esc also un-maximizes: focus moving
+    /// Releasing a focused session with ⇧esc also un-maximizes: focus moving
     /// to a pane that is folded away would land on something invisible.
     #[test]
     fn releasing_a_maximized_session_restores_the_tree() {
@@ -5765,7 +5774,7 @@ mod tests {
         a.active = Some(0);
         a.focus = ManageFocus::Session;
         a.maximized = true;
-        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::ALT);
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::SHIFT);
         assert_eq!(a.on_key(esc), None);
         assert_eq!(a.focus, ManageFocus::Tree);
         assert!(!a.maximized, "the tree pane comes back with focus");
@@ -5981,13 +5990,16 @@ mod tests {
         assert_eq!(a.focus, ManageFocus::Session);
     }
 
-    /// Three ways out of a focused session, because terminals disagree about
-    /// what they report: ⌥esc only exists with the enhanced keyboard protocol,
-    /// so `^]` and `^o` have to work without it.
+    /// Four ways out of a focused session, because terminals disagree about
+    /// what they report: a modified Escape needs the enhanced keyboard
+    /// protocol, so `^]` and `^o` have to work without it. ⇧esc carries the
+    /// pair, because macOS composes Option into a character and Escape has
+    /// none to compose to, which leaves ⌥esc unsendable on a stock terminal.
     #[test]
     fn every_release_chord_works() {
         for release in [
             KeyEvent::new(KeyCode::Esc, KeyModifiers::ALT),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::SHIFT),
             KeyEvent::new(KeyCode::Char(']'), KeyModifiers::CONTROL),
             KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
         ] {

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -1405,9 +1405,22 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     // TUI implements drag-to-copy itself.
     execute!(stdout(), EnterAlternateScreen, EnableMouseCapture, Hide)?;
     // Ask for the enhanced keyboard protocol, which is what makes a modifier on
-    // Escape reportable at all: a plain terminal sends ⌥esc as a bare Escape,
+    // Escape reportable at all: a plain terminal sends ⇧esc as a bare Escape,
     // indistinguishable from the one meant for the agent. Terminals that do not
     // support it ignore the request, which is why `^]` and `^o` also release.
+    //
+    // Disambiguation is deliberately the only flag, and it is worth knowing what
+    // it does not buy. The kitty protocol exempts Enter, Tab and Backspace from
+    // this mode by design — "they still generate the same bytes as in legacy
+    // mode", so a shell stays usable if a crashed program leaves the mode set —
+    // which means shift+enter reaches us as a bare `\r` with no modifier on it,
+    // and no amount of work in `encode_key_for` can recover what the terminal
+    // never said. REPORT_ALL_KEYS_AS_ESCAPE_CODES would lift the exemption, but
+    // crossterm cannot yet read the associated text those events carry, so
+    // composed input would break: the ⌥-composed characters `alt_chord` leans
+    // on, and every dead key and IME besides. Reporting shift+enter is the
+    // terminal's job to opt into (Claude Code's own `/terminal-setup` binds it
+    // to `ESC CR` for exactly this reason); when it does, the pane forwards it.
     if matches!(
         crossterm::terminal::supports_keyboard_enhancement(),
         Ok(true)

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -64,6 +64,50 @@ fn dsr_reply(chunk: &[u8], screen: &vt100::Screen) -> Option<Vec<u8>> {
     })
 }
 
+/// The reply to a primary-device-attributes query (`ESC[c`, or `ESC[0c` with
+/// the parameter spelled out), found anywhere in a chunk — `Some` iff the
+/// query is there.
+///
+/// The other query that blocks the program which sent it, and the one that
+/// stopped `railway-agent-tui` drawing at all. crossterm uses DA1 as the
+/// sentinel in `supports_keyboard_enhancement`: it writes the kitty query and
+/// a DA1 immediately after, then reads until one of them comes back, on the
+/// reasoning that a terminal too old to know the kitty query will still answer
+/// DA1. So answering the kitty query while ignoring DA1 is the single worst
+/// combination available — the harness learns the reply it is waiting for will
+/// never arrive, and waits anyway. That is exactly what this pane started
+/// doing when it learned to answer `ESC[?u`: the launch went from drawing
+/// after a two-second timeout to never drawing at all, leaving a pane with
+/// nothing in it but the relay's banner. Answering both retires the timeout
+/// too — startup goes from ~2s to immediate.
+///
+/// `62;22` claims a VT220 that does ANSI colour, which is the least this
+/// emulator is. Secondary DA (`ESC[>c`) is deliberately not answered: nothing
+/// here asks for it, and inventing a version string for a terminal that does
+/// not exist invites feature detection nobody can honour.
+fn da1_reply(chunk: &[u8]) -> Option<Vec<u8>> {
+    const REPLY: &[u8] = b"\x1b[?62;22c";
+    let mut i = 0;
+    while let Some(at) = chunk[i..].windows(2).position(|w| w == b"\x1b[") {
+        let seq = &chunk[i + at + 2..];
+        // A query carries no parameters or the single default `0`. Anything
+        // else ending in `c` is a different sequence — and `ESC[?…c` is a
+        // terminal's own reply, never a request, so a leading `?` is not one.
+        let query = match seq.first() {
+            Some(b'c') => true,
+            Some(b'0') => seq.get(1) == Some(&b'c'),
+            _ => false,
+        };
+        if query {
+            return Some(REPLY.to_vec());
+        }
+        // Step past the introducer only, like `kitty_scan`: a later `c` may
+        // belong to plain text, and skipping to it would jump real sequences.
+        i += at + 2;
+    }
+    None
+}
+
 /// Track and answer the kitty keyboard protocol inside the pane's stream.
 ///
 /// A harness that wants unambiguous keys (shift+enter as a newline, most
@@ -273,6 +317,13 @@ impl Session {
                             got_output.store(true, Ordering::Relaxed);
                             let mut replies =
                                 kitty_scan(&buf[..n], &kitty_keys).unwrap_or_default();
+                            // In the order they were asked: a harness reads the
+                            // replies back as a stream, and DA1 is the sentinel
+                            // that says the kitty answer before it was the whole
+                            // answer.
+                            if let Some(da1) = da1_reply(&buf[..n]) {
+                                replies.extend_from_slice(&da1);
+                            }
                             if let Some(dsr) = parser.lock().ok().and_then(|mut parser| {
                                 parser.process(&buf[..n]);
                                 dsr_reply(&buf[..n], parser.screen())
@@ -1473,6 +1524,48 @@ mod tests {
         let mut parser = vt100::Parser::new(24, 80, 0);
         parser.process(b"just some output\r\n");
         assert_eq!(dsr_reply(b"just some output\r\n", parser.screen()), None);
+    }
+
+    #[test]
+    fn da1_is_answered_in_either_spelling() {
+        let reply = Some(b"\x1b[?62;22c".to_vec());
+        assert_eq!(da1_reply(b"\x1b[c"), reply);
+        assert_eq!(da1_reply(b"\x1b[0c"), reply);
+        // Anywhere in the chunk, including after sequences that are not it.
+        assert_eq!(da1_reply(b"\x1b[?2004h\x1b[?u\x1b[c\x1b[6n"), reply);
+    }
+
+    /// The `c` final byte is common and the introducer is everywhere, so this
+    /// is the scanner most able to answer a question nobody asked.
+    #[test]
+    fn da1_reply_is_none_without_a_query() {
+        assert_eq!(da1_reply(b"just some output\r\n"), None);
+        // A terminal's own DA1 response is not a request for one.
+        assert_eq!(da1_reply(b"\x1b[?62;22c"), None);
+        // Neither is any other sequence that happens to end in `c`, nor a `c`
+        // in plain text after an unrelated escape sequence.
+        assert_eq!(da1_reply(b"\x1b[38;5;2mcyan code\x1b[0m"), None);
+        assert_eq!(da1_reply(b"\x1b[2J\x1b[Hcat"), None);
+    }
+
+    /// The startup burst `railway-agent-tui` actually sends, in a single write:
+    /// two mode sets, the kitty query, DA1, then the cursor query. Answering
+    /// the kitty query and not DA1 is what left the pane empty — crossterm
+    /// waits on DA1 as its sentinel — so all three answers have to come back,
+    /// in the order they were asked.
+    #[test]
+    fn the_harness_startup_burst_gets_every_answer() {
+        const BURST: &[u8] = b"\x1b[?2004h\x1b[?1004h\x1b[?u\x1b[c\x1b[6n";
+        let kitty = AtomicBool::new(false);
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        parser.process(BURST);
+
+        let mut replies = kitty_scan(BURST, &kitty).expect("the kitty query is answered");
+        replies.extend_from_slice(&da1_reply(BURST).expect("DA1 is answered"));
+        replies.extend_from_slice(
+            &dsr_reply(BURST, parser.screen()).expect("the cursor query is answered"),
+        );
+        assert_eq!(replies, b"\x1b[?0u\x1b[?62;22c\x1b[1;1R");
     }
 
     /// An application with mouse reporting on gets the wheel; the emulator's

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -846,6 +846,16 @@ fn encode_key_for(key: KeyEvent, kitty: bool) -> Option<Vec<u8>> {
             + 4 * u8::from(key.modifiers.contains(KeyModifiers::CONTROL));
         return Some(format!("\x1b[13;{m}u").into_bytes());
     }
+    // Without the push the CSI-u form would land as typed text, so ⇧enter falls
+    // back to meta+enter — `ESC CR`, the newline chord harnesses have always
+    // taken, and the exact bytes Claude Code's own `/terminal-setup` binds
+    // shift+enter to. A bare `\r` submits the half-written prompt, the one
+    // outcome the chord exists to prevent, so guessing newline is the better
+    // way to be wrong. ⌥enter already encodes this way through `encode_key`'s
+    // Alt prefix; this puts ⇧enter alongside it.
+    if key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT) {
+        return Some(b"\x1b\r".to_vec());
+    }
     encode_key(key)
 }
 
@@ -982,8 +992,12 @@ mod tests {
         assert_eq!(bytes(enter(KeyModifiers::NONE), false), b"\r");
 
         // No push, no CSI-u: to a legacy program the escape sequence is
-        // typed text, which is worse than the ambiguity it replaces.
-        assert_eq!(bytes(enter(KeyModifiers::SHIFT), false), b"\r");
+        // typed text, which is worse than the ambiguity it replaces. ⇧enter
+        // still must not submit, so it falls back to the legacy newline chord.
+        assert_eq!(bytes(enter(KeyModifiers::SHIFT), false), b"\x1b\r");
+        assert_eq!(bytes(enter(KeyModifiers::ALT), false), b"\x1b\r");
+        // Ctrl is not a newline in anyone's legacy vocabulary — leave it alone.
+        assert_eq!(bytes(enter(KeyModifiers::CONTROL), false), b"\r");
 
         // Everything else routes through the legacy encoder untouched.
         assert_eq!(bytes(key(KeyCode::Char('a')), true), b"a");

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -988,9 +988,9 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
         .selected_agent_status()
         .is_some_and(|status| status != "running");
     let hint: Vec<(&str, &str)> = if app.maximized {
-        vec![("⌥f", "restore the tree"), ("⌥esc / ^]", "stop typing")]
+        vec![("⌥f", "restore the tree"), ("⌥/⇧esc / ^]", "stop typing")]
     } else if app.focus == ManageFocus::Session {
-        let mut keys = vec![("⌥esc / ^]", "stop typing"), ("⌥f", "maximize")];
+        let mut keys = vec![("⌥/⇧esc / ^]", "stop typing"), ("⌥f", "maximize")];
         // The agent is taking the clicks, so say how to take one back — this is
         // the terminal's own convention, but nobody guesses it.
         if app.active_session().is_some_and(|s| s.wants_mouse()) {
@@ -2947,7 +2947,7 @@ mod tests {
         let out = draw(&app, 100, 30);
         assert!(out.contains("keys"));
         assert!(out.contains("refresh"), "{out}");
-        assert!(out.contains("⌥esc / ^]"), "{out}");
+        assert!(out.contains("⌥/⇧esc / ^]"), "{out}");
         assert!(out.contains("any key closes"));
     }
 


### PR DESCRIPTION
Three fixes in the `railway ca` session pane. All three are the pane failing to speak the terminal's side of a protocol.

## 1. Fix: railway harness hung on launch — pane showed only the relay banner

- `railway-agent-tui` writes its startup burst in one write — bracketed paste, focus reporting, `ESC[?u`, `ESC[c`, `ESC[6n` — then waits.
- crossterm uses DA1 (`ESC[c`) as the sentinel in `supports_keyboard_enhancement`. The pane answered `ESC[?u` but never DA1, so the harness waited on a reply that never came and never reached the cursor query the pane already answered.
- Regression from adding the kitty responder. Before it, nothing was answered, crossterm's 2s timeout expired, and the harness drew.
- **Fix:** answer DA1 with `ESC[?62;22c`.
- Measured against the real binary under a pty: without DA1, 23 bytes then stuck indefinitely; with it, full UI in 0.07s. Also retires the old 2s startup delay.

## 2. Fix: ⌥esc no longer released the session pane

- macOS Option is a compose key unless the terminal maps it to Meta. The other ⌥ chords survive that by arriving as the character they compose to — ⌥f as `ƒ`, ⌥[ as a curly quote — which `alt_chord` already matches.
- Escape composes to nothing, so ⌥esc arrives as a bare Escape with no modifier to distinguish it from the one meant for the agent.
- ⌥esc does work where the terminal maps Option to Alt/Meta and the kitty protocol is live (`CSI 27;3u`); it is dead where Option composes, which is the default in Ghostty and Terminal.app.
- History: #1013 shipped this chord as ⇧esc, #1069 swapped it to ⌥esc.
- **Fix:** accept ⇧esc alongside ⌥esc; the kitty protocol reports it as `CSI 27;2u`. ⌥esc, `^]` and `^o` are untouched, so terminals where ⌥esc already worked are unaffected. Hints read `⌥/⇧esc / ^]`.

## 3. Partial fix: shift+enter did not insert a newline in the harness

- The kitty protocol exempts Enter, Tab and Backspace from disambiguate mode by design, so a stock terminal reports shift+enter as a bare `\r` with no modifier on it. There was nothing for `encode_key_for` to act on — the CSI-u encoding added earlier could never fire.
- **Fix:** modified Enter falls back to `ESC CR` instead of a bare `\r` when the remote has not pushed the kitty protocol. A bare `\r` submits the half-written prompt; `ESC CR` is the legacy newline chord, and the bytes Claude Code's `/terminal-setup` binds shift+enter to.
- **Still needs the terminal to report the key.** Either `/terminal-setup` (or an equivalent keybind sending `ESC CR`), or Option-as-Meta plus ⌥enter, which already worked. `REPORT_ALL_KEYS_AS_ESCAPE_CODES` would lift the exemption, but crossterm cannot pair it with the associated text those events carry — composed ⌥ characters, dead keys and IMEs would all break. Recorded in a comment on `setup_terminal`.

## Tests

- DA1 scanner: both spellings, no false positives on `ESC[?62;22c` replies or other `c`-terminated sequences, and the real startup burst gets all three answers in the order asked.
- Modified-Enter encodings for shift / alt / ctrl, with and without the kitty push.
- ⇧esc added to the release-chord test; the maximized-release test now uses it.

3 pre-existing `auth_sim` failures on master, unrelated to this branch.
