### PR TITLE
Emit IaC partial identity from migrate and apply claim-only plans

### DIFF
--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -223,6 +223,7 @@ fn emit_railway_py(service_name: &str, cac: &CacFile) -> String {
     format!(
         r#"from railway_iac import define_railway, project, service
 
+PARTIAL = {project}
 
 @define_railway
 def main(ctx=None):
@@ -254,6 +255,8 @@ fn emit_railway_go(service_name: &str, cac: &CacFile) -> String {
         r#"package main
 
 import "github.com/railwayapp/railway-go-iac/iac"
+
+const Partial = {name}
 
 func Railway() iac.Project {{
 	web := iac.ServiceNamed({name}, {config})
@@ -328,6 +331,8 @@ fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
 
     format!(
         r#"import {{ defineRailway, project, service }} from "railway/iac";
+
+export const partial = {project};
 
 export default defineRailway(() => {{
 {body}
@@ -441,6 +446,7 @@ mod tests {
         assert!(out.contains("start: \"pnpm start\""));
         assert!(out.contains("healthcheck: \"/health\""));
         assert!(out.contains("service(\"api\""));
+        assert!(out.contains("export const partial = \"api\""));
     }
 
     #[test]

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -80,6 +80,8 @@ pub(super) struct RunnerResponse {
     apply_result: Option<ChangeSetApplyResult>,
     deployment_id: Option<String>,
     staged_patch_id: Option<String>,
+    #[serde(default)]
+    claim: bool,
 }
 
 #[derive(Deserialize, serde::Serialize)]
@@ -213,7 +215,7 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
             .as_ref()
             .map(|change_set| change_set.changes.len())
             .unwrap_or(0);
-        if changes == 0 {
+        if changes == 0 && !preview.claim {
             if !args.json {
                 print_response_with_options(&preview, args.verbose);
             }


### PR DESCRIPTION
## Summary
- `railway config migrate` writes `export const partial` / `PARTIAL` / `const Partial` using the linked service name.
- Apply still proceeds when the ChangeSet is empty but the runner flagged a claim (bind unbound resources).

Stacked on #1111 (CaC warnings + migrate + `--lang`). Merge after that lands, then rebase onto master.

## Test plan
- [ ] `railway config migrate` (ts/py/go) emits the partial sibling constant
- [ ] Claim-only apply is not skipped as a no-op
- [ ] Cargo tests for migrate still pass


Made with [Cursor](https://cursor.com)