### PR TITLE
fix(up): don't fail CI mode when log streaming can't connect

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -248,6 +248,7 @@ pub async fn command(args: Args) -> Result<()> {
     tokio::time::sleep(Duration::from_millis(500)).await;
 
     let build_deployment_id = deployment_id.clone();
+    let poll_deployment_id = deployment_id.clone();
     let json_mode = args.json;
     let ci_flag = args.ci;
     let mut tasks = vec![tokio::task::spawn(async move {
@@ -267,8 +268,15 @@ pub async fn command(args: Args) -> Result<()> {
         {
             eprintln!("Failed to stream build logs: {e}");
 
+            // Losing the log stream is not a build failure. In CI mode the
+            // exit code is the deploy verdict, so fall back to polling the
+            // deployment's status over plain HTTP — which works whenever the
+            // upload could happen at all — instead of failing a deploy that
+            // is still running (and, behind a gate like dev.new's, skipping
+            // its post-deploy steps).
             if ci_mode {
-                std::process::exit(1);
+                eprintln!("Waiting on the deployment status instead…");
+                poll_deployment_verdict(poll_deployment_id, json_mode).await;
             }
         }
     })];
@@ -287,11 +295,27 @@ pub async fn command(args: Args) -> Result<()> {
         }));
     }
 
+    // The status subscription rides the same WebSocket path as the log
+    // streams, so when that path is unusable (see above) it fails the same
+    // way. In CI mode the verdict must still arrive: degrade to HTTP polling
+    // rather than erroring out of a deploy that is already running.
     let mut stream =
