### PR TITLE
warn on CaC files + railway config migrate (CaC → IaC PR1/PR3/PR4)

### DIFF
--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -1,10 +1,7 @@
 //! Migrate Config as Code (`railway.json` / `railway.toml`) into
 //! `.railway/railway.ts`. CaC → graph/DSL translation lives in the CLI only.
 
-use std::{
-    fs,
-    path::Path,
-};
+use std::{fs, path::Path};
 
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
@@ -12,7 +9,7 @@ use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
 use crate::{
-    client::{post_graphql, GQLClient},
+    client::{GQLClient, post_graphql},
     config::Configs,
     gql::mutations::{self, ServiceInstanceUpdate},
     util::cac_deprecation::find_cac_file,
@@ -89,9 +86,8 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
     }
 
     let cwd = std::env::current_dir().context("Unable to get current directory")?;
-    let cac_path = find_cac_file(&cwd).context(
-        "No railway.json or railway.toml found in this directory or its parents.",
-    )?;
+    let cac_path = find_cac_file(&cwd)
+        .context("No railway.json or railway.toml found in this directory or its parents.")?;
 
     let cac = parse_cac_file(&cac_path)?;
     let service_name = args
@@ -117,11 +113,7 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
         "Found".dimmed(),
         cac_path.display().to_string().cyan()
     );
