### PR TITLE
ca tui: give dialogs a solid surface and room to breathe

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -321,8 +321,23 @@ pub struct Toast {
 pub const TOAST_LIFETIME: std::time::Duration = std::time::Duration::from_millis(1800);
 
 impl Toast {
+    /// Errors carry things to read — a failure reason, sometimes a recipe —
+    /// and stay up long enough to read them. A confirmation needs a glance.
+    fn lifetime(&self) -> std::time::Duration {
+        if self.ok {
+            TOAST_LIFETIME
+        } else {
+            TOAST_LIFETIME * 5
+        }
+    }
+
     pub fn expired(&self) -> bool {
-        self.at.elapsed() >= TOAST_LIFETIME
+        self.at.elapsed() >= self.lifetime()
+    }
+
+    /// Time until this toast has had its moment.
+    pub fn remaining(&self) -> std::time::Duration {
+        self.lifetime().saturating_sub(self.at.elapsed())
     }
 }
 
@@ -1604,7 +1619,7 @@ impl App {
             };
         }
         if let Some(err) = refresh_failed {
-            self.status = format!("Couldn't refresh: {err}");
+            self.toast_error(format!("Couldn't refresh: {err}"));
         }
         self.collapse_if_empty(w, p);
         self.settle_watched_agents();
