### PR TITLE
Add debug-only RAILWAY_OAUTH_BASE_URL override for the logout e2e harness

### DIFF
--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -27,7 +27,29 @@ pub fn get_oauth_client_id() -> &'static str {
 }
 
 pub(crate) fn get_oauth_base_url(host: &str) -> String {
+    if let Some(url) = oauth_base_url_override_from_env() {
+        return url;
+    }
     format!("https://backboard.{host}/oauth")
+}
+
+/// Debug-build-only escape hatch so a locally-built binary can point the whole
+/// OAuth surface (authorize, device auth, token, refresh) at a scripted or
+/// fault-injecting local server. The OAuth twin of `RAILWAY_BACKBOARD_URL`
+/// (see `Configs::backboard_url_override_from_env`), and compiled out of
+/// release builds for the same reason: an arbitrary URL override in a shipped
+/// binary would let a hostile environment capture tokens.
+fn oauth_base_url_override_from_env() -> Option<String> {
+    #[cfg(debug_assertions)]
+    {
+        std::env::var("RAILWAY_OAUTH_BASE_URL")
+            .ok()
+            .filter(|url| !url.is_empty())
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        None
+    }
 }
 
 fn build_http_client() -> Result<reqwest::Client> {


### PR DESCRIPTION
## Summary of changes

- Adds a debug-build-only `RAILWAY_OAUTH_BASE_URL` env override to `get_oauth_base_url`, the OAuth twin of the existing `RAILWAY_BACKBOARD_URL` escape hatch. It points the whole OAuth surface (authorize URL, device auth, token polling, refresh) at a local server. Compiled out of release builds for the same reason as the backboard override: an arbitrary URL override in a shipped binary would let a hostile environment capture tokens.

This is the enabler for mono's end-to-end CLI logout cause-finding harness (railwayapp/mono#35143), which drives real CLI and `railway mcp` binaries against a real oidc-provider through a fault proxy.

## How to test these

- `cargo test` (1029 passed), `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt` applied.
- Verified end to end by the mono harness: device-flow login, whoami, MCP tool calls, and token refresh all route through the override in debug builds; release builds ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)