### PR TITLE
Tell scope-denied users the truth instead of sending them to railway login

### DIFF
--- a/src/auth_sim.rs
+++ b/src/auth_sim.rs
@@ -614,3 +614,166 @@ async fn dead_grant_in_a_long_session_refreshes_once_not_per_tool_call() {
         "a dead grant must be discovered once per session, not once per tool call"
     );
 }
+
+// ---------------------------------------------------------------------------
+// "Not Authorized" disambiguation (client::post_graphql_value)
+//
+// The server renders a dead session and a resource-authorization denial
+// identically. These experiments drive the REAL GraphQL send + probe + retry
+// pipeline against a scripted backboard and a scripted token endpoint, and
+// assert which story the user is told for each underlying truth.
+// ---------------------------------------------------------------------------
+
+/// A config fixture holding a LIVE session: valid access token, refresh token.
+struct LiveFixture {
+    path: PathBuf,
+    _dir: tempfile::TempDir,
+}
+
+impl LiveFixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut configs = Configs::for_test(path.clone());
+        configs
+            .save_oauth_tokens("live-access", Some("live-refresh"), 3600)
+            .unwrap();
+        Self { path, _dir: dir }
+    }
+
+    fn load(&self) -> Configs {
+        let mut configs = Configs::for_test(self.path.clone());
+        configs.reload().unwrap();
+        configs
+    }
+}
+
+fn user_meta_body() -> serde_json::Value {
+    serde_json::json!({
+        "operationName": "UserMeta",
+        "query": "query UserMeta { me { id } }",
+        "variables": {},
+    })
+}
+
+async fn send_user_meta(
+    configs: &mut Configs,
+    backboard: &crate::testkit::MockBackboard,
+    token_url: &str,
+) -> Result<serde_json::Value, crate::errors::RailwayError> {
+    let client = crate::client::GQLClient::new_authorized(configs).unwrap();
+    crate::client::post_graphql_value(
+        &client,
+        reqwest::Url::parse(&backboard.url()).unwrap(),
+        &user_meta_body(),
+        Some((configs, token_url)),
+    )
+    .await
+}
+
+/// The Erik shape: the session is alive (refresh succeeds) but the server
+/// keeps refusing the resource. The user must hear "insufficient access",
+/// not "log in again" — re-login can never fix a partially-scoped grant.
+#[tokio::test]
+async fn live_session_with_persistent_denial_reports_insufficient_grant() {
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub_graphql_error("UserMeta", "Not Authorized");
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = LiveFixture::new();
+    let mut configs = fixture.load();
+
+    let result = send_user_meta(&mut configs, &backboard, &token_endpoint.base_url).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(crate::errors::RailwayError::OAuthInsufficientGrant)
+        ),
+        "expected OAuthInsufficientGrant, got {result:?}"
+    );
+    // Exactly one probe, exactly one retry.
+    assert_eq!(token_endpoint.hits(), 1, "one liveness probe");
+    assert_eq!(backboard.hits(), 2, "original request + one retry");
+    // The live credentials survive; nothing tells the user to relogin.
+    let after = fixture.load();
+    assert!(after.has_oauth_token());
+    assert!(after.get_refresh_token().is_some());
+}
+
+/// A genuinely dead grant: the probe comes back invalid_grant, so the
+/// re-login prompt stands and the dead credentials are cleared — the
+/// pre-existing behavior, now backed by evidence instead of assumption.
+#[tokio::test]
+async fn dead_session_keeps_the_relogin_prompt_and_clears_credentials() {
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub_graphql_error("UserMeta", "Not Authorized");
+    let token_endpoint = MockEndpoint::spawn(vec![dead_grant()]);
+    let fixture = LiveFixture::new();
+    let mut configs = fixture.load();
+
+    let result = send_user_meta(&mut configs, &backboard, &token_endpoint.base_url).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(crate::errors::RailwayError::Unauthorized
+                | crate::errors::RailwayError::UnauthorizedLogin)
+        ),
+        "a dead session keeps the relogin story, got {result:?}"
+    );
+    // No retry: a dead session cannot be healed by resending.
+    assert_eq!(backboard.hits(), 1);
+    let after = fixture.load();
+    assert!(!after.has_oauth_token(), "dead credentials are cleared");
+    assert_eq!(after.get_refresh_token(), None);
+}
+
+/// The access token died server-side while still looking fresh locally
+/// (e.g. revoked tokens with a surviving grant). The probe mints a fresh
+/// bearer and the retry succeeds: the user sees nothing at all. Previously
+/// every command failed until the local expiry timestamp passed.
+#[tokio::test]
+async fn server_side_expired_access_token_heals_transparently() {
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub_graphql_error("UserMeta", "Not Authorized");
+    backboard.stub("UserMeta", serde_json::json!({ "me": { "id": "user-1" } }));
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = LiveFixture::new();
+    let mut configs = fixture.load();
+
+    let result = send_user_meta(&mut configs, &backboard, &token_endpoint.base_url).await;
+
+    assert!(result.is_ok(), "the retry should succeed, got {result:?}");
+    assert_eq!(token_endpoint.hits(), 1);
+    assert_eq!(backboard.hits(), 2);
+    // The refreshed credentials were persisted for the next invocation.
+    let after = fixture.load();
+    assert_eq!(after.get_refresh_token(), Some("new-refresh"));
+}
+
+/// Nothing to probe with (legacy token, no refresh token): the original
+/// error stands untouched and the token endpoint is never contacted.
+#[tokio::test]
+async fn no_refresh_token_leaves_the_original_error_untouched() {
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub_graphql_error("UserMeta", "Not Authorized");
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut configs = Configs::for_test(dir.path().join("config.json"));
+    configs.root_config.user.token = Some("legacy-token".to_string());
+    configs.write_credentials().unwrap();
+
+    let result = send_user_meta(&mut configs, &backboard, &token_endpoint.base_url).await;
+
+    assert!(
+        matches!(
+            result,
+            Err(crate::errors::RailwayError::Unauthorized
+                | crate::errors::RailwayError::UnauthorizedLogin)
+        ),
+        "got {result:?}"
+    );
+    assert_eq!(token_endpoint.hits(), 0, "nothing to probe with");
+    assert_eq!(backboard.hits(), 1, "no retry without a live probe");
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -125,9 +125,9 @@ pub async fn post_graphql<Q: GraphQLQuery, U: reqwest::IntoUrl>(
     url: U,
     variables: Q::Variables,
 ) -> Result<Q::ResponseData, RailwayError> {
-    let body = Q::build_query(variables);
-    let response = client.post(url).json(&body).send().await?;
-    parse_graphql_response(response).await
+    let body = serde_json::to_value(Q::build_query(variables))
+        .expect("Failed to serialize GraphQL query body");
+    post_graphql_for_current_session(client, url.into_url()?, &body).await
 }
 
 pub async fn post_graphql_raw<T, U: reqwest::IntoUrl>(
@@ -143,8 +143,112 @@ where
         "query": query,
         "variables": variables,
     });
