### PR TITLE
ca TUI: recover from dropped SSH connections instead of dead-ending

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -52,6 +52,7 @@ pub const KEY_HELP: &[(&str, &[(&str, &str)])] = &[
             ("shift+pgup/pgdn", "scroll without the mouse"),
             ("x", "end the session"),
             ("n", "another session on this agent"),
+            ("r", "reconnect a pane whose connection dropped"),
         ],
     ),
     (
@@ -2035,14 +2036,26 @@ impl App {
                 KeyCode::PageDown if shift => Some(false),
                 _ => None,
             };
-            if let Some(i) = self.active
-                && let Some(session) = self.sessions.get_mut(i)
-            {
-                match scroll {
-                    // No pointer for a keyboard scroll; report it over the
-                    // middle of the pane.
-                    Some(up) => session.scroll(up, 10, (1, 1)),
-                    None => session.send_key(key),
+            if let Some(i) = self.active {
+                // A pane whose connection is gone answers with recovery
+                // instead of typing: bytes sent to a dead pty vanish, which
+                // used to make "session ended" a wall with no door. Scrollback
+                // stays live — reading what the connection said on its way
+                // out is half the point of keeping the screen.
+                let dead = self
+                    .sessions
+                    .get(i)
+                    .is_some_and(|s| s.ended() || s.stalled());
+                if dead && scroll.is_none() {
+                    return self.dead_pane_key(i, key);
+                }
+                if let Some(session) = self.sessions.get_mut(i) {
+                    match scroll {
+                        // No pointer for a keyboard scroll; report it over the
+                        // middle of the pane.
+                        Some(up) => session.scroll(up, 10, (1, 1)),
+                        None => session.send_key(key),
+                    }
                 }
             }
             return None;
@@ -2489,10 +2502,6 @@ impl App {
         self.active.and_then(|i| self.sessions.get(i))
     }
 
-    fn session_index_for(&self, agent_id: &str) -> Option<usize> {
-        self.sessions.iter().position(|s| s.agent_id == agent_id)
-    }
-
     /// Show the pane belonging to the session row under the cursor, if it has
     /// one. Called after every cursor move: walking the tree is how sessions
     /// are switched now, so the pane follows the highlight.
@@ -2564,14 +2573,27 @@ impl App {
     }
 
     /// Show an already-open session. Returns false when there isn't one.
+    ///
+    /// A pane whose connection has ended doesn't count — "connect" must not
+    /// resolve to a corpse — and asking for the agent again is the natural
+    /// moment to clear such panes out of the way of the fresh connection.
     pub fn activate_session(&mut self, agent_id: &str) -> bool {
-        match self.session_index_for(agent_id) {
+        match self
+            .sessions
+            .iter()
+            .position(|s| s.agent_id == agent_id && !s.ended())
+        {
             Some(i) => {
                 self.active = Some(i);
                 self.focus = ManageFocus::Session;
                 true
             }
-            None => false,
+            None => {
+                while let Some(i) = self.sessions.iter().position(|s| s.agent_id == agent_id) {
+                    drop(self.take_session(i));
+                }
+                false
+            }
         }
     }
 
@@ -2656,6 +2678,53 @@ impl App {
         })
     }
 
+    /// Keys for a pane whose connection is gone — its ssh exited (ended) or
+    /// its attach is streaming nothing (stalled).
+    ///
+    /// Reconnect, close, or step back out; everything else is swallowed
+    /// rather than written into a pty nothing is reading. Enter is taken as
+    /// reconnect because it is the reflex after "connection closed", and
+    /// reconnecting is the only thing it could mean here.
+    fn dead_pane_key(&mut self, index: usize, key: KeyEvent) -> Option<Effect> {
+        match key.code {
+            KeyCode::Char('r') | KeyCode::Char('R') | KeyCode::Enter => {
+                self.reconnect_session(index)
+            }
+            KeyCode::Char('x') | KeyCode::Char('X') => Some(Effect::CloseSession { index }),
+            // Nothing in the pane can receive an Escape any more, so it
+            // releases to the tree — the same place the release chords go.
+            KeyCode::Esc => {
+                self.focus = ManageFocus::Tree;
+                self.maximized = false;
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Drop a pane whose connection died and dial its durable session again.
+    ///
+    /// Through [`Effect::Reattach`] rather than respawning ssh from the
+    /// pane's stored plumbing: the reattach path re-resolves the identity and
+    /// passes the ssh-key gate, so a key deregistered mid-session gets the
+    /// gate's question instead of another connection that dies the same way.
+    fn reconnect_session(&mut self, index: usize) -> Option<Effect> {
+        let session = self.take_session(index)?;
+        let Some(environment_id) = session.environment_id() else {
+            // A target that isn't `agent:<env>:<id>` has nothing to resolve;
+            // the session row in the tree still knows how to reach it.
+            self.toast_error("Couldn't resolve this session — reconnect from its row in the tree");
+            return None;
+        };
+        self.status = format!("Reconnecting to {}…", session.durable_name);
+        Some(Effect::Reattach {
+            agent_id: session.agent_id.clone(),
+            agent_name: session.agent_name.clone(),
+            environment_id,
+            session_name: session.durable_name.clone(),
+        })
+    }
+
     /// Connect to a session row: show its pane if we have one, else reattach.
     fn reattach_row(&mut self, kind: RowKind) -> Option<Effect> {
         let RowKind::Session(w, p, e, a, i) = kind else {
@@ -2665,11 +2734,19 @@ impl App {
         let (agent_id, agent_name) = self.agent_at(w, p, e, a)?;
         self.target = self.target_at((w, p, e));
 
-        // Already open: this means "put me in it", not "open another one".
+        // Already open: this means "put me in it", not "open another one" —
+        // unless the pane's connection has died, in which case "connect"
+        // means what it says. Focusing the corpse was a trap: the dead pane
+        // blocked every reattach to its session until someone discovered
+        // that `x` on the *agent* row closes panes.
         if let Some(index) = self.pane_for(&name) {
-            self.active = Some(index);
-            self.focus = ManageFocus::Session;
-            return None;
+            if self.sessions[index].ended() {
+                drop(self.take_session(index));
+            } else {
+                self.active = Some(index);
+                self.focus = ManageFocus::Session;
+                return None;
+            }
         }
         // Not open: reconnect straight to it. Reattaching needs no credential,
         // no skills sync and no provisioning — the agent is already set up,
@@ -4681,6 +4758,132 @@ mod tests {
         a.take_session(0);
         assert!(!a.maximized);
         assert_eq!(a.focus, ManageFocus::Tree);
+    }
+
+    /// A pane whose ssh has died must offer a way back in: `r` drops the dead
+    /// pane and dials the same durable session again — the whole recovery
+    /// path a dropped connection used to be missing.
+    #[test]
+    fn a_dead_pane_reconnects_with_r() {
+        let mut a = with_sessions(&["ca_1"]);
+        a.focus = ManageFocus::Session;
+        a.sessions[0].mark_ended();
+
+        let effect = a.on_key(key(KeyCode::Char('r')));
+        assert_eq!(
+            effect,
+            Some(Effect::Reattach {
+                agent_id: "ca_1".into(),
+                agent_name: "ca_1".into(),
+                // for_test connects as agent:test:test — the environment is
+                // read back out of the relay target.
+                environment_id: "test".into(),
+                session_name: "test".into(),
+            })
+        );
+        assert!(a.sessions.is_empty(), "the dead pane is gone");
+        assert!(a.status.contains("Reconnecting"), "{}", a.status);
+    }
+
+    /// Keystrokes into a dead pane go nowhere on purpose — a pty nothing
+    /// reads must not eat typing — and the recovery keys do their jobs.
+    #[test]
+    fn a_dead_pane_swallows_typing_and_answers_the_recovery_keys() {
+        let mut a = with_sessions(&["ca_1"]);
+        a.focus = ManageFocus::Session;
+        a.sessions[0].mark_ended();
+
+        assert_eq!(a.on_key(key(KeyCode::Char('h'))), None, "typing vanishes");
+        assert_eq!(
+            a.on_key(key(KeyCode::Char('x'))),
+            Some(Effect::CloseSession { index: 0 })
+        );
+        // Enter means reconnect here — it is the reflex after "connection
+        // closed", and there is nothing else it could mean.
+        assert!(matches!(
+            a.on_key(key(KeyCode::Enter)),
+            Some(Effect::Reattach { .. })
+        ));
+    }
+
+    /// Escape on a dead pane releases to the tree: the agent that would have
+    /// received it is not on the other end any more.
+    #[test]
+    fn escape_on_a_dead_pane_returns_to_the_tree() {
+        let mut a = with_sessions(&["ca_1"]);
+        a.focus = ManageFocus::Session;
+        a.sessions[0].mark_ended();
+
+        assert_eq!(a.on_key(key(KeyCode::Esc)), None);
+        assert_eq!(a.focus, ManageFocus::Tree);
+    }
+
+    /// "Connect" must never resolve to a corpse: an agent whose only pane has
+    /// died reads as not connected, and the dead pane is cleared out of the
+    /// way of the fresh connection.
+    #[test]
+    fn a_dead_pane_does_not_count_as_connected() {
+        let mut a = with_sessions(&["ca_1"]);
+        a.sessions[0].mark_ended();
+
+        assert!(!a.activate_session("ca_1"));
+        assert!(a.sessions.is_empty(), "the dead pane was cleared");
+    }
+
+    /// Enter on a session row whose pane has died reconnects instead of
+    /// focusing the corpse. The old behaviour was a trap: the dead pane
+    /// blocked every reattach to its session until it was closed from the
+    /// agent row, which nothing advertised.
+    #[test]
+    fn enter_on_a_session_row_with_a_dead_pane_reattaches() {
+        let mut a = loaded_app();
+        if let Load::Loaded(agents) = &mut a.tree[0].projects[0].envs[0].agents {
+            agents[0].expanded = true;
+            agents[0].sessions = LoadSessions::Loaded(vec![ConsoleSession {
+                // The durable name for_test sessions carry.
+                name: "test".into(),
+                kind: "SHELL".into(),
+                command: None,
+                running: true,
+                attached: false,
+            }]);
+        }
+        a.attach_session(
+            super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+        a.sessions[0].mark_ended();
+        a.focus = ManageFocus::Tree;
+        a.cursor = a.rows().iter().position(|r| r.label == "test").unwrap();
+
+        let effect = a.on_key(key(KeyCode::Enter));
+        assert_eq!(
+            effect,
+            Some(Effect::Reattach {
+                agent_id: "ca_1".into(),
+                agent_name: "nimble-otter".into(),
+                environment_id: "env_prod".into(),
+                session_name: "test".into(),
+            })
+        );
+        assert!(a.sessions.is_empty(), "the dead pane went first");
+    }
+
+    /// A live pane keeps its keys: recovery must only take over once the
+    /// connection is actually gone.
+    #[test]
+    fn a_live_pane_still_owns_the_keyboard() {
+        let mut a = with_sessions(&["ca_1"]);
+        a.focus = ManageFocus::Session;
+
+        assert_eq!(a.on_key(key(KeyCode::Char('r'))), None);
+        assert_eq!(a.on_key(key(KeyCode::Char('x'))), None);
+        assert_eq!(
+            a.sessions.len(),
+            1,
+            "r and x were typing, not pane commands"
+        );
+        assert_eq!(a.focus, ManageFocus::Session);
     }
 
     /// So does leaving the screen.

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -398,6 +398,20 @@ impl Session {
         self.ended.load(Ordering::Relaxed)
     }
 
+    /// The environment this session's agent lives in, read back out of the
+    /// relay target (`agent:<environment>:<agent>`) it connected with.
+    ///
+    /// Reconnecting after a drop needs it — `connect_info` resolves the relay
+    /// plumbing from environment and agent — and the target is the one place
+    /// the session still carries it.
+    pub fn environment_id(&self) -> Option<String> {
+        let mut parts = self.ssh_target.split(':');
+        match (parts.next()?, parts.next()) {
+            ("agent", Some(env)) if !env.is_empty() => Some(env.to_string()),
+            _ => None,
+        }
+    }
+
     /// Resize both the emulator and the pty. Doing only one leaves the agent
     /// drawing to a screen of a different shape than the one being rendered.
     pub fn resize(&mut self, rows: u16, cols: u16) {
@@ -686,6 +700,13 @@ fn url_in(line: &str, col: usize) -> Option<String> {
 
 #[cfg(test)]
 impl Session {
+    /// Flip the session to ended without waiting for its process to die —
+    /// the reader thread races a test that killed `cat`, and the state under
+    /// test is "the connection is gone", not how it went.
+    pub fn mark_ended(&self) {
+        self.ended.store(true, Ordering::Relaxed);
+    }
+
     /// A session backed by a local `cat` instead of ssh, so the state machine
     /// around sessions can be tested without a relay or a network.
     pub fn for_test(agent_id: &str, agent_name: &str) -> Result<Self> {
@@ -1031,6 +1052,15 @@ mod tests {
                 .unwrap_or(false),
             "expected the kitty encoding on the wire"
         );
+    }
+
+    /// Reconnecting resolves the relay plumbing from the environment, which
+    /// the session only holds inside its relay target.
+    #[test]
+    fn the_environment_is_read_back_out_of_the_relay_target() {
+        let session = Session::for_test("ca", "test").unwrap();
+        // for_test connects as agent:test:test.
+        assert_eq!(session.environment_id().as_deref(), Some("test"));
     }
 
     #[test]

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1151,13 +1151,26 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
     let hint: Vec<(&str, &str)> = if app.maximized {
         vec![("⌥f", "restore the tree"), ("⌥/⇧esc / ^]", "stop typing")]
     } else if app.focus == ManageFocus::Session {
-        let mut keys = vec![("⌥/⇧esc / ^]", "stop typing"), ("⌥f", "maximize")];
-        // The agent is taking the clicks, so say how to take one back — this is
-        // the terminal's own convention, but nobody guesses it.
-        if app.active_session().is_some_and(|s| s.wants_mouse()) {
-            keys.push(("shift+drag", "select"));
+        // A dead pane's keys are recovery, not typing — the hint has to say
+        // so, or "stop typing" advertises an input nothing is reading.
+        if app
+            .active_session()
+            .is_some_and(|s| s.ended() || s.stalled())
+        {
+            vec![
+                ("r", "reconnect"),
+                ("x", "close pane"),
+                ("esc", "back to the tree"),
+            ]
+        } else {
+            let mut keys = vec![("⌥/⇧esc / ^]", "stop typing"), ("⌥f", "maximize")];
+            // The agent is taking the clicks, so say how to take one back — this is
+            // the terminal's own convention, but nobody guesses it.
+            if app.active_session().is_some_and(|s| s.wants_mouse()) {
+                keys.push(("shift+drag", "select"));
+            }
+            keys
         }
-        keys
     } else {
         match app.selected_row().map(|r| r.kind) {
             Some(RowKind::Session(..)) => vec![
@@ -1778,7 +1791,15 @@ fn render_session(app: &App, session: &super::session::Session, f: &mut Frame, a
         // strip at the bottom of the screen already has it.
         .title_bottom(Line::from(Span::styled(
             if session.ended() {
-                " session ended "
+                // The keys differ by focus: r/x are the pane's own, enter is
+                // the tree's. Advertising the wrong set would send keystrokes
+                // into the tree — or worse, `x` into a session row, which
+                // kills the session on the agent.
+                if focused {
+                    " connection closed · r reconnects · x closes "
+                } else {
+                    " connection closed · enter on its row reconnects "
+                }
             } else if session.stalled() {
                 " no response "
             } else if session.scrolled_back() {
@@ -1810,10 +1831,7 @@ fn render_session(app: &App, session: &super::session::Session, f: &mut Frame, a
                     "It may have ended when the agent last slept —",
                     dim,
                 )),
-                Line::from(Span::styled(
-                    "x closes this pane, n starts a fresh session.",
-                    dim,
-                )),
+                Line::from(Span::styled("r dials it again, x closes this pane.", dim)),
             ])
             .alignment(ratatui::layout::Alignment::Center),
             inner,

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -585,6 +585,19 @@ fn relay_ssh() -> Result<RelaySsh> {
             format!("UserKnownHostsFile={}", known_hosts.display()),
             "-o".into(),
             "StrictHostKeyChecking=accept-new".into(),
+            // A session pane sits idle for as long as the user reads, and an
+            // idle TCP path through a NAT or load balancer gets dropped without
+            // either end being told. Without keepalives that shows up as a pane
+            // frozen until the kernel gives up on the connection — tens of
+            // minutes — with no error from anything. Probing every 30s keeps
+            // the idle-timeout clocks at zero and turns a dead path into a
+            // detected disconnect within ~90s, which the TUI can then offer to
+            // reconnect. Same numbers as the port-forward path, for the same
+            // reason.
+            "-o".into(),
+            "ServerAliveInterval=30".into(),
+            "-o".into(),
+            "ServerAliveCountMax=3".into(),
         ],
         known_hosts,
         host_pattern,


### PR DESCRIPTION
## Why

SSH connections into cloud agent sessions drop — and when they did, the TUI presented the failure with no path back in (seen repeatedly against a long-lived agent). Two compounding problems:

**The connections were dropping more than they had to.** The interactive relay ssh — both the TUI's pty sessions and full-screen `railway code` — ran with **no keepalives**. The port-forward path already sets `ServerAliveInterval=30 / ServerAliveCountMax=3` ("detect a dead relay connection within ~90s instead of hanging"), but the paths a human actually sits in never got them. A session pane idles for as long as the user reads; any NAT / LB / firewall along the way drops that idle flow without telling either end. The result was either an abrupt `session ended` or a pane frozen until the kernel gave up on the TCP connection — tens of minutes, with no error from anything.

**And when a connection died, there was no recovery path:**

- The pane flipped to `session ended` and kept routing every keystroke into the dead pty, where they vanished.
- Enter on the session row in the tree hit the "already open: put me in it" branch and focused the corpse — the dead pane *blocked* every reattach to its own session.
- The only way out was `x` on the **agent** row (closes the pane) — while `x` on the *session* row kills the session on the agent. Nothing advertised any of this; in practice the recovery path was restarting the TUI.
- The stalled-attach overlay advertised `x` and `n`, which are tree keys — and the pane it appears over holds focus, so neither worked from where the user was standing.

## What

- `relay_ssh()` opts now include `ServerAliveInterval=30` / `ServerAliveCountMax=3`, which reach every session pane, reattach, and full-screen connect. Idle drops are prevented (the probe keeps NAT/LB idle clocks at zero) and dead paths become a detected disconnect within ~90s instead of a silent freeze.
- A pane whose connection is gone (ended or stalled) now answers with recovery instead of typing: **r** (or **enter**) reconnects the same durable session, **x** closes the pane, **esc** releases to the tree. Reconnect rides the existing `Effect::Reattach` path, so it re-resolves the identity and passes the ssh-key gate. Shift+PgUp/PgDn scrollback stays live — the connection's parting words (ssh's error, the relay's refusal) are on that screen.
- Enter on a session row whose pane has died drops the dead pane and reattaches instead of focusing it; `activate_session` no longer counts ended panes as connected and clears them out of the way of the fresh connection.
- The pane footer and manage footer advertise the recovery keys, focus-aware so they never point at another pane's bindings (`connection closed · r reconnects · x closes` when focused; `enter on its row reconnects` from the tree).

## Tests

- `r` on a dead pane emits `Effect::Reattach` for the same durable session and removes the pane; enter does the same; `x` closes; esc releases to the tree; other typing is swallowed.
- A live pane still owns its keyboard — recovery only takes over once the connection is gone.
- Enter on a session row with a dead pane reattaches instead of focusing it.
- `activate_session` skips/clears ended panes.
- The environment id round-trips out of the relay target (`agent:<env>:<id>`).

`cargo test` (the 7 pre-existing `auth_sim` failures reproduce on the base commit in this environment), `cargo fmt`, `cargo clippy` clean on touched files.