### PR TITLE
feat(ca): `railway ca desktop` — cloud agents as remote SSH hosts

### DIFF
--- a/src/commands/cloud_agent/desktop.rs
+++ b/src/commands/cloud_agent/desktop.rs
@@ -1,0 +1,752 @@
+//! `railway ca desktop` — hand a cloud agent to a desktop coding app.
+//!
+//! The Claude Code and Codex desktop apps both drive a remote machine over
+//! ordinary SSH, and the relay already is one: `agent:<env>:<name>@ssh.railway.com`
+//! is a complete destination, resolved by name so it survives a recreated VM.
+//! So this command writes config rather than building a transport — an OpenSSH
+//! block for both apps, plus a `sshConfigs` entry for Claude, which keeps its
+//! connections in its own settings file instead of reading `~/.ssh/config`.
+//!
+//! What it does beyond writing files is provision: the app expects to arrive at
+//! a machine where its harness is already signed in, so this runs the same
+//! credential and skills pipeline as `railway code` and then stops, without
+//! opening a session. That pass also marks the agent `app_mode`, which is what
+//! keeps the `~/.profile` autostart from putting a harness where the app expects
+//! a login shell.
+//!
+//! Waking is deliberately not handled here: a sleeping agent refuses the
+//! connection at the relay and a GUI has no hook to wake it, so the summary says
+//! so and names the command. Auto-wake is its own change.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+use colored::Colorize;
+use serde_json::{Value as JsonValue, json};
+
+use crate::client::GQLClient;
+use crate::commands::code::{self, LaunchArgs, Progress as _};
+use crate::commands::ssh::config as ssh_config;
+use crate::config::Configs;
+use crate::controllers::cloud_agent as ca;
+
+/// Set up a desktop coding app to work on a cloud agent over SSH
+#[derive(Parser)]
+#[clap(
+    after_help = "Examples:\n\n  railway ca desktop --claude              # Claude Code Desktop\n  railway ca desktop --codex               # the Codex app\n  railway ca desktop --claude --codex      # both, on one agent\n\n  railway ca desktop --claude --agent my-box   # an agent you already have\n  railway ca desktop --claude --dir /app/api   # where sessions open\n  railway ca desktop --claude --dry-run        # print the changes, write nothing\n  railway ca desktop --claude --remove         # undo them\n\nWrites an OpenSSH block for the agent (both apps), and for Claude an entry in\n~/.claude/settings.json pointing at that block. Restart the app afterwards.\n\nThe agent must be awake when the app connects — the relay refuses a sleeping\none and a desktop app has no way to wake it. `railway ca wake <name>` does."
+)]
+pub struct Args {
+    /// Configure Claude Code Desktop
+    #[clap(long)]
+    claude: bool,
+
+    /// Configure the Codex app
+    #[clap(long)]
+    codex: bool,
+
+    /// Agent to point the app at, by name or id (defaults to this
+    /// environment's, creating one if there is none)
+    #[clap(long, value_name = "NAME_OR_ID")]
+    agent: Option<String>,
+
+    /// Directory sessions open in on the agent
+    #[clap(long, default_value = "/app", value_name = "PATH")]
+    dir: String,
+
+    /// Host alias to write (defaults to railway-agent-<name>)
+    #[clap(long)]
+    alias: Option<String>,
+
+    /// SSH config file to write
+    #[clap(long, default_value = "~/.ssh/config", value_name = "PATH")]
+    ssh_config: PathBuf,
+
+    /// Print the changes without writing anything
+    #[clap(long)]
+    dry_run: bool,
+
+    /// Remove what this command wrote, for the same agent
+    #[clap(long, conflicts_with_all = ["dry_run", "dir"])]
+    remove: bool,
+
+    /// Skip the connection check after writing
+    #[clap(long)]
+    no_verify: bool,
+
+    /// Environment name or ID (defaults to the linked environment)
+    #[clap(long, short)]
+    environment: Option<String>,
+
+    /// Project ID (defaults to the linked project)
+    #[clap(long, short)]
+    project: Option<String>,
+}
+
+/// A desktop app this command knows how to configure.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum App {
+    Claude,
+    Codex,
+}
+
+impl App {
+    /// The harness slug `railway code` uses, so provisioning seeds the
+    /// credential this app's remote half will look for.
+    fn harness(self) -> &'static str {
+        match self {
+            App::Claude => "claude",
+            App::Codex => "codex",
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            App::Claude => "Claude Code Desktop",
+            App::Codex => "Codex",
+        }
+    }
+
+    /// The binary the app expects to find on the agent's `PATH`.
+    fn remote_bin(self) -> &'static str {
+        match self {
+            App::Claude => "claude",
+            App::Codex => "codex",
+        }
+    }
+
+    /// Where the app finds the connection once this command has written it.
+    fn where_it_appears(self) -> &'static str {
+        match self {
+            App::Claude => "the environment dropdown, under the name below",
+            App::Codex => "the SSH host list — Codex reads ~/.ssh/config itself",
+        }
+    }
+}
+
+pub async fn command(args: Args) -> Result<()> {
+    let apps = selected_apps(&args)?;
+    let home = dirs::home_dir().context("Unable to get home directory")?;
+    let ssh_config_path = ssh_config::expand_tilde(&args.ssh_config)?;
+
+    if args.remove {
+        return remove(&args, &apps, &home, &ssh_config_path).await;
+    }
+    if args.dry_run {
+        return dry_run(&args, &apps, &home, &ssh_config_path).await;
+    }
+
+    // Same preflight as a launch, and for the same reason: without the flag the
+    // create at the end of provisioning is refused, after a credential has
+    // already been spent on it.
+    {
+        let configs = Configs::new()?;
+        let client = GQLClient::new_authorized(&configs)?;
+        super::access::ensure_enabled(&client, &configs).await?;
+    }
+
+    // Provision once per app, on one agent. The first pass resolves (or creates)
+    // it; later passes are pinned to that id, so `--claude --codex` seeds two
+    // credentials on one machine rather than spending two VMs.
+    let pinned = args.pinned_agent().await?;
+    let mut prepared: Option<code::Prepared> = None;
+    for app in &apps {
+        let progress = code::CliProgress::default();
+        let mut launch = LaunchArgs::for_app_mode(
+            app.harness(),
+            args.project.clone(),
+            // A named agent carries its own environment. Without this the launch
+            // pipeline resolves the *linked* one, fails to find the agent there,
+            // and creates a second VM instead of using the one that was named.
+            pinned
+                .as_ref()
+                .map(|a| a.environment_id.clone())
+                .or_else(|| args.environment.clone()),
+        );
+        launch.agent_id = prepared
+            .as_ref()
+            .map(|p| p.agent_id.clone())
+            .or_else(|| pinned.as_ref().map(|a| a.id.clone()));
+        let result = code::prepare(&launch, &progress).await;
+        progress.finish();
+        prepared = Some(result.with_context(|| format!("Preparing the agent for {}", app.name()))?);
+    }
+    let prepared = prepared.expect("selected_apps guarantees at least one app");
+
+    let alias = args
+        .alias
+        .clone()
+        .unwrap_or_else(|| ssh_config::agent_alias(&prepared.agent_name));
+    let block = render_block(
+        &prepared.agent_name,
+        &prepared.environment_id,
+        &alias,
+        prepared.identity.as_deref(),
+    )?;
+    let claude_entry = apps
+        .contains(&App::Claude)
+        .then(|| claude_ssh_entry(&prepared.agent_id, &prepared.agent_name, &alias, &args.dir));
+
+    let marker = ssh_config::agent_marker(&prepared.environment_id, &prepared.agent_name);
+    ssh_config::upsert_marked_block(&ssh_config_path, &marker, &block)
+        .with_context(|| format!("Failed to update {}", ssh_config_path.display()))?;
+    if let Some(entry) = claude_entry {
+        upsert_claude_ssh_config(&home, entry)?;
+    }
+
+    // Verify against the file we just wrote. With the default path that is also
+    // what the apps read; with `--ssh-config` it is not, and the summary says so
+    // rather than passing a check the apps would then fail.
+    let custom_config = ssh_config_path != default_ssh_config_path()?;
+    let checks = if args.no_verify {
+        Vec::new()
+    } else {
+        verify(&alias, &apps, &ssh_config_path).await
+    };
+    if custom_config {
+        println!(
+            "\n{} {} is not where the apps look. Make sure {} pulls it in:\n    {}",
+            "!".yellow().bold(),
+            ssh_config_path.display(),
+            default_ssh_config_path()?.display(),
+            format!("Include {}", ssh_config_path.display()).cyan()
+        );
+    }
+
+    summarize(
+        &prepared,
+        &apps,
+        &alias,
+        &args.dir,
+        &ssh_config_path,
+        &home,
+        &checks,
+    );
+    super::telemetry::track_desktop_configured(
+        &apps
+            .iter()
+            .map(|a| a.harness())
+            .collect::<Vec<_>>()
+            .join(","),
+    )
+    .await;
+    Ok(())
+}
+
+impl Args {
+    /// Resolve `--agent` before any provisioning, so a name that does not exist
+    /// fails before a VM is created rather than after.
+    async fn pinned_agent(&self) -> Result<Option<ca::Agent>> {
+        let Some(selector) = self.agent.as_deref() else {
+            return Ok(None);
+        };
+        let configs = Configs::new()?;
+        let client = GQLClient::new_authorized(&configs)?;
+        let (agent, _) = ca::resolve(&configs, &client, Some(selector), None).await?;
+        Ok(Some(agent))
+    }
+}
+
+/// Where OpenSSH — and so both apps — read per-user config from.
+fn default_ssh_config_path() -> Result<PathBuf> {
+    ssh_config::expand_tilde(Path::new("~/.ssh/config"))
+}
+
+fn render_block(
+    agent_name: &str,
+    environment_id: &str,
+    alias: &str,
+    identity_file: Option<&Path>,
+) -> Result<String> {
+    let known_hosts = code::relay_known_hosts()?;
+    Ok(ssh_config::render_agent_config_block(
+        &ssh_config::AgentBlock {
+            agent_name,
+            environment_id,
+            alias,
+            identity_file,
+            known_hosts: &known_hosts,
+        },
+    ))
+}
+
+/// Print what a real run would write, and touch nothing.
+///
+/// Deliberately not the write path with the writes skipped: provisioning would
+/// still create or wake a VM, and a flag documented as "write nothing" that
+/// quietly bills for a machine is worse than no flag. So this reads an agent
+/// that already exists — it will not create one — and reads the local key
+/// without registering it. The trade is that the identity shown is a best guess
+/// at what a real run would register, which is why it is labelled.
+async fn dry_run(args: &Args, apps: &[App], home: &Path, ssh_config_path: &Path) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (agent, _) = ca::resolve(&configs, &client, args.agent.as_deref(), None).await?;
+
+    let identity = preferred_local_key().await;
+    let alias = args
+        .alias
+        .clone()
+        .unwrap_or_else(|| ssh_config::agent_alias(&agent.name));
+    let block = render_block(
+        &agent.name,
+        &agent.environment_id,
+        &alias,
+        identity.as_deref(),
+    )?;
+
+    println!("\n{}", ssh_config_path.display().to_string().cyan());
+    print!("{block}");
+    if apps.contains(&App::Claude) {
+        let entry = claude_ssh_entry(&agent.id, &agent.name, &alias, &args.dir);
+        println!(
+            "\n{}",
+            claude_settings_path(home).display().to_string().cyan()
+        );
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&json!({ "sshConfigs": [entry] }))?
+        );
+    }
+    if identity.is_none() {
+        println!(
+            "\n{}",
+            "No local key file found, so no IdentityFile line — a real run registers a key and may add one."
+                .dimmed()
+        );
+    }
+    println!(
+        "\n{}",
+        "Nothing written, and no agent created or woken (--dry-run).".dimmed()
+    );
+    Ok(())
+}
+
+/// The key path a real run would most likely use, without registering anything.
+///
+/// Same preferred-key order as the non-interactive `ssh keys add`. `None` covers
+/// both "no keys" and "keys only in an ssh-agent" — neither has a path to write,
+/// and the block is correct without one.
+async fn preferred_local_key() -> Option<PathBuf> {
+    use crate::controllers::ssh::keys::{SshKeySource, find_local_ssh_keys};
+    find_local_ssh_keys()
+        .await
+        .ok()?
+        .into_iter()
+        .find_map(|key| match key.source {
+            SshKeySource::File(path) => Some(path),
+            SshKeySource::Agent => None,
+        })
+}
+
+/// Which apps this run is about. At least one, because there is no sensible
+/// default: configuring both when asked for neither would write files nobody
+/// asked for.
+fn selected_apps(args: &Args) -> Result<Vec<App>> {
+    let mut apps = Vec::new();
+    if args.claude {
+        apps.push(App::Claude);
+    }
+    if args.codex {
+        apps.push(App::Codex);
+    }
+    if apps.is_empty() {
+        bail!("Name an app: --claude, --codex, or both.");
+    }
+    Ok(apps)
+}
+
+async fn remove(args: &Args, apps: &[App], home: &Path, ssh_config_path: &Path) -> Result<()> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    // Removal names the agent the same way everything else does, but must not
+    // create one — an agent that is already gone leaves config behind, and
+    // `--agent` is how that is cleaned up.
+    let (agent, _) = ca::resolve(&configs, &client, args.agent.as_deref(), None).await?;
+
+    let marker = ssh_config::agent_marker(&agent.environment_id, &agent.name);
+    let removed_block = ssh_config::remove_marked_block(ssh_config_path, &marker)?;
+    let removed_entry = if apps.contains(&App::Claude) {
+        remove_claude_ssh_config(home, &agent.id)?
+    } else {
+        false
+    };
+
+    match (removed_block, removed_entry) {
+        (false, false) => println!(
+            "No `railway ca desktop` config found for agent {}.",
+            agent.name.cyan()
+        ),
+        _ => {
+            if removed_block {
+                println!(
+                    "{} Removed the SSH block from {}",
+                    "✓".green(),
+                    ssh_config_path.display()
+                );
+            }
+            if removed_entry {
+                println!(
+                    "{} Removed the connection from {}",
+                    "✓".green(),
+                    claude_settings_path(home).display()
+                );
+            }
+            println!(
+                "\nThe agent itself is untouched. {} deletes it.",
+                format!("railway ca delete {}", agent.name).cyan()
+            );
+        }
+    }
+    Ok(())
+}
+
+// --- Claude Code Desktop's own settings file ------------------------------
+//
+// Claude keeps SSH connections in `sshConfigs` in ~/.claude/settings.json —
+// note that is not the ~/.claude.json that `railway mcp install` writes. Only
+// `id`, `name` and `sshHost` are required; `sshPort` and `sshIdentityFile` are
+// deliberately omitted so the OpenSSH block stays the single source of truth for
+// port and key. A dev-environment CLI writing the relay's :2222 then needs no
+// second place to be right.
+
+fn claude_settings_path(home: &Path) -> PathBuf {
+    home.join(".claude").join("settings.json")
+}
+
+fn claude_ssh_entry(agent_id: &str, agent_name: &str, alias: &str, dir: &str) -> JsonValue {
+    json!({
+        "id": claude_entry_id(agent_id),
+        "name": format!("Railway · {agent_name}"),
+        "sshHost": alias,
+        "startDirectory": dir,
+    })
+}
+
+/// Keyed on the agent id so re-running replaces its own entry instead of adding
+/// a second one, and so a rename does not orphan the old entry.
+fn claude_entry_id(agent_id: &str) -> String {
+    format!("railway-agent-{agent_id}")
+}
+
+fn upsert_claude_ssh_config(home: &Path, entry: JsonValue) -> Result<()> {
+    let path = claude_settings_path(home);
+    let mut root = read_json_or_empty(&path)?;
+    let id = entry.get("id").and_then(JsonValue::as_str).unwrap_or("");
+
+    let configs = root
+        .as_object_mut()
+        .context("settings.json is not a JSON object")?
+        .entry("sshConfigs")
+        .or_insert_with(|| json!([]));
+    let list = configs
+        .as_array_mut()
+        .context("`sshConfigs` in settings.json is not an array")?;
+    // Replace in place when it is already there, so a re-run doesn't move the
+    // user's connection to the bottom of their dropdown.
+    match list
+        .iter()
+        .position(|e| e.get("id").and_then(JsonValue::as_str) == Some(id))
+    {
+        Some(at) => list[at] = entry,
+        None => list.push(entry),
+    }
+
+    write_json_pretty(&path, &root)
+}
+
+fn remove_claude_ssh_config(home: &Path, agent_id: &str) -> Result<bool> {
+    let path = claude_settings_path(home);
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut root = read_json_or_empty(&path)?;
+    let id = claude_entry_id(agent_id);
+    let Some(list) = root.get_mut("sshConfigs").and_then(JsonValue::as_array_mut) else {
+        return Ok(false);
+    };
+    let before = list.len();
+    list.retain(|e| e.get("id").and_then(JsonValue::as_str) != Some(id.as_str()));
+    if list.len() == before {
+        return Ok(false);
+    }
+    write_json_pretty(&path, &root)?;
+    Ok(true)
+}
+
+/// An unreadable settings file is an error, but a missing one is just a first
+/// run. Same split as `railway mcp install` makes.
+fn read_json_or_empty(path: &Path) -> Result<JsonValue> {
+    match std::fs::read_to_string(path) {
+        Ok(text) if text.trim().is_empty() => Ok(json!({})),
+        Ok(text) => serde_json::from_str(&text)
+            .with_context(|| format!("Failed to parse existing JSON at {}", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(json!({})),
+        Err(e) => Err(e).with_context(|| format!("Failed to read {}", path.display())),
+    }
+}
+
+fn write_json_pretty(path: &Path, value: &JsonValue) -> Result<()> {
+    let mut text = serde_json::to_string_pretty(value)?;
+    text.push('\n');
+    crate::util::write_atomic(path, &text)
+        .with_context(|| format!("Failed to write {}", path.display()))
+}
+
+// --- Verification ---------------------------------------------------------
+
+struct Check {
+    label: String,
+    ok: bool,
+    detail: Option<String>,
+}
+
+/// Prove the entry works before claiming it does.
+///
+/// Every failure here is one a desktop app would swallow: it spawns `ssh`
+/// without a terminal, so a rejected key, an unreachable relay or a missing
+/// binary all surface as an unexplained connection error inside a GUI. Better to
+/// find them in the shell that just wrote the config.
+async fn verify(alias: &str, apps: &[App], ssh_config_path: &Path) -> Vec<Check> {
+    let mut checks = Vec::new();
+    let connect = ssh_alias(alias, &["true"], ssh_config_path).await;
+    let connected = connect.is_ok();
+    checks.push(Check {
+        label: format!("ssh {alias}"),
+        ok: connected,
+        detail: connect.err().map(|e| format!("{e:#}")),
+    });
+    if !connected {
+        // The PATH probes all fail the same way, and three copies of one
+        // connection error reads as three problems.
+        return checks;
+    }
+
+    for app in apps {
+        let bin = app.remote_bin();
+        // Through a login shell specifically: that is how Codex bootstraps its
+        // remote server, and the agent image puts the harnesses on PATH in
+        // /root/.profile rather than for non-login shells.
+        let probe = ssh_alias(
+            alias,
+            &["bash", "-lc", &format!("command -v {bin}")],
+            ssh_config_path,
+        )
+        .await;
+        checks.push(Check {
+            label: format!("{bin} on PATH (login shell)"),
+            ok: probe.is_ok(),
+            detail: probe.err().map(|e| format!("{e:#}")),
+        });
+    }
+    checks
+}
+
+/// Run one command through the alias we just wrote, with the system `ssh` and
+/// nothing else — the same way the desktop apps will.
+///
+/// `BatchMode=yes` matters: without it a misconfigured entry can sit on a
+/// password prompt with no one watching.
+async fn ssh_alias(alias: &str, command: &[&str], ssh_config_path: &Path) -> Result<()> {
+    let mut cmd = tokio::process::Command::new("ssh");
+    cmd.arg("-F")
+        .arg(ssh_config_path)
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ConnectTimeout=20")
+        .arg("-T")
+        .arg(alias)
+        .args(command)
+        .stdin(std::process::Stdio::null());
+    let out = cmd.output().await.context("Failed to run `ssh`")?;
+    if out.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // The last non-empty line: ssh's actual complaint, after any banner.
+    let reason = stderr
+        .lines()
+        .rfind(|l| !l.trim().is_empty())
+        .unwrap_or("ssh failed with no output")
+        .trim();
+    bail!("{reason}")
+}
+
+// --- Output ---------------------------------------------------------------
+
+fn summarize(
+    prepared: &code::Prepared,
+    apps: &[App],
+    alias: &str,
+    dir: &str,
+    ssh_config_path: &Path,
+    home: &Path,
+    checks: &[Check],
+) {
+    println!("\n{}", "Cloud agent ready for your desktop app".bold());
+    println!("  {}  {}", "Agent  ".dimmed(), prepared.agent_name.bold());
+    println!("  {}  {}", "Host   ".dimmed(), alias.bold());
+    println!("  {}  {}", "Opens  ".dimmed(), dir.bold());
+    println!(
+        "  {}  {}",
+        "Wrote  ".dimmed(),
+        ssh_config_path.display().to_string().bold()
+    );
+    if apps.contains(&App::Claude) {
+        println!(
+            "  {}  {}",
+            "       ".dimmed(),
+            claude_settings_path(home).display().to_string().bold()
+        );
+    }
+
+    if !checks.is_empty() {
+        println!();
+        for check in checks {
+            let mark = if check.ok { "✓".green() } else { "✗".red() };
+            match &check.detail {
+                Some(detail) => println!("  {mark} {}  {}", check.label, detail.dimmed()),
+                None => println!("  {mark} {}", check.label),
+            }
+        }
+    }
+
+    println!("\n{}", "Next:".bold());
+    for app in apps {
+        println!(
+            "  {} — restart it, then find the agent in {}",
+            app.name(),
+            app.where_it_appears()
+        );
+    }
+    // The one thing that will bite a user who does everything right: an agent
+    // asleep by the time they open the app.
+    println!(
+        "\n{} The agent must be awake when the app connects — the relay refuses a\nsleeping one, and a desktop app can't wake it. {} does.",
+        "!".yellow().bold(),
+        format!("railway ca wake {}", prepared.agent_name).cyan()
+    );
+    println!(
+        "{} stops the compute bill when you're done.",
+        format!("railway ca sleep {}", prepared.agent_name).cyan()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_for(argv: &[&str]) -> Args {
+        Args::parse_from(std::iter::once("desktop").chain(argv.iter().copied()))
+    }
+
+    #[test]
+    fn an_app_must_be_named() {
+        assert!(selected_apps(&args_for(&[])).is_err());
+        assert_eq!(selected_apps(&args_for(&["--claude"])).unwrap().len(), 1);
+        assert_eq!(
+            selected_apps(&args_for(&["--claude", "--codex"]))
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn the_claude_entry_omits_what_the_ssh_block_owns() {
+        let entry = claude_ssh_entry("ca_1", "my-box", "railway-agent-my-box", "/app");
+        assert_eq!(entry["sshHost"], "railway-agent-my-box");
+        assert_eq!(entry["id"], "railway-agent-ca_1");
+        assert_eq!(entry["startDirectory"], "/app");
+        // Port and key live in ~/.ssh/config, so there is one place to be right.
+        assert!(entry.get("sshPort").is_none());
+        assert!(entry.get("sshIdentityFile").is_none());
+    }
+
+    /// Running twice must leave one entry, in its original position — a
+    /// duplicate would show as two identical rows in the app's dropdown.
+    #[test]
+    fn the_settings_merge_is_idempotent() {
+        let home = tempfile::tempdir().unwrap();
+        let path = claude_settings_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            r#"{"sshConfigs":[{"id":"mine","name":"Mine","sshHost":"box"}],"theme":"dark"}"#,
+        )
+        .unwrap();
+
+        let entry = claude_ssh_entry("ca_1", "my-box", "railway-agent-my-box", "/app");
+        upsert_claude_ssh_config(home.path(), entry.clone()).unwrap();
+        upsert_claude_ssh_config(home.path(), entry).unwrap();
+
+        let root: JsonValue =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let list = root["sshConfigs"].as_array().unwrap();
+        assert_eq!(list.len(), 2);
+        // The user's own entry keeps its place and its contents.
+        assert_eq!(list[0]["id"], "mine");
+        assert_eq!(list[1]["id"], "railway-agent-ca_1");
+        // Unrelated settings survive the merge.
+        assert_eq!(root["theme"], "dark");
+    }
+
+    #[test]
+    fn removal_takes_only_our_entry() {
+        let home = tempfile::tempdir().unwrap();
+        let path = claude_settings_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, r#"{"sshConfigs":[{"id":"mine"}]}"#).unwrap();
+
+        upsert_claude_ssh_config(
+            home.path(),
+            claude_ssh_entry("ca_1", "my-box", "railway-agent-my-box", "/app"),
+        )
+        .unwrap();
+        assert!(remove_claude_ssh_config(home.path(), "ca_1").unwrap());
+        // Gone once, and reporting `false` the second time rather than erroring.
+        assert!(!remove_claude_ssh_config(home.path(), "ca_1").unwrap());
+
+        let root: JsonValue =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let list = root["sshConfigs"].as_array().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0]["id"], "mine");
+    }
+
+    /// A settings file with no `sshConfigs` yet is the common first run.
+    #[test]
+    fn a_missing_settings_file_is_a_first_run_not_an_error() {
+        let home = tempfile::tempdir().unwrap();
+        upsert_claude_ssh_config(
+            home.path(),
+            claude_ssh_entry("ca_1", "my-box", "railway-agent-my-box", "/app"),
+        )
+        .unwrap();
+        let root: JsonValue = serde_json::from_str(
+            &std::fs::read_to_string(claude_settings_path(home.path())).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(root["sshConfigs"][0]["id"], "railway-agent-ca_1");
+        // An id that was never written reports `false`, not an error.
+        assert!(!remove_claude_ssh_config(home.path(), "nope").unwrap());
+    }
+
+    #[test]
+    fn corrupt_settings_are_reported_not_overwritten() {
+        let home = tempfile::tempdir().unwrap();
+        let path = claude_settings_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "{not json").unwrap();
+        assert!(
+            upsert_claude_ssh_config(
+                home.path(),
+                claude_ssh_entry("ca_1", "b", "railway-agent-b", "/app")
+            )
+            .is_err()
+        );
+        // Untouched, so the user can fix it.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{not json");
+    }
+}

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -6,6 +6,7 @@
 //! you want to browse first.
 
 pub mod access;
+pub mod desktop;
 pub mod lifecycle;
 pub mod prefs;
 pub mod setup;
@@ -32,7 +33,7 @@ use tui::{App, Outcome};
 #[derive(Parser)]
 #[clap(
     args_conflicts_with_subcommands = true,
-    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run. A\ndirectory linked with `railway link` wins over the saved default project too\n— new agents land there instead.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca desktop --claude       # drive an agent from Claude Code Desktop\n  railway ca desktop --codex        # …or from the Codex app\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # connect to it (starts a session if none)\n  railway ca ssh my-agent -- bash   # a plain shell instead of the agent\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher on its own — same flags, same preferences, no\nTUI. Preferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run. A\ndirectory linked with `railway link` wins over the saved default project too\n— new agents land there instead.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -48,6 +49,9 @@ pub struct Args {
 enum Command {
     /// Configure how cloud agents are launched (default agent, skills)
     Setup(setup::Args),
+
+    /// Set up a desktop coding app to work on a cloud agent over SSH
+    Desktop(desktop::Args),
 
     /// Open the TUI directly on the manage screen, skipping the menu
     Manage,
@@ -105,6 +109,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     match args.command {
         Some(Command::Setup(a)) => setup::command(a).await,
+        Some(Command::Desktop(a)) => tracked("desktop", desktop::command(a)).await,
         Some(Command::Manage) => browse_into(Some(tui::Screen::Manage)).await,
         Some(Command::Start(a)) => crate::commands::code::launch(a).await,
         Some(Command::List(a)) => tracked("list", lifecycle::list(a)).await,

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -186,6 +186,23 @@ pub async fn track_access_blocked() {
 /// of `commands/service.rs`'s `track_service_source`, rather than one event
 /// with all four combined: keeps `sub_command` cardinality small and each
 /// fact independently queryable.
+/// A `railway ca desktop` run that wrote its config.
+///
+/// `apps` is the comma-joined harness slugs the run configured — a fixed set,
+/// like every other slug in this module, so nothing user-supplied rides along.
+/// Failures are already reported by the generic dispatch event; this only marks
+/// which apps people actually point at an agent.
+pub async fn track_desktop_configured(apps: &str) {
+    telemetry::send(event(
+        "cloud_agent",
+        format!("desktop_{apps}"),
+        0,
+        true,
+        None,
+    ))
+    .await;
+}
+
 pub async fn track_setup_saved(entry: &str, prefs: &AgentPrefs) {
     let harness = prefs.agent.as_deref().unwrap_or("none");
     telemetry::send(event(

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -189,6 +189,13 @@ pub struct LaunchArgs {
     /// agent by on a command line.
     #[clap(skip)]
     pub agent_id: Option<String>,
+
+    /// Provision for an external app rather than for a session this CLI opens:
+    /// seed the credential and the skills, but leave the login shell alone. Set
+    /// by `railway ca desktop`; there is no flag because on its own it would
+    /// prepare an agent and then do nothing with it.
+    #[clap(skip)]
+    pub app_mode: bool,
 }
 
 impl LaunchArgs {
@@ -239,6 +246,30 @@ impl LaunchArgs {
             new: force_new,
             initial_prompt: prompt,
             agent_id,
+            ..Self::default()
+        };
+        args.set_harness(harness);
+        args
+    }
+
+    /// The provision `railway ca desktop` asks for: seed this harness onto an
+    /// agent and stop, leaving the sessions to an external app.
+    ///
+    /// Project and environment stay optional here, unlike [`for_target`]: the
+    /// TUI always knows which row it was on, while this command is usually run
+    /// from a linked directory and should resolve the target the same way a bare
+    /// `railway code` does.
+    ///
+    /// [`for_target`]: Self::for_target
+    pub fn for_app_mode(
+        harness: &str,
+        project: Option<String>,
+        environment: Option<String>,
+    ) -> Self {
+        let mut args = Self {
+            project,
+            environment,
+            app_mode: true,
             ..Self::default()
         };
         args.set_harness(harness);
@@ -436,17 +467,25 @@ const HARNESS_PATH: &str = r#"export PATH="$HOME/.local/bin:$HOME/.opencode/bin:
 ///   keeps scp-style and command sessions out. The trailing printf restores
 ///   terminal state a TUI can leave behind on an unclean exit (kitty keyboard
 ///   mode et al) — see `TERMINAL_RESET`.
-/// The autostart block is versioned: the v2 marker gates the append, and the
+/// The autostart block is versioned: the v3 marker gates the append, and the
 /// sed strips any earlier version first (comment line through the closing
 /// `fi` at column zero), so an agent provisioned before the env-guard change
 /// picks it up on its next provision instead of keeping v1 forever.
+///
+/// v3 adds the `~/.railway-app-mode` guard. `railway ca desktop` hands the agent
+/// to an external app that bootstraps through the login shell, so an autostart
+/// firing there would put a harness where the app expects a shell. The marker
+/// file is what the two provision modes disagree about — see
+/// [`provision_script`] — and it is checked here rather than simply omitted from
+/// `~/.railway-code-agent`, because a later `railway code` on the same agent
+/// would write that file straight back.
 const COMMON_SEED: &str = r#"grep -q "^COLORTERM=" /etc/environment 2>/dev/null || echo "COLORTERM=truecolor" >> /etc/environment 2>/dev/null || true
-if ! grep -q "railway-code agent autostart v2" ~/.profile 2>/dev/null; then
+if ! grep -q "railway-code agent autostart v3" ~/.profile 2>/dev/null; then
 sed -i '/# railway-code agent autostart/,/^fi$/d' ~/.profile 2>/dev/null || true
 cat >> ~/.profile <<'PROFEOF'
 
-# railway-code agent autostart v2 (connecting drops into the agent; exit it for a shell)
-if [ -z "$RAILWAY_CODE_AUTOSTARTED" ] && [ -t 1 ] && [ -s "$HOME/.railway-code-agent" ]; then
+# railway-code agent autostart v3 (connecting drops into the agent; exit it for a shell)
+if [ -z "$RAILWAY_CODE_AUTOSTARTED" ] && [ -t 1 ] && [ ! -f "$HOME/.railway-app-mode" ] && [ -s "$HOME/.railway-code-agent" ]; then
   agent="$(cat "$HOME/.railway-code-agent")"
   [ -d "$HOME/.grok/bin" ] && export PATH="$HOME/.grok/bin:$PATH"
   if command -v "$agent" >/dev/null 2>&1; then
@@ -487,7 +526,13 @@ const CLAUDE_CREDENTIAL_PROBE: &str =
 /// and we are reusing it. The seed must then be omitted entirely rather than run
 /// with empty stdin: `cat > ~/.claude-code-env` would truncate the very file we
 /// decided to keep.
-fn provision_script(agent: Agent, write_credential: bool) -> String {
+///
+/// `app_mode` is `railway ca desktop`: the agent is being handed to an external
+/// app that opens its own sessions, so the two marker files are written the
+/// other way round. Both modes write both files — one as a marker, one as a
+/// removal — because either can follow the other on the same agent, and a mode
+/// that only ever adds its own marker would inherit the previous one's.
+fn provision_script(agent: Agent, write_credential: bool, app_mode: bool) -> String {
     let seed = if write_credential {
         agent.credential_seed()
     } else {
@@ -496,12 +541,20 @@ fn provision_script(agent: Agent, write_credential: bool) -> String {
     let name = agent.name();
     let hash_marker = skills_sync::REMOTE_HASH_MARKER;
     let hash_file = skills_sync::REMOTE_HASH_FILE;
+    // The autostart in COMMON_SEED reads both: the sentinel disables it
+    // outright, and `~/.railway-code-agent` is what it would otherwise launch.
+    let mode_seed = if app_mode {
+        "touch ~/.railway-app-mode\nrm -f ~/.railway-code-agent"
+    } else {
+        "rm -f ~/.railway-app-mode\necho AGENT_NAME > ~/.railway-code-agent"
+    };
+    let mode_seed = mode_seed.replace("AGENT_NAME", name);
     format!(
         r#"umask 077
 {HARNESS_PATH}
 {seed}
 {COMMON_SEED}
-echo {name} > ~/.railway-code-agent
+{mode_seed}
 printf '{hash_marker}%s\n' "$(cat "{hash_file}" 2>/dev/null || true)"
 if command -v {name} >/dev/null 2>&1; then echo AGENT-READY; else echo AGENT-MISSING; fi"#
     )
@@ -565,6 +618,16 @@ struct RelaySsh {
     known_hosts: std::path::PathBuf,
     /// known-hosts pattern for ssh-keygen -R: `host` or `[host]:port`.
     host_pattern: String,
+}
+
+/// The known-hosts file the CLI keeps for the relay.
+///
+/// Exposed for `ca desktop`, which writes it into an OpenSSH block so a
+/// third-party client trusts the relay's key the same way this CLI does — and,
+/// more to the point, never lands the relay in the user's `~/.ssh/known_hosts`
+/// or meets a host-key prompt it cannot answer.
+pub fn relay_known_hosts() -> Result<std::path::PathBuf> {
+    Ok(relay_ssh()?.known_hosts)
 }
 
 fn relay_ssh() -> Result<RelaySsh> {
@@ -2121,6 +2184,8 @@ async fn prepare_inner(
         let target = target.clone();
         let identity = identity.clone();
         let relay = relay.clone();
+        // Copied out of `args`, which is a borrow the 'static closure can't take.
+        let app_mode = args.app_mode;
         let skills_note = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
         let notes = skills_note.clone();
         let result = tokio::task::spawn_blocking(move || -> Result<()> {
@@ -2131,7 +2196,7 @@ async fn prepare_inner(
             };
             let out = ssh_plumbing(
                 &target,
-                &provision_script(agent, auth.is_some()),
+                &provision_script(agent, auth.is_some(), app_mode),
                 identity.as_deref(),
                 auth.as_ref().map(|(line, _)| line.as_slice()),
                 &relay,
@@ -2444,7 +2509,7 @@ mod tests {
         // `cat >` truncating a file we have nothing to write to, and every
         // reconnect seed and readiness marker still there.
         for agent in [Agent::Codex, Agent::Claude, Agent::Grok] {
-            let script = provision_script(agent, false);
+            let script = provision_script(agent, false, false);
             assert!(!script.contains("cat > ~/"), "{script}");
             assert!(script.contains("railway-code agent autostart"));
             assert!(script.contains("AGENT-READY"));
@@ -2461,18 +2526,18 @@ mod tests {
 
     #[test]
     fn provision_script_delivers_credentials_only() {
-        let codex = provision_script(Agent::Codex, true);
+        let codex = provision_script(Agent::Codex, true, false);
         assert!(codex.contains("cat > ~/.codex/auth.json"));
         assert!(codex.contains("echo codex > ~/.railway-code-agent"));
 
-        let claude = provision_script(Agent::Claude, true);
+        let claude = provision_script(Agent::Claude, true, false);
         // Written through a compare: an unchanged token must not touch the
         // file's mtime, or it would outrank an on-agent /login forever.
         assert!(claude.contains("cat > \"$tmp\""));
         assert!(claude.contains("cmp -s \"$tmp\" ~/.claude-code-env"));
         assert!(claude.contains("echo claude > ~/.railway-code-agent"));
 
-        let grok = provision_script(Agent::Grok, true);
+        let grok = provision_script(Agent::Grok, true, false);
         assert!(grok.contains("cat > ~/.grok/auth.json"));
         assert!(grok.contains("echo grok > ~/.railway-code-agent"));
 
@@ -2527,10 +2592,30 @@ mod tests {
                 "{guard}"
             );
         }
-        // The v2 marker gates the append and the strip clears any older block,
+        // The v3 marker gates the append and the strip clears any older block,
         // so agents provisioned before this change converge on their next run.
-        assert!(COMMON_SEED.contains("railway-code agent autostart v2"));
+        assert!(COMMON_SEED.contains("railway-code agent autostart v3"));
         assert!(COMMON_SEED.contains("sed -i '/# railway-code agent autostart/,/^fi$/d'"));
+    }
+
+    /// `railway ca desktop` hands the login shell to an external app, so the
+    /// autostart must be off on those agents — and back on if the same agent is
+    /// later launched with `railway code`. Both directions are asserted because
+    /// only writing one's own marker would inherit the other's.
+    #[test]
+    fn app_mode_and_session_mode_disagree_about_the_autostart() {
+        let app = provision_script(Agent::Claude, false, true);
+        assert!(app.contains("touch ~/.railway-app-mode"));
+        assert!(app.contains("rm -f ~/.railway-code-agent"));
+        assert!(!app.contains("> ~/.railway-code-agent"));
+
+        let session = provision_script(Agent::Claude, false, false);
+        assert!(session.contains("rm -f ~/.railway-app-mode"));
+        assert!(session.contains("echo claude > ~/.railway-code-agent"));
+        assert!(!session.contains("touch ~/.railway-app-mode"));
+
+        // The guard the sentinel exists for.
+        assert!(COMMON_SEED.contains(r#"[ ! -f "$HOME/.railway-app-mode" ]"#));
     }
 
     /// The launch note names the cached token's age once it has one, and only
@@ -2555,7 +2640,7 @@ mod tests {
     // to keep.
     #[test]
     fn provision_script_omits_the_seed_when_reusing_a_credential() {
-        let claude = provision_script(Agent::Claude, false);
+        let claude = provision_script(Agent::Claude, false, false);
         assert!(!claude.contains("cat > \"$tmp\""));
         // Everything else still runs.
         assert!(claude.contains("$HOME/.local/bin"));
@@ -2567,8 +2652,8 @@ mod tests {
             (Agent::Codex, "cat > ~/.codex/auth.json"),
             (Agent::Grok, "cat > ~/.grok/auth.json"),
         ] {
-            assert!(provision_script(agent, true).contains(seed));
-            assert!(!provision_script(agent, false).contains(seed));
+            assert!(provision_script(agent, true, false).contains(seed));
+            assert!(!provision_script(agent, false, false).contains(seed));
         }
     }
 
@@ -2578,7 +2663,7 @@ mod tests {
     /// its own binary name like every other harness.
     #[test]
     fn railway_needs_no_credential_seed() {
-        let script = provision_script(Agent::Railway, false);
+        let script = provision_script(Agent::Railway, false, false);
         for other_seed in [
             "cat > \"$tmp\"",
             "cat > ~/.codex/auth.json",
@@ -2601,7 +2686,7 @@ mod tests {
     fn no_provision_step_writes_harness_config() {
         for agent in [Agent::Claude, Agent::Codex, Agent::Grok, Agent::Railway] {
             for write_credential in [true, false] {
-                let script = provision_script(agent, write_credential);
+                let script = provision_script(agent, write_credential, false);
                 assert!(!script.contains(".claude/settings.json"), "{script}");
                 assert!(!script.contains(".claude.json"), "{script}");
                 assert!(!script.contains("apiKeyHelper"), "{script}");
@@ -2616,7 +2701,7 @@ mod tests {
     /// provision script prints, so the two must agree on its shape.
     #[test]
     fn provision_script_reports_the_agents_skills_hash() {
-        let script = provision_script(Agent::Claude, true);
+        let script = provision_script(Agent::Claude, true, false);
         assert!(script.contains(skills_sync::REMOTE_HASH_MARKER));
         assert!(script.contains(skills_sync::REMOTE_HASH_FILE));
         // An agent that has never synced prints an empty value rather than

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -296,6 +296,104 @@ fn render_config_block(
     block
 }
 
+/// What an OpenSSH block for a cloud agent needs to say.
+///
+/// Separate from the service renderer because almost every line differs: the
+/// target grammar is the agent one, the alias is stable across recreations, and
+/// the relay's host key lives in the CLI's own known-hosts file rather than the
+/// user's.
+pub(crate) struct AgentBlock<'a> {
+    pub agent_name: &'a str,
+    pub environment_id: &'a str,
+    pub alias: &'a str,
+    /// `None` for a key that lives only in an ssh-agent — there is no path to
+    /// name, and inventing one would break a connection that works.
+    pub identity_file: Option<&'a Path>,
+    pub known_hosts: &'a Path,
+}
+
+/// The marker that scopes an agent's block, so a rewrite finds it and a removal
+/// takes only it.
+///
+/// Keyed on environment and agent *name*, matching what the block addresses: an
+/// id-keyed marker would orphan the block when an agent of the same name is
+/// recreated, leaving two entries claiming one alias.
+pub(crate) fn agent_marker(environment_id: &str, agent_name: &str) -> String {
+    format!(
+        "agent:{}:{}",
+        marker_name(environment_id),
+        marker_name(agent_name)
+    )
+}
+
+/// The default `Host` alias for an agent.
+pub(crate) fn agent_alias(agent_name: &str) -> String {
+    format!("railway-agent-{}", sanitize_alias(agent_name))
+}
+
+/// Render `block` as an OpenSSH `Host` stanza for a cloud agent.
+///
+/// The relay resolves the agent by name (see `parseCloudAgentTarget` in
+/// backboard), so the block keeps working after a delete-and-recreate — which an
+/// id would not. `StrictHostKeyChecking accept-new` against the CLI's own
+/// known-hosts file is not a convenience: a GUI client that meets an interactive
+/// host-key prompt has nowhere to show it and simply fails.
+pub(crate) fn render_agent_config_block(block: &AgentBlock<'_>) -> String {
+    let marker = agent_marker(block.environment_id, block.agent_name);
+    let (relay_host, relay_port) = native::ssh_relay();
+    let mut out = String::new();
+    let w = |out: &mut String, args: std::fmt::Arguments<'_>| {
+        out.write_fmt(args).expect("writing to String cannot fail");
+    };
+
+    w(&mut out, format_args!("# BEGIN railway:{marker}\n"));
+    w(
+        &mut out,
+        format_args!("# Railway cloud agent: {}\n", marker_name(block.agent_name)),
+    );
+    w(
+        &mut out,
+        format_args!("# Written by `railway ca desktop` — edit with that, not by hand\n"),
+    );
+    w(&mut out, format_args!("Host {}\n", block.alias));
+    w(&mut out, format_args!("    HostName {relay_host}\n"));
+    if let Some(port) = relay_port {
+        w(&mut out, format_args!("    Port {port}\n"));
+    }
+    w(
+        &mut out,
+        format_args!(
+            "    User agent:{}:{}\n",
+            block.environment_id, block.agent_name
+        ),
+    );
+    if let Some(identity_file) = block.identity_file {
+        w(
+            &mut out,
+            format_args!(
+                "    IdentityFile {}\n",
+                quote_ssh_config_value(&identity_file.to_string_lossy())
+            ),
+        );
+    }
+    w(
+        &mut out,
+        format_args!(
+            "    UserKnownHostsFile {}\n",
+            quote_ssh_config_value(&block.known_hosts.to_string_lossy())
+        ),
+    );
+    w(
+        &mut out,
+        format_args!("    StrictHostKeyChecking accept-new\n"),
+    );
+    w(&mut out, format_args!("    ServerAliveInterval 30\n"));
+    w(&mut out, format_args!("    ServerAliveCountMax 3\n"));
+    w(&mut out, format_args!("# END railway:{marker}\n"));
+
+    out
+}
+
 fn upsert_config_block(
     path: &Path,
     config_marker: &str,
@@ -304,20 +402,48 @@ fn upsert_config_block(
 ) -> Result<()> {
     let existing = read_config(path)?;
     let pattern = config_block_regex_with_case(config_marker, false, true)?;
+    if pattern.is_match(&existing) {
+        let updated = pattern.replace(&existing, NoExpand(block)).into_owned();
+        return write_config(path, &updated);
+    }
+    let legacy_pattern = config_block_regex_with_case(service_name, false, true)?;
+    if legacy_pattern.is_match(&existing) {
+        let updated = legacy_pattern
+            .replace(&existing, NoExpand(block))
+            .into_owned();
+        return write_config(path, &updated);
+    }
+    upsert_marked_block(path, config_marker, block)
+}
+
+/// Replace the block carrying `config_marker`, or append it.
+///
+/// [`upsert_config_block`] without the by-service-name fallback, which exists
+/// only to adopt blocks written before markers carried ids. A cloud agent has no
+/// service name to fall back to, and matching one anyway would let an agent
+/// overwrite the block of a service that happens to share its name.
+pub(crate) fn upsert_marked_block(path: &Path, config_marker: &str, block: &str) -> Result<()> {
+    let existing = read_config(path)?;
+    let pattern = config_block_regex_with_case(config_marker, false, true)?;
     let updated = if pattern.is_match(&existing) {
         pattern.replace(&existing, NoExpand(block)).into_owned()
     } else {
-        let legacy_pattern = config_block_regex_with_case(service_name, false, true)?;
-        if legacy_pattern.is_match(&existing) {
-            legacy_pattern
-                .replace(&existing, NoExpand(block))
-                .into_owned()
-        } else {
-            append_config_block(existing, block)
-        }
+        append_config_block(existing, block)
     };
 
     write_config(path, &updated)
+}
+
+/// Remove the block carrying `config_marker`. `false` means there was none.
+pub(crate) fn remove_marked_block(path: &Path, config_marker: &str) -> Result<bool> {
+    let existing = read_config(path)?;
+    let pattern = config_block_regex_with_case(config_marker, true, true)?;
+    if !pattern.is_match(&existing) {
+        return Ok(false);
+    }
+    let updated = pattern.replace(&existing, "").into_owned();
+    write_config(path, &updated)?;
+    Ok(true)
 }
 
 fn remove_config_block_for_target(
@@ -574,7 +700,7 @@ fn quote_ssh_config_value(value: &str) -> String {
     quoted
 }
 
-fn expand_tilde(path: &Path) -> Result<PathBuf> {
+pub(crate) fn expand_tilde(path: &Path) -> Result<PathBuf> {
     let path = path.to_string_lossy();
 
     if path == "~" {
@@ -601,6 +727,97 @@ mod tests {
         assert_eq!(sanitize_alias("API Service"), "api-service");
         assert_eq!(sanitize_alias("railway.API_01"), "railway.api_01");
         assert_eq!(sanitize_alias("!!!"), "service");
+    }
+
+    /// The block a desktop app reads. Asserted whole, because every line of it
+    /// is load-bearing for a client we do not control: the alias it is found by,
+    /// the by-name target that survives a recreate, and the known-hosts pair
+    /// that keeps a GUI off an unanswerable host-key prompt.
+    #[test]
+    fn renders_an_agent_block() {
+        let block = render_agent_config_block(&AgentBlock {
+            agent_name: "my-box",
+            environment_id: "env-id",
+            alias: "railway-agent-my-box",
+            identity_file: Some(Path::new("/home/me/.ssh/id_ed25519")),
+            known_hosts: Path::new("/home/me/.railway/known_hosts_relay"),
+        });
+
+        assert_eq!(
+            block,
+            "\
+# BEGIN railway:agent:env-id:my-box
+# Railway cloud agent: my-box
+# Written by `railway ca desktop` — edit with that, not by hand
+Host railway-agent-my-box
+    HostName ssh.railway.com
+    User agent:env-id:my-box
+    IdentityFile /home/me/.ssh/id_ed25519
+    UserKnownHostsFile /home/me/.railway/known_hosts_relay
+    StrictHostKeyChecking accept-new
+    ServerAliveInterval 30
+    ServerAliveCountMax 3
+# END railway:agent:env-id:my-box
+"
+        );
+    }
+
+    /// A key that lives only in an ssh-agent has no path to name. Omitting the
+    /// directive lets the agent answer; inventing a path would break a
+    /// connection that otherwise works.
+    #[test]
+    fn an_agent_block_omits_an_identity_it_does_not_have() {
+        let block = render_agent_config_block(&AgentBlock {
+            agent_name: "my-box",
+            environment_id: "env-id",
+            alias: "railway-agent-my-box",
+            identity_file: None,
+            known_hosts: Path::new("/k"),
+        });
+        assert!(!block.contains("IdentityFile"));
+        assert!(block.contains("UserKnownHostsFile /k\n"));
+    }
+
+    /// An agent block must never be collateral damage of a service removal, and
+    /// vice versa — they share one file and one marker prefix.
+    #[test]
+    fn agent_and_service_blocks_do_not_remove_each_other() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config");
+
+        let service = render_config_block("my-box", "p:e:s", "railway-my-box", "instance-id", None);
+        upsert_config_block(&path, "p:e:s", "my-box", &service).unwrap();
+
+        let marker = agent_marker("env-id", "my-box");
+        let agent = render_agent_config_block(&AgentBlock {
+            agent_name: "my-box",
+            environment_id: "env-id",
+            alias: &agent_alias("my-box"),
+            identity_file: None,
+            known_hosts: Path::new("/k"),
+        });
+        upsert_marked_block(&path, &marker, &agent).unwrap();
+
+        // Writing the agent block twice must not add a second copy.
+        upsert_marked_block(&path, &marker, &agent).unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        assert_eq!(contents.matches("Host railway-agent-my-box").count(), 1);
+
+        // Removing the agent leaves the identically-named service alone.
+        assert!(remove_marked_block(&path, &marker).unwrap());
+        let contents = fs::read_to_string(&path).unwrap();
+        assert!(!contents.contains("Host railway-agent-my-box"));
+        assert!(contents.contains("Host railway-my-box"));
+        assert!(contents.contains("# Railway service: my-box"));
+
+        // And a second removal is a no-op rather than an error.
+        assert!(!remove_marked_block(&path, &marker).unwrap());
+    }
+
+    #[test]
+    fn agent_aliases_are_sanitized() {
+        assert_eq!(agent_alias("My Box"), "railway-agent-my-box");
+        assert_eq!(agent_marker("env-id", "my-box"), "agent:env-id:my-box");
     }
 
     #[test]

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -6,7 +6,9 @@ use clap::Parser;
 use crate::{client::GQLClient, config::Configs};
 
 mod common;
-mod config;
+// `pub(crate)` so `ca desktop` can write an agent's OpenSSH block with the same
+// marker scheme, file locking and permissions as `railway ssh config`.
+pub(crate) mod config;
 mod keys;
 pub(crate) mod native;
 // `pub(crate)` so `sandbox ssh` can emit the same stage-failure telemetry.


### PR DESCRIPTION
Wires a cloud agent up as a remote SSH host for the Claude Code and Codex desktop apps. Both drive a remote machine over ordinary SSH, and the relay already is one — `agent:<env>:<name>@ssh.railway.com` — so this writes config rather than building a transport.

## Command

```
railway ca desktop --claude | --codex | --claude --codex
  --agent <NAME_OR_ID>   agent to use (default: this environment's, creating one if none)
  --dir <PATH>           where sessions open (default: /app)
  --alias <ALIAS>        Host alias (default: railway-agent-<name>)
  --ssh-config <PATH>    default: ~/.ssh/config
  --dry-run              print both files, touch nothing
  --remove               undo
  --no-verify            skip the post-write connection check
```

## What it writes

`~/.ssh/config` — read by Codex directly, and by Claude via its `sshHost` alias:

```
# BEGIN railway:agent:<envId>:my-box
Host railway-agent-my-box
    HostName ssh.railway.com
    User agent:<envId>:my-box
    IdentityFile ~/.ssh/id_ed25519
    UserKnownHostsFile ~/.railway/known_hosts_relay
    StrictHostKeyChecking accept-new
    ServerAliveInterval 30
    ServerAliveCountMax 3
# END railway:agent:<envId>:my-box
```

`~/.claude/settings.json` (Claude only) — `sshConfigs[]` entry keyed on agent id, `sshHost` pointing at the alias. `sshPort`/`sshIdentityFile` omitted so the OpenSSH block is the single source of truth.

## Decisions

- **Addressed by name, not id.** The backboard resolver accepts either; the name keeps the block valid after a delete-and-recreate.
- **Relay known-hosts + `accept-new`.** A GUI client that meets an interactive host-key prompt has nowhere to show it and just fails. Also keeps the relay out of `~/.ssh/known_hosts`.
- **`COMMON_SEED` v3 + `~/.railway-app-mode`.** Codex bootstraps its server through the remote login shell; the existing autostart would put a harness there. The sentinel disables it, and gates rather than omits, because a later `railway code` on the same agent rewrites `~/.railway-code-agent`. Both modes write both files, so either can follow the other.
- **Provision without launching.** `LaunchArgs::for_app_mode` reuses `code::prepare`, so the app arrives at an already-signed-in harness. `--claude --codex` seeds two credentials on one agent.
- **Verify before reporting.** `ssh -F <config> -o BatchMode=yes` plus a `bash -lc 'command -v <bin>'` login-shell probe. Every failure here is one a GUI swallows.
- **`--dry-run` creates and wakes nothing.** It resolves an existing agent and reads the local key without registering it, rather than being the write path with writes skipped.
- **`--agent` carries its own environment** into the launch pipeline, else a named agent outside the linked environment would create a second VM.

## Out of scope

Waking. A sleeping agent is refused at the relay (`Agent 'x' is not running`) and a desktop app has no hook to wake it. The summary says so and names `railway ca wake`.

## Testing

- `cargo test` — 1077 pass (the 7 `auth_sim` failures on a Railway VM are `RAILWAY_API_TOKEN` in the env, not this change), `cargo clippy` clean on touched files, `cargo fmt` applied.
- New coverage: agent-block golden, `IdentityFile` omitted for agent-only keys, agent/service blocks not removing each other, idempotent re-write, `sshConfigs` merge idempotency + preserved sibling keys + corrupt-file safety, app-mode/session-mode provision scripts.
- `--dry-run` exercised against a real account; generated block validated with `ssh -G` (resolves to `agent:<env>:<name>@ssh.railway.com:22`) and against the live relay, which accepted the host key into `~/.railway/known_hosts_relay` with no prompt and rejected an unregistered key with `Permission denied (publickey)`.
- Not tested end to end: an authenticated relay connection, and either desktop app actually attaching.