### PR TITLE
ca TUI: settle the SSH key before the TUI takes the screen

### DIFF
--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -176,13 +176,18 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
 
-    // Both under one spinner: the flag check is a small query against the same
-    // client, and running it beside the tree load rather than before it keeps
-    // the preflight off the clock for everyone who does have the flag.
+    // All under one spinner: the flag check and the key check are small
+    // queries against the same client, and running them beside the tree load
+    // rather than before it keeps them off the clock.
     let spinner = create_spinner("Loading your projects".to_string());
-    let loaded = tokio::try_join!(
-        access::ensure_enabled(&client, &configs),
-        tui::load_tree(&client, &configs),
+    let (loaded, ssh_key) = tokio::join!(
+        async {
+            tokio::try_join!(
+                access::ensure_enabled(&client, &configs),
+                tui::load_tree(&client, &configs),
+            )
+        },
+        check_ssh_key(&client, &configs),
     );
     spinner.finish_and_clear();
     let (_, tree) = loaded?;
@@ -193,19 +198,6 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
         );
         return Ok(());
     }
-
-    // Settle the SSH key while the real terminal can still host a prompt: the
-    // first-run registration flow asks a question on stdin, and once the TUI
-    // owns the screen no prompt can work (every launch used to hang there).
-    // After this, the launch pipeline's own ensure_ssh_key lookup finds the
-    // registered key and stays silent. Best-effort: the TUI also sleeps and
-    // deletes agents, so a missing key degrades connecting, not managing.
-    let ssh_preflight = crate::commands::ssh::tel::track_for(
-        "cloud_agent_launch",
-        "ssh_key_preflight",
-        crate::commands::ssh::ensure_ssh_key_quiet(&client, &configs).await,
-    )
-    .await;
 
     let home = dirs::home_dir().context("Unable to get home directory")?;
     let stored = AgentPrefs::load_in(&home);
@@ -253,14 +245,9 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
         .map(|(source, _)| source.slug.to_string());
     // Mirrored so the ⌥s settings card opens showing the saved answer.
     app.skills_enabled = saved.skills.enabled;
-    // The preflight's terminal output is gone once the alternate screen opens,
-    // so carry the failure in as a toast. Launch attempts repeat the full
-    // instructions in their own error.
-    if let Err(err) = &ssh_preflight {
-        let reason = err.to_string();
-        let reason = reason.lines().next().unwrap_or("SSH key setup failed");
-        app.toast_error(format!("SSH setup needed before connecting: {reason}"));
-    }
+    // What the key check learned. Connects gate on this in-frame: an
+    // unregistered key raises a register question instead of a hung prompt.
+    app.ssh_key = ssh_key;
     // No preferences yet: ask whether to set them up, rather than dropping
     // someone in front of a prompt whose target, agent and skills are all
     // unanswered. Choosing Setup from the menu skips that question — they have
@@ -323,6 +310,42 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
             }
         }
     }
+}
+
+/// What the TUI needs to know about the user's SSH key, without prompting.
+///
+/// The interactive half of `ensure_ssh_key` — pick a key, confirm, register —
+/// belongs to the TUI now (its gate card), so this only looks. Check failures
+/// come back as `Unknown` rather than an error: the launch pipeline re-checks
+/// and is the better place to fail, with a message instead of a blocked
+/// startup. With several local keys the offer is the first, the same
+/// preferred-key order the non-interactive `ssh keys add` uses.
+async fn check_ssh_key(client: &reqwest::Client, configs: &Configs) -> tui::app::SshKeyState {
+    use crate::controllers::ssh::keys::{find_local_ssh_keys, get_registered_ssh_keys};
+    use tui::app::{SshKeyOffer, SshKeyState};
+
+    let (local, registered) = tokio::join!(
+        find_local_ssh_keys(),
+        get_registered_ssh_keys(client, configs, None),
+    );
+    let (Ok(local), Ok(registered)) = (local, registered) else {
+        return SshKeyState::Unknown;
+    };
+    if local.is_empty() {
+        return SshKeyState::NoLocalKeys;
+    }
+    if local
+        .iter()
+        .any(|l| registered.iter().any(|r| r.fingerprint == l.fingerprint))
+    {
+        return SshKeyState::Ready;
+    }
+    let key = &local[0];
+    SshKeyState::NeedsRegistration(SshKeyOffer {
+        name: key.key_name().to_string(),
+        fingerprint: key.fingerprint.clone(),
+        public_key: key.public_key.to_string(),
+    })
 }
 
 fn persist_theme(home: &std::path::Path, slug: &str) {

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -194,6 +194,19 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
         return Ok(());
     }
 
+    // Settle the SSH key while the real terminal can still host a prompt: the
+    // first-run registration flow asks a question on stdin, and once the TUI
+    // owns the screen no prompt can work (every launch used to hang there).
+    // After this, the launch pipeline's own ensure_ssh_key lookup finds the
+    // registered key and stays silent. Best-effort: the TUI also sleeps and
+    // deletes agents, so a missing key degrades connecting, not managing.
+    let ssh_preflight = crate::commands::ssh::tel::track_for(
+        "cloud_agent_launch",
+        "ssh_key_preflight",
+        crate::commands::ssh::ensure_ssh_key_quiet(&client, &configs).await,
+    )
+    .await;
+
     let home = dirs::home_dir().context("Unable to get home directory")?;
     let stored = AgentPrefs::load_in(&home);
     let first_run = stored.is_none();
@@ -240,6 +253,14 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
         .map(|(source, _)| source.slug.to_string());
     // Mirrored so the ⌥s settings card opens showing the saved answer.
     app.skills_enabled = saved.skills.enabled;
+    // The preflight's terminal output is gone once the alternate screen opens,
+    // so carry the failure in as a toast. Launch attempts repeat the full
+    // instructions in their own error.
+    if let Err(err) = &ssh_preflight {
+        let reason = err.to_string();
+        let reason = reason.lines().next().unwrap_or("SSH key setup failed");
+        app.toast_error(format!("SSH setup needed before connecting: {reason}"));
+    }
     // No preferences yet: ask whether to set them up, rather than dropping
     // someone in front of a prompt whose target, agent and skills are all
     // unanswered. Choosing Setup from the menu skips that question — they have

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -611,6 +611,73 @@ impl PendingConfirm {
     }
 }
 
