### PR TITLE
fix(auth): refresh the token before a subscription (re)connect

### DIFF
--- a/src/auth_sim.rs
+++ b/src/auth_sim.rs
@@ -574,6 +574,48 @@ async fn expired_token_refreshes_and_new_bearer_reaches_the_wire() {
     );
 }
 
+/// A WebSocket authenticates once, at the upgrade, so an expired token only
+/// bites on reconnect — and `stream_http_logs_inner` reconnects a dropped
+/// stream up to twelve times. Without a refresh, every attempt re-presents the
+/// same dead bearer and fails the handshake identically, so a `railway logs -f`
+/// that outlives its token dies at the first network blip.
+#[tokio::test]
+async fn a_subscription_connect_presents_a_refreshed_bearer() {
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = Fixture::new();
+    let mut configs = fixture.load();
+    assert!(configs.is_token_expired(), "fixture starts expired");
+
+    let (name, value) =
+        crate::subscription::connect_auth_header(&mut configs, &token_endpoint.base_url)
+            .await
+            .unwrap();
+
+    assert_eq!(name, "authorization");
+    assert_eq!(
+        value, "Bearer new-access",
+        "the connect must carry the refreshed token, not the expired one it found on disk"
+    );
+    assert_eq!(token_endpoint.hits(), 1);
+}
+
+/// The mirror case: a live token must not cost a refresh on every reconnect.
+#[tokio::test]
+async fn a_subscription_connect_with_a_live_token_does_not_refresh() {
+    let token_endpoint = MockEndpoint::spawn(vec![fresh_tokens()]);
+    let fixture = LiveFixture::new();
+    let mut configs = fixture.load();
+
+    let (name, value) =
+        crate::subscription::connect_auth_header(&mut configs, &token_endpoint.base_url)
+            .await
+            .unwrap();
+
+    assert_eq!(name, "authorization");
+    assert_eq!(value, "Bearer live-access");
+    assert_eq!(token_endpoint.hits(), 0, "nothing to refresh");
+}
+
 /// Load guard for the per-tool-call sync: the expiry predicate that gates the
 /// network call must report a freshly-saved token as valid, so the steady-state
 /// path does no refresh I/O at all.

