### PR TITLE
fix(ca): an agent with a pane open is not still "waking"

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -1434,22 +1434,20 @@ impl App {
     fn push_agent_rows(&self, rows: &mut Vec<Row>, w: usize, p: usize, e: usize) {
         let env = &self.tree[w].projects[p].envs[e];
         let agents = env.agents_vec();
-        for a in sorted_agents(agents) {
+        let attached = self.agents_with_live_panes();
+        for a in sorted_agents(agents, &attached) {
             let agent = &agents[a];
             let pending = self.ops.get(agent.id.as_str()).copied();
+            let status = displayed_status(agent, &attached);
             rows.push(Row {
                 depth: 1,
                 kind: RowKind::Agent(w, p, e, a),
                 label: agent.name.clone(),
                 note: match pending {
                     Some(op) => op.to_string(),
-                    None => agent_note(agent, &self.ending),
+                    None => agent_note(status, agent, &self.ending),
                 },
-                status: Some(
-                    pending
-                        .map(str::to_string)
-                        .unwrap_or_else(|| agent.status.clone()),
-                ),
+                status: Some(pending.unwrap_or(status).to_string()),
                 expanded: Some(agent.expanded),
                 dimmed: false,
             });
@@ -2783,6 +2781,23 @@ impl App {
     /// and closing one because another opened would throw away a running task.
     pub fn attach_session(&mut self, session: super::session::Session, agent_id: String) {
         self.loading.active = false;
+        // A pane just opened on this agent, so a wake we were waiting for has
+        // demonstrably landed — whatever the status projection still says. Left
+        // alone, `waking…` would sit on the row until a poll happened to catch
+        // `running`, and the 1.5s watch tick would keep asking the environment
+        // for up to WAKE_PATIENCE about an agent already taking keystrokes.
+        // Sleep and delete are not settled by this: neither is proven by a pane
+        // opening, and a delete is about to take the row away regardless.
+        if self.ops.get(agent_id.as_str()) == Some(&AgentOp::Wake.pending_label()) {
+            self.ops.remove(agent_id.as_str());
+        }
+        if self
+            .watching
+            .get(agent_id.as_str())
+            .is_some_and(|w| w.want == "running")
+        {
+            self.watching.remove(agent_id.as_str());
+        }
         // The session is what was opened, so that is what the cursor should be
         // on. The agent is only a fallback for a session whose row does not
         // exist yet — a fresh launch, whose session list has not come back.
@@ -4171,6 +4186,18 @@ impl App {
         !self.watching.is_empty()
     }
 
+    /// Agents this TUI currently holds an open, unfinished pane on.
+    ///
+    /// An ended pane does not count: the connection is gone, so it is no longer
+    /// evidence of anything. See [`displayed_status`].
+    fn agents_with_live_panes(&self) -> std::collections::HashSet<&str> {
+        self.sessions
+            .iter()
+            .filter(|session| !session.ended())
+            .map(|session| session.agent_id.as_str())
+            .collect()
+    }
+
     /// Ask again. One environment per tick — in practice there is one agent
     /// waking at a time, and the loop comes back here in a moment anyway.
     pub fn watch_tick(&mut self) -> Option<Effect> {
@@ -4438,8 +4465,11 @@ fn group_label(project: &ProjectNode, e: usize) -> String {
 
 /// Display order for a group's agents: running first, waking next, sleeping
 /// last, then by name. Indices for the same reason as [`App::agent_groups`].
-fn sorted_agents(agents: &[Agent]) -> Vec<usize> {
-    let rank = |agent: &Agent| match agent.status.as_str() {
+///
+/// Ranks on [`displayed_status`], not the raw one, so an agent with a pane open
+/// does not sit in the waking band while its row reads `running`.
+fn sorted_agents(agents: &[Agent], attached: &std::collections::HashSet<&str>) -> Vec<usize> {
+    let rank = |agent: &Agent| match displayed_status(agent, attached) {
         "running" => 0,
         "starting" => 1,
         _ => 2,
@@ -4460,7 +4490,7 @@ fn sorted_agents(agents: &[Agent]) -> Vec<usize> {
 /// running on it once that is known — the same `(N)` a project carries, for the
 /// same reason. Sessions are prefetched for running agents, so the number is
 /// usually there before the row is ever expanded.
-fn agent_note(agent: &Agent, ending: &std::collections::HashSet<String>) -> String {
+fn agent_note(status: &str, agent: &Agent, ending: &std::collections::HashSet<String>) -> String {
     let sessions = match &agent.sessions {
         LoadSessions::Loaded(sessions) => sessions
             .iter()
@@ -4469,9 +4499,31 @@ fn agent_note(agent: &Agent, ending: &std::collections::HashSet<String>) -> Stri
         _ => 0,
     };
     if sessions == 0 {
-        return agent.status.clone();
+        return status.to_string();
     }
-    format!("{} ({sessions})", agent.status)
+    format!("{status} ({sessions})")
+}
+
+/// The status to show for an agent, which is not always the one the platform
+/// last reported.
+///
+/// A pane we are attached to and that has not ended is direct evidence the
+/// agent is up — there is a shell running on it. The platform's status lags
+/// that: a shell routes as soon as the container exists, while `RUNNING`
+/// additionally waits on route publication, a projection hop, and a poll
+/// interval, which is exactly why the launcher stopped gating attach on it
+/// (#1098). So a freshly created agent spends its first seconds reported as
+/// `starting` while its session is already open and taking keystrokes, and the
+/// tree calls that "waking" — about an agent the user is typing into.
+///
+/// Only `starting` is overridden. A pane can outlive the thing it is attached
+/// to, and `sleeping`, `crashed`, `failed` or `deleting` alongside a live pane
+/// is news the user needs rather than a lag to paper over.
+fn displayed_status<'a>(agent: &'a Agent, attached: &std::collections::HashSet<&str>) -> &'a str {
+    if agent.status == "starting" && attached.contains(agent.id.as_str()) {
+        return "running";
+    }
+    &agent.status
 }
 
 /// Display order for a workspace's projects: the ones with agents first, then
@@ -6385,6 +6437,120 @@ mod tests {
     }
 
     /// An agent as the loader builds one: no sessions fetched, collapsed.
+    /// The reported bug: create a new agent, land in its session, and the tree
+    /// still calls it "waking" while you are typing into it.
+    ///
+    /// The launcher attaches as soon as the SSH route answers, which is several
+    /// seconds before the status projection reaches RUNNING (#1098). Nothing
+    /// was wrong with the pane — the row was reporting a status the CLI itself
+    /// had already decided not to wait for.
+    #[test]
+    fn an_agent_with_a_pane_open_is_not_still_waking() {
+        let mut a = loaded_app();
+        a.agents_loaded(
+            (0, 0, 0),
+            Ok(vec![agent("ca_new", "just-created", "starting")]),
+        );
+
+        let note_for = |a: &App| {
+            a.rows()
+                .into_iter()
+                .find(|r| r.label == "just-created")
+                .unwrap()
+                .note
+        };
+        assert_eq!(note_for(&a), "starting", "no pane yet: report what we know");
+
+        a.attach_session(
+            super::super::session::Session::for_test("ca_new", "just-created").unwrap(),
+            "ca_new".to_string(),
+        );
+
+        assert_eq!(
+            note_for(&a),
+            "running",
+            "a live pane is proof the agent is up, whatever the projection says"
+        );
+    }
+
+    /// The override is scoped to the lag it exists for. A pane can outlive what
+    /// it is attached to, and every other status alongside a live pane is news
+    /// rather than latency.
+    #[test]
+    fn only_starting_is_overridden_by_a_live_pane() {
+        let mut a = loaded_app();
+        let attached: std::collections::HashSet<&str> = std::iter::once("ca_1").collect();
+
+        for status in ["sleeping", "crashed", "failed", "deleting"] {
+            let agent = agent("ca_1", "nimble-otter", status);
+            assert_eq!(
+                displayed_status(&agent, &attached),
+                status,
+                "{status} must survive an attached pane"
+            );
+        }
+
+        // And an ended pane stops being evidence of anything.
+        a.agents_loaded(
+            (0, 0, 0),
+            Ok(vec![agent("ca_1", "nimble-otter", "starting")]),
+        );
+        let session = super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap();
+        session.mark_ended();
+        a.attach_session(session, "ca_1".to_string());
+        assert_eq!(
+            a.rows()
+                .into_iter()
+                .find(|r| r.label == "nimble-otter")
+                .unwrap()
+                .note,
+            "starting"
+        );
+    }
+
+    /// A pane opening settles the wake it was waiting on, rather than leaving
+    /// `waking…` up and the 1.5s watch tick asking about an agent that is
+    /// already taking keystrokes.
+    #[test]
+    fn attaching_settles_the_wake_it_was_waiting_for() {
+        let mut a = loaded_app();
+        a.agents_loaded(
+            (0, 0, 0),
+            Ok(vec![agent("ca_1", "nimble-otter", "starting")]),
+        );
+        a.ops.insert("ca_1".into(), AgentOp::Wake.pending_label());
+        a.agent_op_finished("ca_1", "env_prod", AgentOp::Wake, None);
+        assert!(a.watching_agents());
+
+        a.attach_session(
+            super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".to_string(),
+        );
+
+        assert!(a.ops.is_empty(), "the wake landed");
+        assert!(
+            !a.watching_agents(),
+            "and there is nothing left to poll for"
+        );
+    }
+
+    /// A sleep is not settled by a pane opening — nothing about an attach says
+    /// the agent went to sleep, and dropping the label would strand the poll.
+    #[test]
+    fn attaching_does_not_settle_an_unrelated_op() {
+        let mut a = loaded_app();
+        a.ops.insert("ca_1".into(), AgentOp::Sleep.pending_label());
+        a.agent_op_finished("ca_1", "env_prod", AgentOp::Sleep, None);
+
+        a.attach_session(
+            super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".to_string(),
+        );
+
+        assert_eq!(a.ops.get("ca_1").copied(), Some("sleeping…"));
+        assert!(a.watching_agents());
+    }
+
     fn agent(id: &str, name: &str, status: &str) -> Agent {
         Agent {
             id: id.into(),

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -4186,16 +4186,26 @@ impl App {
         !self.watching.is_empty()
     }
 
-    /// Agents this TUI currently holds an open, unfinished pane on.
+    /// Agents this TUI holds an open, unfinished pane on, and how long the
+    /// youngest such pane has been open.
     ///
     /// An ended pane does not count: the connection is gone, so it is no longer
-    /// evidence of anything. See [`displayed_status`].
-    fn agents_with_live_panes(&self) -> std::collections::HashSet<&str> {
-        self.sessions
-            .iter()
-            .filter(|session| !session.ended())
-            .map(|session| session.agent_id.as_str())
-            .collect()
+    /// evidence of anything. The age is what lets [`displayed_status`] tell the
+    /// projection's normal lag apart from an agent that is stuck.
+    fn agents_with_live_panes(&self) -> std::collections::HashMap<&str, std::time::Duration> {
+        let mut open: std::collections::HashMap<&str, std::time::Duration> =
+            std::collections::HashMap::new();
+        for session in self.sessions.iter().filter(|s| !s.ended()) {
+            let age = session.open_for();
+            open.entry(session.agent_id.as_str())
+                .and_modify(|held| {
+                    if age < *held {
+                        *held = age;
+                    }
+                })
+                .or_insert(age);
+        }
+        open
     }
 
     /// Ask again. One environment per tick — in practice there is one agent
@@ -4468,7 +4478,10 @@ fn group_label(project: &ProjectNode, e: usize) -> String {
 ///
 /// Ranks on [`displayed_status`], not the raw one, so an agent with a pane open
 /// does not sit in the waking band while its row reads `running`.
-fn sorted_agents(agents: &[Agent], attached: &std::collections::HashSet<&str>) -> Vec<usize> {
+fn sorted_agents(
+    agents: &[Agent],
+    attached: &std::collections::HashMap<&str, std::time::Duration>,
+) -> Vec<usize> {
     let rank = |agent: &Agent| match displayed_status(agent, attached) {
         "running" => 0,
         "starting" => 1,
@@ -4516,15 +4529,37 @@ fn agent_note(status: &str, agent: &Agent, ending: &std::collections::HashSet<St
 /// `starting` while its session is already open and taking keystrokes, and the
 /// tree calls that "waking" — about an agent the user is typing into.
 ///
-/// Only `starting` is overridden. A pane can outlive the thing it is attached
-/// to, and `sleeping`, `crashed`, `failed` or `deleting` alongside a live pane
-/// is news the user needs rather than a lag to paper over.
-fn displayed_status<'a>(agent: &'a Agent, attached: &std::collections::HashSet<&str>) -> &'a str {
-    if agent.status == "starting" && attached.contains(agent.id.as_str()) {
-        return "running";
+/// Only `starting` is overridden, and only for [`STARTING_GRACE`] after the
+/// pane opened. Two reasons for the bound:
+///
+/// - A pane can outlive the thing it is attached to, so `sleeping`, `crashed`,
+///   `failed` or `deleting` alongside a live pane is news the user needs
+///   rather than a lag to paper over.
+/// - The lag is small. Measured over ten `railway code --claude --new` runs,
+///   status reached RUNNING 5.3–14.2s after create — before the harness
+///   answered, every time. An agent still `starting` well past that is not
+///   lagging, it is stuck, and the row saying `running` would hide the only
+///   signal the user has. That case is real: it is what prompted this fix.
+///
+/// So the override covers the window the lag actually lives in, and past it
+/// the platform's own answer stands.
+fn displayed_status<'a>(
+    agent: &'a Agent,
+    attached: &std::collections::HashMap<&str, std::time::Duration>,
+) -> &'a str {
+    let open_for = attached.get(agent.id.as_str());
+    match open_for {
+        Some(open_for) if agent.status == "starting" && *open_for < STARTING_GRACE => "running",
+        _ => &agent.status,
     }
-    &agent.status
 }
+
+/// How long after a pane opens a `starting` status is still treated as the
+/// projection catching up. Generously past the measured lag (worst observed
+/// 14.2s from create, and a pane opens partway into that), so a normal boot is
+/// never shown as stuck — but bounded, so a stuck one stops being shown as
+/// healthy.
+const STARTING_GRACE: std::time::Duration = std::time::Duration::from_secs(45);
 
 /// Display order for a workspace's projects: the ones with agents first, then
 /// alphabetically within each group.
@@ -6479,7 +6514,8 @@ mod tests {
     #[test]
     fn only_starting_is_overridden_by_a_live_pane() {
         let mut a = loaded_app();
-        let attached: std::collections::HashSet<&str> = std::iter::once("ca_1").collect();
+        let attached: std::collections::HashMap<&str, std::time::Duration> =
+            std::iter::once(("ca_1", std::time::Duration::from_secs(1))).collect();
 
         for status in ["sleeping", "crashed", "failed", "deleting"] {
             let agent = agent("ca_1", "nimble-otter", status);
@@ -6549,6 +6585,50 @@ mod tests {
 
         assert_eq!(a.ops.get("ca_1").copied(), Some("sleeping…"));
         assert!(a.watching_agents());
+    }
+
+    /// The bound that keeps the override honest. A pane that has been open
+    /// well past the measured lag is no longer evidence the agent is merely
+    /// catching up — it is evidence it is stuck, and that is exactly the case
+    /// the user hit. The row must go back to reporting what the platform says.
+    #[test]
+    fn a_long_open_pane_stops_excusing_a_starting_agent() {
+        let agent = agent("ca_1", "nimble-otter", "starting");
+        let attached = |secs| -> std::collections::HashMap<&str, std::time::Duration> {
+            std::iter::once(("ca_1", std::time::Duration::from_secs(secs))).collect()
+        };
+
+        assert_eq!(
+            displayed_status(&agent, &attached(1)),
+            "running",
+            "just attached: the projection is still catching up"
+        );
+        assert_eq!(
+            displayed_status(&agent, &attached(STARTING_GRACE.as_secs() - 1)),
+            "running",
+            "inside the grace window"
+        );
+        assert_eq!(
+            displayed_status(&agent, &attached(STARTING_GRACE.as_secs())),
+            "starting",
+            "past it, the platform's answer stands — a stuck agent must not read as running"
+        );
+        assert_eq!(
+            displayed_status(&agent, &attached(600)),
+            "starting",
+            "and it stays that way"
+        );
+    }
+
+    /// The grace window has to cover a real boot with room to spare, or a
+    /// normal launch would flicker into looking stuck. Worst observed was
+    /// 14.2s from create across ten runs, and the pane opens partway into that.
+    #[test]
+    fn the_grace_window_clears_a_measured_boot() {
+        assert!(
+            STARTING_GRACE >= std::time::Duration::from_secs(30),
+            "too tight for a slow-but-healthy boot"
+        );
     }
 
     fn agent(id: &str, name: &str, status: &str) -> Agent {

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -401,6 +401,13 @@ impl Session {
         Self::STALL_AFTER.checked_sub(self.spawned_at.elapsed())
     }
 
+    /// How long this pane has been open. The tree uses it to tell the status
+    /// projection's normal lag apart from an agent that is genuinely stuck —
+    /// see `displayed_status`.
+    pub fn open_for(&self) -> std::time::Duration {
+        self.spawned_at.elapsed()
+    }
+
     pub fn ended(&self) -> bool {
         self.ended.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
## Problem

Create a new cloud agent, land in its session, and the tree still calls it **"waking"** while you're typing into it.

The row renders the platform's raw status, and `sorted_agents` already spells out the vocabulary — *"running first, waking next, sleeping last"* — where the middle rank is literally `status == "starting"`.

That status **lags routability by design**. #1098 established the gap: the platform routes a shell as soon as the container exists, while `RUNNING` additionally waits on route publication, a projection hop, and a poll interval. The launcher stopped gating attach on it and started probing the route instead — but the tree kept rendering the value the CLI had already decided not to trust.

## Fix

An attached, unfinished pane is direct evidence the agent is up: there's a shell running on it. Believe the pane over the projection.

| Where | Change |
|---|---|
| `displayed_status` | Row status and note read `running` once a pane is open. |
| `sorted_agents` | Ranks on the displayed status, so the row doesn't sit in the waking band while reading `running`. |
| `attach_session` | Clears a settled wake op and its watch — a pane opening proves the wake landed, and it stops the 1.5s watch tick polling that environment for up to `WAKE_PATIENCE` about an agent already taking keystrokes. |

Scoped to `starting` **only**. A pane can outlive what it's attached to, and `sleeping`/`crashed`/`failed`/`deleting` alongside a live pane is news the user needs, not latency to paper over. Sleep and delete ops are untouched — neither is proven by an attach.

## Testing

1126 pass, 0 clippy errors. Four new tests:

- an agent with a pane open reads `running` (fails with `starting` if the override is removed — verified)
- every non-`starting` status survives an attached pane
- an **ended** pane stops counting as evidence
- an in-flight *sleep* isn't settled by an attach

## Why the override is bounded

An unbounded "pane open ⇒ not starting" rule would hide the case that prompted this: an agent that stays `starting`, routes SSH fine, and has to be deleted. Painting that green removes the only signal the user has.

So the override only covers the window the lag actually lives in. Benchmarked with 10 × `railway code --claude --new` (agents cleaned up after):

| metric | min | median | max |
|---|---|---|---|
| create returns | 1.9s | 3.6s | 8.9s |
| status → `RUNNING` | 5.3s | 8.4s | 14.2s |
| end-to-end (create → Claude's first reply) | 10.3s | 13.5s | 19.3s |

Status reached `RUNNING` before the harness answered in **all 10 runs**, worst case 14.2s from create — and a pane opens partway into that. `STARTING_GRACE` is 45s: generously clear of a slow-but-healthy boot, but bounded, so an agent still `starting` past it goes back to reporting what the platform says.

The decision is a pure function of `(status, pane age)`, so the boundary is unit-tested directly rather than through a fabricated `Session` clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