-    let response = client.post(url).json(&body).send().await?;
-    parse_graphql_response(response).await
+    post_graphql_for_current_session(client, url.into_url()?, &body).await
+}
+
+/// Send a GraphQL request with the disambiguation wired to the current
+/// process's stored session and environment. See [`post_graphql_value`].
+async fn post_graphql_for_current_session<T: DeserializeOwned>(
+    client: &reqwest::Client,
+    url: reqwest::Url,
+    body: &serde_json::Value,
+) -> Result<T, RailwayError> {
+    let mut configs = Configs::new().ok();
+    let oauth_base_url = configs
+        .as_ref()
+        .map(|c| oauth::get_oauth_base_url(c.get_host()));
+    post_graphql_value(
+        client,
+        url,
+        body,
+        configs.as_mut().zip(oauth_base_url.as_deref()),
+    )
+    .await
+}
+
+/// What a token-endpoint probe says about the stored session after the API
+/// answered "Not Authorized".
+enum SessionProbe {
+    /// A refresh just succeeded, so the grant is alive: the rejection was
+    /// about the resource, not the session.
+    Alive,
+    /// The grant is dead (`invalid_grant`); the stored credentials have been
+    /// cleared by the refresh policy.
+    Dead,
+    /// Nothing to probe with (token auth, no refresh token) or the probe
+    /// itself failed transiently — nothing can be concluded.
+    Inconclusive,
+}
+
+/// Ask the token endpoint whether the stored session is still alive, under
+/// the config lock (a refresh is a read-modify-write of the credential file).
+async fn probe_session_liveness(configs: &mut Configs, oauth_base_url: &str) -> SessionProbe {
+    if Configs::is_using_token_auth() {
+        // Env-var tokens have no refresh token to probe with.
+        return SessionProbe::Inconclusive;
+    }
+    let _lock = configs.acquire_lock().await;
+    if configs.reload().is_err() {
+        return SessionProbe::Inconclusive;
+    }
+    match refresh_with_policy(configs, oauth_base_url, REFRESH_BACKOFF).await {
+        RefreshOutcome::Refreshed | RefreshOutcome::AlreadyFresh => SessionProbe::Alive,
+        RefreshOutcome::SessionExpired(_) => SessionProbe::Dead,
+        RefreshOutcome::Transient(_) | RefreshOutcome::NoRefreshToken => SessionProbe::Inconclusive,
+    }
+}
+
+/// Send a GraphQL request, disambiguating "Not Authorized".
+///
+/// The server renders two very different failures identically: a dead
+/// session (re-login fixes it) and an authorization denial on the resource —
+/// e.g. an OAuth grant limited to specific workspaces (re-login can NEVER
+/// fix it: consent reuses the same partially-scoped grant). Telling the
+/// second group to "run `railway login` again" wedged them permanently; see
+/// mono's docs/investigations/cli-logout-issue/.
+///
+/// On "Not Authorized" with an OAuth session, probe the token endpoint — a
+/// refresh succeeds only for a live grant — then retry the request once with
+/// the refreshed credentials:
+/// - retry succeeds → the access token had died server-side while looking
+///   fresh locally; the user never sees an error (previously this wedged
+///   every command until local expiry, up to an hour);
+/// - retry still unauthorized → the session is alive and the denial is about
+///   the resource: report [`RailwayError::OAuthInsufficientGrant`] instead
+///   of a re-login prompt;
+/// - probe says the grant is dead → the re-login prompt stands (and the
+///   refresh policy has already cleared the dead credentials).
+pub(crate) async fn post_graphql_value<T: DeserializeOwned>(
+    client: &reqwest::Client,
+    url: reqwest::Url,
+    body: &serde_json::Value,
+    session: Option<(&mut Configs, &str)>,
+) -> Result<T, RailwayError> {
+    let response = client.post(url.clone()).json(body).send().await?;
+    let err = match parse_graphql_response(response).await {
+        Err(e @ (RailwayError::Unauthorized | RailwayError::UnauthorizedLogin)) => e,
+        other => return other,
+    };
+
+    let Some((configs, oauth_base_url)) = session else {
+        return Err(err);
+    };
+    match probe_session_liveness(configs, oauth_base_url).await {
+        SessionProbe::Dead | SessionProbe::Inconclusive => Err(err),
+        SessionProbe::Alive => {
+            // Carry the refreshed bearer; the original client's is baked in.
+            let Ok(fresh_client) = GQLClient::new_authorized(configs) else {
+                return Err(err);
+            };
+            let response = fresh_client.post(url).json(body).send().await?;
+            match parse_graphql_response(response).await {
+                Err(RailwayError::Unauthorized | RailwayError::UnauthorizedLogin) => {
+                    Err(RailwayError::OAuthInsufficientGrant)
+                }
+                other => other,
+            }
+        }
+    }
 }
 
 fn get_security_url() -> String {
@@ -328,8 +432,7 @@ pub async fn post_graphql_skip_none<Q: GraphQLQuery, U: reqwest::IntoUrl>(
         }
     }
 