@@ -2345,10 +2360,15 @@ impl App {
 
     /// The launch pipeline gave up. Land back in Manage with the reason, so a
     /// missing sign-in or a disabled feature is fixable without losing the tree.
+    ///
+    /// The reason rides an error toast over the pane rather than a header
+    /// annotation: a failure squeezed in beside the wordmark reads as
+    /// furniture, and this one usually carries the fix.
     pub fn launch_failed(&mut self, err: String) {
         self.loading.active = false;
         self.screen = Screen::Manage;
-        self.status = format!("Launch failed: {err}");
+        let flat = err.split_whitespace().collect::<Vec<_>>().join(" ");
+        self.toast_error(format!("Launch failed: {flat}"));
     }
 
     /// Advance the loading animation.
@@ -2926,7 +2946,7 @@ impl App {
     pub fn toast_remaining(&self) -> std::time::Duration {
         self.toast
             .as_ref()
-            .map(|toast| TOAST_LIFETIME.saturating_sub(toast.at.elapsed()))
+            .map(Toast::remaining)
             .unwrap_or(TOAST_LIFETIME)
     }
 
@@ -5033,7 +5053,10 @@ mod tests {
         let mut a = app();
         a.launch_failed("no codex sign-in".into());
         assert_eq!(a.screen, Screen::Manage);
-        assert!(a.status.contains("no codex sign-in"));
+        // The reason rides an error toast, not the header status line.
+        let toast = a.toast.as_ref().expect("an error toast");
+        assert!(!toast.ok);
+        assert!(toast.text.contains("no codex sign-in"), "{}", toast.text);
     }
 
     /// Revealing an environment expands its ancestors and refetches — the agent
@@ -7189,13 +7212,15 @@ mod tests {
     }
 
     /// A refresh that fails keeps the stale list — stale beats gone — and
-    /// says why in the status line.
+    /// says why in an error toast.
     #[test]
     fn a_failed_refresh_keeps_the_agents_and_reports() {
         let mut a = loaded_app();
         a.agents_loaded((0, 0, 0), Err("502 from backboard".into()));
         assert!(a.rows().iter().any(|r| r.label == "nimble-otter"));
-        assert!(a.status.contains("502 from backboard"), "{}", a.status);
+        let toast = a.toast.as_ref().expect("an error toast");
+        assert!(!toast.ok);
+        assert!(toast.text.contains("502 from backboard"), "{}", toast.text);
     }
 
     /// A project with agents in one environment still shows its empty ones in

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -150,7 +150,7 @@ fn apply_settings(app: &mut App, outcome: &wizard::Outcome) {
     match save_settings(outcome) {
         // There are preferences now, whatever there was before.
         Ok(_) => app.configured = true,
-        Err(err) => app.status = format!("Couldn't save your settings: {err:#}"),
+        Err(err) => app.toast_error(format!("Couldn't save your settings: {err:#}")),
     }
     app.set_harness(Some(&outcome.agent));
     app.set_theme(Some(&outcome.theme));
@@ -651,12 +651,12 @@ pub async fn run(
                 });
             }
             Some(Effect::SaveSetup(outcome)) => {
-                app.status = match save_setup(app, &outcome) {
+                match save_setup(app, &outcome) {
                     Ok(prefs) => {
                         tokio::spawn(async move {
                             super::telemetry::track_setup_saved("wizard", &prefs).await;
                         });
-                        "Saved — Setup again to change it".into()
+                        app.status = "Saved — Setup again to change it".into();
                     }
                     Err(err) => {
                         let message = format!("{err:#}");
@@ -665,7 +665,7 @@ pub async fn run(
                             super::telemetry::track_setup_failed("wizard", &telemetry_message)
                                 .await;
                         });
-                        format!("Couldn't save your setup: {message}")
+                        app.toast_error(format!("Couldn't save your setup: {message}"));
                     }
                 };
                 // Apply it to the session that just chose it, or the prompt
@@ -887,7 +887,7 @@ fn handle_message(
                     // No target and no default project means nothing loads
                     // lazily either — without this line an expired login
                     // looks like an account with no agents anywhere.
-                    app.status = format!("Couldn't load agents: {err}");
+                    app.toast_error(format!("Couldn't load agents: {err}"));
                 } else {
                     spawn_sweep(sweep, tx, client, backboard, stop_fetching.clone());
                 }

--- a/src/commands/cloud_agent/tui/theme.rs
+++ b/src/commands/cloud_agent/tui/theme.rs
@@ -26,8 +26,13 @@ pub struct Theme {
     pub on_accent: Color,
     /// Fill for dialogs, cards and input boxes. Opaque on purpose: an overlay
     /// that lets the screen underneath show through reads as a rendering bug
-    /// rather than as something sitting on top of the screen.
+    /// rather than as something sitting on top of the screen. A step lighter
+    /// than the page it floats over, which is half of what makes it read as
+    /// raised — the drop shadow is the other half.
     pub surface: Color,
+    /// The drop shadow under a dialog. Darker than anything else in the theme:
+    /// its whole job is to read as the screen falling away behind the card.
+    pub shadow: Color,
     /// Row highlight in the tree.
     pub selection: Color,
     pub running: Color,
@@ -45,7 +50,8 @@ pub const THEMES: &[Theme] = &[
         dim: Color::Rgb(0x8b, 0x84, 0x9c),
         fg: Color::Rgb(0xef, 0xec, 0xf6),
         on_accent: Color::Rgb(0x18, 0x12, 0x28),
-        surface: Color::Rgb(0x1c, 0x16, 0x2c),
+        surface: Color::Rgb(0x25, 0x1d, 0x39),
+        shadow: Color::Rgb(0x14, 0x0f, 0x1f),
         selection: Color::Rgb(0x37, 0x2a, 0x50),
         running: Color::Rgb(0x6e, 0xe7, 0xa8),
         sleeping: Color::Rgb(0x7d, 0x77, 0x8f),
@@ -65,6 +71,9 @@ pub const THEMES: &[Theme] = &[
         // The theme that defers to the terminal's palette, so a dialog fills
         // with the terminal's own background rather than a colour of ours.
         surface: Color::Black,
+        // Nothing darker than black to fall back on, so the shade is a grey
+        // one — the only depth cue the sixteen colours can carry.
+        shadow: Color::DarkGray,
         selection: Color::DarkGray,
         running: Color::Green,
         sleeping: Color::Gray,
@@ -79,7 +88,8 @@ pub const THEMES: &[Theme] = &[
         dim: Color::Rgb(0x93, 0x86, 0x76),
         fg: Color::Rgb(0xf6, 0xf1, 0xe8),
         on_accent: Color::Rgb(0x24, 0x18, 0x06),
-        surface: Color::Rgb(0x22, 0x1a, 0x10),
+        surface: Color::Rgb(0x2c, 0x22, 0x14),
+        shadow: Color::Rgb(0x18, 0x11, 0x08),
         selection: Color::Rgb(0x45, 0x2d, 0x10),
         running: Color::Rgb(0x9a, 0xd8, 0x6a),
         sleeping: Color::Rgb(0x86, 0x7c, 0x6e),
@@ -95,7 +105,8 @@ pub const THEMES: &[Theme] = &[
         dim: Color::Rgb(0x8a, 0x8a, 0x8a),
         fg: Color::Rgb(0xf2, 0xf2, 0xf2),
         on_accent: Color::Rgb(0x10, 0x10, 0x10),
-        surface: Color::Rgb(0x1a, 0x1a, 0x1a),
+        surface: Color::Rgb(0x23, 0x23, 0x23),
+        shadow: Color::Rgb(0x12, 0x12, 0x12),
         selection: Color::Rgb(0x33, 0x33, 0x33),
         running: Color::Rgb(0xe6, 0xe6, 0xe6),
         sleeping: Color::Rgb(0x77, 0x77, 0x77),
@@ -166,7 +177,8 @@ mod tests {
     }
 
     /// A dialog's fill has to differ from everything drawn on top of it, or the
-    /// text disappears into the box.
+    /// text disappears into the box — and from its own shadow, or the card has
+    /// no edge to it.
     #[test]
     fn the_surface_contrasts_with_what_sits_on_it() {
         for theme in THEMES {
@@ -174,6 +186,7 @@ mod tests {
             assert_ne!(theme.surface, theme.dim, "{}", theme.slug);
             assert_ne!(theme.surface, theme.accent, "{}", theme.slug);
             assert_ne!(theme.surface, theme.selection, "{}", theme.slug);
+            assert_ne!(theme.surface, theme.shadow, "{}", theme.slug);
         }
     }
 }

--- a/src/commands/cloud_agent/tui/theme.rs
+++ b/src/commands/cloud_agent/tui/theme.rs
@@ -27,12 +27,8 @@ pub struct Theme {
     /// Fill for dialogs, cards and input boxes. Opaque on purpose: an overlay
     /// that lets the screen underneath show through reads as a rendering bug
     /// rather than as something sitting on top of the screen. A step lighter
-    /// than the page it floats over, which is half of what makes it read as
-    /// raised — the drop shadow is the other half.
+    /// than the page it floats over, so it reads as raised.
     pub surface: Color,
-    /// The drop shadow under a dialog. Darker than anything else in the theme:
-    /// its whole job is to read as the screen falling away behind the card.
-    pub shadow: Color,
     /// Row highlight in the tree.
     pub selection: Color,
     pub running: Color,
@@ -51,7 +47,6 @@ pub const THEMES: &[Theme] = &[
         fg: Color::Rgb(0xef, 0xec, 0xf6),
         on_accent: Color::Rgb(0x18, 0x12, 0x28),
         surface: Color::Rgb(0x25, 0x1d, 0x39),
-        shadow: Color::Rgb(0x14, 0x0f, 0x1f),
         selection: Color::Rgb(0x37, 0x2a, 0x50),
         running: Color::Rgb(0x6e, 0xe7, 0xa8),
         sleeping: Color::Rgb(0x7d, 0x77, 0x8f),
@@ -73,7 +68,6 @@ pub const THEMES: &[Theme] = &[
         surface: Color::Black,
         // Nothing darker than black to fall back on, so the shade is a grey
         // one — the only depth cue the sixteen colours can carry.
-        shadow: Color::DarkGray,
         selection: Color::DarkGray,
         running: Color::Green,
         sleeping: Color::Gray,
@@ -89,7 +83,6 @@ pub const THEMES: &[Theme] = &[
         fg: Color::Rgb(0xf6, 0xf1, 0xe8),
         on_accent: Color::Rgb(0x24, 0x18, 0x06),
         surface: Color::Rgb(0x2c, 0x22, 0x14),
-        shadow: Color::Rgb(0x18, 0x11, 0x08),
         selection: Color::Rgb(0x45, 0x2d, 0x10),
         running: Color::Rgb(0x9a, 0xd8, 0x6a),
         sleeping: Color::Rgb(0x86, 0x7c, 0x6e),
@@ -106,7 +99,6 @@ pub const THEMES: &[Theme] = &[
         fg: Color::Rgb(0xf2, 0xf2, 0xf2),
         on_accent: Color::Rgb(0x10, 0x10, 0x10),
         surface: Color::Rgb(0x23, 0x23, 0x23),
-        shadow: Color::Rgb(0x12, 0x12, 0x12),
         selection: Color::Rgb(0x33, 0x33, 0x33),
         running: Color::Rgb(0xe6, 0xe6, 0xe6),
         sleeping: Color::Rgb(0x77, 0x77, 0x77),
@@ -177,8 +169,7 @@ mod tests {
     }
 
     /// A dialog's fill has to differ from everything drawn on top of it, or the
-    /// text disappears into the box — and from its own shadow, or the card has
-    /// no edge to it.
+    /// text disappears into the box.
     #[test]
     fn the_surface_contrasts_with_what_sits_on_it() {
         for theme in THEMES {
@@ -186,7 +177,6 @@ mod tests {
             assert_ne!(theme.surface, theme.dim, "{}", theme.slug);
             assert_ne!(theme.surface, theme.accent, "{}", theme.slug);
             assert_ne!(theme.surface, theme.selection, "{}", theme.slug);
-            assert_ne!(theme.surface, theme.shadow, "{}", theme.slug);
         }
     }
 }

--- a/src/commands/cloud_agent/tui/theme.rs
+++ b/src/commands/cloud_agent/tui/theme.rs
@@ -24,6 +24,10 @@ pub struct Theme {
     pub fg: Color,
     /// Text drawn on top of `accent` — must stay legible there.
     pub on_accent: Color,
+    /// Fill for dialogs, cards and input boxes. Opaque on purpose: an overlay
+    /// that lets the screen underneath show through reads as a rendering bug
+    /// rather than as something sitting on top of the screen.
+    pub surface: Color,
     /// Row highlight in the tree.
     pub selection: Color,
     pub running: Color,
@@ -41,6 +45,7 @@ pub const THEMES: &[Theme] = &[
         dim: Color::Rgb(0x8b, 0x84, 0x9c),
         fg: Color::Rgb(0xef, 0xec, 0xf6),
         on_accent: Color::Rgb(0x18, 0x12, 0x28),
+        surface: Color::Rgb(0x1c, 0x16, 0x2c),
         selection: Color::Rgb(0x37, 0x2a, 0x50),
         running: Color::Rgb(0x6e, 0xe7, 0xa8),
         sleeping: Color::Rgb(0x7d, 0x77, 0x8f),
@@ -57,6 +62,9 @@ pub const THEMES: &[Theme] = &[
         dim: Color::DarkGray,
         fg: Color::White,
         on_accent: Color::Black,
+        // The theme that defers to the terminal's palette, so a dialog fills
+        // with the terminal's own background rather than a colour of ours.
+        surface: Color::Black,
         selection: Color::DarkGray,
         running: Color::Green,
         sleeping: Color::Gray,
@@ -71,6 +79,7 @@ pub const THEMES: &[Theme] = &[
         dim: Color::Rgb(0x93, 0x86, 0x76),
         fg: Color::Rgb(0xf6, 0xf1, 0xe8),
         on_accent: Color::Rgb(0x24, 0x18, 0x06),
+        surface: Color::Rgb(0x22, 0x1a, 0x10),
         selection: Color::Rgb(0x45, 0x2d, 0x10),
         running: Color::Rgb(0x9a, 0xd8, 0x6a),
         sleeping: Color::Rgb(0x86, 0x7c, 0x6e),
@@ -86,6 +95,7 @@ pub const THEMES: &[Theme] = &[
         dim: Color::Rgb(0x8a, 0x8a, 0x8a),
         fg: Color::Rgb(0xf2, 0xf2, 0xf2),
         on_accent: Color::Rgb(0x10, 0x10, 0x10),
+        surface: Color::Rgb(0x1a, 0x1a, 0x1a),
         selection: Color::Rgb(0x33, 0x33, 0x33),
         running: Color::Rgb(0xe6, 0xe6, 0xe6),
         sleeping: Color::Rgb(0x77, 0x77, 0x77),
@@ -152,6 +162,18 @@ mod tests {
         for theme in THEMES {
             assert_ne!(theme.on_accent, theme.accent, "{}", theme.slug);
             assert_ne!(theme.fg, theme.selection, "{}", theme.slug);
+        }
+    }
+
+    /// A dialog's fill has to differ from everything drawn on top of it, or the
+    /// text disappears into the box.
+    #[test]
+    fn the_surface_contrasts_with_what_sits_on_it() {
+        for theme in THEMES {
+            assert_ne!(theme.surface, theme.fg, "{}", theme.slug);
+            assert_ne!(theme.surface, theme.dim, "{}", theme.slug);
+            assert_ne!(theme.surface, theme.accent, "{}", theme.slug);
+            assert_ne!(theme.surface, theme.selection, "{}", theme.slug);
         }
     }
 }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -6,7 +6,7 @@ use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap,
+    Block, BorderType, Borders, Clear, List, ListItem, ListState, Padding, Paragraph, Wrap,
 };
 
 use super::app::{
@@ -40,6 +40,32 @@ const CARD_GUTTER: usize = 3;
 
 /// Width of the tree column in Manage, borders included.
 const TREE_W: u16 = 32;
+
+/// Columns between a dialog's border and its text.
+const DIALOG_PAD_X: u16 = 2;
+
+/// Rows between a dialog's border and its text.
+const DIALOG_PAD_Y: u16 = 1;
+
+/// What a dialog spends on chrome: two borders plus the padding inside them.
+const DIALOG_CHROME_X: u16 = 2 + DIALOG_PAD_X * 2;
+const DIALOG_CHROME_Y: u16 = 2 + DIALOG_PAD_Y * 2;
+
+/// The chrome every floating card shares.
+///
+/// Opaque fill, because these sit *on top of* the screen rather than in it:
+/// with only [`Clear`] underneath, the terminal's own background shows through
+/// and the card reads as a hole punched in the page instead of a dialog above
+/// it. The padding is part of the same idea — text pressed against a border is
+/// what makes a box look like a frame rather than a surface.
+fn dialog_block(theme: &Theme) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.accent))
+        .style(Style::default().bg(theme.surface).fg(theme.fg))
+        .padding(Padding::symmetric(DIALOG_PAD_X, DIALOG_PAD_Y))
+}
 
 /// One inverse-styled key badge, e.g. ` ^t `. The building block of
 /// [`chord_spans`], and also used solo wherever a shortcut sits beside the
@@ -134,8 +160,8 @@ fn render_toast(app: &App, f: &mut Frame) {
     };
     let theme = app.theme;
     let area = f.area();
-    let text = format!(" {}  {}  ", if toast.ok { "✓" } else { "✕" }, toast.text);
-    let w = (text.chars().count() as u16 + 2).min(area.width);
+    let text = format!("{}  {}", if toast.ok { "✓" } else { "✕" }, toast.text);
+    let w = (text.chars().count() as u16 + DIALOG_CHROME_X).min(area.width);
     let h = 3.min(area.height);
     // Clear of the key strip on the last row and of the pane border above it,
     // so it floats inside the pane rather than colliding with its corner.
@@ -153,10 +179,11 @@ fn render_toast(app: &App, f: &mut Frame) {
     f.render_widget(Clear, rect);
     f.render_widget(
         Paragraph::new(Span::styled(text, Style::default().fg(theme.fg))).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(accent)),
+            dialog_block(theme)
+                .border_style(Style::default().fg(accent))
+                // One line of text, so the room goes at its sides: a toast tall
+                // enough to pad above and below would read as a dialog.
+                .padding(Padding::horizontal(DIALOG_PAD_X)),
         ),
         rect,
     );
@@ -229,7 +256,8 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     let area = f.area();
     let big = area.width >= BANNER_W + 8 && area.height >= 26;
     let banner_h = if big { BANNER_H } else { 1 };
-    let prompt_h = if area.height >= 30 { 6 } else { 4 };
+    // Text rows, plus the border and the padding that frame them.
+    let prompt_h = if area.height >= 30 { 4 } else { 2 } + DIALOG_CHROME_Y;
     let panel_w = 74.min(area.width.saturating_sub(2)).max(40.min(area.width));
     let cards = app.cards();
     // Descriptions cost rows, and on a short screen those rows come out of the
@@ -538,9 +566,14 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
         format!(" {} ", app.prompt.chars().count())
     };
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
+    // Padding is the first thing to go when the box is short: a line to type on
+    // beats room around it.
+    let pad_y = DIALOG_PAD_Y * u16::from(area.height >= 3 + DIALOG_PAD_Y * 2);
+
+    let block = dialog_block(theme)
+        // On a short terminal the box can be squeezed to a couple of rows, and
+        // padding it there would leave no line to type on at all.
+        .padding(Padding::new(DIALOG_PAD_X, DIALOG_PAD_X, pad_y, pad_y))
         .border_style(Style::default().fg(if focused {
             theme.accent
         } else {
@@ -567,9 +600,10 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
 
     // Keep the cursor line in view once the wrapped text outgrows the box.
     // Without this the box simply stops showing what is being typed, which is
-    // the one thing it exists to do.
-    let inner_w = area.width.saturating_sub(2).max(1) as usize;
-    let inner_h = area.height.saturating_sub(2).max(1) as usize;
+    // the one thing it exists to do. The padding is chrome, not writing room,
+    // so the text gets what is left after it.
+    let inner_w = area.width.saturating_sub(DIALOG_CHROME_X).max(1) as usize;
+    let inner_h = area.height.saturating_sub(2 + pad_y * 2).max(1) as usize;
     let scroll_y = wrapped_lines(&text, inner_w).saturating_sub(inner_h) as u16;
 
     f.render_widget(
@@ -1095,21 +1129,17 @@ fn render_panel(f: &mut Frame, theme: &Theme, area: Rect, panel: Panel) {
         .sum::<usize>() as u16;
     // No progress dots means no row held open for them.
     let dots_h = u16::from(panel.position.is_some());
-    let width = 66.min(area.width.saturating_sub(4));
-    let height = (body_h + dots_h + 7).min(area.height.saturating_sub(2));
+    let width = (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
+    let height = (body_h + dots_h + 5 + DIALOG_CHROME_Y).min(area.height.saturating_sub(2));
     let outer = centered(width, height, area);
     f.render_widget(Clear, outer);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(theme.accent))
-        .title(Span::styled(
-            format!(" {} ", panel.title),
-            Style::default()
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD),
-        ));
+    let block = dialog_block(theme).title(Span::styled(
+        format!(" {} ", panel.title),
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD),
+    ));
     let inner = block.inner(outer);
     f.render_widget(block, outer);
 
@@ -1172,7 +1202,7 @@ fn render_panel(f: &mut Frame, theme: &Theme, area: Rect, panel: Panel) {
         let on = i == panel.cursor;
         let mut spans = vec![
             Span::styled(
-                if on { " ▌ " } else { "   " },
+                if on { "▌ " } else { "  " },
                 Style::default().fg(theme.accent),
             ),
             Span::styled(
@@ -1199,7 +1229,7 @@ fn render_panel(f: &mut Frame, theme: &Theme, area: Rect, panel: Panel) {
         // a list of names into a list with gaps in it.
         if !row.detail.is_empty() {
             lines.push(Line::from(Span::styled(
-                format!("     {}", row.detail),
+                format!("  {}", row.detail),
                 Style::default().fg(theme.dim),
             )));
         }
@@ -1440,13 +1470,15 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
     };
     let theme = app.theme;
     let area = f.area();
-    let outer = centered(66.min(area.width.saturating_sub(4)), 7, area);
+    let outer = centered(
+        (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4)),
+        // Five rows to type in, plus the border and the padding around them.
+        5 + DIALOG_CHROME_Y,
+        area,
+    );
     f.render_widget(Clear, outer);
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(theme.accent))
+    let block = dialog_block(theme)
         .title(Span::styled(
             " New Session ",
             Style::default()
@@ -1472,9 +1504,10 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
 
     let text = format!("{draft}▏");
     // Keep the cursor line in view once the wrapped text outgrows the box,
-    // same as the menu's prompt.
-    let inner_w = outer.width.saturating_sub(2).max(1) as usize;
-    let inner_h = outer.height.saturating_sub(2).max(1) as usize;
+    // same as the menu's prompt. The padding is chrome, not writing room, so
+    // it comes off the width and the height the text gets.
+    let inner_w = outer.width.saturating_sub(DIALOG_CHROME_X).max(1) as usize;
+    let inner_h = outer.height.saturating_sub(DIALOG_CHROME_Y).max(1) as usize;
     let scroll_y = wrapped_lines(&text, inner_w).saturating_sub(inner_h) as u16;
 
     f.render_widget(
@@ -1547,7 +1580,7 @@ fn render_keys(app: &App, f: &mut Frame) {
             lines.push(Line::from(""));
         }
         lines.push(Line::from(Span::styled(
-            format!(" {group}"),
+            (*group).to_string(),
             Style::default()
                 .fg(theme.accent)
                 .add_modifier(Modifier::BOLD),
@@ -1555,7 +1588,7 @@ fn render_keys(app: &App, f: &mut Frame) {
         for (chord, what) in *keys {
             lines.push(Line::from(vec![
                 Span::styled(
-                    format!("  {chord:>chord_w$}  "),
+                    format!("{chord:>chord_w$}  "),
                     Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled((*what).to_string(), Style::default().fg(theme.dim)),
@@ -1563,16 +1596,17 @@ fn render_keys(app: &App, f: &mut Frame) {
         }
     }
 
-    let width = 52.min(area.width.saturating_sub(4));
+    let width = (48 + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
     let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
     let panel = centered(width, height, area);
     f.render_widget(Clear, panel);
     f.render_widget(
         Paragraph::new(lines).block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(theme.accent))
+            dialog_block(theme)
+                // The list already spaces itself with a blank line between
+                // groups, and every row it gives up to padding is a key the
+                // reader can no longer see.
+                .padding(Padding::horizontal(DIALOG_PAD_X))
                 .title(Span::styled(
                     " keys ",
                     Style::default()
@@ -2146,6 +2180,89 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// Every cell of a drawn frame, as `(symbol, background)`.
+    fn cells(app: &App, w: u16, h: u16) -> Vec<Vec<(String, Color)>> {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal
+            .draw(|f| {
+                render_with_layout(app, f);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| {
+                        let cell = &buffer[(x, y)];
+                        (cell.symbol().to_string(), cell.bg)
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// The rows a dialog covers, found by its border corners: the first row
+    /// holding `╭` at or after `title`, through the matching `╰`.
+    fn dialog_rows(grid: &[Vec<(String, Color)>], title: &str) -> (usize, usize, usize, usize) {
+        let top = grid
+            .iter()
+            .position(|row| {
+                let line: String = row.iter().map(|(s, _)| s.as_str()).collect();
+                line.contains('╭') && line.contains(title)
+            })
+            .unwrap_or_else(|| panic!("no dialog titled {title}"));
+        let left = grid[top].iter().position(|(s, _)| s == "╭").unwrap();
+        let right = grid[top].iter().rposition(|(s, _)| s == "╮").unwrap();
+        let bottom = (top + 1..grid.len())
+            .find(|y| grid[*y][left].0 == "╰")
+            .expect("a closed dialog");
+        (top, bottom, left, right)
+    }
+
+    /// A dialog is a surface, not a window onto the screen behind it: every
+    /// cell it covers carries its own background, so nothing underneath and no
+    /// terminal wallpaper shows through.
+    #[test]
+    fn dialogs_are_filled_rather_than_transparent() {
+        let mut app = app_with_tree();
+        app.start_settings();
+        let grid = cells(&app, 100, 40);
+        let (top, bottom, left, right) = dialog_rows(&grid, "settings");
+        let surface = app.theme.surface;
+        for row in &grid[top..=bottom] {
+            for (symbol, bg) in &row[left..=right] {
+                // The key badges in the footer paint their own background;
+                // everything else is the surface.
+                assert!(
+                    *bg == surface || *bg == app.theme.accent_dim,
+                    "transparent cell {symbol:?} in the dialog: {bg:?}"
+                );
+            }
+        }
+    }
+
+    /// And the text inside it keeps clear of its edges.
+    #[test]
+    fn dialog_text_is_inset_from_the_border() {
+        let mut app = app_with_tree();
+        app.start_settings();
+        let grid = cells(&app, 100, 40);
+        let (top, bottom, left, right) = dialog_rows(&grid, "settings");
+        // The rows just inside the border are blank, and so are the columns.
+        for y in [top + 1, bottom - 1] {
+            let line: String = grid[y][left + 1..right]
+                .iter()
+                .map(|(s, _)| s.as_str())
+                .collect();
+            assert!(line.trim().is_empty(), "row {y} hugs the border: {line:?}");
+        }
+        for row in &grid[top + 1..bottom] {
+            for x in [left + 1, left + DIALOG_PAD_X as usize, right - 1] {
+                assert_eq!(row[x].0, " ", "column {x} hugs the border");
+            }
+        }
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -44,18 +44,14 @@ const TREE_W: u16 = 32;
 /// Columns between a dialog's border and its text.
 const DIALOG_PAD_X: u16 = 4;
 
-/// Rows between a dialog's border and its text.
+/// Rows between a dialog's border and its text. Half the columns, because a
+/// terminal cell is about twice as tall as it is wide — this is the same gap on
+/// screen at the top and bottom as at the sides.
 const DIALOG_PAD_Y: u16 = 2;
 
 /// What a dialog spends on chrome: two borders plus the padding inside them.
 const DIALOG_CHROME_X: u16 = 2 + DIALOG_PAD_X * 2;
 const DIALOG_CHROME_Y: u16 = 2 + DIALOG_PAD_Y * 2;
-
-/// How far the drop shadow is offset from the card that casts it. Two columns
-/// to one row: a terminal cell is about twice as tall as it is wide, so this is
-/// the same distance in both directions on screen.
-const SHADOW_DX: u16 = 2;
-const SHADOW_DY: u16 = 1;
 
 /// The chrome every floating card shares.
 ///
@@ -63,45 +59,29 @@ const SHADOW_DY: u16 = 1;
 /// with only [`Clear`] underneath, the terminal's own background shows through
 /// and the card reads as a hole punched in the page instead of a dialog above
 /// it. The padding is part of the same idea — text pressed against a border is
-/// what makes a box look like a frame rather than a surface.
+/// what makes a box look like a frame rather than a surface — and it goes on
+/// all four sides, so no edge reads as tighter than another.
 fn dialog_block(theme: &Theme) -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.accent))
         .style(Style::default().bg(theme.surface).fg(theme.fg))
-        .padding(Padding::symmetric(DIALOG_PAD_X, DIALOG_PAD_Y))
+        .padding(Padding::new(
+            DIALOG_PAD_X,
+            DIALOG_PAD_X,
+            DIALOG_PAD_Y,
+            DIALOG_PAD_Y,
+        ))
 }
 
-/// Lift `outer` off the screen: a shadow down and to the right of it, then the
-/// area itself wiped clean for the card to be drawn into.
+/// The vertical padding a box `height` rows tall can afford around `content`.
 ///
-/// The shadow is painted rather than blended — a terminal has no alpha — so the
-/// cells it lands on lose their contents. That is the point: whatever was there
-/// is behind the card now, and a half-lit word poking out from under it reads
-/// as corruption rather than as depth.
-fn raise(f: &mut Frame, theme: &Theme, outer: Rect) {
-    let screen = f.area();
-    let shadow = Rect {
-        x: outer.x + SHADOW_DX,
-        y: outer.y + SHADOW_DY,
-        width: outer.width,
-        height: outer.height,
-    }
-    .intersection(screen);
-    let buffer = f.buffer_mut();
-    for y in shadow.top()..shadow.bottom() {
-        for x in shadow.left()..shadow.right() {
-            // Only the L the shadow sticks out by; the rest is under the card.
-            if outer.contains((x, y).into()) {
-                continue;
-            }
-            buffer[(x, y)]
-                .set_symbol(" ")
-                .set_style(Style::default().bg(theme.shadow));
-        }
-    }
-    f.render_widget(Clear, outer);
+/// The full amount whenever there is room for it, and whatever is left when
+/// there is not: on a short terminal a card that padded itself regardless would
+/// be spending rows of its own content on empty space.
+fn fitted_pad_y(height: u16, content: u16) -> u16 {
+    DIALOG_PAD_Y.min(height.saturating_sub(content + 2) / 2)
 }
 
 /// One inverse-styled key badge, e.g. ` ^t `. The building block of
@@ -199,7 +179,11 @@ fn render_toast(app: &App, f: &mut Frame) {
     let area = f.area();
     let text = format!("{}  {}", if toast.ok { "✓" } else { "✕" }, toast.text);
     let w = (text.chars().count() as u16 + DIALOG_CHROME_X).min(area.width);
-    let h = 3.min(area.height);
+    // Padded on every side like the dialogs, but at half their vertical scale:
+    // a one-line confirmation framed by two rows top and bottom stops reading
+    // as a chip in the corner and starts reading as a dialog nobody asked for.
+    let pad_y = DIALOG_PAD_Y / 2;
+    let h = (1 + 2 + pad_y * 2).min(area.height);
     // Clear of the key strip on the last row and of the pane border above it,
     // so it floats inside the pane rather than colliding with its corner.
     let rect = Rect {
@@ -214,15 +198,16 @@ fn render_toast(app: &App, f: &mut Frame) {
         theme.pending
     };
     f.render_widget(Clear, rect);
-    // No shadow: the toast already floats clear of everything, and the shade
-    // would fall on the key strip it deliberately sits above.
     f.render_widget(
         Paragraph::new(Span::styled(text, Style::default().fg(theme.fg))).block(
             dialog_block(theme)
                 .border_style(Style::default().fg(accent))
-                // One line of text, so the room goes at its sides: a toast tall
-                // enough to pad above and below would read as a dialog.
-                .padding(Padding::horizontal(DIALOG_PAD_X)),
+                .padding(Padding::new(
+                    DIALOG_PAD_X,
+                    DIALOG_PAD_X,
+                    pad_y.min(h.saturating_sub(3) / 2),
+                    pad_y.min(h.saturating_sub(3) / 2),
+                )),
         ),
         rect,
     );
@@ -605,15 +590,14 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
         format!(" {} ", app.prompt.chars().count())
     };
 
-    // Padding is the first thing to go when the box is short: a line to type on
-    // beats room around it.
-    let pad_y = DIALOG_PAD_Y.min(area.height.saturating_sub(3) / 2);
+    // A line to type on comes before the room around it: on a short terminal
+    // the box can be squeezed to a couple of rows, and padding it regardless
+    // would leave nowhere for the draft to go.
+    let pad_y = fitted_pad_y(area.height, 1);
 
-    raise(f, theme, area);
+    f.render_widget(Clear, area);
 
     let block = dialog_block(theme)
-        // On a short terminal the box can be squeezed to a couple of rows, and
-        // padding it there would leave no line to type on at all.
         .padding(Padding::new(DIALOG_PAD_X, DIALOG_PAD_X, pad_y, pad_y))
         .border_style(Style::default().fg(if focused {
             theme.accent
@@ -1173,7 +1157,7 @@ fn render_panel(f: &mut Frame, theme: &Theme, area: Rect, panel: Panel) {
     let width = (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
     let height = (body_h + dots_h + 5 + DIALOG_CHROME_Y).min(area.height.saturating_sub(2));
     let outer = centered(width, height, area);
-    raise(f, theme, outer);
+    f.render_widget(Clear, outer);
 
     let block = dialog_block(theme).title(Span::styled(
         format!(" {} ", panel.title),
@@ -1513,11 +1497,11 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
     let area = f.area();
     let outer = centered(
         (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4)),
-        // Five rows to type in, plus the border and the padding around them.
-        5 + DIALOG_CHROME_Y,
+        // Three rows to type in, plus the border and the padding around them.
+        3 + DIALOG_CHROME_Y,
         area,
     );
-    raise(f, theme, outer);
+    f.render_widget(Clear, outer);
 
     let block = dialog_block(theme)
         .title(Span::styled(
@@ -1637,17 +1621,25 @@ fn render_keys(app: &App, f: &mut Frame) {
         }
     }
 
-    let width = (48 + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
-    let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
+    let rows = lines.len() as u16;
+    // As wide as the widest line it has to carry, so the padding is room around
+    // the list rather than something the descriptions get truncated to pay for.
+    let content_w = lines
+        .iter()
+        .map(|line| line.width() as u16)
+        .max()
+        .unwrap_or(48);
+    let width = (content_w + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
+    let height = (rows + DIALOG_CHROME_Y).min(area.height.saturating_sub(2));
+    // The list is long enough to outgrow a short terminal on its own, and a row
+    // spent on padding there is a key the reader can no longer see.
+    let pad_y = fitted_pad_y(height, rows);
     let panel = centered(width, height, area);
-    raise(f, theme, panel);
+    f.render_widget(Clear, panel);
     f.render_widget(
         Paragraph::new(lines).block(
             dialog_block(theme)
-                // The list already spaces itself with a blank line between
-                // groups, and every row it gives up to padding is a key the
-                // reader can no longer see.
-                .padding(Padding::horizontal(DIALOG_PAD_X))
+                .padding(Padding::new(DIALOG_PAD_X, DIALOG_PAD_X, pad_y, pad_y))
                 .title(Span::styled(
                     " keys ",
                     Style::default()
@@ -2284,57 +2276,36 @@ mod tests {
         }
     }
 
-    /// And the text inside it keeps clear of its edges.
+    /// And the text inside it keeps clear of its edges — on all four of them,
+    /// by the same amount.
     #[test]
-    fn dialog_text_is_inset_from_the_border() {
+    fn dialog_text_is_inset_from_every_border() {
         let mut app = app_with_tree();
         app.start_settings();
         let grid = cells(&app, 100, 40);
         let (top, bottom, left, right) = dialog_rows(&grid, "settings");
-        // The rows just inside the border are blank, and so are the columns.
-        for y in [top + 1, bottom - 1] {
-            let line: String = grid[y][left + 1..right]
-                .iter()
-                .map(|(s, _)| s.as_str())
-                .collect();
-            assert!(line.trim().is_empty(), "row {y} hugs the border: {line:?}");
-        }
-        for row in &grid[top + 1..bottom] {
-            for x in [left + 1, left + DIALOG_PAD_X as usize, right - 1] {
-                assert_eq!(row[x].0, " ", "column {x} hugs the border");
+        let blank = |cells: &[(String, Color)]| cells.iter().all(|(s, _)| s == " ");
+
+        // Top and bottom: DIALOG_PAD_Y clear rows inside each border.
+        for offset in 1..=DIALOG_PAD_Y as usize {
+            for y in [top + offset, bottom - offset] {
+                assert!(
+                    blank(&grid[y][left + 1..right]),
+                    "row {y} is inside the padding and should be clear"
+                );
             }
         }
-    }
-
-    /// And it casts a shadow, so it reads as sitting above the screen rather
-    /// than being painted into it.
-    #[test]
-    fn a_dialog_casts_a_shadow_down_and_to_the_right() {
-        let mut app = app_with_tree();
-        app.start_settings();
-        let grid = cells(&app, 100, 40);
-        let (top, bottom, left, right) = dialog_rows(&grid, "settings");
-        let shadow = app.theme.shadow;
-        // Under the bottom edge, offset right by the same throw.
-        let under = &grid[bottom + SHADOW_DY as usize];
-        for (x, cell) in under
-            .iter()
-            .enumerate()
-            .take(right + 1)
-            .skip(left + SHADOW_DX as usize)
-        {
-            assert_eq!(cell.1, shadow, "no shadow under the card at column {x}");
-        }
-        // And down the right edge, starting below the top of the card.
-        for row in &grid[top + SHADOW_DY as usize..=bottom] {
-            assert_eq!(
-                row[right + SHADOW_DX as usize].1,
-                shadow,
-                "no shadow beside the card"
+        // Left and right: DIALOG_PAD_X clear columns, every row of the body.
+        for row in &grid[top + 1..bottom] {
+            assert!(
+                blank(&row[left + 1..=left + DIALOG_PAD_X as usize]),
+                "text runs into the left border"
+            );
+            assert!(
+                blank(&row[right - DIALOG_PAD_X as usize..right]),
+                "text runs into the right border"
             );
         }
-        // The card itself is unshaded.
-        assert_ne!(grid[top][left].1, shadow);
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow
@@ -2701,10 +2672,21 @@ mod tests {
             "the key strip is untouched: {}",
             lines[lines.len() - 1]
         );
+        // The toast is a closed box: its bottom border sits under the text
+        // (with the padding between them) and above the key strip.
+        let closed = (row + 1..lines.len())
+            .find(|y| lines[*y].contains("╰"))
+            .expect("the toast's bottom border");
         assert!(
-            lines[row + 1].contains("╰") && !lines[row + 1].contains("Copied"),
-            "the toast is closed above the pane border: {}",
-            lines[row + 1]
+            closed < lines.len() - 1,
+            "the toast should close above the key strip: {}",
+            lines[closed]
+        );
+        assert!(
+            lines[row + 1..=closed]
+                .iter()
+                .all(|l| !l.contains("Copied")),
+            "the text is inside the box only once"
         );
     }
 

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -178,14 +178,16 @@ pub fn render_with_layout(app: &App, f: &mut Frame) -> (PaneRects, Option<String
 fn render_inner(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     f.render_widget(Clear, f.area());
     render_screen(app, f, rects);
-    render_toast(app, f);
+    render_toast(app, f, rects);
 }
 
 /// The corner confirmation, over whatever is underneath it.
 ///
-/// Bottom right, clear of the key strip on the left of the same row and of the
-/// `? keys` badge on its right — it sits a line above both.
-fn render_toast(app: &App, f: &mut Frame) {
+/// A confirmation sits bottom right, clear of the key strip on the left of the
+/// same row and of the `? keys` badge on its right — a glance, out of the way.
+/// An error is the thing that needs reading, so it sits front and center at
+/// the bottom of the session pane (or of the page, when no pane is drawn).
+fn render_toast(app: &App, f: &mut Frame, rects: &PaneRects) {
     let Some(toast) = app.toast.as_ref().filter(|toast| !toast.expired()) else {
         return;
     };
@@ -194,13 +196,34 @@ fn render_toast(app: &App, f: &mut Frame) {
     let text = format!(" {}  {}  ", if toast.ok { "✓" } else { "✕" }, toast.text);
     let w = (text.chars().count() as u16 + DIALOG_CHROME_X).min(area.width);
     let h = 3.min(area.height);
-    // Clear of the key strip on the last row and of the pane border above it,
-    // so it floats inside the pane rather than colliding with its corner.
-    let rect = Rect {
-        x: area.right().saturating_sub(w + 2),
-        y: area.bottom().saturating_sub(h + 2),
-        width: w,
-        height: h,
+    let rect = if toast.ok {
+        // Clear of the key strip on the last row and of the pane border above
+        // it, so it floats inside the pane rather than colliding with its
+        // corner.
+        Rect {
+            x: area.right().saturating_sub(w + 2),
+            y: area.bottom().saturating_sub(h + 2),
+            width: w,
+            height: h,
+        }
+    } else {
+        let host = if rects.session.w > 0 {
+            Rect {
+                x: rects.session.x,
+                y: rects.session.y,
+                width: rects.session.w,
+                height: rects.session.h,
+            }
+        } else {
+            area
+        };
+        let w = w.min(host.width);
+        Rect {
+            x: host.x + host.width.saturating_sub(w) / 2,
+            y: host.bottom().saturating_sub(h + 1).max(host.y),
+            width: w,
+            height: h,
+        }
     };
     let accent = if toast.ok {
         theme.accent
@@ -2693,6 +2716,41 @@ mod tests {
             (cols, rows),
             (rects.session.w, rects.session.h),
             "the PTY must be exactly the pane the emulator is drawn into"
+        );
+    }
+
+    /// An error toast sits front and center at the bottom of the session
+    /// pane, where it can actually be read — not squeezed in beside the
+    /// wordmark like a piece of header furniture.
+    #[test]
+    fn an_error_toast_centers_over_the_session_pane() {
+        use crate::commands::cloud_agent::tui::session::Session;
+
+        let mut app = app_with_tree();
+        app.screen = Screen::Manage;
+        app.attach_session(
+            Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+        app.toast_error("Launch failed: boom");
+        let out = draw(&app, 100, 30);
+        let lines: Vec<&str> = out.lines().collect();
+        let row = lines
+            .iter()
+            .position(|l| l.contains("✕"))
+            .expect("the error toast");
+        assert!(row > lines.len() * 2 / 3, "near the bottom: {row}");
+        let start = lines[row].find("Launch failed: boom").expect("the reason");
+        let end = start + "Launch failed: boom".len();
+        // Centered within the session pane, which begins right of the tree.
+        assert!(start > TREE_W as usize, "inside the session pane: {start}");
+        let pane_left = (PAGE_MARGIN_X + TREE_W) as usize;
+        let pane_right = 100 - PAGE_MARGIN_X as usize;
+        let pane_mid = (pane_left + pane_right) / 2;
+        let toast_mid = (start + end) / 2;
+        assert!(
+            toast_mid.abs_diff(pane_mid) <= 3,
+            "centered in the pane: toast mid {toast_mid}, pane mid {pane_mid}"
         );
     }
 

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -42,14 +42,20 @@ const CARD_GUTTER: usize = 3;
 const TREE_W: u16 = 32;
 
 /// Columns between a dialog's border and its text.
-const DIALOG_PAD_X: u16 = 2;
+const DIALOG_PAD_X: u16 = 4;
 
 /// Rows between a dialog's border and its text.
-const DIALOG_PAD_Y: u16 = 1;
+const DIALOG_PAD_Y: u16 = 2;
 
 /// What a dialog spends on chrome: two borders plus the padding inside them.
 const DIALOG_CHROME_X: u16 = 2 + DIALOG_PAD_X * 2;
 const DIALOG_CHROME_Y: u16 = 2 + DIALOG_PAD_Y * 2;
+
+/// How far the drop shadow is offset from the card that casts it. Two columns
+/// to one row: a terminal cell is about twice as tall as it is wide, so this is
+/// the same distance in both directions on screen.
+const SHADOW_DX: u16 = 2;
+const SHADOW_DY: u16 = 1;
 
 /// The chrome every floating card shares.
 ///
@@ -65,6 +71,37 @@ fn dialog_block(theme: &Theme) -> Block<'static> {
         .border_style(Style::default().fg(theme.accent))
         .style(Style::default().bg(theme.surface).fg(theme.fg))
         .padding(Padding::symmetric(DIALOG_PAD_X, DIALOG_PAD_Y))
+}
+
+/// Lift `outer` off the screen: a shadow down and to the right of it, then the
+/// area itself wiped clean for the card to be drawn into.
+///
+/// The shadow is painted rather than blended — a terminal has no alpha — so the
+/// cells it lands on lose their contents. That is the point: whatever was there
+/// is behind the card now, and a half-lit word poking out from under it reads
+/// as corruption rather than as depth.
+fn raise(f: &mut Frame, theme: &Theme, outer: Rect) {
+    let screen = f.area();
+    let shadow = Rect {
+        x: outer.x + SHADOW_DX,
+        y: outer.y + SHADOW_DY,
+        width: outer.width,
+        height: outer.height,
+    }
+    .intersection(screen);
+    let buffer = f.buffer_mut();
+    for y in shadow.top()..shadow.bottom() {
+        for x in shadow.left()..shadow.right() {
+            // Only the L the shadow sticks out by; the rest is under the card.
+            if outer.contains((x, y).into()) {
+                continue;
+            }
+            buffer[(x, y)]
+                .set_symbol(" ")
+                .set_style(Style::default().bg(theme.shadow));
+        }
+    }
+    f.render_widget(Clear, outer);
 }
 
 /// One inverse-styled key badge, e.g. ` ^t `. The building block of
@@ -177,6 +214,8 @@ fn render_toast(app: &App, f: &mut Frame) {
         theme.pending
     };
     f.render_widget(Clear, rect);
+    // No shadow: the toast already floats clear of everything, and the shade
+    // would fall on the key strip it deliberately sits above.
     f.render_widget(
         Paragraph::new(Span::styled(text, Style::default().fg(theme.fg))).block(
             dialog_block(theme)
@@ -257,7 +296,7 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     let big = area.width >= BANNER_W + 8 && area.height >= 26;
     let banner_h = if big { BANNER_H } else { 1 };
     // Text rows, plus the border and the padding that frame them.
-    let prompt_h = if area.height >= 30 { 4 } else { 2 } + DIALOG_CHROME_Y;
+    let prompt_h = if area.height >= 30 { 2 } else { 1 } + DIALOG_CHROME_Y;
     let panel_w = 74.min(area.width.saturating_sub(2)).max(40.min(area.width));
     let cards = app.cards();
     // Descriptions cost rows, and on a short screen those rows come out of the
@@ -568,7 +607,9 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
 
     // Padding is the first thing to go when the box is short: a line to type on
     // beats room around it.
-    let pad_y = DIALOG_PAD_Y * u16::from(area.height >= 3 + DIALOG_PAD_Y * 2);
+    let pad_y = DIALOG_PAD_Y.min(area.height.saturating_sub(3) / 2);
+
+    raise(f, theme, area);
 
     let block = dialog_block(theme)
         // On a short terminal the box can be squeezed to a couple of rows, and
@@ -1132,7 +1173,7 @@ fn render_panel(f: &mut Frame, theme: &Theme, area: Rect, panel: Panel) {
     let width = (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
     let height = (body_h + dots_h + 5 + DIALOG_CHROME_Y).min(area.height.saturating_sub(2));
     let outer = centered(width, height, area);
-    f.render_widget(Clear, outer);
+    raise(f, theme, outer);
 
     let block = dialog_block(theme).title(Span::styled(
         format!(" {} ", panel.title),
@@ -1476,7 +1517,7 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
         5 + DIALOG_CHROME_Y,
         area,
     );
-    f.render_widget(Clear, outer);
+    raise(f, theme, outer);
 
     let block = dialog_block(theme)
         .title(Span::styled(
@@ -1599,7 +1640,7 @@ fn render_keys(app: &App, f: &mut Frame) {
     let width = (48 + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
     let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
     let panel = centered(width, height, area);
-    f.render_widget(Clear, panel);
+    raise(f, theme, panel);
     f.render_widget(
         Paragraph::new(lines).block(
             dialog_block(theme)
@@ -2263,6 +2304,37 @@ mod tests {
                 assert_eq!(row[x].0, " ", "column {x} hugs the border");
             }
         }
+    }
+
+    /// And it casts a shadow, so it reads as sitting above the screen rather
+    /// than being painted into it.
+    #[test]
+    fn a_dialog_casts_a_shadow_down_and_to_the_right() {
+        let mut app = app_with_tree();
+        app.start_settings();
+        let grid = cells(&app, 100, 40);
+        let (top, bottom, left, right) = dialog_rows(&grid, "settings");
+        let shadow = app.theme.shadow;
+        // Under the bottom edge, offset right by the same throw.
+        let under = &grid[bottom + SHADOW_DY as usize];
+        for (x, cell) in under
+            .iter()
+            .enumerate()
+            .take(right + 1)
+            .skip(left + SHADOW_DX as usize)
+        {
+            assert_eq!(cell.1, shadow, "no shadow under the card at column {x}");
+        }
+        // And down the right edge, starting below the top of the card.
+        for row in &grid[top + SHADOW_DY as usize..=bottom] {
+            assert_eq!(
+                row[right + SHADOW_DX as usize].1,
+                shadow,
+                "no shadow beside the card"
+            );
+        }
+        // The card itself is unshaded.
+        assert_ne!(grid[top][left].1, shadow);
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow
@@ -3133,8 +3205,10 @@ mod tests {
             .repeat(3);
         let out = draw(&app, 100, 40);
         // The tail is what matters: the end of the draft has to be on screen.
+        // The last words rather than a whole phrase — the box wraps, and where
+        // a line breaks is the box's business.
         assert!(
-            out.contains("describing what changed"),
+            out.contains("what changed"),
             "the end of the prompt should be visible:\n{out}"
         );
     }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -2493,10 +2493,16 @@ mod tests {
         let bottom = (top + 1..lines.len())
             .find(|&y| lines[y].chars().nth(col) == Some('╰'))
             .expect("a closed box");
+        let right = lines[top]
+            .chars()
+            .collect::<Vec<_>>()
+            .iter()
+            .rposition(|&c| c == '╮')
+            .expect("a top border");
         let below: String = lines[bottom + 1]
             .chars()
             .skip(col)
-            .take(lines[top].chars().count() - col)
+            .take(right - col + 1)
             .collect();
         assert!(
             below.trim().is_empty(),

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -84,6 +84,17 @@ fn page(f: &Frame) -> Rect {
     }
 }
 
+/// The prompt box's shape — width, and height in rows including borders —
+/// shared by the menu's prompt and the ⌥p composer so the two read as the
+/// same control. Text rows plus the border: twice the writing room of the
+/// original two rows on screens with the height for it — a prompt is a
+/// paragraph these days, not a title — and a compact variant below that.
+fn prompt_box_size(area: Rect) -> (u16, u16) {
+    let height = if area.height >= 30 { 6 } else { 2 } + DIALOG_CHROME_Y;
+    let width = 74.min(area.width.saturating_sub(2)).max(40.min(area.width));
+    (width, height)
+}
+
 /// The chrome every floating card shares.
 ///
 /// Opaque fill, because these sit *on top of* the screen rather than in it:
@@ -305,12 +316,9 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     let area = page(f);
     let big = area.width >= BANNER_W + 8 && area.height >= 26;
     let banner_h = if big { BANNER_H } else { 1 };
-    // Text rows plus the border. Twice the writing room of the original two
-    // rows — a prompt is a paragraph these days, not a title.
-    let prompt_h = if area.height >= 30 { 6 } else { 2 } + DIALOG_CHROME_Y;
+    let (panel_w, prompt_h) = prompt_box_size(area);
     // The room around the prompt lives outside its outline, not inside it.
     let prompt_gap = if area.height >= 30 { 2 } else { 1 };
-    let panel_w = 74.min(area.width.saturating_sub(2)).max(40.min(area.width));
     let cards = app.cards();
     // Descriptions cost rows, and on a short screen those rows come out of the
     // prompt box. Names only, rather than a menu with no prompt on it.
@@ -1519,12 +1527,10 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
     };
     let theme = app.theme;
     let area = page(f);
-    let outer = centered(
-        (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4)),
-        // Three rows to type in, plus the border and the padding around them.
-        3 + DIALOG_CHROME_Y,
-        area,
-    );
+    // The same box as the main screen's prompt, so composing a session here
+    // feels like the same act there.
+    let (w, h) = prompt_box_size(area);
+    let outer = centered(w, h, area);
     f.render_widget(Clear, outer);
 
     let block = dialog_block(theme)
@@ -2357,6 +2363,35 @@ mod tests {
                 lines[y]
             );
         }
+    }
+
+    /// The ⌥p composer is the main screen's prompt box opened elsewhere —
+    /// same width, same height — so it reads as the same control.
+    #[test]
+    fn the_composer_matches_the_menu_prompt_box() {
+        fn box_of(out: &str, title: &str) -> (usize, usize) {
+            let lines: Vec<&str> = out.lines().collect();
+            let top = lines
+                .iter()
+                .position(|l| l.contains(title))
+                .unwrap_or_else(|| panic!("{title} not drawn"));
+            let row: Vec<char> = lines[top].chars().collect();
+            let left = row.iter().position(|&c| c == '╭').expect("a top border");
+            let right = row.iter().rposition(|&c| c == '╮').expect("a top border");
+            // The closing corner is found by column, not line start: the
+            // composer floats over the manage screen, whose pane borders own
+            // the starts of these rows.
+            let bottom = (top + 1..lines.len())
+                .find(|&y| lines[y].chars().nth(left) == Some('╰'))
+                .expect("a closed box");
+            (bottom - top + 1, right - left + 1)
+        }
+        let menu = box_of(&draw(&app_with_tree(), 100, 40), " Prompt ");
+        let mut app = app_with_tree();
+        app.screen = Screen::ManagePrompt;
+        app.manage_prompt = Some(String::new());
+        let composer = box_of(&draw(&app, 100, 40), " New Session ");
+        assert_eq!(menu, composer, "(height, width) of the two prompt boxes");
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -530,12 +530,12 @@ fn render_loading(app: &App, f: &mut Frame, area: Rect) {
     };
 
     const STEP_ROWS: u16 = 9;
-    let task_h = match loading.prompt.as_deref() {
-        // Three lines of task plus its border: a prompt is a sentence, and the
-        // whole point of showing it is not making the user wonder what is
-        // starting.
-        Some(_) => 5,
-        None => 0,
+    // The echoed prompt reuses the main screen's box wholesale — same width,
+    // same height — so the transition reads as the box you typed in coming
+    // along, not a different card summarizing what you wrote.
+    let (task_w, task_h) = match loading.prompt.as_deref() {
+        Some(_) => prompt_box_size(area),
+        None => (0, 0),
     };
     // Size the panel to its content and centre *that*, rather than letting it
     // span the pane: the steps read as a left-aligned block, and a block the
@@ -588,17 +588,20 @@ fn render_loading(app: &App, f: &mut Frame, area: Rect) {
     );
 
     if let Some(prompt) = loading.prompt.as_deref() {
-        // A third of the pane, centred: a fixed frame the task wraps inside,
-        // rather than a frame the task drags open.
-        let task_area = centered((area.width / 3).max(24), task_h, rows[3]);
+        // Centered in the pane, not in the (narrower) steps panel: the box is
+        // the pane-wide element the steps sit under.
+        let task_area = Rect {
+            x: area.x + area.width.saturating_sub(task_w) / 2,
+            y: rows[3].y,
+            width: task_w.min(area.width),
+            height: rows[3].height,
+        };
         f.render_widget(
             Paragraph::new(prompt.to_string())
                 .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .border_type(BorderType::Rounded)
+                    dialog_block(theme)
                         .border_style(Style::default().fg(theme.accent_dim))
-                        .title(Span::styled(" Task ", Style::default().fg(theme.dim))),
+                        .title(Span::styled(" Prompt ", Style::default().fg(theme.dim))),
                 )
                 .style(Style::default().fg(theme.fg))
                 .wrap(Wrap { trim: true }),
@@ -2451,6 +2454,29 @@ mod tests {
         app.manage_prompt = Some(String::new());
         let composer = box_of(&draw(&app, 100, 40), " New Session ");
         assert_eq!(menu, composer, "(height, width) of the two prompt boxes");
+    }
+
+    /// Submitting from the main screen carries the prompt box along: the
+    /// loading pane echoes it in the same box (title, dialog surface, shared
+    /// size rule), not a smaller "Task" card.
+    #[test]
+    fn the_loading_screen_echoes_the_prompt_in_its_own_box() {
+        use crate::commands::cloud_agent::tui::app::Loading;
+
+        let mut app = app_with_tree();
+        app.screen = Screen::Manage;
+        app.loading = Loading {
+            active: true,
+            target: "devtools/production".into(),
+            harness: "claude".into(),
+            prompt: Some("ship the release notes".into()),
+            steps: Vec::new(),
+            tick: 0,
+        };
+        let out = draw(&app, 100, 40);
+        assert!(out.contains(" Prompt "), "the box keeps its name:\n{out}");
+        assert!(!out.contains(" Task "), "the old card is gone:\n{out}");
+        assert!(out.contains("ship the release notes"), "{out}");
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -554,12 +554,20 @@ fn render_loading(app: &App, f: &mut Frame, area: Rect) {
         // A floor only so an empty panel is not a sliver; anything larger pads
         // the panel past its content and the centring visibly drifts left.
         .clamp(20, area.width.max(1) as usize) as u16;
-    let panel = centered(content_w, (STEP_ROWS + task_h + 4).min(area.height), area);
+    // A prompt box brings a row of air below it, so the steps don't sit
+    // against its border.
+    let task_gap = if task_h > 0 { 1 } else { 0 };
+    let panel = centered(
+        content_w,
+        (STEP_ROWS + task_h + task_gap + 4).min(area.height),
+        area,
+    );
     let rows = Layout::vertical([
         Constraint::Length(1), // title
         Constraint::Length(1), // target
         Constraint::Length(1), // gap
         Constraint::Length(task_h),
+        Constraint::Length(task_gap),
         Constraint::Length(STEP_ROWS),
         Constraint::Min(0),
         Constraint::Length(1), // hint
@@ -610,8 +618,8 @@ fn render_loading(app: &App, f: &mut Frame, area: Rect) {
     }
 
     f.render_widget(
-        Paragraph::new(step_lines(app, rows[4].width)).wrap(Wrap { trim: false }),
-        rows[4],
+        Paragraph::new(step_lines(app, rows[5].width)).wrap(Wrap { trim: false }),
+        rows[5],
     );
 }
 
@@ -2477,6 +2485,23 @@ mod tests {
         assert!(out.contains(" Prompt "), "the box keeps its name:\n{out}");
         assert!(!out.contains(" Task "), "the old card is gone:\n{out}");
         assert!(out.contains("ship the release notes"), "{out}");
+
+        // A row of air separates the box from the steps below it.
+        let lines: Vec<&str> = out.lines().collect();
+        let top = lines.iter().position(|l| l.contains(" Prompt ")).unwrap();
+        let col = lines[top].chars().position(|c| c == '╭').unwrap();
+        let bottom = (top + 1..lines.len())
+            .find(|&y| lines[y].chars().nth(col) == Some('╰'))
+            .expect("a closed box");
+        let below: String = lines[bottom + 1]
+            .chars()
+            .skip(col)
+            .take(lines[top].chars().count() - col)
+            .collect();
+        assert!(
+            below.trim().is_empty(),
+            "the row under the prompt box should be clear: {below:?}"
+        );
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -53,20 +53,34 @@ const PAGE_MARGIN_X: u16 = 2;
 /// as tall as it is wide — the same gap on screen on every side.
 const PAGE_MARGIN_Y: u16 = 1;
 
+/// What the page margin leaves of a `width` × `height` terminal. Skipped when
+/// the terminal is too small to spend cells on air — a cramped layout beats a
+/// truncated one.
+///
+/// The single source of that answer: [`page`] shapes what is drawn with it,
+/// and [`session_pane_size`] shapes the PTY with it. They must agree — an
+/// emulator wrapping wider than its pane puts the last columns of every row
+/// somewhere the screen never shows, which shears anything long enough to
+/// wrap (an OAuth URL loses four characters at every fold).
+fn page_size(width: u16, height: u16) -> (u16, u16) {
+    if width < 40 || height < 12 {
+        (width, height)
+    } else {
+        (width - PAGE_MARGIN_X * 2, height - PAGE_MARGIN_Y * 2)
+    }
+}
+
 /// The page: the frame minus a slim outer margin, so boxes never press
 /// against the terminal's edges. Every screen and floating card lays out
-/// against this. Skipped when the terminal is too small to spend cells on
-/// air — a cramped layout beats a truncated one.
+/// against this.
 fn page(f: &Frame) -> Rect {
     let area = f.area();
-    if area.width < 40 || area.height < 12 {
-        return area;
-    }
+    let (width, height) = page_size(area.width, area.height);
     Rect {
-        x: area.x + PAGE_MARGIN_X,
-        y: area.y + PAGE_MARGIN_Y,
-        width: area.width - PAGE_MARGIN_X * 2,
-        height: area.height - PAGE_MARGIN_Y * 2,
+        x: area.x + (area.width - width) / 2,
+        y: area.y + (area.height - height) / 2,
+        width,
+        height,
     }
 }
 
@@ -828,16 +842,19 @@ pub fn session_pane_size(
     maximized: bool,
 ) -> Option<(u16, u16)> {
     let area = area?;
+    // The same inset the renderer applies — see `page_size` for why the two
+    // must never disagree.
+    let (width, height) = page_size(area.width, area.height);
     // Maximized there is no tree to leave room for, so no minimum width to
     // meet either.
-    if !maximized && area.width < 70 {
+    if !maximized && width < 70 {
         return None;
     }
     // Rows: header, gap, panes, hint. Columns: the tree, then what is left.
     // Both minus the pane's own border.
-    let rows = area.height.saturating_sub(3).saturating_sub(2).max(1);
+    let rows = height.saturating_sub(3).saturating_sub(2).max(1);
     let tree = if maximized { 0 } else { TREE_W };
-    let cols = area.width.saturating_sub(tree).saturating_sub(2).max(1);
+    let cols = width.saturating_sub(tree).saturating_sub(2).max(1);
     Some((rows, cols))
 }
 
@@ -2648,6 +2665,37 @@ mod tests {
 
     /// A drag that reached the clipboard says so in the corner — the only other
     /// evidence is the clipboard itself, which is not on the screen.
+    /// The PTY and the drawn pane are the same size. An emulator wrapping
+    /// wider than its pane puts the tail of every row somewhere the screen
+    /// never shows — four characters per fold of anything long enough to
+    /// wrap, which sheared OAuth login URLs into invalid links.
+    #[test]
+    fn the_session_pty_matches_the_drawn_pane() {
+        use crate::commands::cloud_agent::tui::session::Session;
+
+        let mut app = app_with_tree();
+        app.screen = Screen::Manage;
+        app.attach_session(
+            Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).unwrap();
+        let mut rects = crate::commands::cloud_agent::tui::app::PaneRects::default();
+        terminal
+            .draw(|f| {
+                let (r, _) = render_with_layout(&app, f);
+                rects = r;
+            })
+            .unwrap();
+        let (rows, cols) =
+            session_pane_size(Some(ratatui::layout::Size::new(100, 40)), false).unwrap();
+        assert_eq!(
+            (cols, rows),
+            (rects.session.w, rects.session.h),
+            "the PTY must be exactly the pane the emulator is drawn into"
+        );
+    }
+
     #[test]
     fn a_toast_floats_in_the_bottom_corner() {
         use crate::commands::cloud_agent::tui::session::Session;
@@ -2795,8 +2843,9 @@ mod tests {
         });
         let (_, split) = session_pane_size(size, false).unwrap();
         let (_, full) = session_pane_size(size, true).unwrap();
-        assert_eq!(split, 100 - TREE_W - 2);
-        assert_eq!(full, 98);
+        // Inside the page margin, like the panes it must agree with.
+        assert_eq!(split, 100 - PAGE_MARGIN_X * 2 - TREE_W - 2);
+        assert_eq!(full, 100 - PAGE_MARGIN_X * 2 - 2);
 
         // And a terminal too narrow for two panes is wide enough for one.
         let narrow = Some(ratatui::layout::Size {

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -268,13 +268,16 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     let area = page(f);
     let big = area.width >= BANNER_W + 8 && area.height >= 26;
     let banner_h = if big { BANNER_H } else { 1 };
-    // Text rows, plus the border and the padding that frame them.
-    let prompt_h = if area.height >= 30 { 2 } else { 1 } + DIALOG_CHROME_Y;
+    // Text rows plus the border. Twice the writing room of the original two
+    // rows — a prompt is a paragraph these days, not a title.
+    let prompt_h = if area.height >= 30 { 6 } else { 2 } + DIALOG_CHROME_Y;
+    // The room around the prompt lives outside its outline, not inside it.
+    let prompt_gap = if area.height >= 30 { 2 } else { 1 };
     let panel_w = 74.min(area.width.saturating_sub(2)).max(40.min(area.width));
     let cards = app.cards();
     // Descriptions cost rows, and on a short screen those rows come out of the
     // prompt box. Names only, rather than a menu with no prompt on it.
-    let chrome = banner_h + prompt_h + 12;
+    let chrome = banner_h + prompt_h + prompt_gap * 2 + 10;
     let mut block = card_block(&cards, panel_w as usize, true);
     if chrome + block.height(cards.len()) > area.height {
         block = card_block(&cards, panel_w as usize, false);
@@ -285,13 +288,13 @@ fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
 
     let rows = Layout::vertical([
         Constraint::Length(banner_h),
-        Constraint::Length(1), // breathing room under the wordmark
-        Constraint::Length(1), // CLOUD AGENTS
-        Constraint::Length(1), // title
-        Constraint::Length(1), // subtitle
-        Constraint::Length(1), // gap
+        Constraint::Length(1),          // breathing room under the wordmark
+        Constraint::Length(1),          // CLOUD AGENTS
+        Constraint::Length(1),          // title
+        Constraint::Length(1),          // subtitle
+        Constraint::Length(prompt_gap), // the prompt's room, outside its outline
         Constraint::Length(prompt_h),
-        Constraint::Length(1), // gap
+        Constraint::Length(prompt_gap), // and the same below
         Constraint::Length(cards_h),
         Constraint::Min(0),
         Constraint::Length(1), // target
@@ -2289,6 +2292,31 @@ mod tests {
             .find(|l| !l.trim().is_empty())
             .unwrap_or_default()
             .to_string()
+    }
+
+    /// The menu prompt holds a paragraph's worth of writing room — six text
+    /// rows inside the outline — and its breathing room sits outside the box:
+    /// blank rows against the border, not padding within it.
+    #[test]
+    fn the_menu_prompt_is_tall_with_its_room_outside() {
+        let app = app_with_tree();
+        let out = draw(&app, 100, 40);
+        let lines: Vec<&str> = out.lines().collect();
+        let top = lines
+            .iter()
+            .position(|l| l.contains(" Prompt "))
+            .expect("the prompt box");
+        let bottom = (top + 1..lines.len())
+            .find(|&y| lines[y].trim_start().starts_with("╰"))
+            .expect("the prompt's bottom border");
+        assert_eq!(bottom - top, 7, "six text rows inside the outline:\n{out}");
+        for y in [top - 1, bottom + 1] {
+            assert!(
+                lines[y].trim().is_empty(),
+                "row {y} should be the prompt's outside gap: {:?}",
+                lines[y]
+            );
+        }
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -2733,24 +2733,48 @@ mod tests {
             "ca_1".into(),
         );
         app.toast_error("Launch failed: boom");
-        let out = draw(&app, 100, 30);
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        let mut rects = crate::commands::cloud_agent::tui::app::PaneRects::default();
+        terminal
+            .draw(|f| {
+                let (r, _) = render_with_layout(&app, f);
+                rects = r;
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let out = (0..30)
+            .map(|y| {
+                (0..100)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
         let lines: Vec<&str> = out.lines().collect();
         let row = lines
             .iter()
             .position(|l| l.contains("✕"))
             .expect("the error toast");
         assert!(row > lines.len() * 2 / 3, "near the bottom: {row}");
-        let start = lines[row].find("Launch failed: boom").expect("the reason");
-        let end = start + "Launch failed: boom".len();
-        // Centered within the session pane, which begins right of the tree.
-        assert!(start > TREE_W as usize, "inside the session pane: {start}");
-        let pane_left = (PAGE_MARGIN_X + TREE_W) as usize;
-        let pane_right = 100 - PAGE_MARGIN_X as usize;
-        let pane_mid = (pane_left + pane_right) / 2;
+        // Char positions, not byte offsets: the row is full of multi-byte
+        // box-drawing cells, and columns are what centering is measured in.
+        let line: Vec<char> = lines[row].chars().collect();
+        let needle: Vec<char> = "Launch failed: boom".chars().collect();
+        let start = line
+            .windows(needle.len())
+            .position(|w| w == needle.as_slice())
+            .expect("the reason");
+        let end = start + needle.len();
+        // Centered within the session pane the frame actually drew.
+        assert!(
+            start > rects.session.x as usize,
+            "inside the session pane: {start}"
+        );
+        let pane_mid = rects.session.x as usize + rects.session.w as usize / 2;
         let toast_mid = (start + end) / 2;
         assert!(
             toast_mid.abs_diff(pane_mid) <= 3,
-            "centered in the pane: toast mid {toast_mid}, pane mid {pane_mid}"
+            "centered in the pane: toast mid {toast_mid}, pane mid {pane_mid}\n{out}"
         );
     }
 

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -6,7 +6,7 @@ use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{
-    Block, BorderType, Borders, Clear, List, ListItem, ListState, Padding, Paragraph, Wrap,
+    Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap,
 };
 
 use super::app::{
@@ -41,47 +41,47 @@ const CARD_GUTTER: usize = 3;
 /// Width of the tree column in Manage, borders included.
 const TREE_W: u16 = 32;
 
-/// Columns between a dialog's border and its text.
-const DIALOG_PAD_X: u16 = 4;
+/// What a dialog spends on chrome: its two border cells. The breathing room
+/// lives *outside* the boxes — see [`page`] — not between a border and its
+/// text.
+const DIALOG_CHROME_X: u16 = 2;
+const DIALOG_CHROME_Y: u16 = 2;
 
-/// Rows between a dialog's border and its text. Half the columns, because a
-/// terminal cell is about twice as tall as it is wide — this is the same gap on
-/// screen at the top and bottom as at the sides.
-const DIALOG_PAD_Y: u16 = 2;
+/// Columns of space between the terminal's edge and the UI.
+const PAGE_MARGIN_X: u16 = 2;
+/// Rows of the same. Half the columns, because a terminal cell is about twice
+/// as tall as it is wide — the same gap on screen on every side.
+const PAGE_MARGIN_Y: u16 = 1;
 
-/// What a dialog spends on chrome: two borders plus the padding inside them.
-const DIALOG_CHROME_X: u16 = 2 + DIALOG_PAD_X * 2;
-const DIALOG_CHROME_Y: u16 = 2 + DIALOG_PAD_Y * 2;
+/// The page: the frame minus a slim outer margin, so boxes never press
+/// against the terminal's edges. Every screen and floating card lays out
+/// against this. Skipped when the terminal is too small to spend cells on
+/// air — a cramped layout beats a truncated one.
+fn page(f: &Frame) -> Rect {
+    let area = f.area();
+    if area.width < 40 || area.height < 12 {
+        return area;
+    }
+    Rect {
+        x: area.x + PAGE_MARGIN_X,
+        y: area.y + PAGE_MARGIN_Y,
+        width: area.width - PAGE_MARGIN_X * 2,
+        height: area.height - PAGE_MARGIN_Y * 2,
+    }
+}
 
 /// The chrome every floating card shares.
 ///
 /// Opaque fill, because these sit *on top of* the screen rather than in it:
 /// with only [`Clear`] underneath, the terminal's own background shows through
 /// and the card reads as a hole punched in the page instead of a dialog above
-/// it. The padding is part of the same idea — text pressed against a border is
-/// what makes a box look like a frame rather than a surface — and it goes on
-/// all four sides, so no edge reads as tighter than another.
+/// it.
 fn dialog_block(theme: &Theme) -> Block<'static> {
     Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.accent))
         .style(Style::default().bg(theme.surface).fg(theme.fg))
-        .padding(Padding::new(
-            DIALOG_PAD_X,
-            DIALOG_PAD_X,
-            DIALOG_PAD_Y,
-            DIALOG_PAD_Y,
-        ))
-}
-
-/// The vertical padding a box `height` rows tall can afford around `content`.
-///
-/// The full amount whenever there is room for it, and whatever is left when
-/// there is not: on a short terminal a card that padded itself regardless would
-/// be spending rows of its own content on empty space.
-fn fitted_pad_y(height: u16, content: u16) -> u16 {
-    DIALOG_PAD_Y.min(height.saturating_sub(content + 2) / 2)
 }
 
 /// One inverse-styled key badge, e.g. ` ^t `. The building block of
@@ -176,19 +176,15 @@ fn render_toast(app: &App, f: &mut Frame) {
         return;
     };
     let theme = app.theme;
-    let area = f.area();
-    let text = format!("{}  {}", if toast.ok { "✓" } else { "✕" }, toast.text);
+    let area = page(f);
+    let text = format!(" {}  {}  ", if toast.ok { "✓" } else { "✕" }, toast.text);
     let w = (text.chars().count() as u16 + DIALOG_CHROME_X).min(area.width);
-    // Padded on every side like the dialogs, but at half their vertical scale:
-    // a one-line confirmation framed by two rows top and bottom stops reading
-    // as a chip in the corner and starts reading as a dialog nobody asked for.
-    let pad_y = DIALOG_PAD_Y / 2;
-    let h = (1 + 2 + pad_y * 2).min(area.height);
+    let h = 3.min(area.height);
     // Clear of the key strip on the last row and of the pane border above it,
     // so it floats inside the pane rather than colliding with its corner.
     let rect = Rect {
-        x: area.width.saturating_sub(w + 2),
-        y: area.height.saturating_sub(h + 2),
+        x: area.right().saturating_sub(w + 2),
+        y: area.bottom().saturating_sub(h + 2),
         width: w,
         height: h,
     };
@@ -199,16 +195,8 @@ fn render_toast(app: &App, f: &mut Frame) {
     };
     f.render_widget(Clear, rect);
     f.render_widget(
-        Paragraph::new(Span::styled(text, Style::default().fg(theme.fg))).block(
-            dialog_block(theme)
-                .border_style(Style::default().fg(accent))
-                .padding(Padding::new(
-                    DIALOG_PAD_X,
-                    DIALOG_PAD_X,
-                    pad_y.min(h.saturating_sub(3) / 2),
-                    pad_y.min(h.saturating_sub(3) / 2),
-                )),
-        ),
+        Paragraph::new(Span::styled(text, Style::default().fg(theme.fg)))
+            .block(dialog_block(theme).border_style(Style::default().fg(accent))),
         rect,
     );
 }
@@ -277,7 +265,7 @@ fn centered(width: u16, height: u16, area: Rect) -> Rect {
 
 fn render_menu(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     let theme = app.theme;
-    let area = f.area();
+    let area = page(f);
     let big = area.width >= BANNER_W + 8 && area.height >= 26;
     let banner_h = if big { BANNER_H } else { 1 };
     // Text rows, plus the border and the padding that frame them.
@@ -590,15 +578,9 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
         format!(" {} ", app.prompt.chars().count())
     };
 
-    // A line to type on comes before the room around it: on a short terminal
-    // the box can be squeezed to a couple of rows, and padding it regardless
-    // would leave nowhere for the draft to go.
-    let pad_y = fitted_pad_y(area.height, 1);
-
     f.render_widget(Clear, area);
 
     let block = dialog_block(theme)
-        .padding(Padding::new(DIALOG_PAD_X, DIALOG_PAD_X, pad_y, pad_y))
         .border_style(Style::default().fg(if focused {
             theme.accent
         } else {
@@ -625,10 +607,9 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
 
     // Keep the cursor line in view once the wrapped text outgrows the box.
     // Without this the box simply stops showing what is being typed, which is
-    // the one thing it exists to do. The padding is chrome, not writing room,
-    // so the text gets what is left after it.
+    // the one thing it exists to do.
     let inner_w = area.width.saturating_sub(DIALOG_CHROME_X).max(1) as usize;
-    let inner_h = area.height.saturating_sub(2 + pad_y * 2).max(1) as usize;
+    let inner_h = area.height.saturating_sub(DIALOG_CHROME_Y).max(1) as usize;
     let scroll_y = wrapped_lines(&text, inner_w).saturating_sub(inner_h) as u16;
 
     f.render_widget(
@@ -859,7 +840,7 @@ pub fn session_pane_size(
 
 fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     let theme = app.theme;
-    let area = f.area();
+    let area = page(f);
     let chunks = Layout::vertical([
         Constraint::Length(1), // header
         Constraint::Length(1), // gap
@@ -1304,7 +1285,7 @@ fn render_wizard(app: &App, f: &mut Frame) {
     render_panel(
         f,
         theme,
-        f.area(),
+        page(f),
         Panel {
             title: "setup",
             heading: wizard.title(),
@@ -1353,7 +1334,7 @@ fn render_settings(app: &App, f: &mut Frame) {
         render_panel(
             f,
             theme,
-            f.area(),
+            page(f),
             Panel {
                 title: "settings",
                 heading: "Where should agents live?",
@@ -1396,7 +1377,7 @@ fn render_settings(app: &App, f: &mut Frame) {
     render_panel(
         f,
         theme,
-        f.area(),
+        page(f),
         Panel {
             title: "settings",
             heading: "Cloud agent settings",
@@ -1436,7 +1417,7 @@ fn render_agent_pick(app: &App, f: &mut Frame) {
     render_panel(
         f,
         theme,
-        f.area(),
+        page(f),
         Panel {
             title: "new session",
             heading: "Which cloud agent?",
@@ -1475,7 +1456,7 @@ fn render_harness_pick(app: &App, f: &mut Frame) {
     render_panel(
         f,
         theme,
-        f.area(),
+        page(f),
         Panel {
             title: "new session",
             heading: "Which agent should run it?",
@@ -1494,7 +1475,7 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
         return;
     };
     let theme = app.theme;
-    let area = f.area();
+    let area = page(f);
     let outer = centered(
         (62 + DIALOG_CHROME_X).min(area.width.saturating_sub(4)),
         // Three rows to type in, plus the border and the padding around them.
@@ -1576,7 +1557,7 @@ fn render_target_pick(app: &App, f: &mut Frame) {
     render_panel(
         f,
         theme,
-        f.area(),
+        page(f),
         Panel {
             title: "target",
             heading: "Where should Cloud Agents run?",
@@ -1592,7 +1573,7 @@ fn render_target_pick(app: &App, f: &mut Frame) {
 /// mode: the next keypress dismisses it.
 fn render_keys(app: &App, f: &mut Frame) {
     let theme = app.theme;
-    let area = f.area();
+    let area = page(f);
 
     let chord_w = KEY_HELP
         .iter()
@@ -1622,8 +1603,7 @@ fn render_keys(app: &App, f: &mut Frame) {
     }
 
     let rows = lines.len() as u16;
-    // As wide as the widest line it has to carry, so the padding is room around
-    // the list rather than something the descriptions get truncated to pay for.
+    // As wide as the widest line it has to carry, so nothing gets truncated.
     let content_w = lines
         .iter()
         .map(|line| line.width() as u16)
@@ -1631,15 +1611,11 @@ fn render_keys(app: &App, f: &mut Frame) {
         .unwrap_or(48);
     let width = (content_w + DIALOG_CHROME_X).min(area.width.saturating_sub(4));
     let height = (rows + DIALOG_CHROME_Y).min(area.height.saturating_sub(2));
-    // The list is long enough to outgrow a short terminal on its own, and a row
-    // spent on padding there is a key the reader can no longer see.
-    let pad_y = fitted_pad_y(height, rows);
     let panel = centered(width, height, area);
     f.render_widget(Clear, panel);
     f.render_widget(
         Paragraph::new(lines).block(
             dialog_block(theme)
-                .padding(Padding::new(DIALOG_PAD_X, DIALOG_PAD_X, pad_y, pad_y))
                 .title(Span::styled(
                     " keys ",
                     Style::default()
@@ -2276,36 +2252,43 @@ mod tests {
         }
     }
 
-    /// And the text inside it keeps clear of its edges — on all four of them,
-    /// by the same amount.
+    /// The breathing room lives outside the boxes: a slim margin of untouched
+    /// cells between the terminal's edges and everything the TUI draws, on
+    /// every screen.
     #[test]
-    fn dialog_text_is_inset_from_every_border() {
-        let mut app = app_with_tree();
-        app.start_settings();
-        let grid = cells(&app, 100, 40);
-        let (top, bottom, left, right) = dialog_rows(&grid, "settings");
-        let blank = |cells: &[(String, Color)]| cells.iter().all(|(s, _)| s == " ");
-
-        // Top and bottom: DIALOG_PAD_Y clear rows inside each border.
-        for offset in 1..=DIALOG_PAD_Y as usize {
-            for y in [top + offset, bottom - offset] {
+    fn the_page_keeps_clear_of_the_terminal_edges() {
+        for screen in [Screen::Menu, Screen::Manage] {
+            let mut app = app_with_tree();
+            app.screen = screen;
+            let grid = cells(&app, 100, 40);
+            let blank = |cells: &[(String, Color)]| cells.iter().all(|(s, _)| s == " ");
+            let h = grid.len();
+            for y in 0..PAGE_MARGIN_Y as usize {
+                assert!(blank(&grid[y]), "top margin row {y} has content");
+                assert!(blank(&grid[h - 1 - y]), "bottom margin row has content");
+            }
+            for (y, row) in grid.iter().enumerate() {
+                let w = row.len();
                 assert!(
-                    blank(&grid[y][left + 1..right]),
-                    "row {y} is inside the padding and should be clear"
+                    blank(&row[..PAGE_MARGIN_X as usize]),
+                    "left margin has content at row {y}"
+                );
+                assert!(
+                    blank(&row[w - PAGE_MARGIN_X as usize..]),
+                    "right margin has content at row {y}"
                 );
             }
         }
-        // Left and right: DIALOG_PAD_X clear columns, every row of the body.
-        for row in &grid[top + 1..bottom] {
-            assert!(
-                blank(&row[left + 1..=left + DIALOG_PAD_X as usize]),
-                "text runs into the left border"
-            );
-            assert!(
-                blank(&row[right - DIALOG_PAD_X as usize..right]),
-                "text runs into the right border"
-            );
-        }
+    }
+
+    /// The last row the TUI actually draws on — the footer/key strip sits
+    /// here, one page margin above the terminal's bottom edge.
+    pub(super) fn last_drawn_line(out: &str) -> String {
+        out.lines()
+            .rev()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or_default()
+            .to_string()
     }
 
     /// The wordmark must be full blocks and spaces only: box-drawing shadow
@@ -2667,10 +2650,10 @@ mod tests {
             .position(|w| w.iter().collect::<String>() == "Copied")
             .expect("the toast text");
         assert!(start > 92 / 2, "on the right: {start}");
+        let strip = last_drawn_line(&out);
         assert!(
-            lines[lines.len() - 1].contains("keys"),
-            "the key strip is untouched: {}",
-            lines[lines.len() - 1]
+            strip.contains("keys"),
+            "the key strip is untouched: {strip}"
         );
         // The toast is a closed box: its bottom border sits under the text
         // (with the padding between them) and above the key strip.
@@ -2732,11 +2715,11 @@ mod tests {
         let out = draw(&app, 92, 20);
         let border = out
             .lines()
-            .find(|l| l.starts_with("╰"))
+            .find(|l| l.trim_start().starts_with("╰"))
             .expect("the pane's bottom border");
         assert!(!border.contains("to leave"), "{border}");
         assert!(
-            out.lines().next_back().unwrap().contains("stop typing"),
+            last_drawn_line(&out).contains("stop typing"),
             "the key strip still has it:\n{out}"
         );
     }
@@ -2769,8 +2752,8 @@ mod tests {
             .expect("the session pane");
         assert_eq!(
             pane.chars().position(|c| c == '╭'),
-            Some(0),
-            "the pane starts at the left edge: {pane}"
+            Some(PAGE_MARGIN_X as usize),
+            "the pane starts at the page's left edge: {pane}"
         );
     }
 
@@ -3058,7 +3041,8 @@ mod tests {
             .unwrap();
 
         let out = draw(&app, 120, 30);
-        let footer = out.lines().last().unwrap();
+        let footer = last_drawn_line(&out);
+        let footer = footer.as_str();
         assert!(footer.contains("connect"), "{footer}");
         assert!(footer.contains("new session"), "{footer}");
         assert!(footer.contains("delete agent"), "{footer}");
@@ -3088,7 +3072,7 @@ mod tests {
             .position(|r| r.label == "nimble-otter")
             .unwrap();
 
-        let footer = draw(&app, 120, 30).lines().last().unwrap().to_string();
+        let footer = last_drawn_line(&draw(&app, 120, 30));
         assert!(footer.contains("wake"), "{footer}");
         assert!(!footer.contains("sleep"), "{footer}");
     }
@@ -3103,7 +3087,7 @@ mod tests {
             .iter()
             .position(|r| r.label == "devtools")
             .unwrap();
-        let footer = draw(&app, 120, 30).lines().last().unwrap().to_string();
+        let footer = last_drawn_line(&draw(&app, 120, 30));
         assert!(footer.contains("new agent"), "{footer}");
         assert!(!footer.contains("delete"), "{footer}");
         assert!(footer.trim_end().ends_with("keys"), "{footer}");
@@ -3115,7 +3099,9 @@ mod tests {
         let mut app = app_with_tree();
         app.screen = Screen::Manage;
         app.keys_open = true;
-        let out = draw(&app, 100, 30);
+        // Two rows taller than before: the page margin trims the overlay's
+        // room, and this list is exactly long enough to notice.
+        let out = draw(&app, 100, 34);
         assert!(out.contains("keys"));
         assert!(out.contains("refresh"), "{out}");
         assert!(out.contains("⌥/⇧esc / ^]"), "{out}");


### PR DESCRIPTION
Dialog and layout polish for the `railway ca` TUI, plus the fixes that fell out of it.

## Changes

- **Solid dialog surfaces**: floating cards get an opaque themed fill (`dialog_block`) instead of reading as holes punched in the page; per-theme `surface` color with contrast tests
- **Page margin**: the whole UI lays out inside a slim outer margin (2 cols / 1 row, skipped on tiny terminals) — breathing room lives outside the boxes, not as padding inside dialogs
- **Session PTY sizing fix**: `page_size()` is the single source for both render and PTY dimensions — the margin had left the PTY 4 columns wider than the drawn pane, clipping 4 chars per wrapped row (sheared OAuth login URLs into "Missing scope parameter")
- **Taller menu prompt**: six text rows (compact variant on short screens), gap doubled outside the outline; the ⌥p composer shares the exact box via `prompt_box_size()`
- **Loading screen echoes the prompt in its own box**: same size rule, surface, and title as the main screen's prompt — replaces the third-width "Task" card
- **Errors are toasts**: failures render as an ✕ toast centered at the bottom of the session pane (5× lifetime), not as header text beside the wordmark; success toasts keep the corner
- Merged master (#1085/#1086) with the SSH gate card adopted onto the shared dialog surface

## Testing

- 1051 tests passing, incl. render tests: PTY == drawn pane, page margin clear on all edges, prompt/composer/loading-box geometry shared, error-toast centering (measured in columns, not bytes)