### PR TITLE
feat(ca): bracketed paste in the TUI session pane

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ futures = { version = "0.3.31", default-features = false, features = [
 ] }
 futures-util = "0.3"
 graphql-ws-client = { version = "0.11.1", features = ["client-graphql-client"] }
-crossterm = { version = "0.27.0", features = ["event-stream"] }
+crossterm = { version = "0.27.0", features = ["event-stream", "bracketed-paste"] }
 http = "0.2"
 is-terminal = "0.4.13"
 serde_with = { version = "3.17.0", default-features = false, features = ["macros"] }

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -2172,6 +2172,53 @@ impl App {
         }
     }
 
+    /// Pasted text — a ⌘v, or a dictation tool like Wispr Flow, which inserts
+    /// into a terminal the same way. It goes where typing would go: a focused
+    /// session gets it as a paste, a prompt box gets it as text. Anywhere
+    /// else it is dropped whole — fed through `on_key` it would spray across
+    /// hotkeys, and a stray paste must never trigger an action.
+    pub fn on_paste(&mut self, text: String) -> Option<Effect> {
+        // The SSH gate is a y/N question; pasted text is not an answer.
+        if self.ssh_gate.is_some() {
+            return None;
+        }
+        if self.focus == ManageFocus::Session && self.screen == Screen::Manage {
+            if let Some(i) = self.active {
+                // A dead pane's keys mean recovery, but a paste is not a
+                // command — bytes to a dead pty vanish, so drop it.
+                let dead = self
+                    .sessions
+                    .get(i)
+                    .is_some_and(|s| s.ended() || s.stalled());
+                if !dead && let Some(session) = self.sessions.get_mut(i) {
+                    session.send_paste(&text);
+                }
+            }
+            return None;
+        }
+        // The prompt boxes are single-line: newlines become spaces rather
+        // than being taken as Enter, and other control characters have no
+        // business in a draft at all.
+        let text: String = text
+            .replace("\r\n", " ")
+            .chars()
+            .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+            .filter(|c| !c.is_control())
+            .collect();
+        match self.screen {
+            Screen::Menu if self.menu_focus == MenuFocus::Prompt && !self.shell_selected() => {
+                self.prompt.push_str(&text);
+            }
+            Screen::ManagePrompt if !self.shell_selected() => {
+                if let Some(draft) = self.manage_prompt.as_mut() {
+                    draft.push_str(&text);
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
     fn on_key_wizard(&mut self, key: KeyEvent) -> Option<Effect> {
         use super::wizard::Action;
         let wizard = self.wizard.as_mut()?;
@@ -4396,6 +4443,37 @@ mod tests {
         a.on_key(ctrl('t'));
         assert_eq!(a.screen, Screen::TargetPick);
         assert_eq!(a.prompt, "te", "retargeting must not eat the draft");
+    }
+
+    /// A paste lands in the prompt as text — dictation tools insert whole
+    /// utterances this way — with newlines flattened to spaces: the box is
+    /// one line, and a line break taken as Enter would launch mid-thought.
+    #[test]
+    fn a_paste_lands_in_the_prompt_as_one_line() {
+        let mut a = app();
+        a.on_key(key(KeyCode::Char('f')));
+        assert_eq!(a.on_paste("ix the login bug\nthen deploy".into()), None);
+        assert_eq!(a.prompt, "fix the login bug then deploy");
+        assert_eq!(a.screen, Screen::Menu, "a pasted newline is not Enter");
+    }
+
+    /// Where typing is refused, pasting is too; and off the prompt a paste
+    /// must not be sprayed across the hotkeys.
+    #[test]
+    fn a_paste_respects_prompt_focus_and_shell() {
+        let mut a = app();
+        a.menu_focus = MenuFocus::Cards;
+        assert_eq!(a.on_paste("stray".into()), None);
+        assert_eq!(a.prompt, "", "cards are not a text box");
+
+        a.menu_focus = MenuFocus::Prompt;
+        a.harness = HARNESSES.len() - 1;
+        assert!(a.shell_selected());
+        assert_eq!(a.on_paste("stray".into()), None);
+        assert_eq!(
+            a.prompt, "",
+            "the box says typing is refused; so is a paste"
+        );
     }
 
     /// The target chooser is the setup flow's project card, not a trip through

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -28,9 +28,9 @@ use std::panic;
 use anyhow::Result;
 use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
-    DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyEventKind, KeyModifiers,
-    KeyboardEnhancementFlags, MouseButton, MouseEventKind, PopKeyboardEnhancementFlags,
-    PushKeyboardEnhancementFlags,
+    DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
+    EventStream, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, MouseButton, MouseEventKind,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -582,6 +582,7 @@ pub async fn run(
                 if app.awaiting_exit_status() => app.reap_ended_sessions(),
             event = events.next() => match event {
                 Some(Ok(Event::Key(key))) if key.kind == KeyEventKind::Press => app.on_key(key),
+                Some(Ok(Event::Paste(text))) => app.on_paste(text),
                 Some(Ok(Event::Mouse(mouse))) => {
                     let action = match mouse.kind {
                         MouseEventKind::Down(MouseButton::Left) => Some(app::MouseAction::Down),
@@ -1579,7 +1580,19 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     crate::util::prompt::set_terminal_owned(true);
     // Mouse capture takes the terminal's own selection away, which is why the
     // TUI implements drag-to-copy itself.
-    execute!(stdout(), EnterAlternateScreen, EnableMouseCapture, Hide)?;
+    //
+    // Bracketed paste is what keeps a paste from arriving as typed keys: text
+    // inserted by the terminal — ⌘v, and dictation tools like Wispr Flow,
+    // which insert into a terminal the same way — comes wrapped in markers
+    // and reaches the loop as one `Event::Paste`, instead of a stream of
+    // keystrokes whose every newline hits Enter in the pane.
+    execute!(
+        stdout(),
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste,
+        Hide
+    )?;
     // Ask for the enhanced keyboard protocol, which is what makes a modifier on
     // Escape reportable at all: a plain terminal sends ⇧esc as a bare Escape,
     // indistinguishable from the one meant for the agent. Terminals that do not
@@ -1616,13 +1629,19 @@ fn restore_terminal() {
     // Popping a protocol that was never pushed is harmless; leaving one pushed
     // would follow the user out of the TUI and into their shell.
     let _ = execute!(stdout(), PopKeyboardEnhancementFlags);
-    let _ = execute!(stdout(), DisableMouseCapture, LeaveAlternateScreen, Show);
+    let _ = execute!(
+        stdout(),
+        DisableBracketedPaste,
+        DisableMouseCapture,
+        LeaveAlternateScreen,
+        Show
+    );
     // Again, on the main screen. Mouse tracking left on is the one piece of
     // state the user cannot see and cannot clear: every pointer movement
     // becomes `35;21;32M` at their shell prompt. Terminals disagree about
     // whether the modes belong to the screen buffer that set them, so turn
     // them off on both.
-    let _ = execute!(stdout(), DisableMouseCapture);
+    let _ = execute!(stdout(), DisableBracketedPaste, DisableMouseCapture);
     let _ = disable_raw_mode();
     crate::util::prompt::set_terminal_owned(false);
     let _ = stdout().flush();

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -690,6 +690,17 @@ impl Session {
         }
     }
 
+    /// Forward pasted text as a paste, not as typed keys. When the program in
+    /// the pane has bracketed paste switched on (Claude Code and every modern
+    /// editor do), the text goes wrapped in the paste markers and lands as one
+    /// atomic paste — a newline stays a newline instead of hitting Enter. A
+    /// program that never asked for the mode (a plain shell) gets the bare
+    /// text, exactly what a real terminal would send it.
+    pub fn send_paste(&mut self, text: &str) {
+        let bracketed = self.with_screen(|s| s.bracketed_paste()).unwrap_or(false);
+        self.send(&encode_paste(text, bracketed));
+    }
+
     /// Stop the local half. The agent and whatever it is running stay up on the
     /// VM — killing ssh detaches, it does not tidy up.
     pub fn detach(&mut self) {
@@ -1004,6 +1015,29 @@ pub fn encode_key(key: KeyEvent) -> Option<Vec<u8>> {
     Some(out)
 }
 
+/// Encode pasted text as the bytes a terminal would send — wrapped in the
+/// bracketed-paste markers when the program on the pty has the mode on, bare
+/// otherwise.
+pub fn encode_paste(text: &str, bracketed: bool) -> Vec<u8> {
+    // A paste containing the end marker would terminate the paste early and
+    // feed the remainder through as keystrokes — the classic bracketed-paste
+    // injection. Real terminals strip it; so does this pane. It is stripped
+    // from an unbracketed paste too: that path is keystrokes, and no keyboard
+    // produces the sequence.
+    let text = text.replace("\x1b[201~", "");
+    // Enter arrives from a keyboard as CR, and programs reading a pty expect
+    // the same from a paste; LF-only text would land as ^J.
+    let text = text.replace("\r\n", "\r").replace('\n', "\r");
+    if !bracketed {
+        return text.into_bytes();
+    }
+    let mut bytes = Vec::with_capacity(text.len() + 12);
+    bytes.extend_from_slice(b"\x1b[200~");
+    bytes.extend_from_slice(text.as_bytes());
+    bytes.extend_from_slice(b"\x1b[201~");
+    bytes
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1159,6 +1193,28 @@ mod tests {
     fn keys_a_terminal_would_not_send_produce_nothing() {
         assert!(encode_key(key(KeyCode::Null)).is_none());
         assert!(encode_key(KeyEvent::new(KeyCode::CapsLock, KeyModifiers::NONE)).is_none());
+    }
+
+    /// A paste reaches the pty the way a real terminal would send it: marker-
+    /// wrapped when the program switched bracketed paste on, bare when it
+    /// never did, and newlines as CR either way — dictated text with a line
+    /// break must not hit Enter mid-thought.
+    #[test]
+    fn paste_encodes_for_the_mode_the_program_asked_for() {
+        assert_eq!(encode_paste("ship it", true), b"\x1b[200~ship it\x1b[201~");
+        assert_eq!(encode_paste("ship it", false), b"ship it");
+        assert_eq!(encode_paste("a\r\nb\nc", false), b"a\rb\rc");
+        assert_eq!(encode_paste("a\nb", true), b"\x1b[200~a\rb\x1b[201~");
+    }
+
+    /// The end marker cannot ride a paste out of its brackets and turn the
+    /// rest of the clipboard into live keystrokes.
+    #[test]
+    fn paste_cannot_smuggle_its_own_end_marker() {
+        assert_eq!(
+            encode_paste("safe\x1b[201~rm -rf /\r", true),
+            b"\x1b[200~saferm -rf /\r\x1b[201~"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A user tried driving Claude in a cloud agent with Wispr Flow (voice dictation) and it fell apart. Dictation tools insert text into a terminal as a paste — and the `railway ca` / `railway code` TUI never enabled bracketed paste, so inserted text arrived as a stream of typed keys. Every newline in the transcript hit Enter in the pane and submitted the prompt mid-thought, and the remote Claude Code never saw a paste at all (the pane is its own vt100 emulator, so the inner app's `?2004h` request never reached the user's real terminal). Plain ⌘v pastes had the same failure.

## Fix

- **Terminal lifecycle** (`tui/mod.rs`): enable bracketed paste alongside mouse capture on setup, disable on teardown (both screen buffers, same as mouse tracking). Requires the `bracketed-paste` crossterm feature.
- **Event loop**: handle `Event::Paste` and route it through a new `App::on_paste`.
- **Routing** (`tui/app.rs`): a paste goes where typing would go — a focused live session gets it as a paste, the menu/manage prompt boxes take it as one line (newlines flattened to spaces, control chars dropped), and anywhere else it is dropped whole rather than fed through `on_key` and sprayed across hotkeys. The SSH gate's y/N question ignores it.
- **Forwarding** (`tui/session.rs`): `send_paste` encodes the text the way a real terminal would — wrapped in `ESC[200~`/`ESC[201~` when the program on the pty has bracketed paste on (the pane's vt100 emulator tracks mode 2004, so Claude Code gets an atomic paste and a plain shell gets bare bytes), newlines converted to CR, and the end marker stripped from the text so a paste can't terminate its own brackets and smuggle the remainder in as keystrokes.

## Testing

- Unit tests for `encode_paste` (marker wrapping, newline→CR, end-marker injection) and `on_paste` routing (prompt insertion, newline flattening, cards/shell refusal).
- Full suite passes: 1104 tests.
- Manual validation with Wispr Flow against a live cloud agent pending (build locally, dictate into the pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)