### PR TITLE
perf(ca): attach by probing the route instead of polling status to RUNNING

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -589,11 +589,36 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
 
     let was_running = matches!(agent.status, ca::Status::Running);
     let spinner = (!was_running).then(|| create_spinner(format!("Waking agent {}", agent.name)));
-    let ready = ca::ensure_running(client, &backboard, &agent).await;
+    // Probe the route instead of polling status to RUNNING: the platform
+    // routes a shell as soon as the container exists, several seconds before
+    // the status flips. STARTING means something else is already booting the
+    // box, so this waits rather than issuing a second wake.
+    let ready = match agent.status {
+        ca::Status::Running => Ok(()),
+        ca::Status::Starting => {
+            code::wait_until_connectable(client, &backboard, &agent.environment_id, &agent.id)
+                .await
+                .map(|_| ())
+        }
+        ca::Status::Sleeping => match ca::wake(client, &backboard, &agent.id).await {
+            Ok(()) => {
+                code::wait_until_connectable(client, &backboard, &agent.environment_id, &agent.id)
+                    .await
+                    .map(|_| ())
+            }
+            Err(e) => Err(e),
+        },
+        _ => Err(anyhow::anyhow!(
+            "Agent {} is {} — it cannot be connected to. `railway ca delete {}` and create a new one.",
+            agent.name,
+            agent.status.label(),
+            agent.name
+        )),
+    };
     if let Some(spinner) = spinner {
         spinner.finish_and_clear();
     }
-    let agent = ready?;
+    ready?;
     ca::remember(configs, &agent)?;
 
     let connected = if !args.command.is_empty() {

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -11,7 +11,7 @@ use crate::commands::cloud_agent::skills_sync;
 use crate::commands::sandbox::{resolve_project_and_env, variables_to_input};
 use crate::commands::ssh::tel as ssh_tel;
 use crate::commands::ssh::{
-    ensure_ssh_key_quiet, run_native_ssh_captured, run_native_ssh_with_opts,
+    ensure_ssh_key_quiet, probe_native_ssh, run_native_ssh_captured, run_native_ssh_with_opts,
 };
 use crate::config::Configs;
 use crate::controllers::project::get_project;
@@ -1411,9 +1411,10 @@ fn ssh_plumbing(
     bail!("SSH to the agent failed after {attempts} attempts (exit {code}):\n{reason}")
 }
 
-/// One cloud agent, reduced to what this command steers on.
+/// One cloud agent, reduced to what this command steers on. `pub(crate)`
+/// because [`wait_until_connectable`] returns it to the `railway ca` verbs.
 #[derive(Clone)]
-struct CodeAgent {
+pub(crate) struct CodeAgent {
     id: String,
     name: String,
     status: queries::cloud_agent::CloudAgentStatus,
@@ -1449,22 +1450,28 @@ async fn fetch_agent(
     }))
 }
 