-    eprintln!(
-        "{} service {}",
-        "Migrating".dimmed(),
-        service_name.cyan()
-    );
+    eprintln!("{} service {}", "Migrating".dimmed(), service_name.cyan());
 
     if !args.apply {
         println!("{emitted}");
@@ -178,8 +170,8 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
 }
 
 fn parse_cac_file(path: &Path) -> Result<CacFile> {
-    let contents = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let contents =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
@@ -295,13 +287,13 @@ fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
         fields.push(format!("    replicas: {},", json_to_ts(regions)));
     } else if let Some(region) = &cac.deploy.region {
         // Single-region placement via replicas map is the IaC form.
-        fields.push(format!(
-            "    replicas: {{ {}: 1 }},",
-            js_string(region)
-        ));
+        fields.push(format!("    replicas: {{ {}: 1 }},", js_string(region)));
     }
     if let Some(dockerfile) = &cac.build.dockerfile_path {
-        fields.push(format!("    // dockerfilePath from CaC: {}", js_string(dockerfile)));
+        fields.push(format!(
+            "    // dockerfilePath from CaC: {}",
+            js_string(dockerfile)
+        ));
     }
     if let Some(builder) = &cac.build.builder {
         fields.push(format!("    // builder from CaC: {}", js_string(builder)));
@@ -310,7 +302,10 @@ fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
         fields.push(format!("    // cronSchedule from CaC: {}", js_string(cron)));
     }
     if let Some(pre) = &cac.deploy.pre_deploy_command {
-        fields.push(format!("    // preDeployCommand from CaC: {}", json_to_ts(pre)));
+        fields.push(format!(
+            "    // preDeployCommand from CaC: {}",
+            json_to_ts(pre)
+        ));
     }
     if let Some(watch) = &cac.build.watch_patterns {
         let arr = watch

--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -1,0 +1,470 @@
+//! Migrate Config as Code (`railway.json` / `railway.toml`) into
+//! `.railway/railway.ts`. CaC → graph/DSL translation lives in the CLI only.
+
+use std::{
+    fs,
+    path::Path,
+};
+
+use anyhow::{Context, Result, bail};
+use colored::Colorize;
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+
+use crate::{
+    client::{post_graphql, GQLClient},
+    config::Configs,
+    gql::mutations::{self, ServiceInstanceUpdate},
+    util::cac_deprecation::find_cac_file,
+};
+
+use super::*;
+
+#[derive(Parser)]
+pub struct MigrateArgs {
+    /// Write files and clear Railway Config File settings (default is dry-run).
+    #[clap(long)]
+    apply: bool,
+
+    /// Overwrite an existing `.railway/railway.ts`.
+    #[clap(long)]
+    force: bool,
+
+    /// Delete discovered `railway.json` / `railway.toml` after a successful apply.
+    #[clap(long)]
+    delete_files: bool,
+
+    /// Service name to emit in the DSL (defaults to directory name).
+    #[clap(long)]
+    service: Option<String>,
+
+    /// Authoring language to emit: `ts` (default), `py`, or `go`.
+    #[clap(long, default_value = "ts")]
+    lang: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CacFile {
+    #[serde(default)]
+    build: CacBuild,
+    #[serde(default)]
+    deploy: CacDeploy,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CacBuild {
+    builder: Option<String>,
+    build_command: Option<String>,
+    dockerfile_path: Option<String>,
+    watch_patterns: Option<Vec<String>>,
+    nixpacks_config_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CacDeploy {
+    start_command: Option<String>,
+    pre_deploy_command: Option<JsonValue>,
+    healthcheck_path: Option<String>,
+    healthcheck_timeout: Option<i64>,
+    restart_policy_type: Option<String>,
+    restart_policy_max_retries: Option<i64>,
+    num_replicas: Option<i64>,
+    region: Option<String>,
+    multi_region_config: Option<JsonValue>,
+    cron_schedule: Option<String>,
+    sleep_application: Option<bool>,
+    draining_seconds: Option<i64>,
+    overlap_seconds: Option<i64>,
+}
+
+pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
+    if !matches!(args.lang.as_str(), "ts" | "py" | "go") {
+        bail!("--lang must be one of: ts, py, go");
+    }
+    if args.delete_files && !args.apply {
+        bail!("--delete-files requires --apply.");
+    }
+
+    let cwd = std::env::current_dir().context("Unable to get current directory")?;
+    let cac_path = find_cac_file(&cwd).context(
+        "No railway.json or railway.toml found in this directory or its parents.",
+    )?;
+
+    let cac = parse_cac_file(&cac_path)?;
+    let service_name = args
+        .service
+        .clone()
+        .unwrap_or_else(|| guess_service_name(&cwd, &cac_path));
+
+    let railway_dir = cwd.join(".railway");
+    let ext = match args.lang.as_str() {
+        "py" => "py",
+        "go" => "go",
+        _ => "ts",
+    };
+    let railway_file = railway_dir.join(format!("railway.{ext}"));
+    let emitted = match args.lang.as_str() {
+        "py" => emit_railway_py(&service_name, &cac),
+        "go" => emit_railway_go(&service_name, &cac),
+        _ => emit_railway_ts(&service_name, &cac),
+    };
+
+    eprintln!(
+        "{} {}",
+        "Found".dimmed(),
+        cac_path.display().to_string().cyan()
+    );
+    eprintln!(
+        "{} service {}",
+        "Migrating".dimmed(),
+        service_name.cyan()
+    );
+
+    if !args.apply {
+        println!("{emitted}");
+        eprintln!(
+            "\n{} Dry-run only. Re-run with {} to write {} and clear the Railway Config File setting.",
+            "Note:".yellow().bold(),
+            "railway config migrate --apply".cyan(),
+            ".railway/railway.{ts,py,go}".cyan()
+        );
+        eprintln!(
+            "  {} Review with {} then {}",
+            "→".cyan(),
+            "railway config plan".cyan(),
+            "railway config apply".cyan()
+        );
+        return Ok(());
+    }
+
+    if railway_file.exists() && !args.force {
+        bail!(
+            "{} already exists. Pass --force to overwrite, or merge the dry-run output manually.",
+            railway_file.display()
+        );
+    }
+
+    fs::create_dir_all(&railway_dir)?;
+    fs::write(&railway_file, &emitted)
+        .with_context(|| format!("Failed to write {}", railway_file.display()))?;
+    eprintln!(
+        "{} {}",
+        "Wrote".green().bold(),
+        railway_file.display().to_string().cyan()
+    );
+
+    clear_railway_config_file_on_linked_service().await?;
+
+    if args.delete_files {
+        fs::remove_file(&cac_path)
+            .with_context(|| format!("Failed to delete {}", cac_path.display()))?;
+        eprintln!(
+            "{} {}",
+            "Deleted".green().bold(),
+            cac_path.display().to_string().cyan()
+        );
+    }
+
+    eprintln!(
+        "\n{} Run {} then {}.",
+        "Next:".dimmed(),
+        "railway config plan".cyan(),
+        "railway config apply".cyan()
+    );
+    Ok(())
+}
+
+fn parse_cac_file(path: &Path) -> Result<CacFile> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "toml" => toml::from_str(&contents)
+            .with_context(|| format!("Failed to parse TOML {}", path.display())),
+        "json" => serde_json::from_str(&contents)
+            .with_context(|| format!("Failed to parse JSON {}", path.display())),
+        other => bail!("Unsupported Config as Code extension: .{other}"),
+    }
+}
+
+fn guess_service_name(cwd: &Path, cac_path: &Path) -> String {
+    cac_path
+        .parent()
+        .and_then(|p| {
+            if p == cwd {
+                cwd.file_name().map(|n| n.to_string_lossy().into_owned())
+            } else {
+                p.file_name().map(|n| n.to_string_lossy().into_owned())
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "web".to_string())
+}
+
+fn emit_railway_py(service_name: &str, cac: &CacFile) -> String {
+    let mut kwargs = Vec::new();
+    if let Some(cmd) = &cac.build.build_command {
+        kwargs.push(format!("        build={}", js_string(cmd)));
+    }
+    if let Some(cmd) = &cac.deploy.start_command {
+        kwargs.push(format!("        start={}", js_string(cmd)));
+    }
+    if let Some(path) = &cac.deploy.healthcheck_path {
+        kwargs.push(format!("        healthcheck={}", js_string(path)));
+    }
+    let service_call = if kwargs.is_empty() {
+        format!("    web = service({})", js_string(service_name))
+    } else {
+        format!(
+            "    web = service(\n        {},\n{},\n    )",
+            js_string(service_name),
+            kwargs.join(",\n")
+        )
+    };
+    format!(
+        r#"from railway_iac import define_railway, project, service
+
+
+@define_railway
+def main(ctx=None):
+{service_call}
+    return project({project}, resources=[web])
+"#,
+        service_call = service_call,
+        project = js_string(service_name),
+    )
+}
+
+fn emit_railway_go(service_name: &str, cac: &CacFile) -> String {
+    let mut fields = Vec::new();
+    if let Some(cmd) = &cac.build.build_command {
+        fields.push(format!("\t\t\"build\": {},", js_string(cmd)));
+    }
+    if let Some(cmd) = &cac.deploy.start_command {
+        fields.push(format!("\t\t\"start\": {},", js_string(cmd)));
+    }
+    if let Some(path) = &cac.deploy.healthcheck_path {
+        fields.push(format!("\t\t\"healthcheck\": {},", js_string(path)));
+    }
+    let config_block = if fields.is_empty() {
+        "nil".to_string()
+    } else {
+        format!("iac.ServiceConfig{{\n{}\n\t}}", fields.join("\n"))
+    };
+    format!(
+        r#"package main
+
+import "github.com/railwayapp/railway-go-iac/iac"
+
+func Railway() iac.Project {{
+	web := iac.ServiceNamed({name}, {config})
+	return iac.ProjectNamed({name}, []any{{web}})
+}}
+"#,
+        name = js_string(service_name),
+        config = config_block,
+    )
+}
+
+fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
+    let mut fields: Vec<String> = Vec::new();
+
+    if let Some(cmd) = &cac.build.build_command {
+        fields.push(format!("    build: {},", js_string(cmd)));
+    }
+    if let Some(cmd) = &cac.deploy.start_command {
+        fields.push(format!("    start: {},", js_string(cmd)));
+    }
+    if let Some(path) = &cac.deploy.healthcheck_path {
+        fields.push(format!("    healthcheck: {},", js_string(path)));
+    }
+    if let Some(timeout) = cac.deploy.healthcheck_timeout {
+        fields.push(format!("    healthcheckTimeout: {timeout},"));
+    }
+    if let Some(replicas) = cac.deploy.num_replicas {
+        fields.push(format!("    replicas: {replicas},"));
+    }
+    if let Some(regions) = &cac.deploy.multi_region_config {
+        fields.push(format!("    replicas: {},", json_to_ts(regions)));
+    } else if let Some(region) = &cac.deploy.region {
+        // Single-region placement via replicas map is the IaC form.
+        fields.push(format!(
+            "    replicas: {{ {}: 1 }},",
+            js_string(region)
+        ));
+    }
+    if let Some(dockerfile) = &cac.build.dockerfile_path {
+        fields.push(format!("    // dockerfilePath from CaC: {}", js_string(dockerfile)));
+    }
+    if let Some(builder) = &cac.build.builder {
+        fields.push(format!("    // builder from CaC: {}", js_string(builder)));
+    }
+    if let Some(cron) = &cac.deploy.cron_schedule {
+        fields.push(format!("    // cronSchedule from CaC: {}", js_string(cron)));
+    }
+    if let Some(pre) = &cac.deploy.pre_deploy_command {
+        fields.push(format!("    // preDeployCommand from CaC: {}", json_to_ts(pre)));
+    }
+    if let Some(watch) = &cac.build.watch_patterns {
+        let arr = watch
+            .iter()
+            .map(|p| js_string(p))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fields.push(format!("    // watchPatterns from CaC: [{arr}]"));
+    }
+
+    let body = if fields.is_empty() {
+        format!("  const web = service({});\n", js_string(service_name))
+    } else {
+        format!(
+            "  const web = service({}, {{\n{}\n  }});\n",
+            js_string(service_name),
+            fields.join("\n")
+        )
+    };
+
+    format!(
+        r#"import {{ defineRailway, project, service }} from "railway/iac";
+
+export default defineRailway(() => {{
+{body}
+  return project({project}, {{
+    resources: [web],
+  }});
+}});
+"#,
+        body = body,
+        project = js_string(service_name),
+    )
+}
+
+fn js_string(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| format!("{:?}", value))
+}
+
+fn json_to_ts(value: &JsonValue) -> String {
+    match value {
+        JsonValue::Object(map) => {
+            let fields = map
+                .iter()
+                .map(|(k, v)| format!("{}: {}", js_string(k), json_to_ts(v)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{ {fields} }}")
+        }
+        JsonValue::Array(items) => {
+            let inner = items.iter().map(json_to_ts).collect::<Vec<_>>().join(", ");
+            format!("[{inner}]")
+        }
+        JsonValue::String(s) => js_string(s),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Null => "null".to_string(),
+    }
+}
+
+async fn clear_railway_config_file_on_linked_service() -> Result<()> {
+    let configs = Configs::new()?;
+    let linked = match configs.get_linked_project().await {
+        Ok(linked) => linked,
+        Err(_) => {
+            eprintln!(
+                "{} No linked project — skipped clearing Railway Config File. Clear it in the dashboard if set.",
+                "Warning:".yellow().bold()
+            );
+            return Ok(());
+        }
+    };
+    let Some(service_id) = linked.service.clone() else {
+        eprintln!(
+            "{} No linked service — skipped clearing Railway Config File.",
+            "Warning:".yellow().bold()
+        );
+        return Ok(());
+    };
+
+    let Some(environment_id) = linked.environment.clone() else {
+        eprintln!(
+            "{} No linked environment — skipped clearing Railway Config File.",
+            "Warning:".yellow().bold()
+        );
+        return Ok(());
+    };
+
+    let client = GQLClient::new_authorized(&configs)?;
+    let input = mutations::service_instance_update::ServiceInstanceUpdateInput {
+        // Empty string clears the dashboard config-file path.
+        railway_config_file: Some(String::new()),
+        ..Default::default()
+    };
+    let vars = mutations::service_instance_update::Variables {
+        service_id,
+        environment_id: Some(environment_id),
+        input,
+    };
+
+    post_graphql::<ServiceInstanceUpdate, _>(&client, configs.get_backboard(), vars)
+        .await
+        .context(
+            "Failed to clear railwayConfigFile on the linked service. Clear it in the dashboard if set.",
+        )?;
+
+    eprintln!(
+        "{} Cleared Railway Config File on the linked service",
+        "Updated".green().bold()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_build_and_start() {
+        let cac = CacFile {
+            build: CacBuild {
+                build_command: Some("pnpm build".into()),
+                ..Default::default()
+            },
+            deploy: CacDeploy {
+                start_command: Some("pnpm start".into()),
+                healthcheck_path: Some("/health".into()),
+                ..Default::default()
+            },
+        };
+        let out = emit_railway_ts("api", &cac);
+        assert!(out.contains("build: \"pnpm build\""));
+        assert!(out.contains("start: \"pnpm start\""));
+        assert!(out.contains("healthcheck: \"/health\""));
+        assert!(out.contains("service(\"api\""));
+    }
+
+    #[test]
+    fn parses_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("railway.toml");
+        fs::write(
+            &path,
+            r#"
+[build]
+buildCommand = "cargo build"
+[deploy]
+startCommand = "./app"
+healthcheckPath = "/"
+"#,
+        )
+        .unwrap();
+        let cac = parse_cac_file(&path).unwrap();
+        assert_eq!(cac.build.build_command.as_deref(), Some("cargo build"));
+        assert_eq!(cac.deploy.start_command.as_deref(), Some("./app"));
+    }
+}

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -1,5 +1,5 @@
-mod runner;
 mod migrate;
+mod runner;
 
 use std::{
     fs,
@@ -1568,12 +1568,12 @@ fn find_railway_files(start: &Path) -> Vec<PathBuf> {
     const NAMES: &[&str] = &["railway.ts", "railway.py", "railway.go"];
     for directory in start.ancestors() {
         let mut found = Vec::new();
-        let railway_dir = if directory.file_name().and_then(|name| name.to_str()) == Some(".railway")
-        {
-            directory.to_path_buf()
-        } else {
-            directory.join(".railway")
-        };
+        let railway_dir =
+            if directory.file_name().and_then(|name| name.to_str()) == Some(".railway") {
+                directory.to_path_buf()
+            } else {
+                directory.join(".railway")
+            };
         if !railway_dir.is_dir() {
             continue;
         }

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -1,4 +1,5 @@
 mod runner;
+mod migrate;
 
 use std::{
     fs,
@@ -40,6 +41,9 @@ enum Command {
 
     /// Import the linked Railway project's current configuration into .railway/railway.ts
     Pull(PullArgs),
+
+    /// Translate railway.json / railway.toml into .railway/railway.ts
+    Migrate(migrate::MigrateArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -171,6 +175,7 @@ pub async fn command(args: Args) -> Result<()> {
         }
         Command::Init(args) => init_config(args).await,
         Command::Pull(args) => pull_config(args).await,
+        Command::Migrate(args) => migrate::migrate_config(args).await,
     }
 }
 
@@ -1510,7 +1515,18 @@ async fn ensure_config_initialized(args: &SharedArgs) -> Result<()> {
     }
 
     let cwd = std::env::current_dir().context("Unable to get current directory")?;
-    if find_railway_file(&cwd).is_some() {
+    let found = find_railway_files(&cwd);
+    if found.len() > 1 {
+        bail!(
+            "Multiple Railway configuration files found ({}). Keep only one of .railway/railway.{{ts,py,go}}.",
+            found
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    if !found.is_empty() {
         return Ok(());
     }
     let railway_file = cwd.join(".railway").join("railway.ts");
@@ -1543,19 +1559,35 @@ async fn ensure_config_initialized(args: &SharedArgs) -> Result<()> {
 }
 
 fn find_railway_file(start: &Path) -> Option<PathBuf> {
+    find_railway_files(start).into_iter().next()
+}
+
+/// Discover IaC authoring files (`.ts` / `.py` / `.go`). Prefer a single file;
+/// when multiple exist, callers should error.
+fn find_railway_files(start: &Path) -> Vec<PathBuf> {
+    const NAMES: &[&str] = &["railway.ts", "railway.py", "railway.go"];
     for directory in start.ancestors() {
-        if directory.file_name().and_then(|name| name.to_str()) == Some(".railway") {
-            let direct = directory.join("railway.ts");
-            if direct.is_file() {
-                return Some(direct);
+        let mut found = Vec::new();
+        let railway_dir = if directory.file_name().and_then(|name| name.to_str()) == Some(".railway")
+        {
+            directory.to_path_buf()
+        } else {
+            directory.join(".railway")
+        };
+        if !railway_dir.is_dir() {
+            continue;
+        }
+        for name in NAMES {
+            let candidate = railway_dir.join(name);
+            if candidate.is_file() {
+                found.push(candidate);
             }
         }
-        let nested = directory.join(".railway").join("railway.ts");
-        if nested.is_file() {
-            return Some(nested);
+        if !found.is_empty() {
+            return found;
         }
     }
-    None
+    Vec::new()
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,6 +489,7 @@ async fn main() -> Result<()> {
     }
 
     util::agent_advisory::maybe_show(&raw_args, subcommand_name.as_deref()).await;
+    util::cac_deprecation::maybe_warn(&raw_args, subcommand_name.as_deref());
 
     handle_update_task(check_updates_handle).await;
 

--- a/src/util/cac_deprecation.rs
+++ b/src/util/cac_deprecation.rs
@@ -1,0 +1,160 @@
+//! Warn when legacy Config as Code files (`railway.json` / `railway.toml`)
+//! are present in the working tree. Signal-only: no behavior change.
+
+use std::path::{Path, PathBuf};
+
+use colored::Colorize;
+
+use crate::util::reporter;
+
+const DOCS_URL: &str = "https://docs.railway.com/infrastructure-as-code#migrating-from-config-as-code";
+const DISABLE_ENV: &str = "RAILWAY_CAC_DEPRECATION_WARNING";
+
+fn disabled_by_env() -> bool {
+    matches!(
+        std::env::var(DISABLE_ENV).as_deref(),
+        Ok("0" | "false" | "off")
+    )
+}
+
+fn command_is_exempt(command: &str) -> bool {
+    matches!(
+        command,
+        "autoupdate"
+            | "check_updates"
+            | "check-updates"
+            | "completion"
+            | "docs"
+            | "help"
+            | "login"
+            | "logout"
+            | "mcp"
+            | "setup"
+            | "skills"
+            | "telemetry"
+            | "telemetry_cmd"
+            | "upgrade"
+            | "whoami"
+    )
+}
+
+fn should_skip_for_args(raw_args: &[String]) -> bool {
+    raw_args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "--json" | "--help" | "-h" | "--version" | "-V"
+        )
+    })
+}
+
+/// Find a Config as Code file in `dir` or its ancestors (up to the filesystem root).
+/// Prefers `railway.toml` over `railway.json` when both exist in the same directory,
+/// matching builderv3 selection.
+pub fn find_cac_file(start: &Path) -> Option<PathBuf> {
+    let mut current = start.to_path_buf();
+    loop {
+        let toml = current.join("railway.toml");
+        if toml.is_file() {
+            return Some(toml);
+        }
+        let json = current.join("railway.json");
+        if json.is_file() {
+            return Some(json);
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+    None
+}
+
+fn display_path(path: &Path) -> String {
+    std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.display().to_string()))
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// Emit a deprecation warning when a CaC file is found near the cwd.
+pub fn maybe_warn(raw_args: &[String], command: Option<&str>) {
+    if disabled_by_env() || should_skip_for_args(raw_args) {
+        return;
+    }
+    let Some(command) = command else {
+        return;
+    };
+    if command_is_exempt(command) {
+        return;
+    }
+
+    let Ok(cwd) = std::env::current_dir() else {
+        return;
+    };
+    let Some(path) = find_cac_file(&cwd) else {
+        return;
+    };
+
+    let shown = display_path(&path);
+    let message = format!(
+            "Config as Code (railway.json / railway.toml) is deprecated. Prefer Infrastructure as Code (.railway/railway.ts). Run `railway config migrate` or see https://docs.railway.com/infrastructure-as-code#migrating-from-config-as-code"
+    );
+    let hint = format!("Migrate: `railway config migrate` — {DOCS_URL}");
+
+    reporter::warn("CAC_DEPRECATED", message, Some(&hint));
+
+    // Human mode: extra dimmed guidance line for discoverability.
+    if reporter::mode() == reporter::OutputMode::Human {
+        eprintln!(
+            "  {}",
+            "Existing files keep working until a published hard cutoff."
+                .dimmed()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn finds_toml_in_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("railway.toml"), "[build]\n").unwrap();
+        let found = find_cac_file(dir.path()).unwrap();
+        assert!(found.ends_with("railway.toml"));
+    }
+
+    #[test]
+    fn prefers_toml_over_json() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("railway.toml"), "[build]\n").unwrap();
+        fs::write(dir.path().join("railway.json"), "{}\n").unwrap();
+        let found = find_cac_file(dir.path()).unwrap();
+        assert!(found.ends_with("railway.toml"));
+    }
+
+    #[test]
+    fn finds_json_when_no_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("railway.json"), "{}\n").unwrap();
+        let found = find_cac_file(dir.path()).unwrap();
+        assert!(found.ends_with("railway.json"));
+    }
+
+    #[test]
+    fn walks_parents() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("railway.toml"), "[build]\n").unwrap();
+        let nested = dir.path().join("apps").join("web");
+        fs::create_dir_all(&nested).unwrap();
+        let found = find_cac_file(&nested).unwrap();
+        assert!(found.ends_with("railway.toml"));
+    }
+
+    #[test]
+    fn returns_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(find_cac_file(dir.path()).is_none());
+    }
+}

--- a/src/util/cac_deprecation.rs
+++ b/src/util/cac_deprecation.rs
@@ -7,7 +7,8 @@ use colored::Colorize;
 
 use crate::util::reporter;
 
-const DOCS_URL: &str = "https://docs.railway.com/infrastructure-as-code#migrating-from-config-as-code";
+const DOCS_URL: &str =
+    "https://docs.railway.com/infrastructure-as-code#migrating-from-config-as-code";
 const DISABLE_ENV: &str = "RAILWAY_CAC_DEPRECATION_WARNING";
 
 fn disabled_by_env() -> bool {
@@ -71,7 +72,11 @@ pub fn find_cac_file(start: &Path) -> Option<PathBuf> {
 fn display_path(path: &Path) -> String {
     std::env::current_dir()
         .ok()
-        .and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.display().to_string()))
+        .and_then(|cwd| {
+            path.strip_prefix(&cwd)
+                .ok()
+                .map(|p| p.display().to_string())
+        })
         .unwrap_or_else(|| path.display().to_string())
 }
 
@@ -96,7 +101,7 @@ pub fn maybe_warn(raw_args: &[String], command: Option<&str>) {
 
     let shown = display_path(&path);
     let message = format!(
-            "Config as Code (railway.json / railway.toml) is deprecated. Prefer Infrastructure as Code (.railway/railway.ts). Run `railway config migrate` or see https://docs.railway.com/infrastructure-as-code#migrating-from-config-as-code"
+        "Config as Code (railway.json / railway.toml) is deprecated. Prefer Infrastructure as Code (.railway/railway.ts). Run `railway config migrate` or see https://docs.railway.com/infrastructure-as-code#migrating-from-config-as-code"
     );
     let hint = format!("Migrate: `railway config migrate` — {DOCS_URL}");
 
@@ -106,8 +111,7 @@ pub fn maybe_warn(raw_args: &[String], command: Option<&str>) {
     if reporter::mode() == reporter::OutputMode::Human {
         eprintln!(
             "  {}",
-            "Existing files keep working until 2026-12-01."
-                .dimmed()
+            "Existing files keep working until 2026-12-01.".dimmed()
         );
     }
 }

--- a/src/util/cac_deprecation.rs
+++ b/src/util/cac_deprecation.rs
@@ -106,7 +106,7 @@ pub fn maybe_warn(raw_args: &[String], command: Option<&str>) {
     if reporter::mode() == reporter::OutputMode::Human {
         eprintln!(
             "  {}",
-            "Existing files keep working until a published hard cutoff."
+            "Existing files keep working until 2026-12-01."
                 .dimmed()
         );
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod agent_advisory;
+pub mod cac_deprecation;
 pub mod check_update;
 pub mod compare_semver;
 pub mod detect;


### PR DESCRIPTION
## Summary
- Emit a deprecation warning when `railway.json` / `railway.toml` is detected during CLI ops (`RAILWAY_CAC_DEPRECATION_WARNING=off` to silence)
- Add `railway config migrate` (dry-run default) to translate CaC → `.railway/railway.{ts,py,go}`
- Discover one of `.railway/railway.{ts,py,go}` for IaC; error if multiple exist
- On `--apply`, write the file and clear the linked service’s Railway Config File setting

CaC → graph/DSL translation lives in the CLI only (thin language SDKs stay authoring-only).

Companion: docs PR + mono `cacLegacy` gate PR.

## Test plan
- [ ] In a repo with `railway.toml`, run `railway status` (or `up`/`link`) and see the warning
- [ ] `RAILWAY_CAC_DEPRECATION_WARNING=off railway status` suppresses it
- [ ] `railway config migrate` prints generated TS without writing
- [ ] `railway config migrate --apply --force` writes `.railway/railway.ts` and clears config file when linked
- [ ] `railway config migrate --lang py` / `--lang go` emit the other authoring files
- [ ] `cargo test -- cac_deprecation migrate`


Made with [Cursor](https://cursor.com)