+/// What the startup check learned about the user's SSH key. Connecting to an
+/// agent rides SSH and the relay only answers registered keys, so a connect
+/// while unregistered is held behind [`SshGate`] rather than sent to fail —
+/// or worse, to the relay's interactive signup screen.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum SshKeyState {
+    /// The check hasn't answered, or couldn't. Connects proceed; the launch
+    /// pipeline re-checks and produces the error if there is one.
+    #[default]
+    Unknown,
+    /// A local key is registered with Railway.
+    Ready,
+    /// A local key exists but Railway doesn't know it yet.
+    NeedsRegistration(SshKeyOffer),
+    /// Nothing in the SSH agent or ~/.ssh to register.
+    NoLocalKeys,
+}
+
+/// The local key the gate offers to register.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SshKeyOffer {
+    pub name: String,
+    pub fingerprint: String,
+    pub public_key: String,
+}
+
+/// A connect held back until the SSH key question is answered.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HeldConnect {
+    Launch(LaunchRequest),
+    Reattach {
+        agent_id: String,
+        agent_name: String,
+        environment_id: String,
+        session_name: String,
+    },
+}
+
+impl HeldConnect {
+    /// Back into the effect it was before the gate held it.
+    pub fn into_effect(self) -> Effect {
+        match self {
+            HeldConnect::Launch(req) => Effect::Launch(req),
+            HeldConnect::Reattach {
+                agent_id,
+                agent_name,
+                environment_id,
+                session_name,
+            } => Effect::Reattach {
+                agent_id,
+                agent_name,
+                environment_id,
+                session_name,
+            },
+        }
+    }
+}
+
+/// The register-your-key question, floated over whatever raised it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SshGate {
+    pub offer: SshKeyOffer,
+    /// Resumed after a successful registration. `None` when the gate came
+    /// from setup rather than a connect: declining just ends the question.
+    pub then: Option<HeldConnect>,
+}
+
 /// What the loading screen is showing.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Loading {
@@ -705,6 +772,11 @@ pub enum Effect {
         agent_id: String,
         environment_id: String,
     },
+    /// Register the gate's key with Railway, then resume the held connect.
+    RegisterSshKey {
+        offer: SshKeyOffer,
+        then: Option<HeldConnect>,
+    },
     Quit,
 }
 
@@ -797,6 +869,10 @@ pub struct App {
     pub pending_copy: Option<Selection>,
     /// An action waiting on a `y`/`n`.
     pub confirm: Option<PendingConfirm>,
+    /// What the startup check learned about the user's SSH key.
+    pub ssh_key: SshKeyState,
+    /// A register-your-key question holding a connect, when one is up.
+    pub ssh_gate: Option<SshGate>,
     /// Agent id → what is happening to it right now. Shown immediately so a
     /// slow mutation looks like an action rather than a frozen key.
     pub ops: std::collections::HashMap<String, &'static str>,
@@ -860,6 +936,8 @@ impl App {
             last_click: None,
             pending_copy: None,
             confirm: None,
+            ssh_key: SshKeyState::default(),
+            ssh_gate: None,
             ops: std::collections::HashMap::new(),
             watching: std::collections::HashMap::new(),
             menu_focus: MenuFocus::Prompt,
@@ -1858,6 +1936,24 @@ impl App {
     }
 
     pub fn on_key(&mut self, key: KeyEvent) -> Option<Effect> {
+        // The SSH gate owns the keyboard until its question is answered.
+        // Anything other than yes cancels: a mistyped key must never register
+        // a credential on the account.
+        if let Some(gate) = self.ssh_gate.take() {
+            return match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => Some(Effect::RegisterSshKey {
+                    offer: gate.offer,
+                    then: gate.then,
+                }),
+                _ => {
+                    if gate.then.is_some() {
+                        self.toast_error("Cancelled — connecting needs a registered SSH key");
+                    }
+                    None
+                }
+            };
+        }
+
         // A focused session owns the keyboard: Ctrl-C must interrupt the agent,
         // Esc must reach its editor, and ⌥/^ chords belong to whatever is
         // running in there. Only one chord is reserved, and it is one no agent
@@ -2893,6 +2989,39 @@ impl App {
                 self.cursor = i;
                 return;
             }
+        }
+    }
+
+    /// Gate a connect on the SSH key. `true` means the effect was consumed
+    /// here — held behind the register question, or refused with the recipe —
+    /// and the caller must not proceed with it.
+    pub fn hold_for_ssh_key(&mut self, held: HeldConnect) -> bool {
+        match &self.ssh_key {
+            SshKeyState::NeedsRegistration(offer) => {
+                self.ssh_gate = Some(SshGate {
+                    offer: offer.clone(),
+                    then: Some(held),
+                });
+                true
+            }
+            SshKeyState::NoLocalKeys => {
+                self.toast_error("No SSH key found — run: ssh-keygen -t ed25519");
+                true
+            }
+            SshKeyState::Ready | SshKeyState::Unknown => false,
+        }
+    }
+
+    /// Offer key registration as part of setup, when the check said one is
+    /// needed. No held connect: declining just ends the question.
+    pub fn offer_ssh_key_setup(&mut self) {
+        if self.ssh_gate.is_none()
+            && let SshKeyState::NeedsRegistration(offer) = &self.ssh_key
+        {
+            self.ssh_gate = Some(SshGate {
+                offer: offer.clone(),
+                then: None,
+            });
         }
     }
 
