### PR TITLE
feat(mcp): default new agent installs to the remote CLI proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,21 @@ Configure Railway agent support for AI coding tools:
 railway setup agent -y
 ```
 
-This installs Railway skills and configures the Railway MCP server for detected tools such as Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, and Factory Droid.
+This installs Railway skills and configures the remote Railway MCP server (`mcp.railway.com` via `railway mcp proxy`, authenticated with your CLI login) for detected tools such as Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, and Factory Droid.
 
 Use the focused commands when you only need one part of the setup:
 
 ```bash
 railway mcp install --agent cursor
 railway skills --agent claude-code
+```
+
+Opt into the local GraphQL-backed MCP server instead:
+
+```bash
+railway setup agent -y --local
+# or
+railway mcp install --local --agent cursor
 ```
 
 ## Contributing

--- a/agents.sh
+++ b/agents.sh
@@ -12,10 +12,11 @@
 #
 #     curl -fsSL railway.com/install.sh | sh -s -- --agents -y
 #
-# Any extra arguments are forwarded to install.sh, e.g. to opt into the
-# remote MCP server:
+# By default this configures the remote MCP server via `railway mcp proxy`
+# (CLI login auth). Extra arguments are forwarded to install.sh, e.g. to opt
+# into the local MCP server instead:
 #
-#     curl -fsSL railway.com/agents.sh | sh -s -- --remote
+#     curl -fsSL railway.com/agents.sh | sh -s -- --local
 #
 set -eu
 

--- a/install.sh
+++ b/install.sh
@@ -25,10 +25,16 @@ help_text="Options
 
    --agents
    Install or reuse the Railway CLI, then configure Railway agent support
+   (defaults to the remote MCP server via \`railway mcp proxy\`)
 
    --remote
-   When used with --agents, configure the remote HTTP MCP server at
-   mcp.railway.com instead of the local stdio server
+   When used with --agents, configure the remote MCP server at
+   mcp.railway.com via the CLI proxy (uses \`railway login\`). This is the
+   default for --agents; the flag is kept for compatibility.
+
+   --local
+   When used with --agents, configure the local GraphQL-backed MCP server
+   (\`railway mcp\`) instead of the remote CLI proxy default.
 
    -r, --remove
    Uninstall railway
@@ -438,6 +444,7 @@ UNINSTALL=0
 HELP=0
 AGENTS=0
 REMOTE=0
+LOCAL=0
 RAILWAY_HOME_DIR=""
 RAILWAY_ENV_FILE=""
 RAILWAY_FISH_ENV_FILE=""
@@ -539,6 +546,10 @@ while [ "$#" -gt 0 ]; do
     REMOTE=1
     shift 1
     ;;
+  --local)
+    LOCAL=1
+    shift 1
+    ;;
   -h | --help)
     HELP=1
     shift 1
@@ -582,10 +593,17 @@ else
   VERBOSE=
 fi
 
-# --remote only takes effect alongside --agents (it routes setup agent to the
-# hosted MCP server). Warn loudly rather than silently no-op.
+# --remote / --local only take effect alongside --agents. Warn loudly rather
+# than silently no-op.
 if [ "$REMOTE" = 1 ] && [ "$AGENTS" != 1 ]; then
   warn "--remote has no effect without --agents. Re-run with both flags to configure remote MCP."
+fi
+if [ "$LOCAL" = 1 ] && [ "$AGENTS" != 1 ]; then
+  warn "--local has no effect without --agents. Re-run with both flags to configure local MCP."
+fi
+if [ "$REMOTE" = 1 ] && [ "$LOCAL" = 1 ]; then
+  error "--remote and --local cannot be used together."
+  exit 1
 fi
 
 write_env_files() {
@@ -970,7 +988,7 @@ warn_existing_path_conflict() {
 run_agent_setup() {
   local railway_bin="$1"
   local yes=""
-  local remote=""
+  local mcp_transport=""
 
   if [ -z "${RAILWAY_INSTALL_REQUEST_ID-}" ]; then
     RAILWAY_INSTALL_REQUEST_ID="install_$(od -vAn -N16 -tx1 < /dev/urandom | tr -d ' \n')"
@@ -981,8 +999,13 @@ run_agent_setup() {
     yes="-y"
   fi
 
-  if [ "$REMOTE" = 1 ]; then
-    remote="--remote"
+  # Explicit transport overrides only. Non-interactive setup on a current CLI
+  # already defaults to the remote CLI proxy; older CLIs without that default
+  # still accept `--remote`. `--local` opts back into the in-process server.
+  if [ "$LOCAL" = 1 ]; then
+    mcp_transport="--local"
+  elif [ "$REMOTE" = 1 ]; then
+    mcp_transport="--remote"
   fi
 
   if [ -t 0 ] && [ -z "${FORCE-}" ]; then
@@ -1002,7 +1025,7 @@ run_agent_setup() {
   # broke, surface the real status, and still point somewhere useful — the old
   # behaviour was to die mid-script with no Railway-branded message at all.
   AGENT_SETUP_RC=0
-  RAILWAY_SETUP_EMBEDDED=1 "$railway_bin" setup agent $yes $remote || AGENT_SETUP_RC=$?
+  RAILWAY_SETUP_EMBEDDED=1 "$railway_bin" setup agent $yes $mcp_transport || AGENT_SETUP_RC=$?
   if [ "$AGENT_SETUP_RC" -ne 0 ]; then
     printf "\n"
     if [ "$AGENT_SETUP_RC" -eq 2 ]; then
@@ -1160,13 +1183,18 @@ if [ "$AGENTS" = 1 ] && has railway; then
   esac
 
   if [ "$BREW_INSTALL" = 1 ]; then
-    if [ "$REMOTE" = 1 ]; then
-      # --remote was added in a newer release. Continuing with an older brewed
-      # CLI would call `setup agent --remote` and fail with an unrecognized-arg
-      # error after we already told the user we were continuing. Refuse early.
+    if [ "$REMOTE" = 1 ] || [ "$LOCAL" = 1 ]; then
+      # Transport flags were added in newer releases. Continuing with an older
+      # brewed CLI would call `setup agent --remote/--local` and fail with an
+      # unrecognized-arg error after we already told the user we were continuing.
+      # Refuse early.
+      flag_name="--remote"
+      if [ "$LOCAL" = 1 ]; then
+        flag_name="--local"
+      fi
       error "Railway CLI was installed via Homebrew (version $CURRENT_VERSION)."
-      error "The --remote flag requires Railway CLI $RAILWAY_VERSION or newer."
-      error "Run 'brew upgrade railway' first, then re-run cli.new --agents --remote."
+      error "The $flag_name flag requires Railway CLI $RAILWAY_VERSION or newer."
+      error "Run 'brew upgrade railway' first, then re-run cli.new --agents $flag_name."
       exit 1
     fi
     warn "Railway CLI was installed via Homebrew."
@@ -1199,10 +1227,14 @@ if [ "$AGENTS" = 1 ] && has railway; then
   fi
 
   if [ "$MANAGED_BIN" = 1 ]; then
-    if [ "$REMOTE" = 1 ]; then
+    if [ "$REMOTE" = 1 ] || [ "$LOCAL" = 1 ]; then
+      flag_name="--remote"
+      if [ "$LOCAL" = 1 ]; then
+        flag_name="--local"
+      fi
       error "Railway CLI on PATH is managed by another tool: $RAILWAY_BIN ($CURRENT_VERSION)."
-      error "The --remote flag requires Railway CLI $RAILWAY_VERSION or newer."
-      error "Update it with that tool first (e.g. 'npm install -g @railway/cli@latest'), then re-run cli.new --agents --remote."
+      error "The $flag_name flag requires Railway CLI $RAILWAY_VERSION or newer."
+      error "Update it with that tool first (e.g. 'npm install -g @railway/cli@latest'), then re-run cli.new --agents $flag_name."
       exit 1
     fi
     warn "Railway CLI on PATH is managed by another tool: $RAILWAY_BIN"

--- a/install.sh
+++ b/install.sh
@@ -24,13 +24,15 @@ help_text="Options
    Override the base URL used for downloading releases
 
    --agents
-   Install or reuse the Railway CLI, then configure Railway agent support
-   (defaults to the remote MCP server via \`railway mcp proxy\`)
+   Install or reuse the Railway CLI, then configure Railway agent support.
+   On supported CLI versions this defaults to the remote MCP server via
+   \`railway mcp proxy\` (CLI login auth).
 
    --remote
    When used with --agents, configure the remote MCP server at
-   mcp.railway.com via the CLI proxy (uses \`railway login\`). This is the
-   default for --agents; the flag is kept for compatibility.
+   mcp.railway.com via the CLI proxy (uses \`railway login\`). Compatibility
+   alias of the default on current CLIs; also forces proxy on older CLIs
+   that still default \`setup agent -y\` to local MCP.
 
    --local
    When used with --agents, configure the local GraphQL-backed MCP server
@@ -999,13 +1001,21 @@ run_agent_setup() {
     yes="-y"
   fi
 
-  # Explicit transport overrides only. Non-interactive setup on a current CLI
-  # already defaults to the remote CLI proxy; older CLIs without that default
-  # still accept `--remote`. `--local` opts back into the in-process server.
+  # Transport selection for `setup agent`:
+  # - `--local` opts into the in-process server.
+  # - `--remote` forces the CLI proxy (alias of the current default).
+  # - Non-interactive agents setup also passes `--remote` when the binary
+  #   supports it, so older CLIs that still default `-y` to local MCP land on
+  #   the proxy. Probe `--help` first: pre-proxy binaries must not die on an
+  #   unrecognized flag when we continue with a managed/Homebrew install.
   if [ "$LOCAL" = 1 ]; then
     mcp_transport="--local"
   elif [ "$REMOTE" = 1 ]; then
     mcp_transport="--remote"
+  elif [ -n "$yes" ]; then
+    if "$railway_bin" setup agent --help 2>&1 | grep -q -- '--remote'; then
+      mcp_transport="--remote"
+    fi
   fi
 
   if [ -t 0 ] && [ -z "${FORCE-}" ]; then

--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -16,12 +16,18 @@ pub struct Args {
 
     /// Configure the remote MCP server at mcp.railway.com, bridged through `railway mcp proxy`
     /// so it authenticates with your existing CLI login (no browser OAuth flow).
-    #[clap(long)]
+    /// This is the default; the flag is kept for compatibility.
+    #[clap(long, conflicts_with = "local")]
     remote: bool,
 
-    /// With --remote: write the plain HTTP server URL instead of the CLI proxy, so the
-    /// editor runs its own OAuth (browser consent) flow.
-    #[clap(long, requires = "remote")]
+    /// Configure the local GraphQL-backed MCP server (`railway mcp`) instead of the
+    /// remote CLI proxy default.
+    #[clap(long, conflicts_with_all = ["remote", "oauth"])]
+    local: bool,
+
+    /// Write the plain HTTP server URL instead of the CLI proxy, so the editor runs
+    /// its own OAuth (browser consent) flow.
+    #[clap(long, conflicts_with = "local")]
     oauth: bool,
 }
 
@@ -38,11 +44,16 @@ pub(crate) enum McpTransport {
 }
 
 impl McpTransport {
-    pub(crate) fn from_flags(remote: bool, oauth: bool) -> Self {
-        match (remote, oauth) {
-            (false, _) => Self::Local,
-            (true, false) => Self::RemoteProxy,
-            (true, true) => Self::RemoteOauth,
+    /// Resolve the install transport from CLI flags.
+    ///
+    /// Default is the remote CLI proxy. `--local` selects the in-process server;
+    /// `--oauth` selects plain `https://mcp.railway.com`. `--remote` remains
+    /// accepted as an explicit alias of the default.
+    pub(crate) fn from_flags(remote: bool, oauth: bool, local: bool) -> Self {
+        match (local, oauth, remote) {
+            (true, _, _) => Self::Local,
+            (false, true, _) => Self::RemoteOauth,
+            (false, false, _) => Self::RemoteProxy,
         }
     }
 }