-        subscribe_graphql::<subscriptions::Deployment>(subscriptions::deployment::Variables {
+        match subscribe_graphql::<subscriptions::Deployment>(subscriptions::deployment::Variables {
             id: deployment_id.clone(),
         })
-        .await?;
+        .await
+        {
+            Ok(stream) => stream,
+            Err(e) if ci_mode => {
+                eprintln!("Failed to subscribe to the deployment status: {e}");
+                eprintln!("Waiting on the deployment status instead…");
+                // Exits the process with the verdict; the spawned build-log task
+                // keeps printing whatever it can in the meantime.
+                poll_deployment_verdict(deployment_id.clone(), json_mode).await;
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
 
     tokio::task::spawn(async move {
         while let Some(Ok(res)) = stream.next().await {
@@ -352,6 +376,62 @@ pub async fn command(args: Args) -> Result<()> {
     futures::future::join_all(tasks).await;
 
     Ok(())
+}
+
+/// HTTP-polling fallback for the deploy verdict, for when the WebSocket
+/// subscriptions can't connect at all. Plain POSTs ride the same path the
+/// upload just used, so they work whenever the deploy could start in the
+/// first place. Exits the process once the deployment reaches a terminal
+/// state — mirroring what the status subscription would have done.
+async fn poll_deployment_verdict(deployment_id: String, json_mode: bool) {
+    use queries::deployment_status::DeploymentStatus as Status;
+    loop {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let status = async {
+            let configs = Configs::new()?;
+            let client = GQLClient::new_authorized(&configs)?;
+            let data = post_graphql::<queries::DeploymentStatus, _>(
+                &client,
+                configs.get_backboard(),
+                queries::deployment_status::Variables {
+                    id: deployment_id.clone(),
+                },
+            )
+            .await?;
+            Ok::<_, anyhow::Error>(data.deployment.status)
+        }
+        .await;
+        match status {
+            Ok(Status::SUCCESS) => {
+                if json_mode {
+                    println!("{}", serde_json::json!({"status": "success"}));
+                } else {
+                    println!("{}", "Deploy complete".green().bold());
+                }
+                std::process::exit(0);
+            }
+            Ok(Status::FAILED) => {
+                if json_mode {
+                    println!("{}", serde_json::json!({"status": "failed"}));
+                } else {
+                    println!("{}", "Deploy failed".red().bold());
+                }
+                std::process::exit(1);
+            }
+            Ok(Status::CRASHED) => {
+                if json_mode {
+                    println!("{}", serde_json::json!({"status": "crashed"}));
+                } else {
+                    println!("{}", "Deploy crashed".red().bold());
+                }
+                std::process::exit(1);
+            }
+            // Still in flight — or a transient read failure; either way the
+            // next tick answers. A deployment that disappears entirely never
+            // terminates here, but the surrounding CI has its own timeout.
+            Ok(_) | Err(_) => {}
+        }
+    }
 }
 
 struct DeployPaths {

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -78,6 +78,14 @@ pub struct Deployments;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/DeploymentStatus.graphql",
+    response_derives = "Debug, Serialize, Clone, PartialEq"
+)]
+pub struct DeploymentStatus;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/BuildLogs.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]

--- a/src/gql/queries/strings/DeploymentStatus.graphql
+++ b/src/gql/queries/strings/DeploymentStatus.graphql
@@ -1,0 +1,5 @@
+query DeploymentStatus($id: String!) {
+  deployment(id: $id) {
+    status
+  }
+}

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -17,9 +17,13 @@ where
     let configs = Configs::new()?;
     let hostname = configs.get_host();
     let client = reqwest::Client::default();
+    // This timeout covers the whole upgrade handshake (DNS + TCP + TLS +
+    // 101). On a CPU-starved machine — a CI runner at full load, or a
+    // Railway VM mid-build — 1s is routinely missed even when the network
+    // is fine, and every retry misses it the same way.
     let mut request = client
         .get(format!("wss://backboard.{hostname}/graphql/v2"))
-        .timeout(Duration::from_secs(1));
+        .timeout(Duration::from_secs(10));
 
     if let Some(token) = &Configs::get_railway_token() {
         request = request.header("project-access-token", token);


### PR DESCRIPTION
TL;DR - Dev New holds the CLI up flow in a long session so bumping up WSS timeout.

## Problem

`railway up --ci` reports **build failure (exit 1)** when the build-log WebSocket subscription can't connect — even though the deploy is running and frequently succeeds. Hit four times today by dev.new publishes (which drive `up --ci` inside the VM); every failed publish had a deployment that built `SUCCESS` server-side. One first-publish victim ended up with a healthy deploy and **no domain**, because the caller trusts the exit code and skipped its post-deploy steps.

The fingerprint: failures at 65.8s, 66.6s, 67.2s, 67.8s. That's exactly `LOGS_RETRY_CONFIG` exhausting — 12 attempts, backoff 1s ×1.5 capped at 8s sums to ~61s of sleeps plus connect overhead ≈ 66s.

Root cause: the WS upgrade request has a **1-second total timeout** (DNS + TCP + TLS + 101 upgrade). On a CPU-starved machine — a loaded CI runner, or a Railway VM with a build pegging its vCPUs (the dev.new case: the coding agent was mid-build) — the handshake misses 1s on every retry, while plain HTTP POSTs (the upload itself!) succeed fine. Network was ruled out: 75ms round trip from the affected host to backboard.

## Fix

1. **`subscription.rs`**: 10s handshake budget instead of 1s.
2. **`up.rs` CI mode**: a dead log stream is a lost *picture*, not a lost *deploy*. Instead of `exit(1)`, fall back to polling the deployment status over plain HTTP every 5s (new `DeploymentStatus` query) and exit with the real verdict, mirroring the status subscription's behavior (`Deploy complete` / `Deploy failed` / `Deploy crashed`, same JSON shapes). The deployment-status subscription's *connect* failure gets the same fallback instead of `?`-ing out of a deploy that's already running.

Non-CI behavior unchanged; detach unchanged.

## Testing

- `cargo build` + `cargo test` (113 passing), `cargo fmt`
- Verdict-path parity checked against the existing subscription match arms (same strings, same JSON, same exit codes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)