@@ -7291,5 +7420,115 @@ mod tests {
 
         a.agents_loaded((0, 0, 1), Ok(Vec::new()));
         assert_eq!(hint(&a), "no cloud agents yet — n creates one");
+    }
+
+    fn offer() -> SshKeyOffer {
+        SshKeyOffer {
+            name: "id_ed25519".into(),
+            fingerprint: "SHA256:abc".into(),
+            public_key: "ssh-ed25519 AAAA test".into(),
+        }
+    }
+
+    fn launch_req() -> LaunchRequest {
+        LaunchRequest {
+            project_id: "proj_1".into(),
+            environment_id: "env_prod".into(),
+            agent_id: None,
+            session_name: None,
+            force_new: false,
+            new_session: false,
+            harness: "claude".into(),
+            prompt: None,
+            label: "devtools/production".into(),
+        }
+    }
+
+    /// An unregistered key holds the connect behind the gate; nothing is
+    /// launched until the question is answered.
+    #[test]
+    fn an_unregistered_key_holds_the_connect() {
+        let mut a = app();
+        a.ssh_key = SshKeyState::NeedsRegistration(offer());
+        let held = HeldConnect::Launch(launch_req());
+        assert!(a.hold_for_ssh_key(held.clone()));
+        assert_eq!(
+            a.ssh_gate,
+            Some(SshGate {
+                offer: offer(),
+                then: Some(held),
+            })
+        );
+    }
+
+    /// A registered key, and a check that never answered, both let the
+    /// connect through — the launch pipeline is the better place to fail.
+    #[test]
+    fn ready_and_unknown_keys_proceed() {
+        let mut a = app();
+        a.ssh_key = SshKeyState::Ready;
+        assert!(!a.hold_for_ssh_key(HeldConnect::Launch(launch_req())));
+        a.ssh_key = SshKeyState::Unknown;
+        assert!(!a.hold_for_ssh_key(HeldConnect::Launch(launch_req())));
+        assert!(a.ssh_gate.is_none());
+    }
+
+    /// With nothing local to offer, the connect is refused with the recipe
+    /// rather than held behind a question that has no good answer.
+    #[test]
+    fn no_local_keys_refuses_with_the_recipe() {
+        let mut a = app();
+        a.ssh_key = SshKeyState::NoLocalKeys;
+        assert!(a.hold_for_ssh_key(HeldConnect::Launch(launch_req())));
+        assert!(a.ssh_gate.is_none());
+        assert!(a.toast.as_ref().is_some_and(|t| !t.ok), "{:?}", a.toast);
+    }
+
+    /// `y` answers the gate with the register effect, carrying the held
+    /// connect along to resume after the mutation.
+    #[test]
+    fn yes_registers_and_carries_the_held_connect() {
+        let mut a = app();
+        a.ssh_key = SshKeyState::NeedsRegistration(offer());
+        assert!(a.hold_for_ssh_key(HeldConnect::Launch(launch_req())));
+        let effect = a.on_key(key(KeyCode::Char('y')));
+        assert_eq!(
+            effect,
+            Some(Effect::RegisterSshKey {
+                offer: offer(),
+                then: Some(HeldConnect::Launch(launch_req())),
+            })
+        );
+        assert!(a.ssh_gate.is_none());
+    }
+
+    /// Anything that isn't a yes cancels: a mistyped key must never register
+    /// a credential on the account.
+    #[test]
+    fn anything_else_cancels_the_gate() {
+        let mut a = app();
+        a.ssh_key = SshKeyState::NeedsRegistration(offer());
+        assert!(a.hold_for_ssh_key(HeldConnect::Launch(launch_req())));
+        assert_eq!(a.on_key(key(KeyCode::Enter)), None);
+        assert!(a.ssh_gate.is_none());
+        // The state is untouched, so the next connect asks again.
+        assert_eq!(a.ssh_key, SshKeyState::NeedsRegistration(offer()));
+    }
+
+    /// Setup's offer has no held connect: declining it is not an error and
+    /// says nothing about a cancelled launch.
+    #[test]
+    fn the_setup_offer_declines_quietly() {
+        let mut a = app();
+        a.ssh_key = SshKeyState::NeedsRegistration(offer());
+        a.offer_ssh_key_setup();
+        assert!(a.ssh_gate.is_some());
+        assert_eq!(a.on_key(key(KeyCode::Esc)), None);
+        assert!(a.toast.is_none(), "{:?}", a.toast);
+
+        // With the key already registered, setup offers nothing.
+        a.ssh_key = SshKeyState::Ready;
+        a.offer_ssh_key_setup();
+        assert!(a.ssh_gate.is_none());
     }
 }

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -777,6 +777,10 @@ pub enum Effect {
         offer: SshKeyOffer,
         then: Option<HeldConnect>,
     },
+    /// Leave the TUI for the Claude mint's manual-paste fallback; the caller
+    /// re-enters with the same request. Raised only after the hidden mint
+    /// already ran and failed under the frame.
+    StepOutForMint(LaunchRequest),
     Quit,
 }
 

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -832,6 +832,18 @@ pub async fn run(
                 });
             }
             Some(Effect::Launch(req)) => {
+                // The launch lives on the manage screen — the tree the agent
+                // will land in — so go there first and reveal its environment.
+                // The ssh gate's question then hangs over the place the answer
+                // matters, not over the menu it happened to be asked from.
+                app.screen = Screen::Manage;
+                if let Some(Effect::LoadAgents {
+                    environment_id,
+                    path,
+                }) = app.reveal_environment(&req.environment_id)
+                {
+                    spawn_env_agents_fetch(environment_id, path, &tx, &client, &backboard);
+                }
                 // Connecting rides SSH, so an unregistered key is settled with
                 // an in-frame question before anything is spent on the launch.
                 if app.hold_for_ssh_key(HeldConnect::Launch(req.clone())) {
@@ -867,39 +879,51 @@ pub async fn run(
                 environment_id,
                 path,
             }) => {
-                let tx = tx.clone();
-                let client = client.clone();
-                let backboard = backboard.clone();
-                tokio::spawn(async move {
-                    // A closed receiver just means the TUI already handed back;
-                    // the next entry re-requests, so the drop is harmless.
-                    match fetch_agents(&client, &backboard, &environment_id).await {
-                        Ok(agents) => {
-                            let _ = tx.send(Message::AgentsLoaded {
-                                path,
-                                result: Ok(agents),
-                            });
-                        }
-                        // The same classification the background fetches do:
-                        // a 429 puts the row back to "not loaded" with the
-                        // Retry-After toast, instead of pinning "rate limited"
-                        // to this one environment as if it were its failure.
-                        Err(err) => match rate_limit_from(&err) {
-                            Some(retry_after_secs) => {
-                                let _ = tx.send(Message::RateLimited { retry_after_secs });
-                            }
-                            None => {
-                                let _ = tx.send(Message::AgentsLoaded {
-                                    path,
-                                    result: Err(err.to_string()),
-                                });
-                            }
-                        },
-                    }
-                });
+                spawn_env_agents_fetch(environment_id, path, &tx, &client, &backboard);
             }
         }
     }