@@ -60,7 +71,7 @@ fn stdio_args(transport: McpTransport) -> Vec<&'static str> {
 pub async fn command(args: Args) -> Result<()> {
     install_mcp(
         &args.agent,
-        McpTransport::from_flags(args.remote, args.oauth),
+        McpTransport::from_flags(args.remote, args.oauth, args.local),
         false,
     )
     .await
@@ -874,5 +885,31 @@ mod tests {
             "factory-droid",
             McpTransport::RemoteOauth
         ));
+    }
+
+    #[test]
+    fn from_flags_defaults_to_remote_proxy() {
+        assert_eq!(
+            McpTransport::from_flags(false, false, false),
+            McpTransport::RemoteProxy
+        );
+        // `--remote` remains an explicit alias of the default.
+        assert_eq!(
+            McpTransport::from_flags(true, false, false),
+            McpTransport::RemoteProxy
+        );
+        assert_eq!(
+            McpTransport::from_flags(false, false, true),
+            McpTransport::Local
+        );
+        assert_eq!(
+            McpTransport::from_flags(false, true, false),
+            McpTransport::RemoteOauth
+        );
+        // `--local` wins over a stale `--remote` if both somehow appear.
+        assert_eq!(
+            McpTransport::from_flags(true, false, true),
+            McpTransport::Local
+        );
     }
 }

