### PR TITLE
railway code: launch inside the ca TUI with the tree collapsed

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -763,7 +763,7 @@ async fn start_session(agent: &ca::Agent) -> Result<i32> {
         format!("No session on {} yet — starting {harness}.", agent.name).dimmed()
     );
     let progress = code::CliProgress::default();
-    let prepared = code::prepare(&launch, &progress).await?;
+    let prepared = code::prepare(&launch, &progress, code::SessionStyle::FullTerminal).await?;
     progress.finish();
 
     let session_name = session::durable_name(prepared.harness);

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -341,6 +341,10 @@ async fn browse_with(opts: BrowseOpts) -> Result<()> {
         app.target = Some(target);
     }
     app.maximized = collapsed;
+    // `railway code` is here for its one session, so the TUI leaves when that
+    // session ends; bare `railway ca` keeps its tree. Held on the app rather
+    // than derived from `autostart`, which the loop consumes on frame one.
+    app.quit_when_done = launch.is_some();
     app.autostart = launch;
 
     let mut pending: Option<tui::LaunchRequest> = None;
@@ -352,6 +356,12 @@ async fn browse_with(opts: BrowseOpts) -> Result<()> {
                 // user set it again next time. Best-effort: failing to save it
                 // is not worth an error on exit.
                 persist_theme(&home, app.theme.slug);
+                // A quit that closed a finished session says so here, on the
+                // restored terminal — the agent is still running (and billing)
+                // even though its session is over.
+                if let Some(note) = app.exit_note.take() {
+                    println!("{}", note.dimmed());
+                }
                 return Ok(());
             }
             Outcome::FullScreen(req) => {

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -1,9 +1,11 @@
 //! `railway ca` — the cloud agent front door.
 //!
 //! Bare `railway ca` on a terminal opens the TUI; everything else is a
-//! subcommand. `railway code` is the same launcher without the TUI, and both
-//! read the same preferences file, so the choice between them is only whether
-//! you want to browse first.
+//! subcommand. `railway code` is the same launcher pointed straight at a
+//! session: it opens the same manage screen with the tree collapsed and the
+//! session already starting, rather than the menu. Both read the same
+//! preferences file, so the choice between them is only whether you want to
+//! browse first. `railway ca start` is the one that skips the TUI entirely.
 
 pub mod access;
 pub mod lifecycle;
@@ -32,7 +34,7 @@ use tui::{App, Outcome};
 #[derive(Parser)]
 #[clap(
     args_conflicts_with_subcommands = true,
-    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run. A\ndirectory linked with `railway link` wins over the saved default project too\n— new agents land there instead.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher pointed straight at a session — same flags,\nsame preferences, no menu: it opens the manage screen with the tree collapsed\nand your default harness already starting (⌥f brings the tree back). `railway\nca start` skips the TUI altogether.\n\nPreferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run. A\ndirectory linked with `railway link` wins over the saved default project too\n— new agents land there instead.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -114,10 +116,11 @@ pub async fn command(args: Args) -> Result<()> {
         Some(Command::Sleep(a)) => tracked("sleep", lifecycle::sleep(a)).await,
         Some(Command::Delete(a)) => tracked("delete", lifecycle::delete(a)).await,
         None if args.launch.is_bare() && is_stdout_terminal() => browse().await,
-        // Flags given, or no terminal to draw on: behave like `railway code`.
+        // Flags given, or no terminal to draw on: behave like `railway code`,
+        // which means the pane on a terminal and a plain ssh session off one.
         // A TUI in a pipe would be gibberish, and erroring instead would break
         // scripted callers that reasonably expect the launcher.
-        None => crate::commands::code::launch(args.launch).await,
+        None => crate::commands::code::command(args.launch).await,
     }
 }
 
@@ -163,15 +166,85 @@ async fn ensure_logged_in(interactive: bool) -> Result<()> {
 /// is what makes connecting feel like stepping into a session and back out
 /// rather than restarting the command.
 async fn browse() -> Result<()> {
-    browse_into(None).await
+    browse_with(BrowseOpts::default()).await
 }
 
-/// Like [`browse`], but opens straight on `initial_screen` instead of the menu
-/// when one is given. `railway ca manage` uses this to land on the manage
-/// screen without a detour through the menu — an explicit ask, so it also
-/// skips the first-run "set up cloud agents?" nudge that a bare `railway ca`
-/// would show.
+/// How the TUI opens, for the callers that want something other than the menu.
+#[derive(Default)]
+struct BrowseOpts {
+    /// Open straight on this screen instead of the menu. An explicit ask, so
+    /// it also skips the first-run "set up cloud agents?" nudge that a bare
+    /// `railway ca` would show. `railway ca manage` passes
+    /// [`tui::Screen::Manage`].
+    initial_screen: Option<tui::Screen>,
+    /// Collapse the tree and give the pane the window from the first frame.
+    /// `railway code` does: it already knows where it is going, so the tree is
+    /// navigation nobody asked for, and ⌥f brings it back.
+    collapsed: bool,
+    /// A launch to start as soon as the first frame is up. Its target and
+    /// harness are already settled — see [`code::resolve_launch`], which has to
+    /// run out here where it can still print and prompt.
+    launch: Option<tui::LaunchRequest>,
+}
+
 async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
+    browse_with(BrowseOpts {
+        initial_screen,
+        ..Default::default()
+    })
+    .await
+}
+
+/// `railway code` on a terminal: settle where and which harness, then open the
+/// manage screen with the tree collapsed and that session already starting.
+///
+/// The resolution happens out here rather than inside the loop because every
+/// part of it may want the terminal — `railway ca setup` runs inline when there
+/// is no default project, the harness prompt when there is no default agent,
+/// and both print. Underneath a frame none of that would be visible.
+pub async fn launch_in_pane(args: LaunchArgs) -> Result<()> {
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    // Before anything is resolved or minted: without the flag the create at the
+    // end of all this is refused anyway.
+    access::ensure_enabled(&client, &configs).await?;
+    eprintln!(
+        "{}",
+        "Warning: Railway cloud agents are experimental and APIs may change or break during testing."
+            .yellow()
+    );
+
+    let resolved = crate::commands::code::resolve_launch(&args, &mut configs, &client).await?;
+    let launch = tui::LaunchRequest {
+        project_id: resolved.project_id,
+        environment_id: resolved.environment_id,
+        // Which agent in that environment is the pipeline's call: it reuses
+        // this environment's remembered one, adopts the caller's only one, and
+        // creates one when there is neither — the same answer `railway code`
+        // has always given, now drawn in a pane.
+        agent_id: None,
+        session_name: None,
+        force_new: args.new,
+        new_session: false,
+        harness: resolved.harness.to_string(),
+        prompt: args.initial_prompt.clone(),
+        label: resolved.harness.to_string(),
+        base: Box::new(args),
+    };
+    browse_with(BrowseOpts {
+        initial_screen: Some(tui::Screen::Manage),
+        collapsed: true,
+        launch: Some(launch),
+    })
+    .await
+}
+
+async fn browse_with(opts: BrowseOpts) -> Result<()> {
+    let BrowseOpts {
+        initial_screen,
+        collapsed,
+        launch,
+    } = opts;
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
@@ -258,6 +331,17 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
     } else if first_run {
         app.start_wizard(true);
     }