+}
+
+/// Fetch one environment's agents in the background, delivering the answer —
+/// or its rate-limit classification — as a message.
+fn spawn_env_agents_fetch(
+    environment_id: String,
+    path: (usize, usize, usize),
+    tx: &mpsc::UnboundedSender<Message>,
+    client: &reqwest::Client,
+    backboard: &str,
+) {
+    let tx = tx.clone();
+    let client = client.clone();
+    let backboard = backboard.to_string();
+    tokio::spawn(async move {
+        // A closed receiver just means the TUI already handed back;
+        // the next entry re-requests, so the drop is harmless.
+        match fetch_agents(&client, &backboard, &environment_id).await {
+            Ok(agents) => {
+                let _ = tx.send(Message::AgentsLoaded {
+                    path,
+                    result: Ok(agents),
+                });
+            }
+            // The same classification the background fetches do:
+            // a 429 puts the row back to "not loaded" with the
+            // Retry-After toast, instead of pinning "rate limited"
+            // to this one environment as if it were its failure.
+            Err(err) => match rate_limit_from(&err) {
+                Some(retry_after_secs) => {
+                    let _ = tx.send(Message::RateLimited { retry_after_secs });
+                }
+                None => {
+                    let _ = tx.send(Message::AgentsLoaded {
+                        path,
+                        result: Err(err.to_string()),
+                    });
+                }
+            },
+        }
+    });
 }
 
 fn handle_message(

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -42,7 +42,8 @@ use ratatui::backend::CrosstermBackend;
 use tokio::sync::mpsc;
 
 use app::{
-    Agent, AgentOp, ConsoleSession, EnvNode, Load, LoadSessions, ProjectNode, WorkspaceNode,
+    Agent, AgentOp, ConsoleSession, EnvNode, HeldConnect, Load, LoadSessions, ProjectNode,
+    SshKeyOffer, SshKeyState, WorkspaceNode,
 };
 pub use app::{App, Effect, LaunchRequest, Screen, Target};
 
@@ -284,6 +285,12 @@ enum Message {
         error: Option<String>,
     },
     ProjectCreated(Result<wizard::ProjectOption, String>),
+    /// The gate's key registration finished. On success the held connect
+    /// resumes as the effect it was before the gate held it.
+    SshKeyRegistered {
+        result: Result<(), String>,
+        then: Option<HeldConnect>,
+    },
     /// Ask again for one agent's sessions.
     RefreshAgentSessions(String),
     /// The session produced output, so the screen needs redrawing.
@@ -617,6 +624,17 @@ pub async fn run(
                 environment_id,
                 session_name,
             }) => {
+                // Same SSH gate as a launch: reattaching is a fresh ssh, and
+                // a key deregistered since the session opened would otherwise
+                // land on the relay's interactive signup screen.
+                if app.hold_for_ssh_key(HeldConnect::Reattach {
+                    agent_id: agent_id.clone(),
+                    agent_name: agent_name.clone(),
+                    environment_id: environment_id.clone(),
+                    session_name: session_name.clone(),
+                }) {
+                    continue;
+                }
                 let tx = tx.clone();
                 tokio::spawn(async move {
                     let message = match code::connect_info(&environment_id, &agent_id).await {
@@ -639,6 +657,22 @@ pub async fn run(
                     let _ = tx.send(message);
                 });
             }
+            Some(Effect::RegisterSshKey { offer, then }) => {
+                let tx = tx.clone();
+                let client = client.clone();
+                tokio::spawn(async move {
+                    let result = register_gate_key(&client, &offer).await;
+                    if let Err(message) = &result {
+                        crate::commands::ssh::tel::report_failure_for(
+                            "cloud_agent_launch",
+                            "ssh_key_register",
+                            message,
+                        )
+                        .await;
+                    }
+                    let _ = tx.send(Message::SshKeyRegistered { result, then });
+                });
+            }
             Some(Effect::CreateDefaultProject(workspace_id)) => {
                 let tx = tx.clone();
                 let client = client.clone();
@@ -656,6 +690,10 @@ pub async fn run(
                         tokio::spawn(async move {
                             super::telemetry::track_setup_saved("wizard", &prefs).await;
                         });
+                        // Setup is where the account gets ready to connect, so
+                        // an unregistered key is offered here too — not just
+                        // at the first launch that would trip over it.
+                        app.offer_ssh_key_setup();
                         "Saved — Setup again to change it".into()
                     }
                     Err(err) => {
@@ -785,6 +823,11 @@ pub async fn run(
                 });
             }
             Some(Effect::Launch(req)) => {
+                // Connecting rides SSH, so an unregistered key is settled with
+                // an in-frame question before anything is spent on the launch.
+                if app.hold_for_ssh_key(HeldConnect::Launch(req.clone())) {
+                    continue;
+                }
                 // Minting needs a browser and a paste, neither of which works
                 // underneath a frame. Only a mint that can actually run needs
                 // the step-out: with nothing to mint from, the launch goes
@@ -981,6 +1024,23 @@ fn handle_message(
             }
             None
         }
+        Message::SshKeyRegistered { result, then } => match result {
+            Ok(()) => {
+                app.ssh_key = SshKeyState::Ready;
+                app.toast("SSH key registered");
+                // The held connect resumes as the effect it was; it passes the
+                // now-Ready gate and takes the normal path from there.
+                then.map(HeldConnect::into_effect)
+            }
+            Err(message) => {
+                // Still unregistered: the next connect raises the gate again.
+                // The toast gets the first line; register_ssh_key already maps
+                // the duplicate-fingerprint rejection to something actionable.
+                let first = message.lines().next().unwrap_or("registration failed");
+                app.toast_error(format!("Couldn't register the key: {first}"));
+                None
+            }
+        },
         Message::SessionKilled {
             agent_id,
             session_name,
@@ -1263,6 +1323,23 @@ fn spawn_session_prefetch(
             });
         }
     });
+}
+
+/// Register the gate's key with Railway. String errors because the result
+/// crosses the message channel; `register_ssh_key` has already mapped the
+/// duplicate-fingerprint rejection to a user-facing message.
+async fn register_gate_key(client: &reqwest::Client, offer: &SshKeyOffer) -> Result<(), String> {
+    let configs = Configs::new().map_err(|e| format!("{e:#}"))?;
+    crate::controllers::ssh::keys::register_ssh_key(
+        client,
+        &configs,
+        &offer.name,
+        &offer.public_key,
+        None,
+    )
+    .await
+    .map(|_| ())
+    .map_err(|e| format!("{e:#}"))
 }
 
 /// Re-ask for an agent's sessions shortly after one is opened.

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -1401,6 +1401,11 @@ fn finish_copy(app: &mut App, text: Option<String>) {
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     enable_raw_mode()?;
+    // While the TUI holds the terminal, no inquire prompt can work — the event
+    // loop would eat its keystrokes and the next frame would paint over it.
+    // This flag makes every prompt helper (and ensure_ssh_key's registration
+    // fallback) fail fast instead of deadlocking the caller.
+    crate::util::prompt::set_terminal_owned(true);
     // Mouse capture takes the terminal's own selection away, which is why the
     // TUI implements drag-to-copy itself.
     execute!(stdout(), EnterAlternateScreen, EnableMouseCapture, Hide)?;
@@ -1448,6 +1453,7 @@ fn restore_terminal() {
     // them off on both.
     let _ = execute!(stdout(), DisableMouseCapture);
     let _ = disable_raw_mode();
+    crate::util::prompt::set_terminal_owned(false);
     let _ = stdout().flush();
 }
 

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -291,6 +291,12 @@ enum Message {
         result: Result<(), String>,
         then: Option<HeldConnect>,
     },
+    /// The under-frame Claude mint finished: the launch resumes on success,
+    /// and steps out for the manual-paste fallback on failure.
+    ClaudeMintDone {
+        ok: bool,
+        req: Box<LaunchRequest>,
+    },
     /// Ask again for one agent's sessions.
     RefreshAgentSessions(String),
     /// The session produced output, so the screen needs redrawing.
@@ -657,6 +663,9 @@ pub async fn run(
                     let _ = tx.send(message);
                 });
             }
