### PR TITLE
Normalize CLI telemetry subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -287,12 +287,11 @@ async fn main() -> Result<()> {
     // automated CLI users. They are allowed to refresh the update cache and
     // kick off background installs, but we keep staged-binary apply TTY-only
     // so the running binary never changes under a scripted invocation.
-    let auto_applied_version =
-        if auto_update_enabled && is_tty && !is_update_management_cmd && !is_read_only_invocation {
-            util::self_update::try_apply_staged()
-        } else {
-            None
-        };
+    let auto_update_applied = auto_update_enabled
+        && is_tty
+        && !is_update_management_cmd
+        && !is_read_only_invocation
+        && util::self_update::try_apply_staged().is_some();
 
     let update = UpdateCheck::read_normalized();
     let skipped_version = update.skipped_version.clone();
@@ -367,7 +366,7 @@ async fn main() -> Result<()> {
         }
     } else if !env_or_ci_suppressed && !is_help_or_error && !embedded_setup {
         // Non-TTY counterpart of the banner above, for agent callers only.
-        // Staged-binary apply is TTY-gated (see auto_applied_version), so a
+        // Staged-binary apply is TTY-gated (see auto_update_applied), so a
         // machine whose railway usage is entirely agent-driven would
         // otherwise never apply a downloaded update nor see a reason to —
         // tell the driving agent once per pending version instead. Skipped
@@ -458,10 +457,10 @@ async fn main() -> Result<()> {
     let exec_result = exec_cli(cli).await;
 
     // Send telemetry for silent auto-update apply (after auth is available).
-    if let Some(ref version) = auto_applied_version {
+    if auto_update_applied {
         telemetry::send(telemetry::CliTrackEvent {
             command: "autoupdate_apply".to_string(),
-            sub_command: Some(version.clone()),
+            sub_command: None,
             success: true,
             error_message: None,
             duration_ms: 0,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -25,6 +25,67 @@ pub struct CliTrackEvent {
     pub is_ci: bool,
 }
 
+/// Normalize CLI telemetry subcommands to the endpoint's lowercase snake_case
+/// contract. Structured producers can use separators, camelCase GraphQL fields,
+/// and numeric identifiers; normalizing at the send boundary keeps those details
+/// without allowing one producer to make the whole event invalid.
+fn normalize_cli_subcommand(value: &str) -> Option<String> {
+    const MAX_LEN: usize = 64;
+    const DIGIT_WORDS: [&str; 10] = [
+        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
+    ];
+
+    let mut normalized = String::with_capacity(value.len().min(MAX_LEN));
+    let push_separator = |output: &mut String| {
+        if !output.is_empty() && !output.ends_with('_') && output.len() < MAX_LEN {
+            output.push('_');
+        }
+    };
+    let mut chars = value.chars().peekable();
+    let mut previous: Option<char> = None;
+
+    while let Some(ch) = chars.next() {
+        if ch.is_ascii_lowercase() {
+            if normalized.len() == MAX_LEN {
+                break;
+            }
+            normalized.push(ch);
+        } else if ch.is_ascii_uppercase() {
+            let starts_word = previous.is_some_and(|previous| {
+                previous.is_ascii_lowercase()
+                    || previous.is_ascii_digit()
+                    || (previous.is_ascii_uppercase()
+                        && chars.peek().is_some_and(|next| next.is_ascii_lowercase()))
+            });
+            if starts_word {
+                push_separator(&mut normalized);
+            }
+            if normalized.len() == MAX_LEN {
+                break;
+            }
+            normalized.push(ch.to_ascii_lowercase());
+        } else if ch.is_ascii_digit() {
+            push_separator(&mut normalized);
+            let word = DIGIT_WORDS[(ch as u8 - b'0') as usize];
+            if normalized.len() + word.len() > MAX_LEN {
+                break;
+            }
+            normalized.push_str(word);
+            push_separator(&mut normalized);
+        } else {
+            push_separator(&mut normalized);
+        }
+
+        previous = Some(ch);
+    }
+
+    while normalized.ends_with('_') {
+        normalized.pop();
+    }
+
+    (!normalized.is_empty()).then_some(normalized)
+}
+
 pub struct SetupAgentTrackEvent {
     pub phase: SetupAgentPhase,
     pub success: Option<bool>,
@@ -1964,9 +2025,13 @@ async fn send_with_caller_override(event: CliTrackEvent, caller_override: Option
     } else {
         Some(error_class(event.error_message.as_deref()))
     };
+    let sub_command = event
+        .sub_command
+        .as_deref()
+        .and_then(normalize_cli_subcommand);
     let input = CliEventTrackInput {
         command: event.command.clone(),
-        sub_command: event.sub_command.clone(),
+        sub_command: sub_command.clone(),
         duration_ms: event.duration_ms as i64,
         success: event.success,
         error_message: event.error_message.clone(),
@@ -1992,7 +2057,7 @@ async fn send_with_caller_override(event: CliTrackEvent, caller_override: Option
     if !post_telemetry_body(&client, configs.get_backboard(), body).await {
         let legacy_input = LegacyCliEventTrackInput {
             command: event.command,
-            sub_command: event.sub_command,
+            sub_command,
             duration_ms: event.duration_ms as i64,
             success: event.success,
             error_message: event.error_message,


### PR DESCRIPTION
## Problem

Structured CLI telemetry subcommands can contain separators and GraphQL casing that do not match the endpoint's lowercase snake_case contract. Detailed events such as `template:build` and `execute:mutation:serviceInstanceUpdate` are rejected even though the generic command event still arrives.

The `autoupdate_apply` event also uses the staged target version as a subcommand, even though the command already identifies that an automatic update was applied.

## Change

- Normalize subcommands at the telemetry send boundary for both the primary request and legacy fallback.
- Preserve existing snake_case values and cap normalized values at the endpoint's 64-character limit.
- Send `autoupdate_apply` without a subcommand.

| Produced value | Sent value |
| --- | --- |
| `template:build` | `template_build` |
| `execute:mutation:serviceInstanceUpdate` | `execute_mutation_service_instance_update` |
| `execute:query:me+projects` | `execute_query_me_projects` |

## Validation

- `cargo fmt --check`
- `cargo check --locked`
- `git diff --check`
- Test suite not run; validation was limited to formatting and compilation.
