### PR TITLE
fix(ca): fail closed on an unsafe agent name in `ca desktop`

### DIFF
--- a/src/commands/cloud_agent/desktop.rs
+++ b/src/commands/cloud_agent/desktop.rs
@@ -260,6 +260,19 @@ fn render_block(
     alias: &str,
     identity_file: Option<&Path>,
 ) -> Result<String> {
+    // Fail closed: never serialize a server-returned name that isn't a safe
+    // single token into ssh config. Backboard validates this at create, but the
+    // sink is here, so we re-check to cover a legacy agent named before that
+    // shipped, or a server regression. We refuse rather than sanitize because
+    // the relay resolves the agent by this exact name.
+    if !ssh_config::is_valid_agent_name(agent_name) {
+        bail!(
+            "Refusing to write an SSH config for agent {agent_name:?}: its name is not a safe \
+             single token (letters, digits, and '.', '_' or '-', starting with a letter or \
+             digit). An agent created before name validation shipped can have such a name; \
+             recreate it with a valid name and re-run."
+        );
+    }
     let known_hosts = code::relay_known_hosts()?;
     Ok(ssh_config::render_agent_config_block(
         &ssh_config::AgentBlock {
@@ -652,6 +665,23 @@ mod tests {
                 .unwrap()
                 .len(),
             2
+        );
+    }
+
+    #[test]
+    fn render_block_refuses_an_unsafe_agent_name() {
+        // A newline in the server-returned name would otherwise become its own
+        // ssh directive; render_block must fail closed rather than emit it.
+        let err = render_block(
+            "bbp\n    ProxyCommand /bin/sh -c 'id'",
+            "env-1",
+            "railway-agent-bbp",
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("not a safe single token"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -331,6 +331,28 @@ pub(crate) fn agent_alias(agent_name: &str) -> String {
     format!("railway-agent-{}", sanitize_alias(agent_name))
 }
 
+/// The strict single-token grammar backboard enforces on a coding-agent name at
+/// create: `^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`. `railway ca desktop` renders the
+/// server-returned name verbatim into an OpenSSH `User` line, so a name outside
+/// this grammar — a legacy agent created before that server validation shipped,
+/// or a regressed/compromised server — could smuggle in an ssh directive (a
+/// newline becomes its own `ProxyCommand`, executed locally). Callers validate
+/// before writing and fail closed rather than emit it. We deliberately do not
+/// sanitize the name here: the relay resolves the agent by this exact name, so
+/// altering it would break resolution or, worse, resolve a different agent.
+pub(crate) fn is_valid_agent_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes.len() > 63 {
+        return false;
+    }
+    if !bytes[0].is_ascii_alphanumeric() {
+        return false;
+    }
+    bytes[1..]
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
 /// Render `block` as an OpenSSH `Host` stanza for a cloud agent.
 ///
 /// The relay resolves the agent by name (see `parseCloudAgentTarget` in
@@ -727,6 +749,43 @@ mod tests {
         assert_eq!(sanitize_alias("API Service"), "api-service");
         assert_eq!(sanitize_alias("railway.API_01"), "railway.api_01");
         assert_eq!(sanitize_alias("!!!"), "service");
+    }
+
+    #[test]
+    fn accepts_safe_agent_names() {
+        for name in [
+            "a",
+            "steadfast-wisdom", // the server-generated default shape
+            "bbp-agent",
+            "My.Agent_01",
+            "0",
+            &"a".repeat(63), // max length
+        ] {
+            assert!(is_valid_agent_name(name), "should accept {name:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_unsafe_agent_names() {
+        for name in [
+            "",                                      // empty
+            " ",                                     // whitespace only
+            "has space",                             // space
+            "bbp\n    ProxyCommand /bin/sh -c 'id'", // newline → ssh directive
+            "carriage\rreturn",                      // CR
+            "tab\there",                             // tab
+            "trailing\n",                            // trailing newline
+            "null\0byte",                            // NUL
+            "colon:inside",                          // colon (User value is colon-delimited)
+            "slash/inside",
+            "-leading-hyphen",
+            ".leading-dot",
+            "_leading-underscore",
+            "café",          // non-ASCII
+            &"a".repeat(64), // one over the limit
+        ] {
+            assert!(!is_valid_agent_name(name), "should reject {name:?}");
+        }
     }
 
     /// The block a desktop app reads. Asserted whole, because every line of it


### PR DESCRIPTION
## What

`railway ca desktop` renders a cloud agent's server-returned `name` verbatim into the `User` line of the OpenSSH config it writes (`User agent:<environmentId>:<name>`), then runs the system `ssh` against that file to verify it. A name containing a newline would land as its own SSH directive (e.g. `ProxyCommand …`) and execute locally — and persist in `~/.ssh/config` for later use.

## Change

Validate the agent name against the single-token grammar the backboard create path enforces (`^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`) inside `render_block`, before the block is built, and **fail closed** when it doesn't match.

- New `ssh_config::is_valid_agent_name` in `commands/ssh/config.rs`, matching the server grammar (ASCII allowlist, first char alphanumeric, ≤63 chars).
- `render_block` returns an error for an out-of-grammar name instead of emitting it — so nothing is written to `~/.ssh/config` and no `ssh` verification runs.

We **refuse rather than sanitize**: the relay resolves the agent by this exact name, so altering it would break resolution or resolve a different agent. A refused name means the agent was created before server-side validation shipped (or a server regression) — the error tells the user to recreate it with a valid name.

This is defense-in-depth at the sink: the server now validates names on create, but the CLI is where the value is serialized into ssh config, and this also covers **legacy** agents the server fix can't retroactively clean.

## Tests

- `is_valid_agent_name`: accepts safe names (incl. the generated `word-word` default and the 63-char bound); rejects empty, spaces, newline/CR/tab/NUL, colon, slash, leading `-`/`.`/`_`, non-ASCII, and 64-char.
- `render_block_refuses_an_unsafe_agent_name`: a name with a newline returns an error (bails before writing anything).

All pass; `cargo check`, `rustfmt --check`, and `cargo clippy` clean on the changed files.