+            Some(Effect::StepOutForMint(req)) => {
+                return Ok(Outcome::NeedsCredential(req));
+            }
             Some(Effect::RegisterSshKey { offer, then }) => {
                 let tx = tx.clone();
                 let client = client.clone();
@@ -828,12 +837,26 @@ pub async fn run(
                 if app.hold_for_ssh_key(HeldConnect::Launch(req.clone())) {
                     continue;
                 }
-                // Minting needs a browser and a paste, neither of which works
-                // underneath a frame. Only a mint that can actually run needs
-                // the step-out: with nothing to mint from, the launch goes
-                // ahead and claude signs in on the agent.
+                // The mint's browser round-trip needs no terminal — the
+                // browser does the interacting and the flow runs hidden — so
+                // it runs under the frame with the loading screen narrating.
+                // Only its manual-paste fallback needs the real terminal, and
+                // only that failure steps out (see ClaudeMintDone).
                 if req.harness == "claude" && code::claude_needs_local_mint() {
-                    return Ok(Outcome::NeedsCredential(req));
+                    app.start_loading(&req);
+                    let _ = tx.send(Message::LaunchStep(
+                        "Minting a Claude token — approve the browser prompt if one appears"
+                            .to_string(),
+                    ));
+                    let tx = tx.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let ok = code::mint_claude_credential_headless().is_ok();
+                        let _ = tx.send(Message::ClaudeMintDone {
+                            ok,
+                            req: Box::new(req),
+                        });
+                    });
+                    continue;
                 }
                 start_launch(app, req, &tx);
             }
@@ -1021,6 +1044,20 @@ fn handle_message(
             {
                 // A create that stuck is a change; it saves like any other.
                 apply_settings(app, &outcome);
+            }
+            None
+        }
+        Message::ClaudeMintDone { ok, req } => {
+            if ok {
+                // The cache holds the token now; the pipeline reads it there.
+                start_launch(app, *req, tx);
+            } else {
+                // The manual paste needs the real terminal. Stop the loading
+                // screen and hand the request back through the step-out; the
+                // fallback skips straight to the paste prompt rather than
+                // re-running the automation that just lost.
+                app.loading.active = false;
+                return Some(Effect::StepOutForMint(*req));
             }
             None
         }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -136,36 +136,36 @@ fn render_ssh_gate(app: &App, f: &mut Frame) {
     let area = f.area();
     // Name and fingerprint on their own lines: together they outrun the card
     // and wrap mid-fingerprint, which reads as garbage. Apart, both fit.
+    // Everything reads in the foreground — this card is the only thing asking
+    // for attention while it is up, so nothing on it is background noise.
+    let body = Style::default().fg(theme.fg);
     let lines = vec![
         Line::from(""),
         Line::from(Span::styled(
             format!("  {}", gate.offer.name),
-            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+            body.add_modifier(Modifier::BOLD),
         )),
-        Line::from(Span::styled(
-            format!("  {}", gate.offer.fingerprint),
-            Style::default().fg(theme.dim),
-        )),
+        Line::from(Span::styled(format!("  {}", gate.offer.fingerprint), body)),
         Line::from(""),
         Line::from(Span::styled(
             "  Agents are reached over SSH, and Railway only answers",
-            Style::default().fg(theme.dim),
+            body,
         )),
         Line::from(Span::styled(
             "  keys it knows. Registered once, it covers every agent.",
-            Style::default().fg(theme.dim),
+            body,
         )),
         Line::from(""),
-        // The same badge-and-label chords as the footers, so the card reads
-        // as part of the product rather than its own little dialect.
-        {
-            let mut answers = vec![Span::raw("  ")];
-            answers.extend(chord_spans(
-                theme,
-                &[("y", "Yes — register this key"), ("n", "No, not now")],
-            ));
-            Line::from(answers)
-        },
+        // The footers' badge chords, centered: the question's answers are the
+        // card's focal point, not another row of copy.
+        Line::from(vec![
+            chord_badge(theme, "y"),
+            Span::styled(" Yes — register this key", body),
+            Span::raw("    "),
+            chord_badge(theme, "n"),
+            Span::styled(" No, not now", body),
+        ])
+        .alignment(Alignment::Center),
     ];
     let width = 62.min(area.width.saturating_sub(4));
     let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
@@ -3258,5 +3258,16 @@ mod tests {
             .position(|l| l.contains("SHA256:hlDEs7CV5clc1lMfsMxr/CPeuKuJNn9hJxjsy1e9zLc"))
             .expect("full fingerprint shown, unwrapped");
         assert_eq!(fp_line, name_line + 1, "fingerprint sits under the name");
+
+        // The answers are centered under the copy, not left-aligned with it.
+        let col = |needle: &str| {
+            out.lines()
+                .find_map(|l| l.find(needle))
+                .unwrap_or_else(|| panic!("{needle} not shown"))
+        };
+        assert!(
+            col("Yes — register this key") > col("raildesk-deploy"),
+            "the answers should sit centered, right of the left-aligned copy"
+        );
     }
 }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -121,7 +121,71 @@ pub fn render_with_layout(app: &App, f: &mut Frame) -> (PaneRects, Option<String
 fn render_inner(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     f.render_widget(Clear, f.area());
     render_screen(app, f, rects);
+    render_ssh_gate(app, f);
     render_toast(app, f);
+}
+
+/// The register-your-SSH-key question, centered over whatever raised it. Up
+/// only while [`App::ssh_gate`] holds a connect (or setup's offer); the next
+/// key answers it — see the gate block at the top of [`App::on_key`].
+fn render_ssh_gate(app: &App, f: &mut Frame) {
+    let Some(gate) = app.ssh_gate.as_ref() else {
+        return;
+    };
+    let theme = app.theme;
+    let area = f.area();
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  {} ({})", gate.offer.name, gate.offer.fingerprint),
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Agents are reached over SSH, and Railway only answers",
+            Style::default().fg(theme.dim),
+        )),
+        Line::from(Span::styled(
+            "  keys it knows. Registered once, it covers every agent.",
+            Style::default().fg(theme.dim),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  y ",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("register", Style::default().fg(theme.fg)),
+            Span::styled(
+                "    n ",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("not now", Style::default().fg(theme.dim)),
+        ]),
+    ];
+    let width = 62.min(area.width.saturating_sub(4));
+    let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
+    let panel = centered(width, height, area);
+    f.render_widget(Clear, panel);
+    f.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(theme.accent))
+                .title(Span::styled(
+                    " Register your SSH key with Railway? ",
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD),
+                )),
+        ),
+        panel,
+    );
 }
 
 /// The corner confirmation, over whatever is underneath it.

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -134,11 +134,17 @@ fn render_ssh_gate(app: &App, f: &mut Frame) {
     };
     let theme = app.theme;
     let area = f.area();
