### PR TITLE
fix(auth): keep long-lived clients current and coalesce token refreshes

### DIFF
--- a/src/auth_sim.rs
+++ b/src/auth_sim.rs
@@ -508,6 +508,11 @@ async fn plain_write_cannot_erase_credentials() {
 /// The local `railway mcp` defect, isolated: `GQLClient::new_authorized` bakes
 /// the bearer into the client's default headers, so a client built at process
 /// start keeps sending the startup token no matter what happens on disk.
+///
+/// Still true of the client itself, and still the reason `post_graphql` sets
+/// the bearer per request rather than trusting the one it was built with — see
+/// `a_long_lived_client_sends_the_current_bearer_not_its_startup_one`, which
+/// covers the same staleness through the real send path.
 #[tokio::test]
 async fn baked_in_bearer_ignores_new_credentials_on_disk() {
     let backboard = MockEndpoint::spawn(vec![ok_empty()]);
@@ -749,6 +754,156 @@ async fn server_side_expired_access_token_heals_transparently() {
     // The refreshed credentials were persisted for the next invocation.
     let after = fixture.load();
     assert_eq!(after.get_refresh_token(), Some("new-refresh"));
+}
+
+/// `railway ca` builds one authorized client and keeps it for the whole
+/// session — hours. The bearer baked into that client's default headers is the
+/// one that existed at startup, so once anything rotates the access token,
+/// every request it sends carries a dead one: a 401, a probe, a token
+/// rotation and a retry each time, with the client no fresher afterwards than
+/// before. Setting the bearer per request from the config on disk is what
+/// stops a long-lived client from going permanently stale.
+#[tokio::test]
+async fn a_long_lived_client_sends_the_current_bearer_not_its_startup_one() {
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub("UserMeta", serde_json::json!({ "me": { "id": "user-1" } }));
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = LiveFixture::new();
+
+    // The client the TUI built at startup, from the credentials of that moment.
+    let at_startup = fixture.load();
+    let client = crate::client::GQLClient::new_authorized(&at_startup).unwrap();
+
+    // Time passes and the access token is rotated — by this process, by another
+    // terminal, by the dashboard. The client knows nothing about it.
+    fixture
+        .load()
+        .save_oauth_tokens("rotated-access", Some("rotated-refresh"), 3600)
+        .unwrap();
+
+    // Every request re-reads the config (see `post_graphql_for_current_session`),
+    // so this is the `Configs` the real send would be holding.
+    let mut per_request = fixture.load();
+    let result = crate::client::post_graphql_value::<serde_json::Value>(
+        &client,
+        reqwest::Url::parse(&backboard.url()).unwrap(),
+        &user_meta_body(),
+        Some((&mut per_request, &token_endpoint.base_url)),
+    )
+    .await;
+
+    assert!(result.is_ok(), "got {result:?}");
+    assert_eq!(
+        backboard.auth_headers(),
+        vec![Some("Bearer rotated-access".to_string())],
+        "the stale client must not send the token it was built with"
+    );
+    assert_eq!(
+        token_endpoint.hits(),
+        0,
+        "the stored token is live, so nothing should have been refreshed"
+    );
+}
+
+/// A burst of requests refused at the same moment — the shape a TUI produces,
+/// where a timer refresh, a watch tick and a sweep are all in flight — must
+/// cost one token rotation between them, not one each. Every extra rotation is
+/// another chance for backboard's reuse detection to see a consumed refresh
+/// token and revoke the whole grant.
+#[tokio::test]
+async fn a_second_refusal_reuses_the_refresh_the_first_one_just_performed() {
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub_graphql_error("UserMeta", "Not Authorized");
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = LiveFixture::new();
+    let mut configs = fixture.load();
+
+    let first = send_user_meta(&mut configs, &backboard, &token_endpoint.base_url).await;
+    let second = send_user_meta(&mut configs, &backboard, &token_endpoint.base_url).await;
+
+    // The story each caller is told is unchanged: the grant is alive, so the
+    // refusal is about the resource.
+    for result in [&first, &second] {
+        assert!(
+            matches!(
+                result,
+                Err(crate::errors::RailwayError::OAuthInsufficientGrant)
+            ),
+            "got {result:?}"
+        );
+    }
+    assert_eq!(
+        token_endpoint.hits(),
+        1,
+        "the second refusal should adopt the first refresh, not rotate again"
+    );
+    // Both requests still went out and were still retried once each.
+    assert_eq!(backboard.hits(), 4);
+}
+
+/// The `railway ca` burst, at full concurrency: an hour in, the access token
+/// is dead and the timer refresh, the watch tick and a sweep are all refused
+/// at the same instant.
+///
+/// Each refusal forces a refresh, and backboard rotates and reuse-detects the
+/// refresh token on every one — so N simultaneous refusals rotating N times
+/// means N-1 of them present an already-consumed token, and the server revokes
+/// the entire grant. That is a hard logout produced by nothing but the CLI's
+/// own concurrency. One rotation between them is the whole point.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_burst_of_simultaneous_refusals_rotates_the_token_exactly_once() {
+    const BURST: usize = 8;
+
+    let backboard = crate::testkit::MockBackboard::spawn();
+    backboard.stub_graphql_error("UserMeta", "Not Authorized");
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = LiveFixture::new();
+
+    let mut tasks = Vec::new();
+    for _ in 0..BURST {
+        // Every request builds its own `Configs` from the same file, exactly as
+        // `post_graphql_for_current_session` does on each send.
+        let path = fixture.path.clone();
+        let url = backboard.url();
+        let token_url = token_endpoint.base_url.clone();
+        tasks.push(tokio::spawn(async move {
+            let mut configs = Configs::for_test(path);
+            configs.reload().unwrap();
+            let client = crate::client::GQLClient::new_authorized(&configs).unwrap();
+            crate::client::post_graphql_value::<serde_json::Value>(
+                &client,
+                reqwest::Url::parse(&url).unwrap(),
+                &user_meta_body(),
+                Some((&mut configs, &token_url)),
+            )
+            .await
+        }));
+    }
+
+    let mut results = Vec::new();
+    for task in tasks {
+        results.push(task.await.unwrap());
+    }
+
+    assert_eq!(
+        token_endpoint.hits(),
+        1,
+        "the burst must cost one token rotation between them, not {BURST}"
+    );
+    // Every caller still gets the right story: the grant is alive, so the
+    // refusal is about the resource. None of them is left holding an error
+    // caused by the coalescing itself.
+    for result in &results {
+        assert!(
+            matches!(
+                result,
+                Err(crate::errors::RailwayError::OAuthInsufficientGrant)
+            ),
+            "got {result:?}"
+        );
+    }
+    // The one refresh that did happen was persisted for everyone else.
+    assert_eq!(fixture.load().get_refresh_token(), Some("new-refresh"));
 }
 
 /// Nothing to probe with (legacy token, no refresh token): the original

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,8 @@
-use std::time::Duration;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
-use colored::Colorize;
 use graphql_client::GraphQLQuery;
 use reqwest::{
     Client,
@@ -106,14 +108,14 @@ fn parse_timeout_secs(raw: Option<&str>) -> u64 {
     match raw.trim().parse::<u64>() {
         Ok(secs) if secs > 0 => secs,
         _ => {
-            eprintln!(
-                "{}",
+            crate::util::reporter::warn(
+                "INVALID_HTTP_TIMEOUT",
                 format!(
-                    "Warning: ignoring invalid {}={raw:?}; expected a positive number of seconds, using {}s",
+                    "ignoring invalid {}={raw:?}; expected a positive number of seconds, using {}s",
                     consts::RAILWAY_HTTP_TIMEOUT_ENV,
                     consts::DEFAULT_HTTP_TIMEOUT_SECS
-                )
-                .yellow()
+                ),
+                None,
             );
             consts::DEFAULT_HTTP_TIMEOUT_SECS
         }
@@ -128,6 +130,25 @@ pub async fn post_graphql<Q: GraphQLQuery, U: reqwest::IntoUrl>(
     let body = serde_json::to_value(Q::build_query(variables))
         .expect("Failed to serialize GraphQL query body");
     post_graphql_for_current_session(client, url.into_url()?, &body).await
+}
+
+/// Send a GraphQL request that must go out unauthenticated, for the queries
+/// backboard answers for anyone (template lookup and search).
+///
+/// Deliberately separate from [`post_graphql`] rather than a property of the
+/// client: [`post_graphql`] keeps the caller's bearer current by setting it per
+/// request (see [`current_bearer`]), and a `reqwest::Client` cannot be asked
+/// whether it was built with one. So the two paths are told apart here, at the
+/// call site that knows — which also keeps a logged-out user's template search
+/// on exactly the same code path as a logged-in user's.
+pub async fn post_graphql_public<Q: GraphQLQuery, U: reqwest::IntoUrl>(
+    client: &reqwest::Client,
+    url: U,
+    variables: Q::Variables,
+) -> Result<Q::ResponseData, RailwayError> {
+    let body = serde_json::to_value(Q::build_query(variables))
+        .expect("Failed to serialize GraphQL query body");
+    post_graphql_value(client, url.into_url()?, &body, None).await
 }
 
 pub async fn post_graphql_raw<T, U: reqwest::IntoUrl>(
@@ -157,6 +178,15 @@ async fn post_graphql_for_current_session<T: DeserializeOwned>(
     let oauth_base_url = configs
         .as_ref()
         .map(|c| oauth::get_oauth_base_url(c.get_host()));
+    // Refresh before sending rather than after being refused. The fast path is
+    // a timestamp comparison on the config this function already read, so it
+    // costs nothing while the token is good; when it is not, one refresh here
+    // replaces a 401 round-trip plus a probe plus a retry. A failure is not
+    // fatal — the request still goes out and the "Not Authorized" handling
+    // below produces the same story it always did.
+    if let Some(configs) = configs.as_mut() {
+        let _ = ensure_valid_token(configs).await;
+    }
     post_graphql_value(
         client,
         url,
@@ -164,6 +194,28 @@ async fn post_graphql_for_current_session<T: DeserializeOwned>(
         configs.as_mut().zip(oauth_base_url.as_deref()),
     )
     .await
+}
+
+/// The `authorization` header the stored session would present right now, or
+/// `None` when this process authenticates some other way.
+///
+/// Callers build a client once and keep it: `railway ca`'s TUI holds a single
+/// one for its entire run, cloned into every sweep and prefetch. The bearer
+/// baked into that client's default headers is the one that existed at
+/// startup, so an hour later — once the access token expires — every request
+/// it sends carries a dead token, 401s, and pays for a probe and a retry that
+/// leave the client just as stale for the next one. Setting the header per
+/// request instead lets a long-lived client pick up refreshes: reqwest applies
+/// a default header only when the request has not already set that key.
+///
+/// `RAILWAY_TOKEN` authenticates with `project-access-token` and no bearer at
+/// all, so that case is left entirely alone.
+fn current_bearer(configs: &Configs) -> Option<HeaderValue> {
+    if Configs::get_railway_token().is_some() {
+        return None;
+    }
+    let token = configs.get_railway_auth_token()?;
+    HeaderValue::from_str(&format!("Bearer {token}")).ok()
 }
 
 /// What a token-endpoint probe says about the stored session after the API
@@ -187,11 +239,7 @@ async fn probe_session_liveness(configs: &mut Configs, oauth_base_url: &str) -> 
         // Env-var tokens have no refresh token to probe with.
         return SessionProbe::Inconclusive;
     }
-    let _lock = configs.acquire_lock().await;
-    if configs.reload().is_err() {
-        return SessionProbe::Inconclusive;
-    }
-    match refresh_with_policy(configs, oauth_base_url, REFRESH_BACKOFF).await {
+    match refresh_locked_at(configs, oauth_base_url, true).await {
         RefreshOutcome::Refreshed | RefreshOutcome::AlreadyFresh => SessionProbe::Alive,
         RefreshOutcome::SessionExpired(_) => SessionProbe::Dead,
         RefreshOutcome::Transient(_) | RefreshOutcome::NoRefreshToken => SessionProbe::Inconclusive,
@@ -224,7 +272,14 @@ pub(crate) async fn post_graphql_value<T: DeserializeOwned>(
     body: &serde_json::Value,
     session: Option<(&mut Configs, &str)>,
 ) -> Result<T, RailwayError> {
-    let response = client.post(url.clone()).json(body).send().await?;
+    let mut request = client.post(url.clone()).json(body);
+    // Override whatever bearer the client was built with; see [`current_bearer`].
+    if let Some((configs, _)) = &session {
+        if let Some(bearer) = current_bearer(configs) {
+            request = request.header(reqwest::header::AUTHORIZATION, bearer);
+        }
+    }
+    let response = request.send().await?;
     let err = match parse_graphql_response(response).await {
         Err(e @ (RailwayError::Unauthorized | RailwayError::UnauthorizedLogin)) => e,
         other => return other,
@@ -327,6 +382,56 @@ pub(crate) enum RefreshOutcome {
 /// Backoff between transient refresh attempts.
 const REFRESH_BACKOFF: Duration = Duration::from_millis(250);
 
+/// Serialises refreshes within this process, ahead of the cross-process file
+/// lock.
+///
+/// The file lock alone does not do this. `fs2` locks are per open file
+/// description, so two tasks in one process contend exactly as two processes
+/// would — and a long-lived TUI is far more concurrent than a one-shot command:
+/// `railway ca` runs an account-wide refresh on a timer, watch ticks at 1.5s,
+/// and sweeps that fan out per environment. Let those all queue on the file
+/// lock and each waiter sits through every earlier waiter's token round-trip,
+/// blows the lock's timeout, and prints a warning — for a refresh the first one
+/// already performed. Taking this gate first means at most one task in the
+/// process ever waits on the file lock, and the rest arrive after the config
+/// has been rewritten and find nothing left to do.
+static REFRESH_GATE: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(Default::default);
+
+/// When this process last minted tokens for a given config file. Keyed by path
+/// rather than kept as a single global so tests, which each drive their own
+/// temporary config, cannot see one another's refreshes.
+static LAST_REFRESH: LazyLock<std::sync::Mutex<HashMap<PathBuf, Instant>>> =
+    LazyLock::new(Default::default);
+
+/// How recently a refresh has to have happened for a *forced* one to stand
+/// down. Long enough to absorb a burst of simultaneous 401s, short enough that
+/// a grant revoked moments after a refresh is still discovered promptly.
+const RECENT_REFRESH_WINDOW: Duration = Duration::from_secs(10);
+
+/// How long to wait for [`REFRESH_GATE`] before proceeding without it.
+///
+/// A refresh normally takes well under a second, but a hung token endpoint can
+/// hold the gate for the full retry budget — three attempts against a 30s HTTP
+/// timeout, plus backoff, so about 90s. Waiting that out would make one stuck
+/// refresh stall every other request in the process, which is what the old
+/// unbounded file-lock wait did. Waiters give up here instead and use whatever
+/// credentials are on disk; they do NOT refresh on their own, since two
+/// concurrent rotations are exactly the hard-logout this gate exists to avoid.
+const REFRESH_GATE_TIMEOUT: Duration = Duration::from_secs(15);
+
+fn refreshed_recently(path: &std::path::Path) -> bool {
+    LAST_REFRESH.lock().is_ok_and(|seen| {
+        seen.get(path)
+            .is_some_and(|at| at.elapsed() < RECENT_REFRESH_WINDOW)
+    })
+}
+
+fn mark_refreshed(path: &std::path::Path) {
+    if let Ok(mut seen) = LAST_REFRESH.lock() {
+        seen.insert(path.to_path_buf(), Instant::now());
+    }
+}
+
 /// Take the config lock, re-read credentials, and refresh.
 ///
 /// The lock matters because the refresh is a read-modify-write of the on-disk
@@ -339,6 +444,24 @@ const REFRESH_BACKOFF: Duration = Duration::from_millis(250);
 /// `force` skips the "someone else already did it" short-circuit, for callers
 /// reacting to an actual authorization failure rather than to local expiry.
 async fn refresh_locked(configs: &mut Configs, force: bool) -> RefreshOutcome {
+    let base_url = oauth::get_oauth_base_url(configs.get_host());
+    refresh_locked_at(configs, &base_url, force).await
+}
+
+/// [`refresh_locked`] against an explicit token endpoint, so the probe path can
+/// pass the base URL it already resolved (and tests can point at a scripted
+/// one) instead of re-deriving it.
+async fn refresh_locked_at(configs: &mut Configs, base_url: &str, force: bool) -> RefreshOutcome {
+    let Ok(_gate) = tokio::time::timeout(REFRESH_GATE_TIMEOUT, REFRESH_GATE.lock()).await else {
+        // Someone else's refresh is wedged. Adopt whatever it has written so
+        // far and report a transient failure: the caller proceeds with the
+        // stored credentials, and a request that still comes back unauthorized
+        // says so plainly instead of being explained away as a grant problem.
+        let _ = configs.reload();
+        return RefreshOutcome::Transient(RailwayError::OAuthRefreshFailed(
+            "timed out waiting for an in-flight token refresh".to_string(),
+        ));
+    };
     let _lock = configs.acquire_lock().await;
 
     if configs.reload().is_err() {
@@ -347,9 +470,20 @@ async fn refresh_locked(configs: &mut Configs, force: bool) -> RefreshOutcome {
     if !force && (!configs.has_oauth_token() || !configs.is_token_expired()) {
         return RefreshOutcome::AlreadyFresh;
     }
+    // A forced refresh answers an actual 401, and concurrent requests all get
+    // refused at the same moment. The first through the gate rotates the
+    // token; the rest have just reloaded its result and would otherwise spend a
+    // rotation each — every one of them a chance for backboard's reuse
+    // detection to see a consumed token and revoke the grant.
+    if force && refreshed_recently(configs.config_path()) {
+        return RefreshOutcome::AlreadyFresh;
+    }
 
-    let base_url = oauth::get_oauth_base_url(configs.get_host());
-    refresh_with_policy(configs, &base_url, REFRESH_BACKOFF).await
+    let outcome = refresh_with_policy(configs, base_url, REFRESH_BACKOFF).await;
+    if matches!(outcome, RefreshOutcome::Refreshed) {
+        mark_refreshed(configs.config_path());
+    }
+    outcome
 }
 
 /// Refresh unconditionally, ignoring the local expiry timestamp.
@@ -397,9 +531,10 @@ pub(crate) async fn refresh_with_policy(
         // into a fleet-wide forced logout.
         Err(oauth::RefreshFailure::Terminal(err)) => {
             if let Err(clear_err) = configs.clear_oauth_tokens() {
-                eprintln!(
-                    "{}: {clear_err}",
-                    "Warning: could not clear the expired login from disk".yellow()
+                crate::util::reporter::warn(
+                    "CREDENTIAL_CLEAR_FAILED",
+                    format!("could not clear the expired login from disk: {clear_err}"),
+                    None,
                 );
             }
             RefreshOutcome::SessionExpired(err)
@@ -581,7 +716,7 @@ mod tests {
         });
 
         let client = GQLClient::new_public().unwrap();
-        let response = post_graphql::<queries::TemplateDetail, _>(
+        let response = post_graphql_public::<queries::TemplateDetail, _>(
             &client,
             server_url,
             queries::template_detail::Variables {

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -111,7 +111,7 @@ pub async fn fetch_and_create(
         eprintln!("fetching details for template")
     }
     let public_client = GQLClient::new_public()?;
-    let details = post_graphql::<queries::TemplateDetail, _>(
+    let details = crate::client::post_graphql_public::<queries::TemplateDetail, _>(
         &public_client,
         configs.get_backboard(),
         queries::template_detail::Variables {

--- a/src/commands/mcp/tools/service.rs
+++ b/src/commands/mcp/tools/service.rs
@@ -283,7 +283,7 @@ impl RailwayMcp {
             code: params.template_code,
         };
 
-        let template_resp = post_graphql::<queries::TemplateDetail, _>(
+        let template_resp = crate::client::post_graphql_public::<queries::TemplateDetail, _>(
             &public_client,
             self.configs.get_backboard(),
             template_vars,
@@ -335,7 +335,7 @@ impl RailwayMcp {
             category: params.category,
         };
 
-        let resp = post_graphql::<queries::TemplateSearch, _>(
+        let resp = crate::client::post_graphql_public::<queries::TemplateSearch, _>(
             &public_client,
             self.configs.get_backboard(),
             vars,

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -1763,7 +1763,12 @@ async fn fetch_template_search(
         category: request.category.clone(),
     };
 
-    Ok(post_graphql::<queries::TemplateSearch, _>(client, backboard, vars).await?)
+    // Template search is answered for anyone, and its only caller holds a
+    // `new_public` client; sending it unauthenticated keeps that explicit.
+    Ok(
+        crate::client::post_graphql_public::<queries::TemplateSearch, _>(client, backboard, vars)
+            .await?,
+    )
 }
 
 fn spawn_search(
@@ -2013,6 +2018,12 @@ fn maybe_load_more(
 
 fn setup_terminal() -> Result<(Terminal<CrosstermBackend<std::io::Stdout>>, TerminalTheme)> {
     enable_raw_mode()?;
+    // Raw mode plus the alternate screen means stderr writes land wherever
+    // the cursor is and stay there until a full repaint, and an inquire
+    // prompt can never complete. The flag makes `reporter::warn` hold its
+    // tongue and every prompt helper fail fast for as long as this screen
+    // is up.
+    crate::util::prompt::set_terminal_owned(true);
     execute!(stdout(), EnterAlternateScreen, Hide)?;
     let theme = detect_terminal_theme();
     let backend = CrosstermBackend::new(stdout());
@@ -2024,6 +2035,7 @@ fn setup_terminal() -> Result<(Terminal<CrosstermBackend<std::io::Stdout>>, Term
 fn restore_terminal() {
     let _ = execute!(stdout(), LeaveAlternateScreen, Show);
     let _ = disable_raw_mode();
+    crate::util::prompt::set_terminal_owned(false);
 }
 
 fn render_picker(app: &PickerApp, frame: &mut Frame) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
-use colored::Colorize;
 use inquire::ui::{Attributes, RenderConfig, StyleSheet, Styled};
 use serde::{Deserialize, Serialize};
 
@@ -139,7 +138,11 @@ impl Configs {
 
             let root_config: RailwayConfig = serde_json::from_slice(&serialized_config)
                 .unwrap_or_else(|_| {
-                    eprintln!("{}", "Unable to parse config file, regenerating".yellow());
+                    crate::util::reporter::warn(
+                        "CONFIG_UNPARSEABLE",
+                        "Unable to parse config file, regenerating",
+                        None,
+                    );
                     RailwayConfig::default()
                 });
 
@@ -354,6 +357,13 @@ impl Configs {
             root_config_path,
             backboard_url_override: Self::backboard_url_override_from_env(),
         }
+    }
+
+    /// The config file this instance reads and writes. Identifies the
+    /// credentials being operated on, which the refresh path uses to keep its
+    /// per-config bookkeeping from colliding across configs.
+    pub(crate) fn config_path(&self) -> &std::path::Path {
+        &self.root_config_path
     }
 
     /// Take the exclusive config lock covering this config file, without
@@ -1070,9 +1080,10 @@ impl ConfigLock {
                 return Self { file: Some(file) };
             }
             if std::time::Instant::now() >= deadline {
-                eprintln!(
-                    "{}",
-                    "Warning: timed out waiting for config lock; proceeding without it".yellow()
+                crate::util::reporter::warn(
+                    "CONFIG_LOCK_TIMEOUT",
+                    "timed out waiting for config lock; proceeding without it",
+                    None,
                 );
                 return Self { file: None };
             }

--- a/src/controllers/develop/tui/mod.rs
+++ b/src/controllers/develop/tui/mod.rs
@@ -26,6 +26,12 @@ use super::LogLine;
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     enable_raw_mode()?;
+    // Raw mode plus the alternate screen means stderr writes land wherever
+    // the cursor is and stay there until a full repaint, and an inquire
+    // prompt can never complete. The flag makes `reporter::warn` hold its
+    // tongue and every prompt helper fail fast for as long as this screen
+    // is up.
+    crate::util::prompt::set_terminal_owned(true);
     execute!(stdout(), EnterAlternateScreen, Hide, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -36,6 +42,7 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
 fn restore_terminal() {
     let _ = execute!(stdout(), DisableMouseCapture, LeaveAlternateScreen, Show);
     let _ = disable_raw_mode();
+    crate::util::prompt::set_terminal_owned(false);
 }
 
 pub async fn run(

--- a/src/controllers/metrics_tui/mod.rs
+++ b/src/controllers/metrics_tui/mod.rs
@@ -69,6 +69,12 @@ pub struct ProjectTuiParams {
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     enable_raw_mode()?;
+    // Raw mode plus the alternate screen means stderr writes land wherever
+    // the cursor is and stay there until a full repaint, and an inquire
+    // prompt can never complete. The flag makes `reporter::warn` hold its
+    // tongue and every prompt helper fail fast for as long as this screen
+    // is up.
+    crate::util::prompt::set_terminal_owned(true);
     execute!(
         stdout(),
         EnterAlternateScreen,
@@ -89,6 +95,7 @@ fn restore_terminal() {
         crossterm::event::DisableMouseCapture
     );
     let _ = disable_raw_mode();
+    crate::util::prompt::set_terminal_owned(false);
 }
 
 /// Time range presets matching the Railway dashboard

--- a/src/controllers/scale_tui/mod.rs
+++ b/src/controllers/scale_tui/mod.rs
@@ -65,6 +65,12 @@ pub fn run(params: ScaleTuiParams) -> Result<ScaleTuiOutput> {
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     enable_raw_mode()?;
+    // Raw mode plus the alternate screen means stderr writes land wherever
+    // the cursor is and stay there until a full repaint, and an inquire
+    // prompt can never complete. The flag makes `reporter::warn` hold its
+    // tongue and every prompt helper fail fast for as long as this screen
+    // is up.
+    crate::util::prompt::set_terminal_owned(true);
     execute!(stdout(), EnterAlternateScreen, Hide)?;
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -75,4 +81,5 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
 fn restore_terminal() {
     let _ = execute!(stdout(), LeaveAlternateScreen, Show);
     let _ = disable_raw_mode();
+    crate::util::prompt::set_terminal_owned(false);
 }

--- a/src/controllers/volume_browser/mod.rs
+++ b/src/controllers/volume_browser/mod.rs
@@ -847,6 +847,12 @@ fn shell_quote(value: &str) -> String {
 
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     enable_raw_mode()?;
+    // Raw mode plus the alternate screen means stderr writes land wherever
+    // the cursor is and stay there until a full repaint, and an inquire
+    // prompt can never complete. The flag makes `reporter::warn` hold its
+    // tongue and every prompt helper fail fast for as long as this screen
+    // is up.
+    crate::util::prompt::set_terminal_owned(true);
     execute!(stdout(), EnterAlternateScreen, Hide)?;
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
@@ -857,4 +863,5 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
 fn restore_terminal() {
     let _ = execute!(stdout(), LeaveAlternateScreen, Show);
     let _ = disable_raw_mode();
+    crate::util::prompt::set_terminal_owned(false);
 }

--- a/src/testkit.rs
+++ b/src/testkit.rs
@@ -30,6 +30,10 @@ type ResponseTable = Arc<Mutex<HashMap<String, ResponseQueue>>>;
 pub struct MockBackboard {
     base_url: String,
     requests: Arc<Mutex<Vec<Value>>>,
+    /// The `authorization` header of each request, in the same order as
+    /// `requests` — so a test can assert which credential went out, not just
+    /// which operation did.
+    auth_headers: Arc<Mutex<Vec<Option<String>>>>,
     responses: ResponseTable,
 }
 
@@ -38,16 +42,18 @@ impl MockBackboard {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let requests: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let auth_headers: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
         let responses: ResponseTable = Arc::new(Mutex::new(HashMap::new()));
 
         let requests_for_thread = Arc::clone(&requests);
+        let auth_for_thread = Arc::clone(&auth_headers);
         let responses_for_thread = Arc::clone(&responses);
 
         std::thread::spawn(move || {
             for stream in listener.incoming() {
                 let Ok(mut stream) = stream else { break };
 
-                let Some(body) = read_http_body(&mut stream) else {
+                let Some((headers, body)) = read_http_request(&mut stream) else {
                     continue;
                 };
                 let parsed: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
@@ -56,6 +62,12 @@ impl MockBackboard {
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_string();
+                // Recorded before the body so the two vectors stay index-aligned
+                // even if a test reads them mid-flight.
+                auth_for_thread
+                    .lock()
+                    .unwrap()
+                    .push(authorization_of(&headers));
                 requests_for_thread.lock().unwrap().push(parsed);
 
                 let (status, response_body) = {
@@ -105,6 +117,7 @@ impl MockBackboard {
         Self {
             base_url: format!("http://127.0.0.1:{port}/graphql/v2"),
             requests,
+            auth_headers,
             responses,
         }
     }
@@ -176,14 +189,21 @@ impl MockBackboard {
             .collect()
     }
 
+    /// The `authorization` header each received request carried, in arrival
+    /// order. `None` for a request that sent none.
+    pub fn auth_headers(&self) -> Vec<Option<String>> {
+        self.auth_headers.lock().unwrap().clone()
+    }
+
     pub fn hits(&self) -> usize {
         self.requests.lock().unwrap().len()
     }
 }
 
-/// Reads one HTTP request off `stream` and returns its body. `None` when the
-/// stream closes before a full request arrives.
-fn read_http_body(stream: &mut std::net::TcpStream) -> Option<Vec<u8>> {
+/// Reads one HTTP request off `stream` and returns its header block (verbatim,
+/// so values keep their case) and its body. `None` when the stream closes
+/// before a full request arrives.
+fn read_http_request(stream: &mut std::net::TcpStream) -> Option<(String, Vec<u8>)> {
     let mut buf = Vec::new();
     let mut tmp = [0u8; 1024];
     let mut content_length = 0usize;
@@ -194,18 +214,30 @@ fn read_http_body(stream: &mut std::net::TcpStream) -> Option<Vec<u8>> {
         }
         buf.extend_from_slice(&tmp[..read]);
         if let Some(pos) = find_headers_end(&buf) {
-            let headers = String::from_utf8_lossy(&buf[..pos]).to_lowercase();
+            let headers = String::from_utf8_lossy(&buf[..pos]).to_string();
             for line in headers.lines() {
-                if let Some(v) = line.strip_prefix("content-length:") {
+                if let Some(v) = line.to_ascii_lowercase().strip_prefix("content-length:") {
                     content_length = v.trim().parse().unwrap_or(0);
                 }
             }
             if buf.len() >= pos + 4 + content_length {
                 let body_start = pos + 4;
-                return Some(buf[body_start..body_start + content_length].to_vec());
+                return Some((
+                    headers,
+                    buf[body_start..body_start + content_length].to_vec(),
+                ));
             }
         }
     }
+}
+
+/// The value of the `authorization` header in a request's header block, if it
+/// carried one.
+fn authorization_of(headers: &str) -> Option<String> {
+    headers
+        .lines()
+        .find(|line| line.to_ascii_lowercase().starts_with("authorization:"))
+        .map(|line| line["authorization:".len()..].trim().to_string())
 }
 
 fn find_headers_end(buf: &[u8]) -> Option<usize> {

--- a/src/util/prompt.rs
+++ b/src/util/prompt.rs
@@ -23,9 +23,16 @@ use anyhow::{Context, Result};
 static TERMINAL_OWNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
 /// Mark the terminal as owned (or released) by a full-screen TUI. While set,
-/// every prompt in this module fails fast instead of deadlocking.
+/// every prompt in this module fails fast instead of deadlocking, and
+/// `reporter::warn` holds its output back rather than painting over the frame.
+///
+/// Releasing flushes those held-back warnings, so a TUI gets that for free from
+/// its existing `restore_terminal` and cannot forget to ask for it.
 pub fn set_terminal_owned(owned: bool) {
     TERMINAL_OWNED.store(owned, std::sync::atomic::Ordering::SeqCst);
+    if !owned {
+        crate::util::reporter::flush_deferred();
+    }
 }
 
 /// Whether a full-screen TUI currently owns the terminal. Code that would

--- a/src/util/reporter.rs
+++ b/src/util/reporter.rs
@@ -58,11 +58,50 @@ pub fn emit_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Warnings raised while a TUI owned the terminal, waiting for it to give the
+/// terminal back. Deduplicated by rendered text and kept in first-seen order,
+/// so a condition that recurs on a timer surfaces once with a count instead of
+/// as a wall of identical lines.
+static DEFERRED: std::sync::Mutex<Vec<(String, usize)>> = std::sync::Mutex::new(Vec::new());
+
+/// Cap on distinct deferred warnings. A TUI session runs for hours; without a
+/// bound, a warning raised from a loop would hold unbounded memory for all of
+/// it. Past the cap, further *distinct* warnings are dropped — repeats of ones
+/// already held still count up, which is the case that actually matters.
+const MAX_DEFERRED: usize = 20;
+
 /// Emit a non-fatal warning. Always goes to stderr so it never pollutes
 /// a result on stdout: a yellow line in human mode, a structured object
 /// in JSON mode.
+///
+/// Held back while a full-screen TUI owns the terminal, and released by
+/// [`flush_deferred`] when it exits. Nothing reads stderr while a TUI is up —
+/// ratatui owns the alternate screen and paints from its own buffer — so a
+/// warning written then does not inform anyone, it corrupts the frame: the
+/// text lands wherever the cursor happens to be and survives until something
+/// forces a full repaint. A long-lived `railway ca` session could accumulate
+/// hundreds of them across the whole screen. Deferring rather than discarding
+/// keeps the diagnostic; it just arrives when there is a terminal to read it
+/// on.
 pub fn warn(code: &str, message: impl std::fmt::Display, hint: Option<&str>) {
-    match mode() {
+    let rendered = render_warning(code, message, hint, mode());
+    if crate::util::prompt::terminal_owned() {
+        defer(rendered);
+        return;
+    }
+    eprint!("{rendered}");
+}
+
+/// The exact bytes a warning writes to stderr, including the trailing newline.
+/// Rendering up front is what lets the deferred path dedupe on the final text
+/// and replay it verbatim later.
+fn render_warning(
+    code: &str,
+    message: impl std::fmt::Display,
+    hint: Option<&str>,
+    mode: OutputMode,
+) -> String {
+    match mode {
         OutputMode::Json => {
             let obj = serde_json::json!({
                 "level": "warning",
@@ -70,13 +109,43 @@ pub fn warn(code: &str, message: impl std::fmt::Display, hint: Option<&str>) {
                 "message": message.to_string(),
                 "hint": hint,
             });
-            eprintln!("{obj}");
+            format!("{obj}\n")
         }
         OutputMode::Human => {
-            eprintln!("{} {message}", "warning:".yellow().bold());
+            let mut out = format!("{} {message}\n", "warning:".yellow().bold());
             if let Some(hint) = hint {
-                eprintln!("  {} {hint}", "→".cyan());
+                out.push_str(&format!("  {} {hint}\n", "→".cyan()));
             }
+            out
+        }
+    }
+}
+
+fn defer(rendered: String) {
+    let Ok(mut held) = DEFERRED.lock() else {
+        return;
+    };
+    if let Some(entry) = held.iter_mut().find(|(text, _)| *text == rendered) {
+        entry.1 += 1;
+    } else if held.len() < MAX_DEFERRED {
+        held.push((rendered, 1));
+    }
+}
+
+/// Write out everything [`warn`] held back while a TUI owned the terminal, and
+/// forget it. Called from `prompt::set_terminal_owned(false)`, so every TUI's
+/// `restore_terminal` releases them without needing to know they exist.
+pub fn flush_deferred() {
+    let Ok(mut held) = DEFERRED.lock() else {
+        return;
+    };
+    for (rendered, count) in held.drain(..) {
+        eprint!("{rendered}");
+        if count > 1 {
+            eprintln!(
+                "  {}",
+                format!("(repeated {count} times while the screen was open)").dimmed()
+            );
         }
     }
 }
@@ -135,6 +204,66 @@ pub fn render_error(err: &anyhow::Error) {
 mod tests {
     use super::*;
     use crate::errors::RailwayError;
+
+    /// `DEFERRED` is process-global, so the tests that drive it directly have
+    /// to run one at a time or they consume each other's entries.
+    static DEFERRED_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// A warning raised under a TUI must survive to be read, not vanish — and a
+    /// condition that recurs on a timer (the config-lock timeout fired every
+    /// few seconds in a long `railway ca` session) must come back as one line
+    /// with a count, which is the whole reason it is deduplicated rather than
+    /// queued.
+    #[test]
+    fn deferred_warnings_are_deduplicated_and_counted() {
+        let _guard = DEFERRED_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        flush_deferred(); // start from a clean slate
+
+        defer("lock timed out\n".to_string());
+        defer("lock timed out\n".to_string());
+        defer("lock timed out\n".to_string());
+        defer("something else\n".to_string());
+
+        let held = DEFERRED.lock().unwrap().clone();
+        assert_eq!(
+            held,
+            vec![
+                ("lock timed out\n".to_string(), 3),
+                ("something else\n".to_string(), 1),
+            ],
+            "repeats collapse into a count, and first-seen order is kept"
+        );
+
+        flush_deferred();
+        assert!(
+            DEFERRED.lock().unwrap().is_empty(),
+            "flushing must drain, or the next TUI exit replays them"
+        );
+    }
+
+    /// An unbounded buffer would be a slow leak across an hours-long session.
+    #[test]
+    fn deferred_warnings_are_capped() {
+        let _guard = DEFERRED_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        flush_deferred();
+
+        for i in 0..(MAX_DEFERRED + 10) {
+            defer(format!("distinct warning {i}\n"));
+        }
+        // The cap bounds distinct entries, but a repeat of one already held
+        // still counts up — that is the case worth keeping.
+        defer("distinct warning 0\n".to_string());
+
+        let held = DEFERRED.lock().unwrap().clone();
+        assert_eq!(held.len(), MAX_DEFERRED);
+        assert_eq!(held[0].1, 2);
+
+        flush_deferred();
+    }
 
     #[test]
     fn human_error_surfaces_railway_hint() {


### PR DESCRIPTION
## Problem

A long-running `railway ca` / `railway code` session fills the screen with:

```
warning: timed out waiting for config lock; proceeding without it
```

Three causes:

1. **The TUI's bearer is frozen at startup.** `GQLClient::new_authorized` bakes the token into `default_headers`; the TUI holds one client for its whole run. Once the token expires, every request 401s — permanently, since the 401 retry builds a throwaway client and leaves the long-lived one stale.
2. **Each 401 forced a token refresh under the config file lock.** `fs2` locks are per open file description, so the TUI's own tasks contend like separate processes. Bursts (25s auto-refresh, 1.5s watch ticks, per-env sweeps) queued on the lock until the 10s timeout fired, printing into a raw-mode alternate screen.
3. **`probe_session_liveness` refreshed unconditionally**, bypassing the `AlreadyFresh` check. Backboard rotates and reuse-detects the refresh token on every refresh, so N simultaneous 401s = N rotations, N-1 presenting a consumed token → **grounds for revoking the whole grant.**

Cause 3 is a hard logout caused by our own concurrency, not just cosmetic. Disabling the new coalescing makes the burst test report the real number:

```
assertion `left == right` failed: the burst must cost one token rotation between them, not 8
  left: 8    right: 1
```

## Fix

| Cause | Change |
|---|---|
| 1 | Set `authorization` per request from disk; run `ensure_valid_token` before sending, not after being refused. reqwest applies a default header only when the request hasn't set that key, so long-lived clients pick up refreshes. Fast path is a timestamp compare on an already-read config — no new I/O. |
| 2 | In-process refresh gate taken *ahead* of the file lock, so at most one task waits on it. Capped at 15s: a hung token endpoint can hold it for the full ~90s retry budget. Waiters fall back to stored credentials and do **not** refresh on their own. |
| 3 | 10s window in which a forced refresh stands down because one just completed. A burst now costs one rotation. |
| — | `reporter::warn` defers output while a TUI owns the terminal, flushing on exit with a repeat count. Wired into `set_terminal_owned`, so all TUIs get it from their existing `restore_terminal`. Five other TUIs never set that flag; they do now. |

**New:** `post_graphql_public`. Since `post_graphql` now attaches a bearer and a `reqwest::Client` can't be asked whether it was built with one, the template lookup/search queries that must go out unauthenticated declare it at the call site. The existing "public template lookup sends no auth headers" test caught this.

## Testing

1122 tests pass, 5 consecutive clean runs, 0 clippy errors. `whoami` and `templates search` verified against the real API.

New in `auth_sim.rs`:
- a stale client sends the rotated token through the real send path
- a second refusal reuses the first one's refresh
- 8 concurrent refusals rotate the token exactly once (fails with 8 if coalescing is removed)

`MockBackboard` now records each request's `authorization` header.

## Risks

- **Touches every GraphQL request in the CLI**, not just `ca`. Main risk; worth a canary.
- **10s recency window:** a grant revoked within 10s of a refresh reports `OAuthInsufficientGrant` instead of "log in again". Self-heals. Easy to tighten.
- **`post_graphql_public` is opt-in, no compile-time guard.** A future public call site that forgets it sends a redundant bearer. Contained — all ~230 GraphQL call sites target `get_backboard()`, so it's never a cross-host leak. A newtype over `reqwest::Client` would make it checkable; out of scope here.
- **Logout in another terminal doesn't disarm a running TUI** — with no token on disk, the client's baked bearer is still used. Pre-existing; unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