-    let response = client.post(url).json(&body_json).send().await?;
-    parse_graphql_response(response).await
+    post_graphql_for_current_session(client, url.into_url()?, &body_json).await
 }
 
 async fn parse_graphql_response<T>(response: reqwest::Response) -> Result<T, RailwayError>

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,15 @@ pub enum RailwayError {
     #[error("Unauthorized. Please run `railway login` again.")]
     UnauthorizedLogin,
 
+    /// The session is demonstrably alive (a token refresh just succeeded)
+    /// but the server still refused the resource: an authorization failure,
+    /// not an authentication one. Kept free of the AUTH_FAILURE_MARKERS
+    /// substrings on purpose — re-authenticating cannot fix a grant that
+    /// doesn't cover the resource, so the MCP layer must not burn a re-auth
+    /// retry on it, and the user must not be told to simply log in again.
+    #[error("You do not have access to this resource.")]
+    OAuthInsufficientGrant,
+
     #[error(
         "Invalid {0}. Please check that it is valid and has access to the resource you're trying to use."
     )]
@@ -193,6 +202,7 @@ impl RailwayError {
             RailwayError::OAuthAccessDenied => "OAUTH_ACCESS_DENIED",
             RailwayError::OAuthRefreshFailed(_) => "OAUTH_REFRESH_FAILED",
             RailwayError::OAuthInvalidGrant(_) => "OAUTH_INVALID_GRANT",
+            RailwayError::OAuthInsufficientGrant => "OAUTH_INSUFFICIENT_GRANT",
             RailwayError::OAuthError(_) => "OAUTH_ERROR",
             RailwayError::NotAuthenticated => "NOT_AUTHENTICATED",
         }