+    // Name and fingerprint on their own lines: together they outrun the card
+    // and wrap mid-fingerprint, which reads as garbage. Apart, both fit.
     let lines = vec![
         Line::from(""),
         Line::from(Span::styled(
-            format!("  {} ({})", gate.offer.name, gate.offer.fingerprint),
+            format!("  {}", gate.offer.name),
             Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            format!("  {}", gate.offer.fingerprint),
+            Style::default().fg(theme.dim),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -150,29 +156,23 @@ fn render_ssh_gate(app: &App, f: &mut Frame) {
             Style::default().fg(theme.dim),
         )),
         Line::from(""),
-        Line::from(vec![
-            Span::styled(
-                "  y ",
-                Style::default()
-                    .fg(theme.accent)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("register", Style::default().fg(theme.fg)),
-            Span::styled(
-                "    n ",
-                Style::default()
-                    .fg(theme.accent)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled("not now", Style::default().fg(theme.dim)),
-        ]),
+        // The same badge-and-label chords as the footers, so the card reads
+        // as part of the product rather than its own little dialect.
+        {
+            let mut answers = vec![Span::raw("  ")];
+            answers.extend(chord_spans(
+                theme,
+                &[("y", "Yes — register this key"), ("n", "No, not now")],
+            ));
+            Line::from(answers)
+        },
     ];
     let width = 62.min(area.width.saturating_sub(4));
     let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
     let panel = centered(width, height, area);
     f.render_widget(Clear, panel);
     f.render_widget(
-        Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+        Paragraph::new(lines).block(
             Block::default()
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
@@ -3226,5 +3226,37 @@ mod tests {
         app.screen = Screen::Manage;
         let out = draw(&app, 80, 24);
         assert!(out.contains("RAILWAY CLOUD-AGENTS"));
+    }
+
+    /// The gate card: name and fingerprint each on their own line (together
+    /// they outrun the card and wrap mid-fingerprint), and the answers in the
+    /// same badge-and-label chords as the footers.
+    #[test]
+    fn the_ssh_gate_card_lays_out_key_and_answers() {
+        use crate::commands::cloud_agent::tui::app::{SshGate, SshKeyOffer};
+        let mut app = app_with_tree();
+        app.ssh_gate = Some(SshGate {
+            offer: SshKeyOffer {
+                name: "raildesk-deploy".into(),
+                fingerprint: "SHA256:hlDEs7CV5clc1lMfsMxr/CPeuKuJNn9hJxjsy1e9zLc".into(),
+                public_key: "ssh-ed25519 AAAA test".into(),
+            },
+            then: None,
+        });
+        let out = draw(&app, 80, 30);
+        assert!(out.contains("Register your SSH key with Railway?"), "{out}");
+        assert!(out.contains(" y "), "{out}");
+        assert!(out.contains("Yes — register this key"), "{out}");
+        assert!(out.contains("No, not now"), "{out}");
+
+        let name_line = out
+            .lines()
+            .position(|l| l.contains("raildesk-deploy"))
+            .expect("key name shown");
+        let fp_line = out
+            .lines()
+            .position(|l| l.contains("SHA256:hlDEs7CV5clc1lMfsMxr/CPeuKuJNn9hJxjsy1e9zLc"))
+            .expect("full fingerprint shown, unwrapped");
+        assert_eq!(fp_line, name_line + 1, "fingerprint sits under the name");
     }
 }

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -815,29 +815,31 @@ fn mint_claude_credentials() -> Result<Option<(Vec<u8>, String)>> {
     // existing session + prior consent it completes hands-free; an approve
     // click also works. Only the degenerate paste-the-code-into-the-terminal
     // path can't complete hidden — that times out and falls back to the
-    // manual paste prompt below.
-    let spinner = create_shimmer_spinner(
-        "Minting a Claude token — approve the browser prompt if one appears",
-    );
-    match run_claude_setup_token() {
-        Ok(tok) => {
-            spinner.finish_and_clear();
-            validate_claude_token(&tok)?;
-            cache_claude_token(&tok);
-            return Ok(Some((
-                format!("CLAUDE_CODE_OAUTH_TOKEN={tok}\n").into_bytes(),
-                "claude setup-token".to_string(),
-            )));
-        }
-        Err(e) => {
-            spinner.finish_and_clear();
-            eprintln!(
-                "{}",
-                format!(
-                    "Couldn't mint a token automatically ({e}) — run `claude setup-token` in another terminal instead."
+    // manual paste prompt below. Skipped when the TUI already ran (and lost)
+    // this exact flow under its frame: re-running it here would spend another
+    // two-minute timeout to arrive at the same paste prompt.
+    if !CLAUDE_AUTO_MINT_FAILED.load(std::sync::atomic::Ordering::Relaxed) {
+        let spinner = create_shimmer_spinner(
+            "Minting a Claude token — approve the browser prompt if one appears",
+        );
+        match mint_claude_credential_headless() {
+            Ok(tok) => {
+                spinner.finish_and_clear();
+                return Ok(Some((
+                    format!("CLAUDE_CODE_OAUTH_TOKEN={tok}\n").into_bytes(),
+                    "claude setup-token".to_string(),
+                )));
+            }
+            Err(e) => {
+                spinner.finish_and_clear();
+                eprintln!(
+                    "{}",
+                    format!(
+                        "Couldn't mint a token automatically ({e}) — run `claude setup-token` in another terminal instead."
+                    )
+                    .yellow()
                 )
-                .yellow()
-            )
+            }
         }
     }
 
@@ -863,6 +865,36 @@ fn mint_claude_credentials() -> Result<Option<(Vec<u8>, String)>> {
 /// before we kill it and fall back to the manual paste prompt. Generous: the
 /// user may need to click Approve (or even sign in) in the browser first.
 const SETUP_TOKEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Set once the hidden mint has run and lost this process, so no later path
+/// spends another two-minute timeout re-running automation on its way to the
+/// same manual paste prompt.
+static CLAUDE_AUTO_MINT_FAILED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// The hidden half of the mint, for a TUI that stays on screen: the browser
+/// does all the interacting, the terminal is never touched, and success lands
+/// in the cache the launch pipeline already reads. `Err` means this flow needs
+/// the real terminal (the manual paste fallback) — the caller steps out the
+/// way it always has, and the step-out skips straight to the paste prompt.
+///
+/// Blocking (a child process wait) — a TUI calls it via `spawn_blocking`.
+pub fn mint_claude_credential_headless() -> Result<String> {
+    let minted = run_claude_setup_token().and_then(|tok| {
+        validate_claude_token(&tok)?;
+        Ok(tok)
+    });
+    match minted {
+        Ok(tok) => {
+            cache_claude_token(&tok);
+            Ok(tok)
+        }
+        Err(e) => {
+            CLAUDE_AUTO_MINT_FAILED.store(true, std::sync::atomic::Ordering::Relaxed);
+            Err(e)
+        }
+    }
+}
 
 /// Run `claude setup-token` invisibly under `script(1)`'s PTY: claude's TUI
 /// needs a tty, `script` provides one and records every byte to a file, and

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -142,8 +142,13 @@ async fn ensure_ssh_key_impl(
         return Ok(identity_for(key));
     }
 
-    // No local key is registered - need to register one
-    if !std::io::stdin().is_terminal() {
+    // No local key is registered - need to register one. A TUI that owns the
+    // terminal can't host the registration prompt any more than a pipe can —
+    // its event loop consumes the keystrokes and repaints over the output —
+    // so both get the recipe instead. `railway ca` runs this same function as
+    // a preflight before taking the screen, so inside its TUI this path only
+    // fires if the key disappeared mid-session.
+    if !std::io::stdin().is_terminal() || crate::util::prompt::terminal_owned() {
         bail!(
             "No registered SSH keys found. Register one with:\n  railway ssh keys add\n\n\
             Or import from GitHub:\n  railway ssh keys github"

--- a/src/controllers/ssh/keys.rs
+++ b/src/controllers/ssh/keys.rs
@@ -232,8 +232,29 @@ pub async fn register_ssh_key(
         },
     };
 
-    let response =
-        post_graphql::<SshPublicKeyCreate, _>(client, configs.get_backboard(), vars).await?;
+    let response = post_graphql::<SshPublicKeyCreate, _>(client, configs.get_backboard(), vars)
+        .await
+        .map_err(|err| {
+            // Fingerprints are unique across all of Railway, so a key that is
+            // registered anywhere else — another account, or a workspace this
+            // query context doesn't list — is rejected outright. Without the
+            // owner in hand the only working fix is a fresh key, so say that
+            // instead of surfacing the raw API error.
+            if format!("{err:#}")
+                .to_lowercase()
+                .contains("already registered")
+            {
+                anyhow::anyhow!(
+                    "This SSH key is already registered to a different Railway account \
+                    or workspace, and a key can only be registered once.\n\n\
+                    Generate a separate key for this account:\n  \
+                    ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_railway\n\n\
+                    Then run this command again."
+                )
+            } else {
+                anyhow::Error::new(err)
+            }
+        })?;
 
     Ok(response.ssh_public_key_create)
 }

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -16,7 +16,40 @@ use crate::{
 };
 use anyhow::{Context, Result};
 
+/// Set while a full-screen TUI holds the terminal — raw mode, alternate
+/// screen, and its own crossterm event reader. An inquire prompt started then
+/// can never complete: the TUI's event stream consumes the keystrokes while
+/// the prompt blocks forever, and the next frame paints over its output.
+static TERMINAL_OWNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Mark the terminal as owned (or released) by a full-screen TUI. While set,
+/// every prompt in this module fails fast instead of deadlocking.
+pub fn set_terminal_owned(owned: bool) {
+    TERMINAL_OWNED.store(owned, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Whether a full-screen TUI currently owns the terminal. Code that would
+/// prompt as a fallback should treat this the same as a non-interactive stdin.
+pub fn terminal_owned() -> bool {
+    TERMINAL_OWNED.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Refuse to prompt while a TUI owns the terminal: loud in debug builds so
+/// the call site gets fixed, a clean error in release builds so the user gets
+/// a message instead of a hang.
+fn ensure_promptable() -> Result<()> {
+    if terminal_owned() {
+        debug_assert!(
+            false,
+            "interactive prompt attempted while a TUI owns the terminal"
+        );
+        anyhow::bail!("an interactive prompt can't run while the TUI holds the terminal");
+    }
+    Ok(())
+}
+
 pub fn prompt_options<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
+    ensure_promptable()?;
     let select = inquire::Select::new(message, options);
     select
         .with_render_config(Configs::get_render_config())
@@ -25,6 +58,7 @@ pub fn prompt_options<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
 }
 
 pub fn prompt_options_skippable<T: Display>(message: &str, options: Vec<T>) -> Result<Option<T>> {
+    ensure_promptable()?;
     let select = inquire::Select::new(message, options);
     select
         .with_render_config(Configs::get_render_config())
@@ -37,6 +71,7 @@ pub fn prompt_options_skippable_with_default<T: Display>(
     options: Vec<T>,
     default_index: usize,
 ) -> Result<Option<T>> {
+    ensure_promptable()?;
     let select = inquire::Select::new(message, options);
     select
         .with_render_config(Configs::get_render_config())
@@ -46,6 +81,7 @@ pub fn prompt_options_skippable_with_default<T: Display>(
 }
 
 pub fn prompt_text(message: &str) -> Result<String> {
+    ensure_promptable()?;
     let select = inquire::Text::new(message);
     select
         .with_render_config(Configs::get_render_config())
@@ -56,6 +92,7 @@ pub fn prompt_text(message: &str) -> Result<String> {
 /// Prompt for a secret (token, key): input is masked as it's typed and never
 /// echoed back, with no confirmation round-trip.
 pub fn prompt_secret(message: &str) -> Result<String> {
+    ensure_promptable()?;
     inquire::Password::new(message)
         .with_render_config(Configs::get_render_config())
         .with_display_mode(inquire::PasswordDisplayMode::Masked)
@@ -68,6 +105,7 @@ pub fn prompt_u64_with_placeholder_and_validation_and_cancel(
     message: &str,
     placeholder: &str,
 ) -> Result<Option<String>> {
+    ensure_promptable()?;
     let validator = |input: &str| {
         if input.parse::<u64>().is_ok() {
             Ok(Validation::Valid)
@@ -90,6 +128,7 @@ pub fn prompt_text_with_placeholder_if_blank(
     placeholder: &str,
     blank_message: &str,
 ) -> Result<String> {
+    ensure_promptable()?;
     let select = inquire::Text::new(message);
     select
         .with_render_config(Configs::get_render_config())
@@ -106,6 +145,7 @@ pub fn prompt_text_with_placeholder_if_blank(
 }
 
 pub fn prompt_text_with_placeholder_disappear(message: &str, placeholder: &str) -> Result<String> {
+    ensure_promptable()?;
     let select = inquire::Text::new(message);
     select
         .with_render_config(Configs::get_render_config())
@@ -118,6 +158,7 @@ pub fn prompt_text_with_placeholder_disappear_skippable(
     message: &str,
     placeholder: &str,
 ) -> Result<Option<String>> {
+    ensure_promptable()?;
     let select = inquire::Text::new(message);
     select
         .with_render_config(Configs::get_render_config())
@@ -127,6 +168,7 @@ pub fn prompt_text_with_placeholder_disappear_skippable(
 }
 
 pub fn prompt_confirm_with_default(message: &str, default: bool) -> Result<bool> {
+    ensure_promptable()?;
     let confirm = inquire::Confirm::new(message);
     confirm
         .with_default(default)
@@ -139,6 +181,7 @@ pub fn prompt_confirm_with_default_with_cancel(
     message: &str,
     default: bool,
 ) -> Result<Option<bool>> {
+    ensure_promptable()?;
     let confirm = inquire::Confirm::new(message);
     confirm
         .with_default(default)
@@ -148,6 +191,7 @@ pub fn prompt_confirm_with_default_with_cancel(
 }
 
 pub fn prompt_multi_options<T: Display>(message: &str, options: Vec<T>) -> Result<Vec<T>> {
+    ensure_promptable()?;
     let multi_select = inquire::MultiSelect::new(message, options);
     multi_select
         .with_render_config(Configs::get_render_config())
@@ -156,6 +200,7 @@ pub fn prompt_multi_options<T: Display>(message: &str, options: Vec<T>) -> Resul
 }
 
 pub fn prompt_select<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
+    ensure_promptable()?;
     inquire::Select::new(message, options)
         .with_render_config(Configs::get_render_config())
         .prompt()
@@ -163,6 +208,7 @@ pub fn prompt_select<T: Display>(message: &str, options: Vec<T>) -> Result<T> {
 }
 
 pub fn prompt_select_with_cancel<T: Display>(message: &str, options: Vec<T>) -> Result<Option<T>> {
+    ensure_promptable()?;
     inquire::Select::new(message, options)
         .with_render_config(Configs::get_render_config())
         .prompt_skippable()
@@ -333,6 +379,7 @@ impl Autocomplete for PathAutocompleter {
 }
 
 pub fn prompt_path(message: &str) -> Result<PathBuf> {
+    ensure_promptable()?;
     inquire::Text::new(message)
         .with_autocomplete(PathAutocompleter)
         .with_render_config(Configs::get_render_config())
@@ -342,6 +389,7 @@ pub fn prompt_path(message: &str) -> Result<PathBuf> {
 }
 
 pub fn prompt_path_with_default(message: &str, default: &str) -> Result<PathBuf> {
+    ensure_promptable()?;
     inquire::Text::new(message)
         .with_autocomplete(PathAutocompleter)
         .with_render_config(Configs::get_render_config())
@@ -349,4 +397,29 @@ pub fn prompt_path_with_default(message: &str, default: &str) -> Result<PathBuf>
         .prompt()
         .map(PathBuf::from)
         .context("Failed to prompt for path")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The guard is what turns "prompt under the TUI" from a silent deadlock
+    /// (two crossterm readers racing for the same keystrokes) into a loud
+    /// failure: an assert in debug builds, a clean error in release.
+    #[test]
+    fn prompts_refuse_while_a_tui_owns_the_terminal() {
+        set_terminal_owned(true);
+        let hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::panic::catch_unwind(ensure_promptable);
+        std::panic::set_hook(hook);
+        set_terminal_owned(false);
+        match result {
+            // Release builds: the prompt call fails instead of hanging.
+            Ok(outcome) => assert!(outcome.is_err()),
+            // Debug builds: the debug_assert fired, naming the call site.
+            Err(_) => {}
+        }
+        assert!(ensure_promptable().is_ok());
+    }
 }


### PR DESCRIPTION
Fixes the unanswerable SSH-key registration prompt in the `railway ca` TUI: inquire prompts can't run while the TUI owns the terminal (two crossterm readers race for keystrokes; the frame paints over the prompt), so users with no registered key hung on every launch.

## Changes

- **In-TUI SSH gate**: startup checks key state beside the tree load; launch/reattach with an unregistered key raises a y/n card (key name + fingerprint, footer-style chords, all-fg text, centered answers) and resumes the held connect after registering via `sshPublicKeyCreate`
- Launches land on the manage screen first, with the target environment revealed — the gate asks there
- Wizard completion offers the same card (no held connect)
- No local key → connect refused with the `ssh-keygen` recipe
- **Claude mint under the frame**: the hidden `setup-token` browser flow runs as a loading-screen step; only the manual-paste fallback steps out, and it skips the already-failed automation
- **Backstops**: `ensure_ssh_key` treats a TUI-owned terminal as non-interactive; all `util/prompt.rs` helpers refuse under the TUI (debug assert / clean release error)
- Duplicate-fingerprint rejection (`sshPublicKeyCreate`) mapped to an actionable message
- Telemetry: `ssh_key_register` stage under `cloud_agent_launch`

## Testing

- 1037 tests passing (gate hold/cancel/resume, render layout, guardrail)
- Live-verified against production via PTY harness: no stdin prompt, gate on launch, `n` cancels, `y` registers + resumes onto a running agent