--- a/src/client.rs
+++ b/src/client.rs
@@ -342,6 +342,13 @@ pub(crate) fn auth_failure_error() -> RailwayError {
 /// config and re-check expiry after acquiring the lock: whichever process wins
 /// the lock performs the single refresh, and the others pick up its result.
 pub async fn ensure_valid_token(configs: &mut Configs) -> Result<()> {
+    let base_url = oauth::get_oauth_base_url(configs.get_host());
+    ensure_valid_token_at(configs, &base_url).await
+}
+
+/// [`ensure_valid_token`] against an explicit token endpoint, for callers that
+/// have already resolved one (and for tests, which point at a scripted one).
+pub(crate) async fn ensure_valid_token_at(configs: &mut Configs, base_url: &str) -> Result<()> {
     // Env var tokens are not managed by us
     if Configs::is_using_token_auth() {
         return Ok(());
@@ -352,7 +359,7 @@ pub async fn ensure_valid_token(configs: &mut Configs) -> Result<()> {
         return Ok(());
     }
 
-    match refresh_locked(configs, false).await {
+    match refresh_locked_at(configs, base_url, false).await {
         RefreshOutcome::Refreshed | RefreshOutcome::AlreadyFresh => Ok(()),
         RefreshOutcome::SessionExpired(e) | RefreshOutcome::Transient(e) => Err(e.into()),
         RefreshOutcome::NoRefreshToken => {

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -14,24 +14,20 @@ where
     <T as GraphQLQuery>::Variables: Send + Sync + Unpin,
     <T as GraphQLQuery>::ResponseData: std::fmt::Debug,
 {
-    let configs = Configs::new()?;
+    let mut configs = Configs::new()?;
     let hostname = configs.get_host();
+    let oauth_base_url = crate::oauth::get_oauth_base_url(hostname);
+    let (header_name, header_value) = connect_auth_header(&mut configs, &oauth_base_url).await?;
+
     let client = reqwest::Client::default();
     // This timeout covers the whole upgrade handshake (DNS + TCP + TLS +
     // 101). On a CPU-starved machine — a CI runner at full load, or a
     // Railway VM mid-build — 1s is routinely missed even when the network
     // is fine, and every retry misses it the same way.
-    let mut request = client
+    let request = client
         .get(format!("wss://backboard.{hostname}/graphql/v2"))
-        .timeout(Duration::from_secs(10));
-
-    if let Some(token) = &Configs::get_railway_token() {
-        request = request.header("project-access-token", token);
-    } else if let Some(token) = configs.get_railway_auth_token() {
-        request = request.header("authorization", format!("Bearer {token}"));
-    } else {
-        bail!("Not authorized");
-    };
+        .timeout(Duration::from_secs(10))
+        .header(header_name, header_value);
 
     let resp = request
         .upgrade()
@@ -44,6 +40,39 @@ where
     Ok(Client::build(GraphQLWebSocket(web_socket))
         .subscribe(StreamingOperation::<T>::new(variables))
         .await?)
+}
+
+/// The credential header a (re)connect should present, after making sure it is
+/// current.
+///
+/// A WebSocket authenticates once, at the upgrade — so a connection opened with
+/// a good token keeps working past its expiry, and the staleness only bites on
+/// reconnect. `stream_http_logs_inner` retries a dropped stream up to twelve
+/// times, and without this refresh every one of those attempts re-presents the
+/// same expired bearer and fails the handshake identically: a `logs -f` that
+/// outlives its token dies at the first network blip. That gets worse, not
+/// better, with a subscription meant to stay open for a whole session.
+///
+/// A refresh failure is deliberately not fatal. The stored token may still be
+/// good (this only fires once local expiry has passed, which is conservative),
+/// and the handshake reports a genuinely dead credential better than a
+/// speculative refresh does.
+///
+/// Split out from [`subscribe_graphql`] so the refresh can be tested without
+/// standing up a WebSocket server.
+pub(crate) async fn connect_auth_header(
+    configs: &mut Configs,
+    oauth_base_url: &str,
+) -> Result<(&'static str, String)> {
+    let _ = crate::client::ensure_valid_token_at(configs, oauth_base_url).await;
+
+    if let Some(token) = Configs::get_railway_token() {
+        return Ok(("project-access-token", token));
+    }
+    if let Some(token) = configs.get_railway_auth_token() {
+        return Ok(("authorization", format!("Bearer {token}")));
+    }
+    bail!("Not authorized")
 }
 
 struct GraphQLWebSocket(WebSocket);


### PR DESCRIPTION
Follow-up to #1102, which fixed bearer staleness on the HTTP path and left the WebSocket path untouched.

## Problem

`subscribe_graphql` reads the bearer straight off disk and never calls `ensure_valid_token`.

A WebSocket authenticates once, at the upgrade. So a connection opened with a good token keeps working past its expiry — the staleness only bites on **reconnect**, and `stream_http_logs_inner` retries a dropped stream up to twelve times. Every attempt re-presents the same expired bearer and fails the handshake identically.

**Today:** a `railway logs -f` that outlives its access token dies at the first network blip, twelve identical failures deep, with no path back.

Doing this now rather than later because an always-on cloud-agent subscription — a socket *expected* to outlive many token lifetimes — would make it load-bearing rather than an edge case.

## Fix

| | |
|---|---|
| `subscription.rs` | Credential resolution moves into `connect_auth_header`, which refreshes before picking the header. Testable without a WebSocket server. |
| `client.rs` | `ensure_valid_token_at` — `ensure_valid_token` against an explicit token endpoint. Lets the test point at a scripted one; `ensure_valid_token` is now a thin wrapper that derives the URL. |

A refresh failure stays **non-fatal**. It only fires once local expiry has passed, the stored token may still be good, and the handshake reports a genuinely dead credential better than a speculative refresh does. `RAILWAY_TOKEN` still short-circuits to `project-access-token` untouched.

## Testing

1124 tests pass, 3 consecutive clean runs, 0 clippy errors.

Two new tests in `auth_sim.rs`:
- an expired token on disk connects with the refreshed bearer (fails with `Bearer stale-access` if the refresh line is removed — verified)
- a live token costs no refresh, so reconnects don't rotate needlessly

**Not covered:** the live WebSocket handshake. This checkout has no linked project, so `logs -f` couldn't be exercised end to end. The credential resolution is tested both ways; the remaining change is mechanical — the same two headers, applied from a resolved `(name, value)` pair instead of two inline branches.

## Context

Came out of a feasibility review for putting `railway ca`'s agent/session state on GraphQL subscriptions. That work is blocked on backboard exposing a cloud-agent subscription at all — this fix is the piece that's independent of it and worth landing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