@@ -206,6 +216,9 @@ impl RailwayError {
             RailwayError::NotAuthenticated | RailwayError::OAuthInvalidGrant(_) => {
                 Some("Run `railway login` to authenticate, then re-run.")
             }
+            RailwayError::OAuthInsufficientGrant => Some(
+                "If you believe you have access, run `railway login` again and ensure the integration has access to this project.",
+            ),
             RailwayError::NoLinkedProject | RailwayError::ProjectNotFound => {
                 Some("Run `railway link` to connect to a project.")
             }


### PR DESCRIPTION
## Summary of changes

- The API renders two different failures as the same "Not Authorized": a **dead session** (re-login fixes it) and an **authorization denial** on the resource — e.g. an OAuth login granted access to specific workspaces only, where re-login can never help because consent reuses the same partially-scoped grant. The CLI told both groups "Unauthorized. Please run `railway login` again.", permanently wedging the second group while `whoami` kept working (root cause of the 2026-08-10 re-escalation of the CLI logout cluster; see mono `docs/investigations/cli-logout-issue/`).
- On an unauthorized GraphQL response under an OAuth session, all three GraphQL senders now **probe the token endpoint** (a refresh succeeds only for a live grant), then **retry the request once** with the refreshed bearer:
  - retry succeeds → the access token had died server-side while looking fresh locally; the command just works (previously wedged until local expiry, up to an hour);
  - retry still unauthorized → the session is demonstrably alive: report the new `OAuthInsufficientGrant` error — "You do not have access to this resource." with a hint (`→` line in human mode, `hint` field + `OAUTH_INSUFFICIENT_GRANT` code in `--json`) to re-run `railway login` and grant the integration access;
  - probe returns `invalid_grant` → the re-login prompt stands and the dead credentials are cleared, exactly as before.
- `OAuthInsufficientGrant` deliberately contains none of the `AUTH_FAILURE_MARKERS` substrings, so the MCP layer doesn't burn its re-auth retry on a scope denial.
- Token-auth (`RAILWAY_TOKEN`/`RAILWAY_API_TOKEN`) and legacy-token sessions are untouched: nothing to probe with, original behavior preserved.

Server-side counterpart: railwayapp/mono#35151 stops enumeration queries (`railway link`'s listing) from throwing on ungranted-workspace projects; this PR covers direct access to a resource the grant doesn't include (e.g. commands against a linked project after the grant was narrowed).

## How to test these

- Four new `auth_sim` experiments drive the real send → probe → retry pipeline against a scripted backboard + token endpoint: persistent denial on a live session reports `OAuthInsufficientGrant` with exactly one probe and one retry and credentials intact; a dead grant keeps the re-login story, clears credentials, and never retries; a server-side-expired access token heals transparently; a session with no refresh token leaves the original error untouched with zero probe traffic.
- Full suite passes (1033), `cargo fmt` applied; clippy findings on the branch are pre-existing in unrelated files.
- Validated manually against production: a partial-workspace grant with a linked project in an ungranted workspace — `railway status` now shows the new message + hint instead of the false re-login prompt, and `whoami` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)