### PR TITLE
ca: add a shell-only option to the new agent surfaces

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -23,8 +23,16 @@ use super::theme::Theme;
 /// leads the list — and so is the default pick with nothing configured —
 /// since it is the one exception needing no credential of its own: no
 /// carry-a-local-sign-in step, just the VM's own integrated Railway
-/// credentials.
-pub const HARNESSES: &[&str] = &["railway", "claude", "codex", "grok"];
+/// credentials. `shell` closes it: not a harness at all, just the VM's login
+/// shell, so it takes no prompt and sits after every real agent.
+pub const HARNESSES: &[&str] = &["railway", "claude", "codex", "grok", "shell"];
+
+/// The slice of [`HARNESSES`] that can be saved as the default agent —
+/// everything but `shell`, which starts no harness and so makes no sense as
+/// a standing default. What the setup wizard and settings offer.
+pub fn default_harnesses() -> &'static [&'static str] {
+    &HARNESSES[..HARNESSES.len() - 1]
+}
 
 /// Everything the Manage screen responds to, grouped for the `?` overlay. The
 /// footer shows two or three of these; this is where the rest lives, so the
@@ -1133,7 +1141,9 @@ impl App {
 
     fn new_session_on(&self, agent_id: &str, agent_name: &str) -> Option<Effect> {
         let target = self.target.clone()?;
-        let prompt = (!self.prompt.trim().is_empty()).then(|| self.prompt.trim().to_string());
+        // Same contract as `launch`: shell sessions carry no prompt.
+        let prompt = (!self.shell_selected() && !self.prompt.trim().is_empty())
+            .then(|| self.prompt.trim().to_string());
         Some(Effect::Launch(LaunchRequest {
             project_id: target.project_id,
             environment_id: target.environment_id,
@@ -1215,10 +1225,18 @@ impl App {
                 environment_id: t.environment_id.clone(),
                 environment_name: t.environment_name.clone(),
             });
+        // The settings card is over the saved default, whose index space is
+        // `default_harnesses()` — a live shell selection has no row there and
+        // falls back to the first entry rather than clamping onto the last
+        // real agent.
+        let agent = default_harnesses()
+            .iter()
+            .position(|slug| *slug == self.harness_name())
+            .unwrap_or(0);
         self.settings = Some(super::settings::Settings::new(
             &self.tree,
             project,
-            self.harness,
+            agent,
             self.skills_enabled,
             self.skills_source.clone(),
             self.theme,
@@ -1241,6 +1259,12 @@ impl App {
 
     pub fn harness_name(&self) -> &'static str {
         HARNESSES[self.harness.min(HARNESSES.len() - 1)]
+    }
+
+    /// Is the shell option selected? It launches no harness, so the prompt
+    /// boxes go inert while it is: there is nothing to hand a prompt to.
+    pub fn shell_selected(&self) -> bool {
+        self.harness_name() == "shell"
     }
 
     /// The flattened, currently-visible tree: agent groups first, then the
@@ -1929,7 +1953,10 @@ impl App {
     }
 
     fn launch(&self, agent_id: Option<String>, force_new: bool) -> Option<Effect> {
-        let draft = (!self.prompt.trim().is_empty()).then(|| self.prompt.trim().to_string());
+        // A shell session takes no prompt; a draft left over from cycling
+        // through the agents must not ride along.
+        let draft = (!self.shell_selected() && !self.prompt.trim().is_empty())
+            .then(|| self.prompt.trim().to_string());
         self.launch_prompted(agent_id, force_new, draft)
     }
 
@@ -3201,12 +3228,17 @@ impl App {
 
     fn on_key_menu(&mut self, key: KeyEvent) -> Option<Effect> {
         match self.menu_focus {
+            // Typing is refused while shell is selected — the box says so —
+            // rather than cleared: a draft typed for a real agent survives
+            // cycling past shell.
             MenuFocus::Prompt => match key.code {
-                KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                KeyCode::Char(c)
+                    if !key.modifiers.contains(KeyModifiers::CONTROL) && !self.shell_selected() =>
+                {
                     self.prompt.push(c);
                     None
                 }
-                KeyCode::Backspace => {
+                KeyCode::Backspace if !self.shell_selected() => {
                     self.prompt.pop();
                     None
                 }
@@ -3570,16 +3602,20 @@ impl App {
     }
 
     /// Keys while the ⌥p composer is up: the menu prompt box's contract —
-    /// type, shift+tab cycles the agent, enter sends, esc closes.
+    /// type, shift+tab cycles the agent, enter sends, esc closes. And the
+    /// menu box's shell contract too: typing goes inert, and enter launches
+    /// the session bare, since a shell has nothing to hand a prompt to.
     fn on_key_manage_prompt(&mut self, key: KeyEvent) -> Option<Effect> {
         let mut draft = self.manage_prompt.take()?;
         match key.code {
-            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char(c)
+                if !key.modifiers.contains(KeyModifiers::CONTROL) && !self.shell_selected() =>
+            {
                 draft.push(c);
                 self.manage_prompt = Some(draft);
                 None
             }
-            KeyCode::Backspace => {
+            KeyCode::Backspace if !self.shell_selected() => {
                 draft.pop();
                 self.manage_prompt = Some(draft);
                 None
@@ -3588,6 +3624,10 @@ impl App {
                 self.harness = (self.harness + 1) % HARNESSES.len();
                 self.manage_prompt = Some(draft);
                 None
+            }
+            KeyCode::Enter if self.shell_selected() => {
+                self.screen = Screen::Manage;
+                self.new_here_prompted(None)
             }
             KeyCode::Enter if !draft.trim().is_empty() => {
                 self.screen = Screen::Manage;
@@ -4999,9 +5039,55 @@ mod tests {
         a.on_key(key(KeyCode::BackTab));
         assert_eq!(a.harness_name(), "grok");
         a.on_key(key(KeyCode::BackTab));
-        assert_eq!(a.harness_name(), "railway");
+        assert_eq!(a.harness_name(), "shell", "shell closes the cycle");
         a.on_key(key(KeyCode::BackTab));
-        assert_eq!(a.harness_name(), "claude", "cycling wraps");
+        assert_eq!(a.harness_name(), "railway", "cycling wraps");
+    }
+
+    /// The order is a contract: `railway` is the unconfigured default, and
+    /// `shell` sits after every real agent on every surface that lists them.
+    #[test]
+    fn railway_leads_the_harnesses_and_shell_closes_them() {
+        assert_eq!(HARNESSES.first(), Some(&"railway"));
+        assert_eq!(HARNESSES.last(), Some(&"shell"));
+        assert_eq!(default_harnesses(), &HARNESSES[..HARNESSES.len() - 1]);
+        assert!(
+            !default_harnesses().contains(&"shell"),
+            "shell is not a saveable default"
+        );
+    }
+
+    /// The shell option takes no prompt: the menu box refuses keystrokes while
+    /// it is selected, keeps a draft typed for a real agent, and launches
+    /// without one.
+    #[test]
+    fn the_menu_prompt_goes_inert_on_shell() {
+        let mut a = app();
+        a.target = Some(Target {
+            project_id: "p".into(),
+            project_name: "p".into(),
+            environment_id: "e".into(),
+            environment_name: "e".into(),
+        });
+        a.on_key(key(KeyCode::Char('h')));
+        a.on_key(key(KeyCode::Char('i')));
+        assert_eq!(a.prompt, "hi");
+        while a.harness_name() != "shell" {
+            a.on_key(key(KeyCode::BackTab));
+        }
+        a.on_key(key(KeyCode::Char('x')));
+        a.on_key(key(KeyCode::Backspace));
+        assert_eq!(a.prompt, "hi", "typing is refused, the draft survives");
+        let Effect::Launch(req) = a.on_key(key(KeyCode::Enter)).unwrap() else {
+            panic!("expected a launch");
+        };
+        assert_eq!(req.harness, "shell");
+        assert_eq!(req.prompt, None, "a leftover draft must not ride along");
+        while a.harness_name() != "claude" {
+            a.on_key(key(KeyCode::BackTab));
+        }
+        a.on_key(key(KeyCode::Char('!')));
+        assert_eq!(a.prompt, "hi!", "typing resumes on a real agent");
     }
 
     fn alt(c: char) -> KeyEvent {
@@ -6127,6 +6213,70 @@ mod tests {
         assert_eq!(a.screen, Screen::ManagePrompt, "nothing to send yet");
         assert_eq!(a.on_key(key(KeyCode::Esc)), None);
         assert_eq!(a.screen, Screen::Manage);
+    }
+
+    /// The ⌥p composer follows the menu box's shell contract: cycling can
+    /// land on shell, typing goes inert there, and enter launches the session
+    /// bare instead of demanding a prompt a shell could never take.
+    #[test]
+    fn alt_p_launches_a_bare_shell_session() {
+        let mut a = app();
+        a.screen = Screen::Manage;
+        a.target = Some(Target {
+            project_id: "p1".into(),
+            project_name: "devtools".into(),
+            environment_id: "env_prod".into(),
+            environment_name: "production".into(),
+        });
+        a.on_key(alt('p'));
+        for c in "fix it".chars() {
+            a.on_key(key(KeyCode::Char(c)));
+        }
+        while a.harness_name() != "shell" {
+            a.on_key(key(KeyCode::BackTab));
+        }
+        a.on_key(key(KeyCode::Char('x')));
+        assert_eq!(
+            a.manage_prompt.as_deref(),
+            Some("fix it"),
+            "typing is refused while shell is selected"
+        );
+        let effect = a.on_key(key(KeyCode::Enter));
+        assert_eq!(a.screen, Screen::Manage);
+        let Some(Effect::Launch(req)) = effect else {
+            panic!("expected a launch, got {effect:?}");
+        };
+        assert_eq!(req.harness, "shell");
+        assert_eq!(req.prompt, None, "the abandoned draft must not ride along");
+    }
+
+    /// ⌥n's picker offers shell like any agent — last in the list — and
+    /// picking it makes the same promptless session `n` would.
+    #[test]
+    fn alt_n_offers_shell_last() {
+        let mut a = app();
+        a.screen = Screen::Manage;
+        a.target = Some(Target {
+            project_id: "p1".into(),
+            project_name: "devtools".into(),
+            environment_id: "env_prod".into(),
+            environment_name: "production".into(),
+        });
+        a.on_key(alt('n'));
+        for _ in 0..HARNESSES.len() {
+            a.on_key(key(KeyCode::Down));
+        }
+        assert_eq!(
+            a.harness_pick,
+            Some(HARNESSES.len() - 1),
+            "the cursor bottoms out on shell"
+        );
+        let effect = a.on_key(key(KeyCode::Enter));
+        let Some(Effect::Launch(req)) = effect else {
+            panic!("expected a launch, got {effect:?}");
+        };
+        assert_eq!(req.harness, "shell");
+        assert_eq!(req.prompt, None);
     }
 
     /// The launchers work from inside a session, which is where the thought

--- a/src/commands/cloud_agent/tui/settings.rs
+++ b/src/commands/cloud_agent/tui/settings.rs
@@ -11,7 +11,7 @@
 //! project list is too long to flick through blind, so its row opens the same
 //! card the wizard's project step uses, and comes straight back here.
 
-use super::app::{HARNESSES, WorkspaceNode};
+use super::app::{WorkspaceNode, default_harnesses};
 use super::theme::{THEMES, Theme};
 use super::wizard::{Outcome, ProjectOption, harness_blurb, project_options};
 
@@ -91,7 +91,7 @@ impl Settings {
                 .map(|ws| (ws.id.clone(), ws.name.clone()))
                 .collect(),
             project,
-            agent: agent.min(HARNESSES.len() - 1),
+            agent: agent.min(default_harnesses().len() - 1),
             // "On" with nothing to sync is not a state; it reads as a promise.
             skills: skills && skills_source.is_some(),
             skills_source,
@@ -120,8 +120,8 @@ impl Settings {
             .map(|row| match row {
                 Row::Agent => (
                     "Coding agent".into(),
-                    HARNESSES[self.agent].to_string(),
-                    harness_blurb(HARNESSES[self.agent]).into(),
+                    default_harnesses()[self.agent].to_string(),
+                    harness_blurb(default_harnesses()[self.agent]).into(),
                 ),
                 Row::Project => (
                     "Default project".into(),
@@ -284,7 +284,9 @@ impl Settings {
         }
         match self.row() {
             Row::Agent => {
-                self.agent = wrap(self.agent, HARNESSES.len(), forward);
+                // Cycles the default-able harnesses only: `shell` is a way
+                // to launch a session, not a default agent to save.
+                self.agent = wrap(self.agent, default_harnesses().len(), forward);
                 self.save()
             }
             Row::Skills if self.skills_source.is_some() => {
@@ -336,7 +338,7 @@ impl Settings {
     fn save(&self) -> Action {
         Action::Save(Box::new(Outcome {
             project: self.project.clone(),
-            agent: HARNESSES[self.agent].to_string(),
+            agent: default_harnesses()[self.agent].to_string(),
             skills: self.skills,
             skills_source: self.skills_source.clone(),
             theme: THEMES[self.theme].slug.to_string(),

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -677,7 +677,15 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
     let theme = app.theme;
     let focused = app.menu_focus == MenuFocus::Prompt;
     let empty = app.prompt.is_empty();
-    let (text, fg) = if empty && !focused {
+    // The shell option takes no prompt, so the box explains itself instead of
+    // taking dictation. Any draft stays in `app.prompt`, hidden until the
+    // cycle moves back to a real agent.
+    let (text, fg) = if app.shell_selected() {
+        (
+            "A plain shell on the agent — no prompt, enter to launch".to_string(),
+            theme.dim,
+        )
+    } else if empty && !focused {
         (
             "Fix a bug, scaffold a service, explain a repo…".to_string(),
             theme.dim,
@@ -690,7 +698,7 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect) {
 
     // Only the harness. Where it lands is on its own line under the cards —
     // it changes rarely, and it was crowding the one control being used.
-    let count = if empty {
+    let count = if empty || app.shell_selected() {
         String::new()
     } else {
         format!(" {} ", app.prompt.chars().count())
@@ -1643,13 +1651,26 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
         ]))
         .title_bottom(
             Line::from(Span::styled(
-                " enter send · esc close ",
+                if app.shell_selected() {
+                    " enter launch · esc close "
+                } else {
+                    " enter send · esc close "
+                },
                 Style::default().fg(theme.dim),
             ))
             .right_aligned(),
         );
 
-    let text = format!("{draft}▏");
+    // The menu box's shell contract, here too: the box explains itself
+    // instead of taking dictation, and the draft waits out of sight.
+    let (text, fg) = if app.shell_selected() {
+        (
+            "A plain shell on the agent — no prompt, enter to launch".to_string(),
+            theme.dim,
+        )
+    } else {
+        (format!("{draft}▏"), theme.fg)
+    };
     // Keep the cursor line in view once the wrapped text outgrows the box,
     // same as the menu's prompt. The padding is chrome, not writing room, so
     // it comes off the width and the height the text gets.
@@ -1660,7 +1681,7 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
     f.render_widget(
         Paragraph::new(text)
             .block(block)
-            .style(Style::default().fg(theme.fg))
+            .style(Style::default().fg(fg))
             .wrap(ratatui::widgets::Wrap { trim: false })
             .scroll((scroll_y, 0)),
         outer,
@@ -2718,6 +2739,32 @@ mod tests {
         app.configured = false;
         let out = draw(&app, 100, 40);
         assert!(out.contains("Default agent, skills"), "{out}");
+    }
+
+    /// With shell selected the box stops being a prompt: it says what enter
+    /// does instead of inviting text, and hides a draft typed for a real
+    /// agent rather than showing words that would go nowhere.
+    #[test]
+    fn the_prompt_box_explains_itself_on_shell() {
+        let mut app = app_with_tree();
+        app.prompt = "fix the tests".into();
+        while app.harness_name() != "shell" {
+            app.on_key(crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::BackTab,
+                crossterm::event::KeyModifiers::SHIFT,
+            ));
+        }
+        let out = draw(&app, 100, 40);
+        assert!(out.contains("A plain shell on the agent"), "{out}");
+        assert!(
+            !out.contains("fix the tests"),
+            "the hidden draft must not show through: {out}"
+        );
+        let footer = out
+            .lines()
+            .find(|l| l.contains("shell") && l.contains("shift+tab"))
+            .expect("the prompt box footer names the selection");
+        assert!(footer.contains("shell"), "{footer}");
     }
 
     /// Where the prompt lands is its own line above the keys, not a chip inside

--- a/src/commands/cloud_agent/tui/wizard.rs
+++ b/src/commands/cloud_agent/tui/wizard.rs
@@ -142,6 +142,7 @@ pub fn harness_blurb(slug: &str) -> &'static str {
         "codex" => "OpenAI's Codex",
         "grok" => "xAI's Grok",
         "railway" => "Railway's own agent — no sign-in needed",
+        "shell" => "No agent — just a shell on the VM",
         // Named rather than folded into a catch-all: an unknown slug is a
         // preferences file someone hand-edited, and labelling it as whichever
         // harness happens to sit in the `_` arm is worse than saying nothing.
@@ -196,7 +197,7 @@ impl Wizard {
             project: None,
             workspaces,
             agent: harness
-                .and_then(|h| super::app::HARNESSES.iter().position(|x| *x == h))
+                .and_then(|h| super::app::default_harnesses().iter().position(|x| *x == h))
                 .unwrap_or(0),
             skills: skills_source.is_some(),
             skills_source,
@@ -302,7 +303,9 @@ impl Wizard {
                 .into_iter()
                 .map(|row| self.target_row_label(row))
                 .collect(),
-            Step::Agent => super::app::HARNESSES
+            // The default-able harnesses only: `shell` is a way to launch a
+            // session, not a default agent to save.
+            Step::Agent => super::app::default_harnesses()
                 .iter()
                 .map(|slug| ((*slug).to_string(), harness_blurb(slug).to_string()))
                 .collect(),
@@ -435,7 +438,7 @@ impl Wizard {
                 }
             },
             Step::Agent => {
-                self.agent = self.cursor.min(super::app::HARNESSES.len() - 1);
+                self.agent = self.cursor.min(super::app::default_harnesses().len() - 1);
                 self.go(Step::Skills);
                 Action::Redraw
             }
@@ -449,7 +452,7 @@ impl Wizard {
                 self.theme = self.cursor.min(THEMES.len() - 1);
                 Action::Finish(Box::new(Outcome {
                     project: self.project.clone(),
-                    agent: super::app::HARNESSES[self.agent].to_string(),
+                    agent: super::app::default_harnesses()[self.agent].to_string(),
                     skills: self.skills,
                     skills_source: self.skills_source.clone(),
                     theme: THEMES[self.theme].slug.to_string(),

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -189,6 +189,13 @@ pub struct LaunchArgs {
     /// agent by on a command line.
     #[clap(skip)]
     pub agent_id: Option<String>,
+
+    /// Launch no harness at all — just the VM's login shell. Set by the TUI's
+    /// shell option, not a flag: the CLI already has a spelling for this
+    /// (`railway ca ssh <agent> -- bash`), and a second one would compete
+    /// with it.
+    #[clap(skip)]
+    pub shell: bool,
 }
 
 impl LaunchArgs {
@@ -210,6 +217,7 @@ impl LaunchArgs {
             && self.variables.is_empty()
             && self.env_files.is_empty()
             && self.agent_args.is_empty()
+            && !self.shell
     }
 
     /// Force one harness, overriding preferences — how the TUI passes the
@@ -219,6 +227,7 @@ impl LaunchArgs {
         self.codex = slug == "codex";
         self.grok = slug == "grok";
         self.railway = slug == "railway";
+        self.shell = slug == "shell";
     }
 
     /// The launch the TUI asks for: an explicit project and environment, an
@@ -256,12 +265,17 @@ impl LaunchArgs {
 /// create time, the same way skills and MCP config are reconciled by
 /// express-agent. There is no local sign-in to copy or mint, so it needs none
 /// of the client-side credential machinery the other three do.
+///
+/// `Shell` is not a harness at all: the session is the VM's login shell and
+/// nothing else starts. No credential, no autostart retarget — just the
+/// machine.
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum Agent {
     Codex,
     Claude,
     Grok,
     Railway,
+    Shell,
 }
 
 impl Agent {
@@ -277,6 +291,9 @@ impl Agent {
             Agent::Claude => "claude",
             Agent::Grok => "grok",
             Agent::Railway => "railway-agent-tui",
+            // What the session runs and what the readiness probe checks;
+            // never autostarted, because `Shell` skips the autostart record.
+            Agent::Shell => "bash",
         }
     }
 
@@ -293,6 +310,7 @@ impl Agent {
             Agent::Claude => "claude",
             Agent::Grok => "grok",
             Agent::Railway => "railway",
+            Agent::Shell => "shell",
         }
     }
 
@@ -302,6 +320,7 @@ impl Agent {
             "codex" => Some(Agent::Codex),
             "grok" => Some(Agent::Grok),
             "railway" => Some(Agent::Railway),
+            "shell" => Some(Agent::Shell),
             _ => None,
         }
     }
@@ -313,6 +332,7 @@ impl Agent {
             Agent::Claude => "Claude Code",
             Agent::Grok => "Grok",
             Agent::Railway => "Railway",
+            Agent::Shell => "a plain shell",
         }
     }
 
@@ -324,7 +344,7 @@ impl Agent {
             Agent::Codex => CODEX_SEED,
             Agent::Claude => CLAUDE_SEED,
             Agent::Grok => GROK_SEED,
-            Agent::Railway => "",
+            Agent::Railway | Agent::Shell => "",
         }
     }
 
@@ -337,7 +357,7 @@ impl Agent {
         match self {
             Agent::Codex => Some([".codex", "auth.json"]),
             Agent::Grok => Some([".grok", "auth.json"]),
-            Agent::Claude | Agent::Railway => None,
+            Agent::Claude | Agent::Railway | Agent::Shell => None,
         }
     }
 
@@ -354,6 +374,7 @@ impl Agent {
             Agent::Claude => "sign in there with `/login`",
             Agent::Grok => "sign in there when it asks",
             Agent::Railway => "no sign-in needed — the agent carries its own",
+            Agent::Shell => "no sign-in needed — nothing starts but a shell",
         }
     }
 }
@@ -494,6 +515,13 @@ fn provision_script(agent: Agent, write_credential: bool) -> String {
         "true"
     };
     let name = agent.name();
+    // A shell launch is "give me the machine", not "retarget this VM": the
+    // recorded autostart agent stays whatever a previous launch made it, so
+    // plain reconnects keep dropping into that agent.
+    let record = match agent {
+        Agent::Shell => "true".to_string(),
+        _ => format!("echo {name} > ~/.railway-code-agent"),
+    };
     let hash_marker = skills_sync::REMOTE_HASH_MARKER;
     let hash_file = skills_sync::REMOTE_HASH_FILE;
     format!(
@@ -501,7 +529,7 @@ fn provision_script(agent: Agent, write_credential: bool) -> String {
 {HARNESS_PATH}
 {seed}
 {COMMON_SEED}
-echo {name} > ~/.railway-code-agent
+{record}
 printf '{hash_marker}%s\n' "$(cat "{hash_file}" 2>/dev/null || true)"
 if command -v {name} >/dev/null 2>&1; then echo AGENT-READY; else echo AGENT-MISSING; fi"#
     )
@@ -525,6 +553,14 @@ fn remote_command(
     initial_prompt: Option<&str>,
     agent_args: &[String],
 ) -> String {
+    // No harness: the login shell IS the session, so there is nothing to hand
+    // a prompt or args to and both are ignored (the TUI never sends either —
+    // its prompt box goes inert on the shell option). The autostart guard
+    // still matters: `bash -l` sources ~/.profile, which would otherwise
+    // relaunch whatever agent the VM last recorded on top of the user.
+    if agent == Agent::Shell {
+        return format!("{env_prefix}export RAILWAY_CODE_AUTOSTARTED=1; exec bash -l");
+    }
     let name = agent.name();
     match initial_prompt.map(str::trim).filter(|p| !p.is_empty()) {
         Some(prompt) => format!(
@@ -1697,6 +1733,7 @@ fn resolve_agent_choice(args: &LaunchArgs, prefs: &mut AgentPrefs, home: &Path) 
         (args.claude, Agent::Claude),
         (args.grok, Agent::Grok),
         (args.railway, Agent::Railway),
+        (args.shell, Agent::Shell),
     ]
     .into_iter()
     .filter_map(|(set, agent)| set.then_some(agent))
@@ -1712,7 +1749,7 @@ fn resolve_agent_choice(args: &LaunchArgs, prefs: &mut AgentPrefs, home: &Path) 
         if !slug.is_empty() {
             let agent = Agent::from_slug(&slug).ok_or_else(|| {
                 anyhow!(
-                    "{AGENT_ENV_VAR}={slug} is not a known agent (claude, codex, grok, or railway)."
+                    "{AGENT_ENV_VAR}={slug} is not a known agent (claude, codex, grok, railway, or shell)."
                 )
             })?;
             return Ok(agent);
@@ -1880,10 +1917,19 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
         println!("Agents persist between runs — this one is yours until you --rm it.");
     }
     println!("Get back in:");
-    println!(
-        "  railway code --{}   # wakes it and drops back into {}",
-        prepared.harness, prepared.harness
-    );
+    // There is no --shell flag to point at; the ssh spelling is the way back
+    // into a bare shell.
+    if prepared.harness == "shell" {
+        println!(
+            "  railway ca ssh {} -- bash   # wakes it and opens a plain shell",
+            prepared.agent_name
+        );
+    } else {
+        println!(
+            "  railway code --{}   # wakes it and drops back into {}",
+            prepared.harness, prepared.harness
+        );
+    }
     println!(
         "  railway ca ssh {}   # same, by name — and reattaches your session",
         prepared.agent_name
@@ -1993,8 +2039,9 @@ async fn prepare_inner(
             )
             .await?
         }
-        // Nothing to read or mint — the VM already carries its own.
-        Agent::Railway => PendingAuth::None,
+        // Nothing to read or mint — the VM already carries its own, and a
+        // plain shell has nothing to sign in to.
+        Agent::Railway | Agent::Shell => PendingAuth::None,
     };
     match pending {
         PendingAuth::Ready { ref source, .. } => progress.note(&format!(
@@ -2004,6 +2051,9 @@ async fn prepare_inner(
         // Said up front, before the VM: the sign-in is the first thing waiting
         // on the other end, and finding that out on arrival reads as a bug.
         PendingAuth::SignInOnAgent { ref note } => progress.note(note),
+        PendingAuth::None if agent == Agent::Shell => {
+            progress.note("No coding agent — opening a plain shell on the VM")
+        }
         PendingAuth::None => progress.note("Using the agent's own integrated Railway credentials"),
         PendingAuth::MintClaude => {}
     }
@@ -2592,6 +2642,40 @@ mod tests {
         assert!(script.contains("AGENT-READY"));
     }
 
+    /// The shell option starts nothing and changes nothing: no credential, no
+    /// autostart retarget — reconnects keep dropping into whatever agent a
+    /// previous launch recorded — and the session is one login shell, with any
+    /// prompt or args ignored rather than handed to a harness that isn't there.
+    #[test]
+    fn a_shell_launch_starts_no_harness_and_retargets_nothing() {
+        for (prompt, args) in [
+            (None, vec![]),
+            (Some("fix the tests"), vec![]),
+            (None, vec!["exec".to_string(), "explain this".to_string()]),
+        ] {
+            let cmd = remote_command(Agent::Shell, "P; ", prompt, &args);
+            assert_eq!(cmd, "P; export RAILWAY_CODE_AUTOSTARTED=1; exec bash -l");
+        }
+
+        let script = provision_script(Agent::Shell, false);
+        assert!(
+            !script.contains("~/.railway-code-agent"),
+            "a shell launch must not retarget reconnects: {script}"
+        );
+        for seed in [
+            "cat > \"$tmp\"",
+            "cat > ~/.codex/auth.json",
+            "cat > ~/.grok/auth.json",
+        ] {
+            assert!(!script.contains(seed), "{script}");
+        }
+        // The rest of the provision still runs, and readiness probes the one
+        // binary the session needs.
+        assert!(script.contains("railway-code agent autostart"));
+        assert!(script.contains("if command -v bash"), "{script}");
+        assert!(script.contains("AGENT-READY"));
+    }
+
     /// Harness config on an agent VM belongs to express-agent, which reconciles
     /// it on every boot. The CLI used to copy the laptop's
     /// `~/.claude/settings.json` up; it no longer does, and must not drift back
@@ -2599,7 +2683,13 @@ mod tests {
     /// statusline commands that only resolve on the machine that wrote them.
     #[test]
     fn no_provision_step_writes_harness_config() {
-        for agent in [Agent::Claude, Agent::Codex, Agent::Grok, Agent::Railway] {
+        for agent in [
+            Agent::Claude,
+            Agent::Codex,
+            Agent::Grok,
+            Agent::Railway,
+            Agent::Shell,
+        ] {
             for write_credential in [true, false] {
                 let script = provision_script(agent, write_credential);
                 assert!(!script.contains(".claude/settings.json"), "{script}");
@@ -2765,6 +2855,13 @@ mod tests {
         railway.set_harness("railway");
         assert!(!railway.is_bare());
 
+        let mut shell = LaunchArgs::default();
+        shell.set_harness("shell");
+        assert!(shell.shell, "the shell choice must survive the mapping");
+        assert!(!shell.is_bare());
+        shell.set_harness("claude");
+        assert!(!shell.shell, "picking a harness clears it");
+
         let targeted = LaunchArgs::for_target(
             "proj_1".into(),
             "env_1".into(),
@@ -2851,6 +2948,11 @@ mod tests {
         assert_eq!(Agent::from_slug("railway"), Some(Agent::Railway));
         assert_eq!(Agent::Railway.slug(), "railway");
         assert_eq!(Agent::Railway.name(), "railway-agent-tui");
+        // Shell is the other: the slug is the option's name, and what the
+        // session runs (and the readiness probe checks) is bash.
+        assert_eq!(Agent::from_slug("shell"), Some(Agent::Shell));
+        assert_eq!(Agent::Shell.slug(), "shell");
+        assert_eq!(Agent::Shell.name(), "bash");
         assert!(Agent::from_slug("droid").is_none());
         assert!(Agent::from_slug("").is_none());
     }


### PR DESCRIPTION
## What

- Adds a **shell** option to the cloud-agent launch surfaces: a session that starts no harness and drops into the VM's login shell.

## Where it shows up

- **Main screen**: `shift+tab` cycles `railway → claude → codex → grok → shell` — railway always first, shell always last. With shell selected the prompt box is non-typable (dim explainer, a draft typed for a real agent is kept but never sent) and `enter` launches bare.
- **⌥n picker**: shell listed last, with a blurb; picking it opens a promptless session.
- **⌥p composer**: same contract as the menu box — typing inert on shell, `enter` launches bare.
- **Setup wizard / settings**: unchanged — they offer only real harnesses (`default_harnesses()`); shell is not a saveable default.

## VM side

- New `Agent::Shell` (slug `shell`, remote binary `bash`): no credential machinery (`PendingAuth::None`).
- Provision skips the `~/.railway-code-agent` autostart record — a shell launch does not retarget what reconnects drop into.
- Remote command is `export RAILWAY_CODE_AUTOSTARTED=1; exec bash -l` — the guard keeps `.profile` from relaunching a previously recorded agent; prompt/args are never handed to it.
- `launch`'s "get back in" hint points at `railway ca ssh <agent> -- bash` for shell (there is no `--shell` flag; `LaunchArgs.shell` is `#[clap(skip)]`, set by the TUI).

## Tests

- Cycle order contract (railway first, shell last, excluded from defaults), inert menu/⌥p prompt + bare launch, ⌥n bottoms out on shell, shell prompt-box rendering, `remote_command`/`provision_script`/slug round-trip/`is_bare` coverage for `Agent::Shell`.
- `cargo test`: 1068 passed, 0 failed. No new clippy warnings in touched files.