-/// Poll until the agent is RUNNING. A terminal state (CRASHED/FAILED/DELETING)
-/// is reported immediately instead of burning the whole timeout on a box that
-/// will never come up.
-async fn wait_until_running(
+/// Wait until the agent is *connectable*, by probing the SSH route itself
+/// rather than polling status up to RUNNING. The platform routes a shell as
+/// soon as the agent's container exists — several seconds before the status
+/// flips, which additionally waits out route publication, the status
+/// projection, and a poll interval. Status is still read each round, but only
+/// to catch terminal states (CRASHED/FAILED/DELETING) early instead of
+/// burning the whole timeout on a box that will never come up.
+pub(crate) async fn wait_until_connectable(
     client: &reqwest::Client,
     backboard: &str,
     environment_id: &str,
     id: &str,
 ) -> Result<CodeAgent> {
     use queries::cloud_agent::CloudAgentStatus as S;
+    let info = connect_info(environment_id, id).await?;
     let deadline = std::time::Instant::now() + READY_TIMEOUT;
     loop {
         let agent = fetch_agent(client, backboard, environment_id, id)
             .await?
             .ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
         match agent.status {
+            // RUNNING routes by definition; skip the probe round-trip.
             S::RUNNING => return Ok(agent),
             S::STARTING | S::SLEEPING => {}
             S::CRASHED => bail!(
@@ -1478,15 +1485,28 @@ async fn wait_until_running(
             S::DELETING => bail!("Agent {} is being deleted.", agent.name),
             S::Other(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
         }
+
+        let target = info.ssh_target.clone();
+        let identity = info.identity.clone();
+        let opts = info.relay_opts.clone();
+        let routed = tokio::task::spawn_blocking(move || {
+            probe_native_ssh(&target, identity.as_deref(), &opts)
+        })
+        .await?
+        .unwrap_or(false);
+        if routed {
+            return Ok(agent);
+        }
+
         if std::time::Instant::now() >= deadline {
             bail!(
-                "Agent {} did not reach RUNNING within {}s (last state: {:?}).",
+                "Agent {} did not become connectable within {}s (last state: {:?}).",
                 agent.name,
                 READY_TIMEOUT.as_secs(),
                 agent.status
             );
         }
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(750)).await;
     }
 }
 
@@ -1527,7 +1547,8 @@ async fn ready_existing_agent(
             {
                 return Err(e.into());
             }
-            let running = wait_until_running(client, backboard, environment_id, &agent.id).await?;
+            let running =
+                wait_until_connectable(client, backboard, environment_id, &agent.id).await?;
             progress.note(&format!(
                 "Woke agent {} — your work is on its disk",
                 running.name
@@ -1834,7 +1855,7 @@ async fn resolve_agent(
     configs.set_code_agent(environment_id, &created.id);
     configs.write()?;
 
-    match wait_until_running(client, &backboard, environment_id, &created.id).await {
+    match wait_until_connectable(client, &backboard, environment_id, &created.id).await {
         Ok(running) => {
             progress.note(&format!("Created agent {}", running.name));
             Ok((running, true))

--- a/src/commands/ssh/mod.rs
+++ b/src/commands/ssh/mod.rs
@@ -20,8 +20,8 @@ use common::*;
 // native SSH transport (key registration + `ssh <target>@<env relay host>`).
 pub use native::{
     DurableResume, PortForward, ensure_ssh_key, ensure_ssh_key_quiet, get_service_instance_id,
-    run_native_ssh, run_native_ssh_captured, run_native_ssh_forward, run_native_ssh_with_opts,
-    spawn_native_ssh_forward,
+    probe_native_ssh, run_native_ssh, run_native_ssh_captured, run_native_ssh_forward,
+    run_native_ssh_with_opts, spawn_native_ssh_forward,
 };
 
 /// Connect to a service via SSH or manage SSH keys

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -425,6 +425,39 @@ pub fn run_native_ssh_with_opts(
     Ok(status.code().unwrap_or(1))
 }
 
+/// Marker a readiness probe asks the guest to echo back. Success is this
+/// string round-tripping, never the exit code: the relay answers a session
+/// against a target it cannot route yet with a status JSON and a clean exit
+/// 0, so `ssh <target> true` reports success seconds before a command can
+/// actually run (verified against prod, 2026-08-13).
+const PROBE_MARKER: &str = "RAILWAY_CONNECT_PROBE_OK";
+
+/// Silently test whether a target is connectable yet: ask it to echo a
+/// marker, with success defined as the marker coming back. Failure carries no
+/// diagnosis (a booting agent and a typo'd target look the same), so callers
+/// only ever use this inside a loop that also watches status.
+pub fn probe_native_ssh(
+    ssh_target: &str,
+    identity_file: Option<&Path>,
+    extra_opts: &[String],
+) -> Result<bool> {
+    let (mut ssh_cmd, target) = base_ssh_command(ssh_target, identity_file);
+    for opt in extra_opts {
+        ssh_cmd.arg(opt);
+    }
+    // Bound the probe so one blackholed connection can't eat the caller's
+    // whole readiness budget; the loop retries anyway.
+    ssh_cmd.arg("-o").arg("ConnectTimeout=10");
+    ssh_cmd.arg("-T");
+    ssh_cmd.arg(&target);
+    ssh_cmd.arg(format!("echo {PROBE_MARKER}"));
+    ssh_cmd.stdin(Stdio::null());
+    ssh_cmd.stderr(Stdio::null());
+    let output = ssh_cmd.output().context("Failed to execute ssh command")?;
+    Ok(output.status.success()
+        && String::from_utf8_lossy(&output.stdout).contains(PROBE_MARKER))
+}
+
 /// One `-L` style forward: localhost:`local_port` → 127.0.0.1:`remote_port`
 /// inside the target.
 #[derive(Clone)]

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -454,8 +454,7 @@ pub fn probe_native_ssh(
     ssh_cmd.stdin(Stdio::null());
     ssh_cmd.stderr(Stdio::null());
     let output = ssh_cmd.output().context("Failed to execute ssh command")?;
-    Ok(output.status.success()
-        && String::from_utf8_lossy(&output.stdout).contains(PROBE_MARKER))
+    Ok(output.status.success() && String::from_utf8_lossy(&output.stdout).contains(PROBE_MARKER))
 }
 
 /// One `-L` style forward: localhost:`local_port` → 127.0.0.1:`remote_port`

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -314,38 +314,6 @@ pub async fn wait_until_running(
     }
 }
 
-/// Bring an existing agent up to RUNNING, waking it if it is asleep.
-///
-/// Deliberately unlike the launcher's [`crate::commands::code`] path, which
-/// treats a crashed agent as a cue to create a fresh one. That is a reasonable
-/// answer to "get me coding" and a terrible answer to "wake this agent": the
-/// caller named a machine, and silently handing back a different, empty one
-/// while the original's disk sits there is not a thing to do quietly.
-pub async fn ensure_running(
-    client: &reqwest::Client,
-    backboard: &str,
-    agent: &Agent,
-) -> Result<Agent> {
-    match agent.status {
-        Status::Running => Ok(agent.clone()),
-        // STARTING means something else is already booting it, so this waits
-        // rather than issuing a second wake.
-        Status::Starting => {
-            wait_until_running(client, backboard, &agent.environment_id, &agent.id).await
-        }
-        Status::Sleeping => {
-            wake(client, backboard, &agent.id).await?;
-            wait_until_running(client, backboard, &agent.environment_id, &agent.id).await
-        }
-        _ => bail!(
-            "Agent {} is {} — it cannot be connected to. `railway ca delete {}` and create a new one.",
-            agent.name,
-            agent.status.label(),
-            agent.name
-        ),
-    }
-}
-
 /// A durable console session on an agent.
 ///
 /// Sessions outlive the ssh that started them — that is the point of them — so


### PR DESCRIPTION
## What

`railway code` and `railway ca ssh` polled agent status until RUNNING before attaching. RUNNING lands ~2.5-3s after the shell is actually connectable: it waits out route publication the tunnel doesn't use, a ~0.7s status-projection hop, and a poll interval (code.rs still had its own 2s poll — the adaptive poll from #1095 never covered it).

Now: probe the route directly every 750ms and attach on the first success. Status is still fetched each round, but only to fail fast on crashed/failed/deleting. Applies to create, wake, and `ca ssh` paths.

## The probe is output-verified, not exit-code-verified

Found during live testing: the relay answers a session against a target it can't route yet with a status JSON and a **clean exit 0**, so `ssh <target> true` reports success seconds before a command can run — an exit-code probe attaches prematurely and the session dies with "Provisioning produced no status marker". The probe asks the guest to `echo` a marker and succeeds only when the marker round-trips.

## Server pairing

Pairs with mono #35462 (route agents at STARTING_WORKLOAD). Ships safely in either order: against today's servers the probe first succeeds at RUNNING — verified live with a dev build (prompt at 14.5s, same as release; the ~3s win arrives when the server side deploys).

## Cost

2-5 probe connections per launch through the relay (each is one route auth + a no-op session), inside the per-IP budget.

## Testing

- 1104 tests pass, no new warnings
- Live dev-build runs against prod: no premature attach, no behavior change pre-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)