--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -14,9 +14,9 @@ pub struct Args {
     #[clap(long)]
     agent: Vec<String>,
 
-    /// Configure the remote MCP server at mcp.railway.com, bridged through `railway mcp proxy`
-    /// so it authenticates with your existing CLI login (no browser OAuth flow).
-    /// This is the default; the flag is kept for compatibility.
+    /// Configure the remote MCP server via the CLI proxy (`railway mcp proxy` →
+    /// mcp.railway.com, auth via `railway login`). This is the default; the flag is
+    /// kept as a compatibility alias. Ignored when `--oauth` is set.
     #[clap(long, conflicts_with = "local")]
     remote: bool,
 
@@ -25,8 +25,8 @@ pub struct Args {
     #[clap(long, conflicts_with_all = ["remote", "oauth"])]
     local: bool,
 
-    /// Write the plain HTTP server URL instead of the CLI proxy, so the editor runs
-    /// its own OAuth (browser consent) flow.
+    /// Use editor OAuth against https://mcp.railway.com directly (not the CLI proxy).
+    /// Takes precedence over `--remote`.
     #[clap(long, conflicts_with = "local")]
     oauth: bool,
 }
@@ -69,6 +69,14 @@ fn stdio_args(transport: McpTransport) -> Vec<&'static str> {
 }
 
 pub async fn command(args: Args) -> Result<()> {
+    if args.oauth && args.remote {
+        eprintln!(
+            "{} {}",
+            "!".yellow().bold(),
+            "Using editor OAuth (https://mcp.railway.com); --remote is ignored with --oauth."
+                .yellow()
+        );
+    }
     install_mcp(
         &args.agent,
         McpTransport::from_flags(args.remote, args.oauth, args.local),

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -32,17 +32,24 @@ enum SetupCommand {
 pub struct AgentArgs {
     /// Skip prompts and accept defaults: auto-detect installed editors, skip the login flow.
     /// Also auto-engaged when stdout is not a terminal (e.g. piped or running under CI).
+    /// Non-interactive MCP default is the remote CLI proxy (`railway mcp proxy`).
     #[clap(short = 'y', long)]
     yes: bool,
 
     /// Configure the remote MCP server (mcp.railway.com) via the CLI proxy — it authenticates
-    /// with your existing `railway login`, no browser OAuth flow.
-    #[clap(long)]
+    /// with your existing `railway login`, no browser OAuth flow. This is the default for
+    /// `-y` / non-interactive setup; the flag is kept for compatibility.
+    #[clap(long, conflicts_with = "local")]
     remote: bool,
 
-    /// With --remote: write the plain HTTP server URL instead of the CLI proxy, so the
-    /// editor runs its own OAuth (browser consent) flow.
-    #[clap(long, requires = "remote")]
+    /// Configure the local GraphQL-backed MCP server (`railway mcp`) instead of the
+    /// remote CLI proxy default.
+    #[clap(long, conflicts_with_all = ["remote", "oauth"])]
+    local: bool,
+
+    /// Write the plain HTTP server URL (https://mcp.railway.com) instead of the CLI proxy,
+    /// so the editor runs its own OAuth (browser consent) flow.
+    #[clap(long, conflicts_with = "local")]
     oauth: bool,
 }
 
@@ -69,7 +76,7 @@ impl fmt::Display for ToolChoice {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum McpChoice {
     Local,
     RemoteProxy,
@@ -80,15 +87,15 @@ enum McpChoice {
 impl fmt::Display for McpChoice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            McpChoice::Local => write!(
-                f,
-                "Local (default)  {}",
-                "— runs `railway mcp` as a stdio server".dimmed()
-            ),
             McpChoice::RemoteProxy => write!(
                 f,
-                "Remote           {}",
+                "Remote (default) {}",
                 "— mcp.railway.com via the CLI proxy (uses your `railway login`)".dimmed()
+            ),
+            McpChoice::Local => write!(
+                f,
+                "Local            {}",
+                "— runs `railway mcp` as a stdio server".dimmed()
             ),
             McpChoice::RemoteOauth => write!(
                 f,
@@ -103,21 +110,22 @@ impl fmt::Display for McpChoice {
 fn pick_mcp_choice(
     remote_flag: bool,
     oauth_flag: bool,
+    local_flag: bool,
     non_interactive: bool,
 ) -> Result<McpChoice> {
-    if remote_flag {
-        return Ok(if oauth_flag {
-            McpChoice::RemoteOauth
-        } else {
-            McpChoice::RemoteProxy
-        });
-    }
-    if non_interactive {
+    if local_flag {
         return Ok(McpChoice::Local);
     }
+    if oauth_flag {
+        return Ok(McpChoice::RemoteOauth);
+    }
+    if remote_flag || non_interactive {
+        // `--remote` is now an explicit no-op alias of the non-interactive default.
+        return Ok(McpChoice::RemoteProxy);
+    }
     let options = vec![
-        McpChoice::Local,
         McpChoice::RemoteProxy,
+        McpChoice::Local,
         McpChoice::RemoteOauth,
         McpChoice::Skip,
     ];
@@ -259,8 +267,8 @@ async fn agent_setup_inner(args: AgentArgs) -> Result<Vec<String>> {
     }
 
     // Step 2: MCP install (skips universal internally — no MCP convention).
-    // `--remote` short-circuits the prompt; `-y`/non-TTY defaults to local.
-    let mcp_choice = pick_mcp_choice(args.remote, args.oauth, non_interactive)?;
+    // Flags short-circuit the prompt; `-y`/non-TTY defaults to the remote CLI proxy.
+    let mcp_choice = pick_mcp_choice(args.remote, args.oauth, args.local, non_interactive)?;
     let mcp_transport = match mcp_choice {
         McpChoice::Local => {
             install_missing_mcp(
@@ -544,4 +552,46 @@ async fn ensure_logged_in_interactive() -> Result<()> {
 
     println!("\n{}", "Logging in to Railway...".bold());
     login::command(login::Args { browserless: false }).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_interactive_defaults_to_remote_proxy() {
+        assert_eq!(
+            pick_mcp_choice(false, false, false, true).unwrap(),
+            McpChoice::RemoteProxy
+        );
+    }
+
+    #[test]
+    fn remote_flag_selects_proxy_and_remains_compatible() {
+        assert_eq!(
+            pick_mcp_choice(true, false, false, false).unwrap(),
+            McpChoice::RemoteProxy
+        );
+        assert_eq!(
+            pick_mcp_choice(true, false, false, true).unwrap(),
+            McpChoice::RemoteProxy
+        );
+    }
+
+    #[test]
+    fn local_and_oauth_flags_override_default() {
+        assert_eq!(
+            pick_mcp_choice(false, false, true, true).unwrap(),
+            McpChoice::Local
+        );
+        assert_eq!(
+            pick_mcp_choice(false, true, false, true).unwrap(),
+            McpChoice::RemoteOauth
+        );
+        // `--local` wins if both local and remote somehow appear.
+        assert_eq!(
+            pick_mcp_choice(true, false, true, true).unwrap(),
+            McpChoice::Local
+        );
+    }
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -36,9 +36,9 @@ pub struct AgentArgs {
     #[clap(short = 'y', long)]
     yes: bool,
 
-    /// Configure the remote MCP server (mcp.railway.com) via the CLI proxy — it authenticates
-    /// with your existing `railway login`, no browser OAuth flow. This is the default for
-    /// `-y` / non-interactive setup; the flag is kept for compatibility.
+    /// Configure the remote MCP server via the CLI proxy (`railway mcp proxy` →
+    /// mcp.railway.com, auth via `railway login`). Default for `-y` / non-interactive
+    /// setup; kept as a compatibility alias. Ignored when `--oauth` is set.
     #[clap(long, conflicts_with = "local")]
     remote: bool,
 
@@ -47,8 +47,8 @@ pub struct AgentArgs {
     #[clap(long, conflicts_with_all = ["remote", "oauth"])]
     local: bool,
 
-    /// Write the plain HTTP server URL (https://mcp.railway.com) instead of the CLI proxy,
-    /// so the editor runs its own OAuth (browser consent) flow.
+    /// Use editor OAuth against https://mcp.railway.com directly (not the CLI proxy).
+    /// Takes precedence over `--remote`.
     #[clap(long, conflicts_with = "local")]
     oauth: bool,
 }
@@ -117,6 +117,14 @@ fn pick_mcp_choice(
         return Ok(McpChoice::Local);
     }
     if oauth_flag {
+        if remote_flag {
+            eprintln!(
+                "{} {}",
+                "!".yellow().bold(),
+                "Using editor OAuth (https://mcp.railway.com); --remote is ignored with --oauth."
+                    .yellow()
+            );
+        }
         return Ok(McpChoice::RemoteOauth);
     }
     if remote_flag || non_interactive {
@@ -129,7 +137,9 @@ fn pick_mcp_choice(
         McpChoice::RemoteOauth,
         McpChoice::Skip,
     ];
+    // Remote is index 0 and labeled default; start the cursor there so Enter accepts it.
     inquire::Select::new("Configure MCP server:", options)
+        .with_starting_cursor(0)
         .with_render_config(Configs::get_render_config())
         .prompt()
         .context("Failed to prompt for MCP transport")

--- a/src/main.rs
+++ b/src/main.rs
@@ -899,6 +899,10 @@ mod cli_tests {
             assert_parses(&["setup", "agent", "-y"]);
             assert_parses(&["setup", "agent", "--remote"]);
             assert_parses(&["setup", "agent", "--remote", "-y"]);
+            assert_parses(&["setup", "agent", "--local"]);
+            assert_parses(&["setup", "agent", "--local", "-y"]);
+            assert_parses(&["setup", "agent", "--oauth"]);
+            assert_parses(&["setup", "agent", "--oauth", "-y"]);
         }
 
         #[test]
@@ -1042,6 +1046,10 @@ mod cli_tests {
             assert_parses(&["mcp", "install", "--remote"]);
             assert_parses(&["mcp", "install", "--remote", "--agent", "cursor"]);
             assert_parses(&["mcp", "install", "--remote", "--agent", "codex"]);
+            assert_parses(&["mcp", "install", "--local"]);
+            assert_parses(&["mcp", "install", "--local", "--agent", "cursor"]);
+            assert_parses(&["mcp", "install", "--oauth"]);
+            assert_parses(&["mcp", "install", "--oauth", "--agent", "cursor"]);
         }
     }
 }


### PR DESCRIPTION
## Summary
- New agent installs now default to the **remote CLI proxy** (`railway mcp proxy` → `mcp.railway.com`, auth via `railway login`):
  - `railway setup agent -y` / non-TTY setup
  - `railway mcp install` (no flags)
  - `curl -fsSL agents.railway.com | sh` / `install.sh --agents`
- Interactive setup picker lists **Remote** first as the default option.
- Escape hatches:
  - `--local` → old in-process `railway mcp`
  - `--oauth` → plain `https://mcp.railway.com` (editor OAuth)
  - `--remote` kept as a compatibility alias of the new default
- **Re-run behavior:** if a user already has local MCP configured and re-runs `setup agent` / `mcp install`, their railway entry is updated to the proxy. That migration-on-rerun is intentional for this phase.
- **Not in this PR:** bare `railway mcp` still runs the local server. Users who never re-run setup/install keep local until the later runtime default flip.

## Why
Canary the remote-proxy path on new installs and voluntary re-runs before flipping bare `railway mcp` for everyone.

## Test plan
- [x] `cargo test commands::setup::tests`
- [x] `cargo test from_flags_defaults_to_remote_proxy`
- [x] `cargo test mcp_install_subcommand`
- [x] `cargo test setup_agent_subcommand`
- [x] Fresh `$HOME`: `railway setup agent -y` writes `args: ["mcp","proxy"]`
- [x] Existing local entry + `mcp install` / `setup agent -y` migrates to proxy
- [x] `railway mcp install --local` still writes local `args: ["mcp"]`
- [x] `--local` conflicts with `--remote` / `--oauth`
- [ ] Smoke agents.sh / install.sh --agents against a current CLI binary