### PR TITLE
ca manage: say when the highlighted session is disconnected

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -2703,7 +2703,7 @@ impl App {
 
     /// The open pane a row refers to: a session's own, or the first one on an
     /// agent.
-    fn pane_for_row(&self, kind: RowKind) -> Option<usize> {
+    pub fn pane_for_row(&self, kind: RowKind) -> Option<usize> {
         match kind {
             RowKind::Session(w, p, e, a, i) => {
                 let name = self.console_session(w, p, e, a, i)?.name.clone();

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -2289,6 +2289,12 @@ impl App {
                 None
             }
             MouseAction::Down => {
+                // A click clears the status line, the same as a keypress
+                // (see on_key): the message answered the previous gesture,
+                // and whatever this click means sets a fresh one — clicking
+                // a disconnected session must not leave "not connected"
+                // standing once the cursor is on a connected one.
+                self.status.clear();
                 let pane = self.pane_at(col, row)?;
                 // An agent with clickable output — "click here to copy", a menu
                 // you can point at — turns mouse reporting on and waits for the
@@ -5757,6 +5763,55 @@ mod tests {
         a.on_mouse(MouseAction::Down, 5, 3 + row as u16);
         assert_eq!(a.focus, ManageFocus::Tree);
         assert!(a.status.contains("enter to reattach"), "{}", a.status);
+    }
+
+    /// The reattach prompt answers the click that raised it: clicking a
+    /// connected session afterwards clears it, the same as a keypress would,
+    /// instead of leaving "not connected" standing over a connected pane.
+    #[test]
+    fn clicking_a_connected_session_clears_the_reattach_prompt() {
+        let mut a = loaded_app();
+        if let Load::Loaded(agents) = &mut a.tree[0].projects[0].envs[0].agents {
+            agents[0].expanded = true;
+            agents[0].sessions = LoadSessions::Loaded(vec![
+                ConsoleSession {
+                    name: "claude-one".into(),
+                    kind: "SHELL".into(),
+                    command: None,
+                    running: true,
+                    attached: true,
+                },
+                ConsoleSession {
+                    name: "claude-two".into(),
+                    kind: "SHELL".into(),
+                    command: None,
+                    running: true,
+                    attached: false,
+                },
+            ]);
+        }
+        let mut pane = super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap();
+        pane.durable_name = "claude-one".into();
+        a.sessions = vec![pane];
+        a.active = Some(0);
+        a.panes = panes_fixture();
+
+        let two = a
+            .rows()
+            .iter()
+            .position(|r| r.label == "claude-two")
+            .unwrap();
+        a.on_mouse(MouseAction::Down, 5, 3 + two as u16);
+        assert!(a.status.contains("enter to reattach"), "{}", a.status);
+
+        let one = a
+            .rows()
+            .iter()
+            .position(|r| r.label == "claude-one")
+            .unwrap();
+        a.on_mouse(MouseAction::Down, 5, 3 + one as u16);
+        assert!(a.status.is_empty(), "{}", a.status);
+        assert_eq!(a.active, Some(0));
     }
 
     /// Enter on a project toggles it: the first press opens it straight

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1064,28 +1064,37 @@ fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
         // What the right pane shows follows the selection, not merely whether a
         // session happens to be open: standing on an agent should show that
         // agent's cards even while one of its sessions is running in the
-        // background. Typing in a session is the exception — the pane it has
+        // background, and standing on a session that has no pane must not keep
+        // showing whichever pane was connected last — it gets a card saying
+        // so instead. Typing in a session is the exception — the pane it has
         // the keyboard in cannot vanish from under it.
+        let selected_kind = app.selected_row().map(|row| row.kind);
         let show_session = app.focus == ManageFocus::Session
-            || matches!(
-                app.selected_row().map(|row| row.kind),
-                Some(RowKind::Session(..))
-            );
+            || selected_kind.is_some_and(|kind| {
+                matches!(kind, RowKind::Session(..)) && app.pane_for_row(kind).is_some()
+            });
         if app.loading.active {
             render_loading(app, f, panes[1]);
         } else {
             match app.active_session().filter(|_| show_session) {
                 Some(session) => render_session(app, session, f, panes[1]),
-                None => f.render_widget(
-                    Paragraph::new(detail_lines(app)).block(
-                        Block::default()
-                            .borders(Borders::ALL)
-                            .border_type(BorderType::Rounded)
-                            .border_style(Style::default().fg(theme.accent_dim))
-                            .title(Span::styled(" agent ", Style::default().fg(theme.dim))),
-                    ),
-                    panes[1],
-                ),
+                None => {
+                    let title = if matches!(selected_kind, Some(RowKind::Session(..))) {
+                        " session "
+                    } else {
+                        " agent "
+                    };
+                    f.render_widget(
+                        Paragraph::new(detail_lines(app)).block(
+                            Block::default()
+                                .borders(Borders::ALL)
+                                .border_type(BorderType::Rounded)
+                                .border_style(Style::default().fg(theme.accent_dim))
+                                .title(Span::styled(title, Style::default().fg(theme.dim))),
+                        ),
+                        panes[1],
+                    )
+                }
             }
         }
     }
@@ -2204,11 +2213,8 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
             ))];
             // The command lives here, not in the row: it is a whole launch
             // line, and this is the pane with room for it.
-            if let Load::Loaded(agents) = &app.tree[w].projects[p].envs[e].agents
-                && let Some(agent) = agents.get(a)
-                && let LoadSessions::Loaded(sessions) = &agent.sessions
-                && let Some(session) = sessions.get(i)
-            {
+            let session = app.console_session(w, p, e, a, i);
+            if let Some(session) = session {
                 lines.push(Line::from(""));
                 lines.push(kv(
                     "state",
@@ -2222,10 +2228,35 @@ fn detail_lines(app: &App) -> Vec<Line<'static>> {
                 )));
             }
             lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                " enter reattaches in the pane",
-                Style::default().fg(theme.dim),
-            )));
+            // This card only shows for a session without a pane (one with a
+            // pane shows the pane itself), so say that plainly, and say how
+            // to get the pane back — via a wake first when the agent is
+            // asleep, since a reattach to a sleeping agent is refused.
+            let connected = session
+                .is_some_and(|s| app.sessions.iter().any(|pane| pane.durable_name == s.name));
+            if connected {
+                lines.push(Line::from(Span::styled(
+                    " enter puts the keyboard in its pane",
+                    Style::default().fg(theme.dim),
+                )));
+            } else {
+                let sleeping = app
+                    .selected_agent_status()
+                    .is_some_and(|status| status != "running");
+                lines.push(Line::from(Span::styled(
+                    " not connected — its output isn't shown here",
+                    Style::default().fg(theme.pending),
+                )));
+                lines.push(Line::from(""));
+                lines.push(Line::from(Span::styled(
+                    if sleeping {
+                        " w wakes the agent, then enter reconnects"
+                    } else {
+                        " enter reconnects · c copies the ssh command"
+                    },
+                    Style::default().fg(theme.dim),
+                )));
+            }
             lines
         }
         RowKind::OtherProjects => vec![
@@ -3469,6 +3500,60 @@ mod tests {
         assert!(
             out.contains("nimble-otter · claude-one"),
             "the session pane's title:\n{out}"
+        );
+    }
+
+    /// Standing on a session that has no pane says so and offers the way
+    /// back, instead of leaving whichever pane was connected last on screen.
+    #[test]
+    fn a_disconnected_session_says_so() {
+        let mut app = app_with_tree();
+        app.screen = Screen::Manage;
+        if let Load::Loaded(agents) = &mut app.tree[0].projects[0].envs[0].agents {
+            agents[0].expanded = true;
+            agents[0].sessions = LoadSessions::Loaded(vec![
+                crate::commands::cloud_agent::tui::app::ConsoleSession {
+                    name: "claude-one".into(),
+                    kind: "SHELL".into(),
+                    command: None,
+                    running: true,
+                    attached: true,
+                },
+                crate::commands::cloud_agent::tui::app::ConsoleSession {
+                    name: "claude-two".into(),
+                    kind: "SHELL".into(),
+                    command: None,
+                    running: true,
+                    attached: false,
+                },
+            ]);
+        }
+        // One pane is open, for the *other* session.
+        let mut pane =
+            crate::commands::cloud_agent::tui::session::Session::for_test("ca_1", "nimble-otter")
+                .unwrap();
+        pane.durable_name = "claude-one".into();
+        app.sessions = vec![pane];
+        app.active = Some(0);
+        app.focus = ManageFocus::Tree;
+        app.cursor = app
+            .rows()
+            .iter()
+            .position(|r| r.label == "claude-two")
+            .unwrap();
+
+        let out = draw(&app, 110, 30);
+        assert!(
+            !out.contains("nimble-otter · claude-one"),
+            "the other session's pane must not linger:\n{out}"
+        );
+        assert!(
+            out.contains("not connected"),
+            "the card says the session is disconnected:\n{out}"
+        );
+        assert!(
+            out.contains("enter reconnects"),
+            "the card says how to get it back:\n{out}"
         );
     }
 

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1848,6 +1848,15 @@ fn screen_lines(screen: &vt100::Screen, focused: bool) -> Vec<Line<'static>> {
         let mut run_style: Option<Style> = None;
 
         for col in 0..cols {
+            // A wide character's second cell: the glyph already spans both
+            // columns when drawn, so a space here would shift the rest of
+            // the line right by one column per wide character.
+            if screen
+                .cell(row, col)
+                .is_some_and(vt100::Cell::is_wide_continuation)
+            {
+                continue;
+            }
             let (text, mut style) = match screen.cell(row, col) {
                 Some(cell) => (
                     {
@@ -1899,6 +1908,11 @@ fn cell_style(cell: &vt100::Cell) -> Style {
     }
     if cell.bold() {
         style = style.add_modifier(Modifier::BOLD);
+    }
+    // Claude Code's ghost text — the follow-up prompt → fills in — is plain
+    // SGR 2, no colour of its own; dropping dim renders it as ordinary text.
+    if cell.dim() {
+        style = style.add_modifier(Modifier::DIM);
     }
     if cell.italic() {
         style = style.add_modifier(Modifier::ITALIC);
@@ -3574,6 +3588,45 @@ mod tests {
             out.contains("what changed"),
             "the end of the prompt should be visible:\n{out}"
         );
+    }
+
+    /// Every text attribute the emulator tracks survives into the drawn
+    /// pane. Dim is the one that regressed: Claude Code's ghost text is
+    /// plain SGR 2 with no colour of its own, so dropping it rendered the
+    /// suggestion as ordinary text.
+    #[test]
+    fn emulator_attributes_reach_the_pane() {
+        let mut parser = vt100::Parser::new(4, 40, 0);
+        parser.process(b"plain \x1b[2mghost\x1b[22m \x1b[3mslant\x1b[23m \x1b[1mloud\x1b[22m");
+        let lines = screen_lines(parser.screen(), false);
+        let style_of = |word: &str| {
+            lines[0]
+                .spans
+                .iter()
+                .find(|span| span.content.contains(word))
+                .unwrap_or_else(|| panic!("{word} is on screen"))
+                .style
+        };
+        assert!(style_of("ghost").add_modifier.contains(Modifier::DIM));
+        assert!(style_of("slant").add_modifier.contains(Modifier::ITALIC));
+        assert!(style_of("loud").add_modifier.contains(Modifier::BOLD));
+        assert!(style_of("plain").add_modifier.is_empty());
+    }
+
+    /// A wide character owns two columns but is one glyph: its continuation
+    /// cell must not become a phantom space that shifts the rest of the line
+    /// right.
+    #[test]
+    fn wide_characters_keep_their_columns() {
+        let mut parser = vt100::Parser::new(2, 10, 0);
+        parser.process("\u{65e5}x".as_bytes());
+        let lines = screen_lines(parser.screen(), false);
+        let text: String = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.clone().into_owned())
+            .collect();
+        assert_eq!(text, "\u{65e5}x       ");
     }
 
     /// Wrapping arithmetic the scroll depends on.


### PR DESCRIPTION
Two UX fixes for walking the session tree in `railway ca manage`:

**The right pane follows the cursor onto disconnected sessions.** Previously it only followed the cursor onto sessions that already had a connected pane — landing on a disconnected one left whichever pane was connected last on screen, reading as if it were that session's output. A session row without a pane now gets a card saying it is not connected and how to get it back: enter reconnects, `c` copies the ssh command, or `w` first when the agent is asleep (a reattach to a sleeping agent is refused).

**A click clears the status line, the same as a keypress.** Clicking a disconnected session sets "Not connected — enter to reattach", but the mouse path never cleared the status the way `on_key` does, so the message outlived the click and stood over whatever was selected next — including a connected session. It now clears at the top of the mouse-down arm, and the handler sets a fresh one when the newly clicked row warrants it.

Both have regression tests (`a_disconnected_session_says_so`, `clicking_a_connected_session_clears_the_reattach_prompt`).

**Text attributes survive the trip into the session pane.** Claude Code's ghost text (the follow-up prompt → fills in) is plain SGR 2 — dim, no colour of its own. The vt100 emulator tracked dim but `cell_style` never mapped it to `Modifier::DIM`, so the suggestion drew as ordinary full-intensity text; dim was the only attribute vt100 exposes that the mapping dropped. Same function, second gap found while auditing: a wide character's continuation cell was emitted as a phantom space, shifting the rest of the line right one column per CJK/emoji glyph — continuations are now skipped (`url_at` keeps its space on purpose; it maps click columns to char indices). Tests: `emulator_attributes_reach_the_pane`, `wide_characters_keep_their_columns`. Known limitation, out of reach here: the vt100 crate itself ignores strikethrough/blink/conceal (SGR 9/5/8), so those can't be carried through without changing emulators.