+    // A launch the caller arrived with points the prompt too: `-p`/`-e` can
+    // aim it somewhere the linked directory and the saved default both
+    // disagree with, and ⌥n a minute later should mean "another one here",
+    // not "another one where I was standing when I typed the command".
+    if let Some(req) = launch.as_ref()
+        && let Some(target) = target_in_tree(&app.tree, &req.environment_id)
+    {
+        app.target = Some(target);
+    }
+    app.maximized = collapsed;
+    app.autostart = launch;
 
     let mut pending: Option<tui::LaunchRequest> = None;
     loop {
@@ -366,6 +450,27 @@ fn pause_for_reentry() {
     let _ = std::io::stdout().flush();
     let mut line = String::new();
     let _ = std::io::stdin().lock().read_line(&mut line);
+}
+
+/// The tree's own name for an environment id, so a target resolved from ids
+/// alone can be shown and labelled like any other. `None` when the id is not
+/// in the tree, which leaves the caller's target alone.
+fn target_in_tree(tree: &[tui::app::WorkspaceNode], environment_id: &str) -> Option<tui::Target> {
+    for ws in tree {
+        for project in &ws.projects {
+            for env in &project.envs {
+                if env.id == environment_id {
+                    return Some(tui::Target {
+                        project_id: project.id.clone(),
+                        project_name: project.name.clone(),
+                        environment_id: env.id.clone(),
+                        environment_name: env.name.clone(),
+                    });
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Seed the prompt target from the linked project, when this directory has one

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -845,6 +845,17 @@ pub struct App {
     /// the same path a keypress would, so the ssh-key gate and the Claude
     /// mint still get their say.
     pub autostart: Option<LaunchRequest>,
+    /// Leave the TUI when the last session pane closes on its own.
+    ///
+    /// `railway code` came for one session; when the harness exits (ctrl-c
+    /// included), the person is done, and the right place to land is their
+    /// local prompt — not a browser they never opened. Bare `railway ca`
+    /// keeps its tree instead.
+    pub quit_when_done: bool,
+    /// One line for the caller to print after the terminal is restored — how
+    /// a quit that closed a session says the agent is still running (and
+    /// billing) now that the frame it would have said it in is gone.
+    pub exit_note: Option<String>,
     /// This gesture belongs to the application in the session, not to us.
     pointer_to_app: bool,
     /// A short confirmation in the corner, and when it was raised.
@@ -939,6 +950,8 @@ impl App {
             agent_pick: None,
             maximized: false,
             autostart: None,
+            quit_when_done: false,
+            exit_note: None,
             pointer_to_app: false,
             toast: None,
             theme: Theme::from_slug(theme),
@@ -2639,6 +2652,37 @@ impl App {
         }
         self.unmaximize_without_a_session();
         Some(session)
+    }
+
+    /// Close panes whose ssh has ended because the harness exited.
+    ///
+    /// The reader thread flips `ended` and wakes the loop, which calls this.
+    /// Before it, a finished session sat as a dead pane — and with the pane
+    /// remote command's shell fallback gone, "finished" now includes ctrl-c:
+    /// interrupting the agent out of existence ends the session rather than
+    /// dropping into a VM shell inside the frame. A connect that died young
+    /// stays up instead (see [`Session::ended_after_working`]): whatever ssh
+    /// printed is the only account of what failed. When the last pane closes
+    /// under `railway code`, the TUI leaves with it — see
+    /// [`Self::quit_when_done`].
+    pub fn reap_ended_sessions(&mut self) -> Option<Effect> {
+        let mut closed = None;
+        while let Some(i) = self.sessions.iter().position(|s| s.ended_after_working()) {
+            // Dropping the session detaches its local half; the agent stays
+            // running (sleeping is deliberate, never a side effect).
+            if let Some(session) = self.take_session(i) {
+                closed = Some(session.agent_name.clone());
+            }
+        }
+        let agent_name = closed?;
+        if self.quit_when_done && self.sessions.is_empty() {
+            self.exit_note = Some(format!(
+                "Session ended — agent {agent_name} is still running. `railway ca sleep {agent_name}` stops the compute bill."
+            ));
+            return Some(Effect::Quit);
+        }
+        self.toast(format!("Session on {agent_name} ended"));
+        None
     }
 
     /// Hand the whole terminal to the session under the cursor.
@@ -4558,6 +4602,64 @@ mod tests {
         // ⌥s is not intercepted there — it belongs to whatever is running.
         a.on_key(alt('s'));
         assert!(a.settings.is_none());
+    }
+
+    /// The harness exiting ends its pane. Under `railway code` — one session,
+    /// `quit_when_done` — the TUI leaves with it, back to the local prompt;
+    /// this is what ctrl-c out of the agent lands on now that the pane's
+    /// remote command has no shell fallback to strand you in.
+    #[test]
+    fn an_ended_session_under_railway_code_quits_the_tui() {
+        let mut a = loaded_app();
+        a.quit_when_done = true;
+        a.attach_session(
+            super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+
+        // Still running: nothing to reap.
+        assert_eq!(a.reap_ended_sessions(), None);
+        assert_eq!(a.sessions.len(), 1);
+
+        a.sessions[0].end_for_test();
+        assert_eq!(a.reap_ended_sessions(), Some(Effect::Quit));
+        assert!(a.sessions.is_empty());
+        let note = a.exit_note.as_deref().expect("says the agent still runs");
+        assert!(note.contains("nimble-otter"), "{note}");
+    }
+
+    /// From bare `railway ca`, an ended pane closes back to the tree — the
+    /// browser was asked for, so it stays.
+    #[test]
+    fn an_ended_session_from_the_tree_closes_back_to_it() {
+        let mut a = loaded_app();
+        a.attach_session(
+            super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+        a.sessions[0].end_for_test();
+
+        assert_eq!(a.reap_ended_sessions(), None);
+        assert!(a.sessions.is_empty());
+        assert_eq!(a.focus, ManageFocus::Tree);
+        assert!(a.toast.is_some(), "the close is announced, not silent");
+        assert!(a.exit_note.is_none());
+    }
+
+    /// An ssh that dies inside the stall window is a failed connect, and its
+    /// pane is the only place the failure was printed — it stays up.
+    #[test]
+    fn a_connect_that_died_young_keeps_its_pane() {
+        let mut a = loaded_app();
+        a.quit_when_done = true;
+        a.attach_session(
+            super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+        a.sessions[0].end_young_for_test();
+
+        assert_eq!(a.reap_ended_sessions(), None);
+        assert_eq!(a.sessions.len(), 1, "the error stays on screen");
     }
 
     /// `railway code` collapses the tree from the first frame, before there is

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -801,6 +801,18 @@ pub struct LaunchRequest {
     pub prompt: Option<String>,
     /// Human-facing description of where this is going, for the handoff line.
     pub label: String,
+    /// The command-line flags this launch started from, when a command line
+    /// started it. The fields above overwrite the target, harness, agent and
+    /// prompt; everything else — `--name`, `--variable`, `--env-file`,
+    /// `--refresh-auth` — rides along from here, because nothing in the TUI
+    /// asks for those and dropping them would quietly ignore what was typed.
+    /// Default for launches the TUI starts itself.
+    ///
+    /// Boxed because a `LaunchRequest` is the largest thing several enums
+    /// carry — `Effect`, `HeldConnect`, `Outcome`, `Message` — and inlining
+    /// another 200 bytes of flags widens every one of them for a field only
+    /// the command line ever fills.
+    pub base: Box<crate::commands::code::LaunchArgs>,
 }
 
 pub struct App {
@@ -825,6 +837,14 @@ pub struct App {
     pub agent_pick: Option<AgentPicker>,
     /// The session pane has the whole screen: no tree, no detail column.
     pub maximized: bool,
+    /// A launch to start as soon as the first frame is up, and then forget.
+    ///
+    /// How `railway code` opens: it has already answered where and which
+    /// harness, so there is nothing to browse for — the TUI is here to hold
+    /// the session, not to ask a question. Taken by the loop and fed through
+    /// the same path a keypress would, so the ssh-key gate and the Claude
+    /// mint still get their say.
+    pub autostart: Option<LaunchRequest>,
     /// This gesture belongs to the application in the session, not to us.
     pointer_to_app: bool,
     /// A short confirmation in the corner, and when it was raised.
@@ -918,6 +938,7 @@ impl App {
             manage_prompt: None,
             agent_pick: None,
             maximized: false,
+            autostart: None,
             pointer_to_app: false,
             toast: None,
             theme: Theme::from_slug(theme),
@@ -1076,6 +1097,20 @@ impl App {
         }
     }
 
+    /// Is the right-hand pane taking the whole screen — no tree, no detail
+    /// column?
+    ///
+    /// The layout and the terminal emulator both have to agree on this, or a
+    /// remote TUI wraps at the wrong column, so both ask here rather than
+    /// reading `maximized` and re-deriving the rest. A launch in flight counts:
+    /// `railway code` collapses the tree from the first frame, and the loading
+    /// screen is what stands in for the session until there is one. A
+    /// maximized flag with neither is not a full pane — it is a blank screen,
+    /// which is what happens between a failed launch and the next key.
+    pub fn pane_is_full(&self) -> bool {
+        self.maximized && (self.active.is_some() || self.loading.active)
+    }
+
     /// The agents in the target environment: (id, name, status).
     fn agents_in_target(&self) -> Vec<(String, String, String)> {
         let Some(target) = self.target.as_ref() else {
@@ -1128,6 +1163,7 @@ impl App {
             harness: self.harness_name().to_string(),
             prompt,
             label: format!("{agent_name} · new session"),
+            base: Default::default(),
         }))
     }
 
@@ -1936,6 +1972,7 @@ impl App {
             harness: self.harness_name().to_string(),
             prompt,
             label: target.label(),
+            base: Default::default(),
         }))
     }
 
@@ -3404,6 +3441,7 @@ impl App {
                     harness: self.harness_name().to_string(),
                     prompt,
                     label: format!("{agent_name} · new session"),
+                    base: Default::default(),
                 }))
             }
             Some(RowKind::Environment(w, p, e)) | Some(RowKind::Group(w, p, e)) => {
@@ -4522,6 +4560,25 @@ mod tests {
         assert!(a.settings.is_none());
     }
 
+    /// `railway code` collapses the tree from the first frame, before there is
+    /// a session to collapse it around — the loading pane stands in for one.
+    /// Without this the tree would be drawn for the whole boot and then vanish,
+    /// which is the flicker the collapsed layout exists to avoid.
+    #[test]
+    fn a_launch_in_flight_fills_the_pane_on_its_own() {
+        let mut a = loaded_app();
+        a.maximized = true;
+        assert!(!a.pane_is_full(), "nothing to show yet");
+
+        a.start_loading(&launch_req());
+        assert!(a.pane_is_full(), "the loading pane has the screen");
+
+        // A launch that fails leaves neither: the tree comes back rather than
+        // the screen going blank.
+        a.launch_failed("no".into());
+        assert!(!a.pane_is_full());
+    }
+
     fn with_sessions(names: &[&str]) -> App {
         let mut a = loaded_app();
         for name in names {
@@ -5141,6 +5198,7 @@ mod tests {
             harness: "claude".into(),
             prompt: Some("fix the tests".into()),
             label: "devtools/production".into(),
+            base: Default::default(),
         };
         a.start_loading(&req);
         assert!(a.loading.active, "the pane shows the wait");
@@ -6803,6 +6861,7 @@ mod tests {
             harness: "claude".into(),
             prompt: None,
             label: "p/e".into(),
+            base: Default::default(),
         };
         // A plain connect reuses whatever is open.
         assert!(!base.wants_new_session());
@@ -7445,6 +7504,7 @@ mod tests {
             harness: "claude".into(),
             prompt: None,
             label: "devtools/production".into(),
+            base: Default::default(),
         }
     }
 

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -1089,7 +1089,9 @@ fn handle_message(
         }
         Message::RefreshAgentSessions(agent_id) => app.refresh_agent_sessions(&agent_id),
         // The draw at the top of the loop is the response.
-        Message::SessionOutput => None,
+        // Output also carries the end: the reader thread flips `ended` and
+        // sends one last wake, which is when a finished pane gets closed.
+        Message::SessionOutput => app.reap_ended_sessions(),
     }
 }
 
@@ -1469,7 +1471,7 @@ fn start_launch(app: &mut App, req: LaunchRequest, tx: &mpsc::UnboundedSender<Me
         let req = req;
         let args = launch_args_for(&req);
         let progress = ChannelProgress(tx.clone());
-        let message = match code::prepare(&args, &progress).await {
+        let message = match code::prepare(&args, &progress, code::SessionStyle::Pane).await {
             Ok(prepared) => Message::LaunchReady(Box::new(prepared), Box::new(req)),
             Err(err) => Message::LaunchFailed(format!("{err:#}")),
         };

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -532,6 +532,16 @@ pub async fn run(
         }
         sync_session_size(app, &terminal);
 
+        // A launch the caller arrived with, started once the first frame is on
+        // screen so the terminal is already in the state the loading pane will
+        // draw into. Routed through the effect handling rather than straight to
+        // `start_launch`, so it meets the ssh-key gate and the Claude mint the
+        // same way a launch someone pressed a key for does.
+        if let Some(req) = app.autostart.take() {
+            dispatch_launch(app, req, &tx, &client, &backboard);
+            continue;
+        }
+
         let effect = tokio::select! {
             // Background work first: draining it keeps the tree and the session
             // honest even while keys arrive faster than frames.
@@ -831,47 +841,7 @@ pub async fn run(
                     });
                 });
             }
-            Some(Effect::Launch(req)) => {
-                // The launch lives on the manage screen — the tree the agent
-                // will land in — so go there first and reveal its environment.
-                // The ssh gate's question then hangs over the place the answer
-                // matters, not over the menu it happened to be asked from.
-                app.screen = Screen::Manage;
-                if let Some(Effect::LoadAgents {
-                    environment_id,
-                    path,
-                }) = app.reveal_environment(&req.environment_id)
-                {
-                    spawn_env_agents_fetch(environment_id, path, &tx, &client, &backboard);
-                }
-                // Connecting rides SSH, so an unregistered key is settled with
-                // an in-frame question before anything is spent on the launch.
-                if app.hold_for_ssh_key(HeldConnect::Launch(req.clone())) {
-                    continue;
-                }
-                // The mint's browser round-trip needs no terminal — the
-                // browser does the interacting and the flow runs hidden — so
-                // it runs under the frame with the loading screen narrating.
-                // Only its manual-paste fallback needs the real terminal, and
-                // only that failure steps out (see ClaudeMintDone).
-                if req.harness == "claude" && code::claude_needs_local_mint() {
-                    app.start_loading(&req);
-                    let _ = tx.send(Message::LaunchStep(
-                        "Minting a Claude token — approve the browser prompt if one appears"
-                            .to_string(),
-                    ));
-                    let tx = tx.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let ok = code::mint_claude_credential_headless().is_ok();
-                        let _ = tx.send(Message::ClaudeMintDone {
-                            ok,
-                            req: Box::new(req),
-                        });
-                    });
-                    continue;
-                }
-                start_launch(app, req, &tx);
-            }
+            Some(Effect::Launch(req)) => dispatch_launch(app, req, &tx, &client, &backboard),
             Some(Effect::LoadSessions { agent_id, path }) => {
                 spawn_session_fetch(agent_id, path, &tx, &client, &backboard);
             }
@@ -1426,7 +1396,7 @@ fn schedule_session_refresh(agent_id: String, tx: &mpsc::UnboundedSender<Message
 /// dropped it, leaving the pipeline to infer one and create a VM when it could
 /// not. Tested directly, so a dropped field fails here rather than on a bill.
 fn launch_args_for(req: &LaunchRequest) -> LaunchArgs {
-    LaunchArgs::for_target(
+    (*req.base).clone().retargeted(
         req.project_id.clone(),
         req.environment_id.clone(),
         &req.harness,
@@ -1434,6 +1404,61 @@ fn launch_args_for(req: &LaunchRequest) -> LaunchArgs {
         req.prompt.clone(),
         req.agent_id.clone(),
     )
+}
+
+/// Everything a launch has to clear before the pipeline sees it: the screen it
+/// belongs on, the ssh key it will connect with, and the Claude credential it
+/// may need minting.
+///
+/// A function rather than the body of one match arm because two things start
+/// launches — an [`Effect::Launch`] someone pressed a key for, and the
+/// `autostart` a `railway code` invocation arrived with — and the second must
+/// clear exactly the same gates as the first. Each gate that holds the launch
+/// stores it and returns; the loop redraws with whatever question it raised.
+fn dispatch_launch(
+    app: &mut App,
+    req: LaunchRequest,
+    tx: &mpsc::UnboundedSender<Message>,
+    client: &reqwest::Client,
+    backboard: &str,
+) {
+    // The launch lives on the manage screen — the tree the agent will land in —
+    // so go there first and reveal its environment. The ssh gate's question
+    // then hangs over the place the answer matters, not over the menu it
+    // happened to be asked from.
+    app.screen = Screen::Manage;
+    if let Some(Effect::LoadAgents {
+        environment_id,
+        path,
+    }) = app.reveal_environment(&req.environment_id)
+    {
+        spawn_env_agents_fetch(environment_id, path, tx, client, backboard);
+    }
+    // Connecting rides SSH, so an unregistered key is settled with an in-frame
+    // question before anything is spent on the launch.
+    if app.hold_for_ssh_key(HeldConnect::Launch(req.clone())) {
+        return;
+    }
+    // The mint's browser round-trip needs no terminal — the browser does the
+    // interacting and the flow runs hidden — so it runs under the frame with
+    // the loading screen narrating. Only its manual-paste fallback needs the
+    // real terminal, and only that failure steps out (see ClaudeMintDone).
+    if req.harness == "claude" && code::claude_needs_local_mint() {
+        app.start_loading(&req);
+        let _ = tx.send(Message::LaunchStep(
+            "Minting a Claude token — approve the browser prompt if one appears".to_string(),
+        ));
+        let tx = tx.clone();
+        tokio::task::spawn_blocking(move || {
+            let ok = code::mint_claude_credential_headless().is_ok();
+            let _ = tx.send(Message::ClaudeMintDone {
+                ok,
+                req: Box::new(req),
+            });
+        });
+        return;
+    }
+    start_launch(app, req, tx);
 }
 
 /// Kick off a launch in the background and show the loading screen.
@@ -1507,7 +1532,7 @@ async fn close_session(app: &mut App, index: usize, _client: &reqwest::Client, _
 /// draw, when the layout that produced the pane is known. A mismatch here is
 /// what makes a remote TUI wrap in the wrong place.
 fn sync_session_size(app: &mut App, terminal: &Terminal<CrosstermBackend<std::io::Stdout>>) {
-    let Some((rows, cols)) = ui::session_pane_size(terminal.size().ok(), app.maximized) else {
+    let Some((rows, cols)) = ui::session_pane_size(terminal.size().ok(), app.pane_is_full()) else {
         return;
     };
     // Every session gets the pane's shape, not just the visible one: a
@@ -1610,6 +1635,7 @@ mod tests {
             harness: "claude".into(),
             prompt: None,
             label: "devtools/production".into(),
+            base: Default::default(),
         }
     }
 
@@ -1652,6 +1678,38 @@ mod tests {
         assert!(command.contains("agent:env_1:ca_1@"), "{command}");
         // The target is a username on the relay, not a host of its own.
         assert!(!command.contains(" agent:env_1:ca_1 "), "{command}");
+    }
+
+    /// A `railway code` launch opens in the pane, so its flags reach the
+    /// pipeline through the request rather than straight off the command line.
+    /// The ones no card asks for have nowhere else to travel.
+    /// Compared whole rather than field by field: `--name` and `--variable`
+    /// are private to `code`, and comparing against the retargeted base is the
+    /// stronger claim anyway — nothing was dropped, not just the two we
+    /// thought to name.
+    #[test]
+    fn a_command_line_launch_keeps_the_flags_it_arrived_with() {
+        use clap::Parser;
+
+        let base = LaunchArgs::parse_from(["code", "--new", "--name", "api", "--variable", "K=V"]);
+        let args = launch_args_for(&LaunchRequest {
+            base: Box::new(base.clone()),
+            force_new: true,
+            ..request()
+        });
+        assert_eq!(
+            args,
+            base.retargeted(
+                "proj_1".into(),
+                "env_prod".into(),
+                "claude",
+                true,
+                None,
+                None
+            )
+        );
+        // And the request is what aimed it: the base named no target.
+        assert_eq!(args.environment.as_deref(), Some("env_prod"));
     }
 
     /// A prompt rides through to the session it seeds.

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -1475,7 +1475,15 @@ mod tests {
             let history = session
                 .with_screen(|s| s.scrollback())
                 .expect("the emulator stays lockable");
-            assert_eq!(held, history, "the held offset tracks the emulator");
+            // The reader thread may process this round's echo between the
+            // scroll above and this read, and output arriving while scrolled
+            // back pins the view by pushing the emulator's offset deeper. So
+            // the emulator may run ahead of the held offset here — but it can
+            // never sit above it, which is the wedge this test is for.
+            assert!(
+                history >= held,
+                "the held offset never passes the emulator (held {held}, emulator {history})"
+            );
             assert!(
                 session.with_screen(|s| s.contents()).is_some(),
                 "the view renders mid-churn"

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -398,6 +398,17 @@ impl Session {
         self.ended.load(Ordering::Relaxed)
     }
 
+    /// Ended after living like a real session: it produced output and lasted
+    /// past the stall window. This is "the harness exited" — the pane can
+    /// close on it. An ssh that dies quickly is a failed connect instead, and
+    /// its pane has to stay up, because whatever ssh printed is the only
+    /// account of what went wrong.
+    pub fn ended_after_working(&self) -> bool {
+        self.ended()
+            && self.got_output.load(Ordering::Relaxed)
+            && self.spawned_at.elapsed() >= Self::STALL_AFTER
+    }
+
     /// Resize both the emulator and the pty. Doing only one leaves the agent
     /// drawing to a screen of a different shape than the one being rendered.
     pub fn resize(&mut self, rows: u16, cols: u16) {
@@ -686,6 +697,20 @@ fn url_in(line: &str, col: usize) -> Option<String> {
 
 #[cfg(test)]
 impl Session {
+    /// Put the session in the state [`Self::ended_after_working`] looks for:
+    /// output seen, stall window outlived, reader done.
+    pub fn end_for_test(&mut self) {
+        self.ended.store(true, Ordering::Relaxed);
+        self.got_output.store(true, Ordering::Relaxed);
+        self.spawned_at = std::time::Instant::now() - Self::STALL_AFTER;
+    }
+
+    /// Ended inside the stall window — the shape of a connect that failed.
+    pub fn end_young_for_test(&mut self) {
+        self.ended.store(true, Ordering::Relaxed);
+        self.got_output.store(true, Ordering::Relaxed);
+    }
+
     /// A session backed by a local `cat` instead of ssh, so the state machine
     /// around sessions can be tested without a relay or a network.
     pub fn for_test(agent_id: &str, agent_name: &str) -> Result<Self> {

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -901,7 +901,7 @@ fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     // whitespace.
     // ⌥f hands the whole width to the session: the tree is navigation, and
     // once you are working in a session there is nothing to navigate.
-    let full = app.maximized && app.active_session().is_some();
+    let full = app.pane_is_full();
     let two_pane = !full && chunks[2].width >= 70;
     let panes = if two_pane {
         Layout::horizontal([Constraint::Length(TREE_W), Constraint::Min(20)]).split(chunks[2])
@@ -915,7 +915,11 @@ fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
         rects.session_outer = whole(pane);
         rects.tree = PaneBox::default();
         rects.tree_outer = PaneBox::default();
-        if let Some(session) = app.active_session() {
+        // Same order as the two-pane branch: a launch in flight owns the pane
+        // until it produces the session that replaces it.
+        if app.loading.active {
+            render_loading(app, f, pane);
+        } else if let Some(session) = app.active_session() {
             render_session(app, session, f, pane);
         }
         render_manage_footer(app, f, chunks[3], rects);
@@ -1051,7 +1055,7 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
     let sleeping = app
         .selected_agent_status()
         .is_some_and(|status| status != "running");
-    let hint: Vec<(&str, &str)> = if app.maximized {
+    let hint: Vec<(&str, &str)> = if app.pane_is_full() {
         vec![("⌥f", "restore the tree"), ("⌥/⇧esc / ^]", "stop typing")]
     } else if app.focus == ManageFocus::Session {
         let mut keys = vec![("⌥/⇧esc / ^]", "stop typing"), ("⌥f", "maximize")];
@@ -2893,6 +2897,7 @@ mod tests {
             harness: "claude".into(),
             prompt: Some("fix the failing tests".into()),
             label: "devtools/production".into(),
+            base: Default::default(),
         });
         app.loading_step("Creating a cloud agent".into());
 
@@ -2936,6 +2941,39 @@ mod tests {
             gap_left.abs_diff(gap_right) <= 4,
             "left {gap_left} and right {gap_right} gaps should be close:\n{out}"
         );
+    }
+
+    /// …unless the tree was collapsed on the way in. `railway code` has
+    /// already answered where and which harness, so there is nothing to
+    /// navigate: the wait gets the whole window, and the session that replaces
+    /// it inherits the same shape rather than jumping a pane's width sideways
+    /// the moment it connects.
+    #[test]
+    fn a_collapsed_launch_gives_the_wait_the_whole_window() {
+        let mut app = app_with_tree();
+        app.maximized = true;
+        app.start_loading(&crate::commands::cloud_agent::tui::LaunchRequest {
+            project_id: "proj_1".into(),
+            environment_id: "env_prod".into(),
+            agent_id: None,
+            session_name: None,
+            force_new: false,
+            new_session: false,
+            harness: "claude".into(),
+            prompt: None,
+            label: "devtools/production".into(),
+            base: Default::default(),
+        });
+        app.loading_step("Creating a cloud agent".into());
+
+        let out = draw(&app, 100, 30);
+        assert!(out.contains("Creating a cloud agent"), "steps:\n{out}");
+        assert!(
+            !out.contains("cloud agents "),
+            "the tree pane's title should be gone:\n{out}"
+        );
+        // ⌥f is how it comes back, and the footer has to say so.
+        assert!(out.contains("restore the tree"), "footer:\n{out}");
     }
 
     /// The footer carries the actions that apply where the cursor is, with help
@@ -3114,6 +3152,7 @@ mod tests {
                 "fix the failing retry tests in the worker service and update the changelog".into(),
             ),
             label: "devtools/production".into(),
+            base: Default::default(),
         });
         app.loading_step("Creating a cloud agent".into());
 

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -563,6 +563,22 @@ if command -v {name} >/dev/null 2>&1; then echo AGENT-READY; else echo AGENT-MIS
     )
 }
 
+/// Where a prepared session's output lands, which decides what quitting the
+/// harness should leave behind.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SessionStyle {
+    /// ssh owns the real terminal (`railway ca start`, piped and `--`
+    /// callers): quitting the agent lands in a shell on the VM, matching the
+    /// `~/.profile` autostart, and `exit` ends the connection.
+    FullTerminal,
+    /// The TUI's session pane: when the harness exits the remote command ends,
+    /// the durable session with it, and the pane closes. A shell fallback here
+    /// would strand the user on a bare VM prompt inside what still looks like
+    /// the TUI — and leave the durable session alive as a shell nobody wants
+    /// to reattach to.
+    Pane,
+}
+
 /// The command the launch session runs on the VM. Three shapes, and the
 /// difference between them is whether you are left in a session afterwards:
 ///
@@ -571,25 +587,32 @@ if command -v {name} >/dev/null 2>&1; then echo AGENT-READY; else echo AGENT-MIS
 /// - `-- args` execs the agent and exits with it, so a pipeline doesn't hang
 ///   waiting on a shell nobody is typing into.
 ///
-/// Neither interactive form uses `exec`: quitting the agent lands in a shell on
-/// the VM, matching the `~/.profile` autostart. `RAILWAY_CODE_AUTOSTARTED`
-/// stops that autostart relaunching the agent on top of the user, and the reset
-/// scrubs terminal state a TUI can leave behind on an unclean exit.
+/// "Keeps the session" is [`SessionStyle`]'s call: a full-terminal caller gets
+/// a VM shell after the agent quits, a pane ends with it. Neither interactive
+/// form uses `exec`, so the reset always runs. `RAILWAY_CODE_AUTOSTARTED`
+/// stops the `~/.profile` autostart relaunching the agent on top of the user,
+/// and the reset scrubs terminal state a TUI can leave behind on an unclean
+/// exit.
 fn remote_command(
     agent: Agent,
     env_prefix: &str,
     initial_prompt: Option<&str>,
     agent_args: &[String],
+    style: SessionStyle,
 ) -> String {
     let name = agent.name();
+    let after = match style {
+        SessionStyle::FullTerminal => "; exec bash -l",
+        SessionStyle::Pane => "",
+    };
     match initial_prompt.map(str::trim).filter(|p| !p.is_empty()) {
         Some(prompt) => format!(
-            "{env_prefix}export RAILWAY_CODE_AUTOSTARTED=1; {name} {}; {}; exec bash -l",
+            "{env_prefix}export RAILWAY_CODE_AUTOSTARTED=1; {name} {}; {}{after}",
             shell_join(std::slice::from_ref(&prompt.to_string())),
             terminal_reset_printf()
         ),
         None if agent_args.is_empty() => format!(
-            "{env_prefix}export RAILWAY_CODE_AUTOSTARTED=1; {name}; {}; exec bash -l",
+            "{env_prefix}export RAILWAY_CODE_AUTOSTARTED=1; {name}; {}{after}",
             terminal_reset_printf()
         ),
         None => format!("{env_prefix}exec {name} {}", shell_join(agent_args)),
@@ -1933,7 +1956,7 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
     );
 
     let progress = CliProgress::default();
-    let prepared = prepare(&args, &progress).await?;
+    let prepared = prepare(&args, &progress, SessionStyle::FullTerminal).await?;
     progress.finish();
 
     println!("Launching {}…", prepared.harness);
@@ -2008,7 +2031,11 @@ pub fn run_session(prepared: &Prepared) -> Result<i32> {
 /// steps itself. The one thing that cannot happen here is an interactive Claude
 /// mint — see [`ensure_claude_credential_cached`], which a TUI caller runs
 /// before it takes the screen.
-pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepared> {
+pub async fn prepare(
+    args: &LaunchArgs,
+    progress: &dyn Progress,
+    style: SessionStyle,
+) -> Result<Prepared> {
     // Timed and reported separately from `prepare_inner` so every caller
     // (`railway code`, `railway ca start`, and the TUI's `start_launch`) gets
     // the same outcome event without duplicating it at each call site — none
@@ -2034,7 +2061,7 @@ pub async fn prepare(args: &LaunchArgs, progress: &dyn Progress) -> Result<Prepa
         }
     };
 
-    let result = prepare_inner(args, progress, agent, prefs, &home).await;
+    let result = prepare_inner(args, progress, agent, prefs, &home, style).await;
     crate::commands::cloud_agent::telemetry::track_launch_outcome(
         agent.slug(),
         result.as_ref().ok().map(|p| p.created),
@@ -2051,6 +2078,7 @@ async fn prepare_inner(
     agent: Agent,
     mut prefs: AgentPrefs,
     home: &Path,
+    style: SessionStyle,
 ) -> Result<Prepared> {
     // --- Resolve the local credential (client-side only, announced).
     //
@@ -2284,6 +2312,7 @@ async fn prepare_inner(
         &env_prefix,
         args.initial_prompt.as_deref(),
         &args.agent_args,
+        style,
     );
 
     Ok(Prepared {
@@ -2788,12 +2817,20 @@ mod tests {
     /// to work in, or hang a script on a shell.
     #[test]
     fn remote_command_shapes() {
-        let seeded = remote_command(Agent::Claude, "P; ", Some("fix the tests"), &[]);
+        use SessionStyle::FullTerminal;
+
+        let seeded = remote_command(
+            Agent::Claude,
+            "P; ",
+            Some("fix the tests"),
+            &[],
+            FullTerminal,
+        );
         assert!(seeded.contains("claude 'fix the tests';"), "{seeded}");
         assert!(seeded.ends_with("exec bash -l"));
         assert!(!seeded.contains("exec claude"));
 
-        let interactive = remote_command(Agent::Claude, "P; ", None, &[]);
+        let interactive = remote_command(Agent::Claude, "P; ", None, &[], FullTerminal);
         assert!(interactive.contains("claude;"), "{interactive}");
         assert!(interactive.ends_with("exec bash -l"));
 
@@ -2802,6 +2839,7 @@ mod tests {
             "P; ",
             None,
             &["exec".into(), "explain this".into()],
+            FullTerminal,
         );
         assert!(
             scripted.contains("exec codex exec 'explain this'"),
@@ -2810,15 +2848,39 @@ mod tests {
         assert!(!scripted.contains("bash -l"));
 
         // A prompt of only whitespace is not a prompt.
-        let blank = remote_command(Agent::Grok, "P; ", Some("   "), &[]);
-        assert_eq!(blank, remote_command(Agent::Grok, "P; ", None, &[]));
+        let blank = remote_command(Agent::Grok, "P; ", Some("   "), &[], FullTerminal);
+        assert_eq!(
+            blank,
+            remote_command(Agent::Grok, "P; ", None, &[], FullTerminal)
+        );
+    }
+
+    /// A pane session must end when the harness does. The shell fallback that
+    /// serves a full-terminal caller strands a pane on a bare VM prompt inside
+    /// what still looks like the TUI — ctrl-c out of the agent read as the CLI
+    /// breaking, with a leftover shell session to reattach to.
+    #[test]
+    fn a_pane_session_ends_with_the_harness() {
+        for prompt in [None, Some("fix the tests")] {
+            let pane = remote_command(Agent::Claude, "P; ", prompt, &[], SessionStyle::Pane);
+            assert!(!pane.contains("bash -l"), "{pane}");
+            // The reset still runs — the pane's emulator swallows it, and a
+            // full-screen takeover of the same session needs it.
+            assert!(pane.ends_with("\\033[?25h'"), "{pane}");
+        }
     }
 
     /// A prompt is user text arriving on a remote shell's command line; it has
     /// to be quoted, not interpolated.
     #[test]
     fn a_prompt_cannot_break_out_of_its_quoting() {
-        let nasty = remote_command(Agent::Claude, "P; ", Some("'; rm -rf / #"), &[]);
+        let nasty = remote_command(
+            Agent::Claude,
+            "P; ",
+            Some("'; rm -rf / #"),
+            &[],
+            SessionStyle::FullTerminal,
+        );
         assert!(!nasty.contains("; rm -rf / #;"), "{nasty}");
         assert!(
             nasty.contains(r"'\''"),

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -77,10 +77,11 @@ use crate::util::shell::shell_join;
 // `railway ca sleep`, or `s` on the TUI tree.
 // ---------------------------------------------------------------------------
 
-/// `railway code` is the launcher on its own: the same flags and the same
-/// preferences as `railway ca`, minus the TUI. Kept as a distinct command
-/// rather than an alias because the two now differ in exactly one way — one
-/// browses first and one does not — and that is the reason to type either.
+/// `railway code` is the launcher: it answers "where, and which harness"
+/// from flags and preferences, then opens that session. On a terminal it opens
+/// it inside `railway ca`'s manage screen with the tree collapsed, so the
+/// session has the whole window and the rest of the tool is one key away;
+/// everywhere else it hands the terminal straight to ssh.
 pub type Args = LaunchArgs;
 
 pub async fn command(args: Args) -> Result<()> {
@@ -93,18 +94,24 @@ pub async fn command(args: Args) -> Result<()> {
             "`railway code` passes arguments straight to the agent, so this would run `setup` on the VM.\nDid you mean `railway ca setup`?"
         );
     }
-    launch(args).await
+    match args.wants_pane() {
+        true => crate::commands::cloud_agent::launch_in_pane(args).await,
+        false => launch(args).await,
+    }
 }
 
 /// Launch a coding agent on a Railway cloud agent VM
 //
 // `Default` is derived so the TUI can build a launch without going through
 // clap: every field is an Option/Vec/bool, so the derive produces exactly the
-// "nothing was passed" state clap would. Kept out of the doc comment — clap
-// renders those as `long_about` and it would show up in `--help`.
-#[derive(Parser, Default)]
+// "nothing was passed" state clap would. `Clone` is what lets a command-line
+// launch ride into the TUI as the base of a `LaunchRequest`, so flags the TUI
+// has no way to ask for — `--name`, `--variable` — still reach the pipeline.
+// Both kept out of the doc comment — clap renders those as `long_about` and
+// they would show up in `--help`.
+#[derive(Parser, Default, Clone, Debug, PartialEq, Eq)]
 #[clap(
-    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run).\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` clears both\ncaches and re-mints.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run). With no project or environment\nflag, this directory's linked project is used, and your default project when\nthe directory has no link.\n\nOn a terminal the session opens inside `railway ca`'s manage screen with the\ntree collapsed, so it has the whole window and the other agents are one key\naway — ⌥f brings the tree back, ⌥n starts another session. `--rm`, a `--`\npassthrough, and anything piped take the terminal directly instead; so does\n`railway ca start`, which never draws the TUI.\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` clears both\ncaches and re-mints.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct LaunchArgs {
     /// Launch OpenAI Codex, carrying your local ChatGPT sign-in
@@ -212,6 +219,30 @@ impl LaunchArgs {
             && self.agent_args.is_empty()
     }
 
+    /// Should this launch open in the TUI's session pane rather than taking
+    /// the terminal for itself?
+    ///
+    /// Yes for the shapes a person types at a prompt, which is nearly all of
+    /// them: the pane gives the session the whole window and leaves the tree,
+    /// the other agents and the lifecycle keys one chord away. No for the
+    /// three that a frame would break or spoil:
+    ///
+    /// - `--rm` destroys an agent and prints; there is no session to show.
+    /// - `-- args` execs the agent and exits with its status, which is a
+    ///   caller asking for an exit code, not for a window.
+    /// - no terminal at all — a TUI in a pipe is gibberish, and scripted
+    ///   callers reasonably expect the launcher.
+    pub fn wants_pane(&self) -> bool {
+        self.pane_shaped() && is_stdout_terminal()
+    }
+
+    /// The flag half of [`Self::wants_pane`], split off the terminal check so
+    /// the rule is checked by tests rather than by reading it — `cargo test`
+    /// captures stdout, so the whole predicate is always false under one.
+    fn pane_shaped(&self) -> bool {
+        !self.rm && self.agent_args.is_empty()
+    }
+
     /// Force one harness, overriding preferences — how the TUI passes the
     /// choice made in its prompt footer.
     pub fn set_harness(&mut self, slug: &str) {
@@ -233,16 +264,41 @@ impl LaunchArgs {
         prompt: Option<String>,
         agent_id: Option<String>,
     ) -> Self {
-        let mut args = Self {
-            project: Some(project_id),
-            environment: Some(environment_id),
-            new: force_new,
-            initial_prompt: prompt,
+        Self::default().retargeted(
+            project_id,
+            environment_id,
+            harness,
+            force_new,
+            prompt,
             agent_id,
-            ..Self::default()
-        };
-        args.set_harness(harness);
-        args
+        )
+    }
+
+    /// [`Self::for_target`] over an existing set of flags instead of an empty
+    /// one — how a `railway code` invocation that opened in the pane gets its
+    /// remaining flags to the pipeline.
+    ///
+    /// Everything the TUI decides is overwritten: it knows the target, the
+    /// harness and the agent better than the command line did, because the
+    /// user may have moved since typing it. Everything else survives, which is
+    /// the point — `railway code --new --name api --variable K=V` creates the
+    /// agent the command line described, even though no card asks for a name.
+    pub fn retargeted(
+        mut self,
+        project_id: String,
+        environment_id: String,
+        harness: &str,
+        force_new: bool,
+        prompt: Option<String>,
+        agent_id: Option<String>,
+    ) -> Self {
+        self.project = Some(project_id);
+        self.environment = Some(environment_id);
+        self.new = force_new;
+        self.initial_prompt = prompt;
+        self.agent_id = agent_id;
+        self.set_harness(harness);
+        self
     }
 }
 
@@ -1547,7 +1603,7 @@ async fn resolve_agent(
         if let Some(ready) =
             ready_existing_agent(client, &backboard, environment_id, agent, progress).await?
         {
-            warn_ignored_variables(args);
+            warn_ignored_variables(args, progress);
             configs.set_code_agent(environment_id, &ready.id);
             configs.write()?;
             return Ok((ready, false));
@@ -1596,13 +1652,17 @@ async fn resolve_agent(
 
 /// `--variable`/`--env-file` only reach the VM spec at create time, so say so
 /// rather than silently dropping them on a reuse.
-fn warn_ignored_variables(args: &LaunchArgs) {
+///
+/// Through the progress sink rather than straight to stderr: these flags can
+/// now arrive on a launch that opens in the TUI's pane, and a stray write there
+/// lands on top of the frame.
+fn warn_ignored_variables(args: &LaunchArgs, progress: &dyn Progress) {
     use colored::Colorize;
     if !args.variables.is_empty() || !args.env_files.is_empty() {
-        eprintln!(
-            "{}",
-            "Note: --variable/--env-file only apply when an agent is created — reusing this environment's. Add --new to create with these variables."
+        progress.note(
+            &"Note: --variable/--env-file only apply when an agent is created — reusing this environment's. Add --new to create with these variables."
                 .yellow()
+                .to_string(),
         );
     }
 }
@@ -1806,6 +1866,42 @@ pub struct Prepared {
     pub harness: &'static str,
     /// True when this run created the agent, which only affects messaging.
     pub created: bool,
+}
+
+/// Where a launch lands and what it runs there, settled before anything is
+/// spent on it.
+pub struct ResolvedLaunch {
+    pub project_id: String,
+    pub environment_id: String,
+    /// The harness slug, matching [`Agent::slug`].
+    pub harness: &'static str,
+}
+
+/// Answer a launch's two unavoidable questions — where, and which harness —
+/// using the same order the direct path uses.
+///
+/// Split out so the pane path can settle both *before* the TUI takes the
+/// screen. Either answer can print, prompt, or run `railway ca setup` inline,
+/// and none of that survives underneath a ratatui frame.
+///
+/// The target goes first because `railway ca setup` is one of its answers, and
+/// setup also writes the default harness — asking for the harness first would
+/// ask a question setup is about to ask again.
+pub async fn resolve_launch(
+    args: &LaunchArgs,
+    configs: &mut Configs,
+    client: &reqwest::Client,
+) -> Result<ResolvedLaunch> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to get home directory"))?;
+    let mut prefs = AgentPrefs::load_in(&home).unwrap_or_default();
+    let (project_id, environment_id) =
+        resolve_target(configs, client, args, &mut prefs, &home).await?;
+    let harness = resolve_agent_choice(args, &mut prefs, &home)?.slug();
+    Ok(ResolvedLaunch {
+        project_id,
+        environment_id,
+        harness,
+    })
 }
 
 pub async fn launch(args: LaunchArgs) -> Result<()> {
@@ -2377,6 +2473,81 @@ pub fn ensure_claude_credential_cached(harness: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
+
+    /// The shapes someone types at a prompt open in the pane. Nothing about a
+    /// target, a harness or a variable changes that — they all describe a
+    /// session, and a session is what the pane holds.
+    #[test]
+    fn an_ordinary_launch_opens_in_the_pane() {
+        for argv in [
+            vec!["code"],
+            vec!["code", "--claude"],
+            vec!["code", "--new", "--name", "api"],
+            vec!["code", "-p", "proj_1", "-e", "env_prod"],
+            vec!["code", "--variable", "K=V", "--refresh-auth"],
+        ] {
+            let args = LaunchArgs::parse_from(&argv);
+            assert!(args.pane_shaped(), "{argv:?} should open in the pane");
+        }
+    }
+
+    /// The two that a frame would break: `--rm` has no session to draw, and
+    /// `-- args` is a caller asking for an exit code rather than a window.
+    #[test]
+    fn destroying_and_exec_take_the_terminal_instead() {
+        assert!(!LaunchArgs::parse_from(["code", "--rm"]).pane_shaped());
+        assert!(
+            !LaunchArgs::parse_from(["code", "--codex", "--", "exec", "explain this"])
+                .pane_shaped()
+        );
+    }
+
+    /// What the TUI knows — where, which harness, which agent — wins, because
+    /// the user may have moved since typing the command.
+    #[test]
+    fn retargeting_overrides_what_the_tui_decides() {
+        let args = LaunchArgs::parse_from(["code", "--codex", "-p", "old_p", "-e", "old_e"])
+            .retargeted(
+                "new_p".into(),
+                "new_e".into(),
+                "claude",
+                true,
+                Some("fix the tests".into()),
+                Some("ca_1".into()),
+            );
+        assert_eq!(args.project.as_deref(), Some("new_p"));
+        assert_eq!(args.environment.as_deref(), Some("new_e"));
+        assert_eq!(args.agent_id.as_deref(), Some("ca_1"));
+        assert_eq!(args.initial_prompt.as_deref(), Some("fix the tests"));
+        assert!(args.new);
+        assert!(args.claude, "the harness the TUI chose");
+        assert!(!args.codex, "and only that one");
+    }
+
+    /// Everything the TUI has no way to ask for survives the trip through it.
+    /// Dropping these would silently ignore what was typed: `railway code
+    /// --new --name api --variable K=V` would create an agent with a generated
+    /// name and none of the variables.
+    #[test]
+    fn retargeting_carries_the_flags_the_tui_cannot_ask_for() {
+        let args = LaunchArgs::parse_from([
+            "code",
+            "--new",
+            "--name",
+            "api",
+            "--variable",
+            "DB=postgres.DATABASE_URL",
+            "--env-file",
+            ".env",
+            "--refresh-auth",
+        ])
+        .retargeted("p".into(), "e".into(), "claude", true, None, None);
+        assert_eq!(args.name.as_deref(), Some("api"));
+        assert_eq!(args.variables, ["DB=postgres.DATABASE_URL"]);
+        assert_eq!(args.env_files, [std::path::PathBuf::from(".env")]);
+        assert!(args.refresh_auth);
+    }
 
     fn note_of(pending: PendingAuth) -> String {
         match pending {


### PR DESCRIPTION
## What

`railway code` now opens `railway ca`'s manage screen with the tree collapsed and the session autostarting in the full-width pane, instead of ssh-ing directly into the VM.

## Behavior

- `railway code` → launches the saved default harness; `railway code --<harness>` overrides it
- Target resolution unchanged: flags > linked directory > default project > inline `railway ca setup`
- ⌥f restores the tree; ⌥n starts another session; failed launch restores the tree instead of a blank screen
- Direct (non-TUI) path kept for: `--rm`, `-- <args>` passthrough, piped/non-terminal runs, and `railway ca start`

## Changes

- `code::resolve_launch` — settles target + harness before the TUI takes the screen
- `cloud_agent::launch_in_pane` — enters the TUI collapsed with the launch queued as `App.autostart`
- `dispatch_launch` — extracted from the `Effect::Launch` arm; autostart clears the same gates (ssh-key, Claude mint) as a keypress launch
- `LaunchRequest.base` — carries the original `LaunchArgs` so `--name` / `--variable` / `--env-file` / `--refresh-auth` survive the trip through the TUI; `retargeted()` overlays the TUI's decisions
- `pane_is_full()` — counts a launch in flight so the collapsed layout holds from the first frame

## Testing

- 1050 tests pass (7 new: pane predicate, flag passthrough, collapsed loading layout)
- clippy at baseline, `cargo fmt` clean