### PR TITLE
Move IaC evaluation into the CLI

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -72,7 +72,7 @@ struct SharedArgs {
     #[clap(long)]
     include_types: bool,
 
-    /// Path to the TypeScript configuration runner. Defaults to RAILWAY_IAC_TS_BIN or railway-iac-ts.
+    /// Optional TypeScript runner binary. When set, plan/apply use railway-iac-ts instead of the CLI engine.
     #[clap(long)]
     runner: Option<String>,
 
@@ -125,7 +125,7 @@ struct PullArgs {
     #[clap(long)]
     json: bool,
 
-    /// Path to the TypeScript configuration runner. Defaults to RAILWAY_IAC_TS_BIN or railway-iac-ts.
+    /// Optional TypeScript runner binary. When set, plan/apply use railway-iac-ts instead of the CLI engine.
     #[clap(long)]
     runner: Option<String>,
 

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -47,7 +47,8 @@ pub struct Args {
     #[clap(long)]
     pub(super) include_types: bool,
 
-    /// Path to the TypeScript IaC runner binary. Defaults to RAILWAY_IAC_TS_BIN or railway-iac-ts.
+    /// Path to the TypeScript IaC runner. When set (or RAILWAY_IAC_TS_BIN / RAILWAY_IAC_ENGINE=ts),
+    /// plan/apply use railway-iac-ts. Default is the CLI-native engine.
     #[clap(long)]
     pub(super) runner: Option<String>,
 
@@ -385,6 +386,21 @@ async fn invoke_runner(
     command: &str,
 ) -> Result<RunnerResponse> {
     let cwd_path = env::current_dir().context("Unable to get current working directory")?;
+    if !crate::iac::use_legacy_ts_runner(args.runner.as_deref()) {
+        let value = crate::iac::run_native(
+            &crate::iac::NativeRun {
+                file: args.file.clone(),
+                decrypt_variables: args.decrypt_variables,
+                show_values: args.show_values,
+            },
+            configs,
+            linked_project,
+            command,
+        )
+        .await?;
+        return serde_json::from_value(value)
+            .context("Native IaC engine returned a response the CLI could not parse");
+    }
     let runner = resolve_runner(args.runner.as_deref(), &cwd_path);
 
     let cwd = cwd_path.to_string_lossy().to_string();

--- a/src/iac/change_set.rs
+++ b/src/iac/change_set.rs
@@ -1,0 +1,1160 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+use super::graph::{RailwayGraph, resource_addr, resource_name, resource_type};
+use super::json::{field, field_str, stable_stringify};
+use super::partial::{
+    IacPartials, effective_partial, foreign_resource_message, has_named_partials,
+    nameless_file_message, owner_of,
+};
+
+pub const RAILWAY_CHANGE_SET_VERSION: u32 = 1;
+const MASKED_CREDENTIAL_VALUE: &str = "*****";
+const REDACTED_VARIABLE_VALUE: &str = "«hidden»";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ChangeSet {
+    pub version: u32,
+    pub changes: Vec<Value>,
+    pub diagnostics: Vec<Diagnostic>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub partial: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub declared: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Diagnostic {
+    pub severity: String,
+    pub path: String,
+    pub message: String,
+}
+
+pub struct DiffOptions<'a> {
+    pub current: &'a RailwayGraph,
+    pub desired: &'a RailwayGraph,
+    pub reveal_values: bool,
+    pub partial: Option<&'a str>,
+    pub owners: Option<&'a IacPartials>,
+}
+
+pub fn diff_graphs(options: DiffOptions<'_>) -> ChangeSet {
+    let mut changes = Vec::new();
+    let mut diagnostics = Vec::new();
+    let current_by: Map<String, Value> = options
+        .current
+        .resources
+        .iter()
+        .map(|resource| (resource_addr(resource), resource.clone()))
+        .collect();
+    let desired_by: Map<String, Value> = options
+        .desired
+        .resources
+        .iter()
+        .map(|resource| (resource_addr(resource), resource.clone()))
+        .collect();
+    let p = effective_partial(options.partial).to_string();
+    let declared: Vec<String> = options
+        .desired
+        .resources
+        .iter()
+        .map(resource_addr)
+        .collect();
+
+    if p == super::partial::PROJECT_PARTIAL && has_named_partials(options.owners) {
+        diagnostics.push(Diagnostic {
+            severity: "error".into(),
+            path: "partial".into(),
+            message: nameless_file_message(),
+        });
+        return change_set_result(changes, diagnostics, options.partial, declared);
+    }
+
+    for resource in &options.desired.resources {
+        let address = resource_addr(resource);
+        let previous = current_by.get(&address);
+        if let Some(owner) = owner_of(options.owners, &address) {
+            if owner != p {
+                diagnostics.push(Diagnostic {
+                    severity: "error".into(),
+                    path: format!("resources.{address}"),
+                    message: foreign_resource_message(&address, owner),
+                });
+                continue;
+            }
+        }
+        if let Some(previous) = previous {
+            if is_managed_by_repo_config(previous) {
+                let config_file = field_str(previous, "configFile").unwrap_or("repo config");
+                diagnostics.push(Diagnostic {
+                    severity: "error".into(),
+                    path: format!("resources.{address}.configFile"),
+                    message: format!(
+                        "{} is already managed by {config_file}. Remove or migrate the repo config before managing this service from .railway/railway.ts.",
+                        resource_name(previous)
+                    ),
+                });
+                continue;
+            }
+        }
+        if previous.is_none() {
+            diagnose_unsupported_custom_domains(resource, &mut diagnostics, None);
+            changes.push(json!({
+                "kind": "resource.create",
+                "address": address,
+                "resource": resource,
+                "path": format!("resources.{address}"),
+                "summary": format!("Create {} {}", resource_type(resource), resource_name(resource)),
+                "severity": "safe",
+                "deployEffect": if matches!(resource_type(resource), "service" | "database") { "deploy" } else { "none" },
+            }));
+            continue;
+        }
+        let previous = previous.unwrap();
+        if field_str(previous, "name") != field_str(resource, "name") {
+            changes.push(update(
+                &address,
+                "name",
+                json!(field_str(previous, "name")),
+                json!(field_str(resource, "name")),
+                format!(
+                    "Rename {} {} to {}",
+                    resource_type(resource),
+                    resource_name(previous),
+                    resource_name(resource)
+                ),
+                None,
+                "safe",
+            ));
+        }
+        diff_variables(
+            previous,
+            resource,
+            &mut changes,
+            &desired_by,
+            options.reveal_values,
+        );
+        diff_top_level_field(previous, resource, "source", &mut changes);
+        diff_top_level_field(previous, resource, "build", &mut changes);
+        if resource_type(previous) == "database" && resource_type(resource) == "database" {
+            diff_database_deploy(previous, resource, &mut changes);
+        } else if resource_type(previous) == "service" && resource_type(resource) == "service" {
+            diff_service_deploy(previous, resource, &mut changes);
+        } else {
+            diff_top_level_field(previous, resource, "deploy", &mut changes);
+        }
+        diff_top_level_field(previous, resource, "groupId", &mut changes);
+        diff_networking(previous, resource, &mut changes, &mut diagnostics);
+        if resource_type(previous) == "bucket" && resource_type(resource) == "bucket" {
+            if bucket_region(previous) != bucket_region(resource) {
+                diagnostics.push(Diagnostic {
+                    severity: "error".into(),
+                    path: format!("resources.{address}.config.region"),
+                    message: format!(
+                        "Bucket region cannot be changed after creation. Create a new bucket in {} and migrate data instead.",
+                        bucket_region(resource).unwrap_or_else(|| "the desired region".to_string())
+                    ),
+                });
+            } else {
+                diff_top_level_field(previous, resource, "config", &mut changes);
+            }
+        } else if resource_type(previous) == "volume" && resource_type(resource) == "volume" {
+            diff_volume_config(previous, resource, &mut changes);
+        } else {
+            diff_top_level_field(previous, resource, "config", &mut changes);
+        }
+        diff_volume_attachments(previous, resource, &mut changes);
+    }
+
+    for resource in &options.current.resources {
+        let address = resource_addr(resource);
+        if desired_by.contains_key(&address) {
+            continue;
+        }
+        if p != super::partial::PROJECT_PARTIAL
+            && owner_of(options.owners, &address) != Some(p.as_str())
+        {
+            continue;
+        }
+        if resource_type(resource) == "volume" {
+            let mounted = options.current.edges.iter().any(|edge| {
+                edge.kind == "mount" && edge.to == address && desired_by.contains_key(&edge.from)
+            });
+            if mounted {
+                diagnostics.push(Diagnostic {
+                    severity: "warning".into(),
+                    path: format!("resources.{address}"),
+                    message: format!(
+                        "Volume {} exists on Railway but is not declared in the config. Volumes are never deleted by config apply; delete it from the dashboard if that is intended.",
+                        resource_name(resource)
+                    ),
+                });
+            }
+            continue;
+        }
+        changes.push(json!({
+            "kind": "resource.delete",
+            "address": address,
+            "previous": resource,
+            "path": format!("resources.{address}"),
+            "summary": format!("Delete {} {}", resource_type(resource), resource_name(resource)),
+            "severity": "destructive",
+            "deployEffect": if matches!(resource_type(resource), "service" | "database") { "deploy" } else { "none" },
+        }));
+    }
+
+    change_set_result(changes, diagnostics, options.partial, declared)
+}
+
+fn change_set_result(
+    changes: Vec<Value>,
+    diagnostics: Vec<Diagnostic>,
+    partial: Option<&str>,
+    declared: Vec<String>,
+) -> ChangeSet {
+    ChangeSet {
+        version: RAILWAY_CHANGE_SET_VERSION,
+        changes,
+        diagnostics,
+        partial: partial.map(str::to_string),
+        declared,
+    }
+}
+
+pub fn render_change_set(change_set: &ChangeSet) -> String {
+    if change_set.changes.is_empty() {
+        return "No changes.".to_string();
+    }
+    change_set
+        .changes
+        .iter()
+        .map(|change| {
+            let marker = match field_str(change, "kind") {
+                Some("resource.create") | Some("domain.create") => "+",
+                Some("resource.delete") => "-",
+                _ => "~",
+            };
+            format!(
+                "{marker} {}",
+                field_str(change, "summary").unwrap_or("change")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn diff_variables(
+    previous: &Value,
+    resource: &Value,
+    changes: &mut Vec<Value>,
+    resources_by_address: &Map<String, Value>,
+    reveal_values: bool,
+) {
+    if previous.get("variables").is_none() && resource.get("variables").is_none() {
+        return;
+    }
+    let before = previous
+        .get("variables")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let after = resource
+        .get("variables")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (key, value) in &after {
+        if is_preserved_variable(value) {
+            continue;
+        }
+        let current = before.get(key);
+        if !is_unknown_current_variable(current)
+            && stable_stringify(&normalize_variable_for_diff(current, resources_by_address))
+                == stable_stringify(&normalize_variable_for_diff(
+                    Some(value),
+                    resources_by_address,
+                ))
+        {
+            continue;
+        }
+        let mut change = json!({
+            "kind": "variable.set",
+            "address": resource_addr(resource),
+            "variable": key,
+            "after": value,
+            "path": format!("resources.{}.variables.{key}", resource_addr(resource)),
+            "summary": format!("{} variable {}.{}", if current.is_some() { "Update" } else { "Set" }, resource_name(resource), key),
+            "details": [format!(
+                "{}.{} ({} → {})",
+                resource_name(resource),
+                key,
+                format_variable_diff_value(current, resources_by_address, reveal_values),
+                format_variable_diff_value(Some(value), resources_by_address, reveal_values)
+            )],
+            "severity": "safe",
+            "deployEffect": "deploy",
+        });
+        if let Some(current) = current {
+            change["before"] = current.clone();
+        }
+        changes.push(change);
+    }
+    for (key, value) in &before {
+        if after.contains_key(key) {
+            continue;
+        }
+        changes.push(json!({
+            "kind": "variable.delete",
+            "address": resource_addr(resource),
+            "variable": key,
+            "previous": value,
+            "path": format!("resources.{}.variables.{key}", resource_addr(resource)),
+            "summary": format!("Delete variable {}.{}", resource_name(resource), key),
+            "severity": "destructive",
+            "deployEffect": "deploy",
+        }));
+    }
+}
+
+fn diff_networking(
+    previous: &Value,
+    resource: &Value,
+    changes: &mut Vec<Value>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let before = previous.get("networking");
+    let after = resource.get("networking");
+    let before_domains = before.and_then(|n| n.get("customDomains"));
+    diagnose_unsupported_custom_domains(resource, diagnostics, before_domains);
+    let mut before_copy = before.cloned().unwrap_or(json!({}));
+    let mut after_copy = after.cloned().unwrap_or(json!({}));
+    if let Some(obj) = before_copy.as_object_mut() {
+        obj.remove("customDomains");
+        obj.remove("serviceDomains");
+    }
+    if let Some(obj) = after_copy.as_object_mut() {
+        obj.remove("customDomains");
+        obj.remove("serviceDomains");
+    }
+    let normalized_before = normalize_for_diff("networking", &before_copy);
+    let normalized_after = normalize_for_diff("networking", &after_copy);
+    if stable_stringify(&normalized_before) != stable_stringify(&normalized_after) {
+        changes.push(update(
+            &resource_addr(resource),
+            "networking",
+            normalized_before,
+            normalized_after,
+            format!("Update {} networking", resource_name(resource)),
+            None,
+            "safe",
+        ));
+    }
+}
+
+fn diagnose_unsupported_custom_domains(
+    resource: &Value,
+    diagnostics: &mut Vec<Diagnostic>,
+    existing_domains: Option<&Value>,
+) {
+    let desired = resource
+        .get("networking")
+        .and_then(|n| n.get("customDomains"))
+        .and_then(Value::as_object);
+    let Some(desired) = desired else {
+        return;
+    };
+    let existing = existing_domains.and_then(Value::as_object);
+    for domain in desired.keys() {
+        if existing.is_some_and(|map| map.contains_key(domain)) {
+            continue;
+        }
+        diagnostics.push(Diagnostic {
+            severity: "error".into(),
+            path: format!("resources.{}.domains.{domain}", resource_addr(resource)),
+            message: format!(
+                "Custom-domain registration is not supported by Railway configuration. Add {domain} in the dashboard, then run railway config pull."
+            ),
+        });
+    }
+}
+
+fn diff_volume_attachments(previous: &Value, resource: &Value, changes: &mut Vec<Value>) {
+    let before = previous.get("volumeAttachments");
+    let after = resource.get("volumeAttachments");
+    let normalized_before = normalize_for_diff("volumeAttachments", before.unwrap_or(&Value::Null));
+    let normalized_after = normalize_for_diff("volumeAttachments", after.unwrap_or(&Value::Null));
+    if stable_stringify(&normalized_before) == stable_stringify(&normalized_after) {
+        return;
+    }
+    let destructive = before
+        .and_then(Value::as_object)
+        .map(|before| {
+            let after = after
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            before.keys().any(|key| !after.contains_key(key))
+        })
+        .unwrap_or(false);
+    let details = changed_leaf_paths(&normalized_before, &normalized_after, "volumeAttachments");
+    changes.push(update(
+        &resource_addr(resource),
+        "volumeAttachments",
+        before.cloned().unwrap_or(Value::Null),
+        after.cloned().unwrap_or(Value::Null),
+        summary_for_field(
+            resource,
+            "volumeAttachments",
+            &normalized_before,
+            &normalized_after,
+        ),
+        Some(details),
+        if destructive { "destructive" } else { "safe" },
+    ));
+}
+
+fn diff_top_level_field(
+    previous: &Value,
+    resource: &Value,
+    field_name: &str,
+    changes: &mut Vec<Value>,
+) {
+    let mut before = previous.get(field_name).cloned().unwrap_or(Value::Null);
+    let mut after = resource.get(field_name).cloned().unwrap_or(Value::Null);
+    if field_name == "source"
+        && resource_type(previous) == "database"
+        && is_equivalent_database_source(previous, &after)
+    {
+        return;
+    }
+    if field_name == "source"
+        && resource_type(resource) == "service"
+        && !source_supports_auto_updates(resource.get("source"))
+    {
+        before = without_auto_updates(&before);
+        after = without_auto_updates(&after);
+    }
+    if field_name == "deploy" {
+        let stripped = strip_write_only_registry_credentials(&before, &after);
+        before = stripped.0;
+        after = stripped.1;
+    }
+    let normalized_before = normalize_for_diff(field_name, &before);
+    let normalized_after = normalize_for_diff(field_name, &after);
+    if stable_stringify(&normalized_before) == stable_stringify(&normalized_after) {
+        return;
+    }
+    let details = changed_leaf_paths(&normalized_before, &normalized_after, field_name);
+    changes.push(update(
+        &resource_addr(resource),
+        field_name,
+        before,
+        after,
+        summary_for_field(resource, field_name, &normalized_before, &normalized_after),
+        Some(details),
+        "safe",
+    ));
+}
+
+fn diff_service_deploy(previous: &Value, resource: &Value, changes: &mut Vec<Value>) {
+    let desired_deploy =
+        service_deploy_with_current_region(previous.get("deploy"), resource.get("deploy"));
+    let switching_away_from_image =
+        field_str(previous.get("source").unwrap_or(&Value::Null), "type") == Some("image")
+            && field_str(resource.get("source").unwrap_or(&Value::Null), "type") != Some("image");
+    let (before, after) = if switching_away_from_image
+        && previous
+            .get("deploy")
+            .and_then(|d| d.get("registryCredentials"))
+            .is_some()
+    {
+        (
+            without_registry_credentials(previous.get("deploy").unwrap_or(&Value::Null)),
+            {
+                let mut copy = desired_deploy.clone();
+                if copy.is_null() {
+                    copy = json!({});
+                }
+                copy["registryCredentials"] = Value::Null;
+                copy
+            },
+        )
+    } else {
+        strip_write_only_registry_credentials(
+            previous.get("deploy").unwrap_or(&Value::Null),
+            &desired_deploy,
+        )
+    };
+    let normalized_before = normalize_for_diff("deploy", &before);
+    let normalized_after = normalize_for_diff("deploy", &after);
+    if stable_stringify(&normalized_before) == stable_stringify(&normalized_after) {
+        return;
+    }
+    let details = changed_leaf_paths(&normalized_before, &normalized_after, "deploy");
+    changes.push(update(
+        &resource_addr(resource),
+        "deploy",
+        before,
+        after,
+        summary_for_field(resource, "deploy", &normalized_before, &normalized_after),
+        Some(details),
+        "safe",
+    ));
+}
+
+fn service_deploy_with_current_region(previous: Option<&Value>, desired: Option<&Value>) -> Value {
+    let desired = desired.cloned().unwrap_or(Value::Null);
+    if desired.get("numReplicas").is_none() || desired.get("multiRegionConfig").is_some() {
+        return desired;
+    }
+    let Some(region) = single_deploy_region(previous) else {
+        return desired;
+    };
+    let mut rest = desired.clone();
+    let replicas = rest.get("numReplicas").cloned();
+    if let Some(obj) = rest.as_object_mut() {
+        obj.remove("numReplicas");
+        if let Some(replicas) = replicas {
+            obj.insert(
+                "multiRegionConfig".into(),
+                json!({ region: { "numReplicas": replicas } }),
+            );
+        }
+    }
+    rest
+}
+
+fn single_deploy_region(deploy: Option<&Value>) -> Option<String> {
+    let regions = deploy
+        .and_then(|d| d.get("multiRegionConfig"))
+        .and_then(Value::as_object)?;
+    let present: Vec<_> = regions
+        .iter()
+        .filter(|(_, config)| !config.is_null())
+        .collect();
+    if present.len() != 1 {
+        return None;
+    }
+    Some(present[0].0.clone())
+}
+
+fn diff_volume_config(previous: &Value, resource: &Value, changes: &mut Vec<Value>) {
+    let previous_config = drop_unauthored_platform_fields(
+        previous.get("config").unwrap_or(&Value::Null),
+        resource.get("config").unwrap_or(&Value::Null),
+        &["alerts", "allowOnlineResize"],
+    );
+    let before = normalize_for_diff("config", &previous_config);
+    let after = normalize_for_diff("config", resource.get("config").unwrap_or(&Value::Null));
+    if stable_stringify(&before) == stable_stringify(&after) {
+        return;
+    }
+    let previous_size = previous_config.get("sizeMB").and_then(Value::as_i64);
+    let desired_size = resource
+        .get("config")
+        .and_then(|c| c.get("sizeMB"))
+        .and_then(Value::as_i64);
+    let severity = if previous_config.get("region")
+        != resource.get("config").and_then(|c| c.get("region"))
+        || matches!((previous_size, desired_size), (Some(prev), Some(next)) if next < prev)
+    {
+        "destructive"
+    } else {
+        "safe"
+    };
+    let details = changed_leaf_paths(&before, &after, "config");
+    let summary = if let (Some(prev), Some(next)) = (previous_size, desired_size) {
+        if next > prev {
+            format!(
+                "Resize volume {} from {prev}MB to {next}MB",
+                resource_name(resource)
+            )
+        } else {
+            summary_for_field(resource, "config", &before, &after)
+        }
+    } else {
+        summary_for_field(resource, "config", &before, &after)
+    };
+    changes.push(update(
+        &resource_addr(resource),
+        "config",
+        previous_config,
+        resource.get("config").cloned().unwrap_or(Value::Null),
+        summary,
+        Some(details),
+        severity,
+    ));
+}
+
+fn diff_database_deploy(previous: &Value, resource: &Value, changes: &mut Vec<Value>) {
+    let (mut previous_deploy, resource_deploy) = strip_write_only_registry_credentials(
+        previous.get("deploy").unwrap_or(&Value::Null),
+        resource.get("deploy").unwrap_or(&Value::Null),
+    );
+    previous_deploy = drop_platform_start_command(&previous_deploy, &resource_deploy);
+    let previous_region = database_region(previous);
+    let desired_region = database_region(resource);
+    if desired_region.is_some() && desired_region != previous_region {
+        let details = changed_leaf_paths(
+            &normalize_database_deploy(&previous_deploy),
+            &normalize_database_deploy(&resource_deploy),
+            "deploy",
+        );
+        changes.push(update(
+            &resource_addr(resource),
+            "deploy",
+            previous_deploy,
+            resource_deploy,
+            format!(
+                "Move database {} to {}",
+                resource_name(resource),
+                desired_region.unwrap()
+            ),
+            Some(details),
+            "destructive",
+        ));
+        return;
+    }
+    let before = normalize_database_deploy(&previous_deploy);
+    let after = normalize_database_deploy(&resource_deploy);
+    if stable_stringify(&before) == stable_stringify(&after) {
+        return;
+    }
+    let details = changed_leaf_paths(&before, &after, "deploy");
+    changes.push(update(
+        &resource_addr(resource),
+        "deploy",
+        previous_deploy,
+        resource_deploy,
+        summary_for_field(resource, "deploy", &before, &after),
+        Some(details),
+        "safe",
+    ));
+}
+
+fn drop_unauthored_platform_fields(
+    previous_value: &Value,
+    desired_value: &Value,
+    fields: &[&str],
+) -> Value {
+    let Some(obj) = previous_value.as_object() else {
+        return previous_value.clone();
+    };
+    let desired = desired_value.as_object().cloned().unwrap_or_default();
+    let mut copy = obj.clone();
+    let mut changed = false;
+    for field_name in fields {
+        if copy.contains_key(*field_name) && !desired.contains_key(*field_name) {
+            copy.remove(*field_name);
+            changed = true;
+        } else if copy.contains_key(*field_name)
+            && desired.get(*field_name).is_none_or(Value::is_null)
+        {
+            copy.remove(*field_name);
+            changed = true;
+        }
+    }
+    if !changed {
+        return previous_value.clone();
+    }
+    if copy.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(copy)
+    }
+}
+
+fn drop_platform_start_command(previous_deploy: &Value, resource_deploy: &Value) -> Value {
+    drop_unauthored_platform_fields(previous_deploy, resource_deploy, &["startCommand"])
+}
+
+fn is_masked_registry_credentials(value: Option<&Value>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    if value.is_null() {
+        return true;
+    }
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    obj.get("username").and_then(Value::as_str) == Some(MASKED_CREDENTIAL_VALUE)
+        || obj.get("password").and_then(Value::as_str) == Some(MASKED_CREDENTIAL_VALUE)
+}
+
+fn strip_write_only_registry_credentials(before: &Value, after: &Value) -> (Value, Value) {
+    let before_credentials = before.get("registryCredentials");
+    let after_credentials = after.get("registryCredentials");
+    let desired_credentials = real_credential_fields(after_credentials);
+    let with_credentials = |value: &Value, credentials: Option<&Value>| {
+        if !value.is_object() {
+            return value.clone();
+        }
+        let mut copy = value.as_object().cloned().unwrap();
+        match credentials {
+            None => {
+                copy.remove("registryCredentials");
+            }
+            Some(credentials) => {
+                copy.insert("registryCredentials".into(), credentials.clone());
+            }
+        }
+        if copy.is_empty() {
+            Value::Null
+        } else {
+            Value::Object(copy)
+        }
+    };
+    let desired_side = if after_credentials.is_none() {
+        after.clone()
+    } else {
+        with_credentials(after, desired_credentials.as_ref())
+    };
+    if desired_credentials.is_some() && is_masked_registry_credentials(after_credentials) {
+        return (with_credentials(before, None), desired_side);
+    }
+    if desired_credentials.is_some() && !is_masked_registry_credentials(before_credentials) {
+        return (before.clone(), desired_side);
+    }
+    let stripped_before = if before_credentials.is_none() {
+        before.clone()
+    } else {
+        with_credentials(before, None)
+    };
+    let stripped_after = if desired_credentials.is_none() {
+        desired_side
+    } else {
+        with_credentials(&desired_side, None)
+    };
+    (stripped_before, stripped_after)
+}
+
+fn source_supports_auto_updates(source: Option<&Value>) -> bool {
+    let Some(source) = source else {
+        return false;
+    };
+    if field_str(source, "type") != Some("image") {
+        return false;
+    }
+    let Some(image) = field_str(source, "image")
+        .map(str::trim)
+        .map(str::to_lowercase)
+    else {
+        return false;
+    };
+    if image.is_empty() {
+        return false;
+    }
+    if !image.contains('/') {
+        return true;
+    }
+    let registry = image.split('/').next().unwrap_or("");
+    (!registry.contains('.') && !registry.contains(':') && registry != "localhost")
+        || registry == "docker.io"
+        || registry == "ghcr.io"
+}
+
+fn without_auto_updates(source: &Value) -> Value {
+    let Some(obj) = source.as_object() else {
+        return source.clone();
+    };
+    let mut copy = obj.clone();
+    copy.remove("autoUpdates");
+    if copy.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(copy)
+    }
+}
+
+fn without_registry_credentials(deploy: &Value) -> Value {
+    let Some(obj) = deploy.as_object() else {
+        return deploy.clone();
+    };
+    let mut copy = obj.clone();
+    copy.remove("registryCredentials");
+    if copy.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(copy)
+    }
+}
+
+fn real_credential_fields(credentials: Option<&Value>) -> Option<Value> {
+    let obj = credentials.and_then(Value::as_object)?;
+    let entries: Map<String, Value> = obj
+        .iter()
+        .filter(|(_, value)| !value.is_null() && value.as_str() != Some(MASKED_CREDENTIAL_VALUE))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    if entries.is_empty() {
+        None
+    } else {
+        Some(Value::Object(entries))
+    }
+}
+
+fn normalize_database_deploy(value: &Value) -> Value {
+    let mut normalized = normalize_for_diff("deploy", value);
+    if let Some(obj) = normalized.as_object_mut() {
+        obj.remove("requiredMountPath");
+        if obj.is_empty() {
+            return Value::Null;
+        }
+    }
+    normalized
+}
+
+fn summary_for_field(resource: &Value, field_name: &str, before: &Value, after: &Value) -> String {
+    let details = changed_leaf_paths(before, after, field_name);
+    if !details.is_empty() {
+        let shown = details
+            .iter()
+            .take(3)
+            .map(|detail| detail_path_for_summary(detail))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let remaining = details.len().saturating_sub(3);
+        return format!(
+            "Update {} {shown}{}",
+            resource_name(resource),
+            if remaining > 0 {
+                format!(" and {remaining} more")
+            } else {
+                String::new()
+            }
+        );
+    }
+    format!("Update {} {field_name}", resource_name(resource))
+}
+
+fn detail_path_for_summary(detail: &str) -> String {
+    detail.split(" (").next().unwrap_or(detail).to_string()
+}
+
+fn changed_leaf_paths(before: &Value, after: &Value, prefix: &str) -> Vec<String> {
+    let before_flat = flatten_for_diff(before, "");
+    let after_flat = flatten_for_diff(after, "");
+    let mut keys: Vec<_> = before_flat
+        .keys()
+        .chain(after_flat.keys())
+        .cloned()
+        .collect();
+    keys.sort();
+    keys.dedup();
+    let changed: Vec<_> = keys
+        .into_iter()
+        .filter(|key| {
+            stable_stringify(before_flat.get(key).unwrap_or(&Value::Null))
+                != stable_stringify(after_flat.get(key).unwrap_or(&Value::Null))
+        })
+        .collect();
+    changed
+        .iter()
+        .filter(|key| key.is_empty() && changed.len() == 1 || !key.is_empty())
+        .filter(|key| {
+            key.is_empty()
+                || !changed
+                    .iter()
+                    .any(|other| *other != **key && other.starts_with(&format!("{key}.")))
+        })
+        .map(|key| {
+            let path = if key.is_empty() {
+                prefix.to_string()
+            } else {
+                format!("{prefix}.{key}")
+            };
+            if path.contains("registryCredentials") {
+                return format!(
+                    "{} ({REDACTED_VARIABLE_VALUE} → {REDACTED_VARIABLE_VALUE})",
+                    friendly_path(&path)
+                );
+            }
+            format!(
+                "{} ({} → {})",
+                friendly_path(&path),
+                format_diff_value(before_flat.get(key).unwrap_or(&Value::Null)),
+                format_diff_value(after_flat.get(key).unwrap_or(&Value::Null))
+            )
+        })
+        .collect()
+}
+
+fn flatten_for_diff(value: &Value, prefix: &str) -> Map<String, Value> {
+    match value {
+        Value::Object(map) if !map.is_empty() => {
+            let mut out = Map::new();
+            for (key, child) in map {
+                let next = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                out.extend(flatten_for_diff(child, &next));
+            }
+            out
+        }
+        other => {
+            let mut out = Map::new();
+            out.insert(prefix.to_string(), other.clone());
+            out
+        }
+    }
+}
+
+fn friendly_path(path: &str) -> String {
+    if let Some(caps) = regex::Regex::new(r"^deploy\.multiRegionConfig\.([^.]+)\.numReplicas$")
+        .ok()
+        .and_then(|re| re.captures(path))
+    {
+        return format!("regions.{}", &caps[1]);
+    }
+    path.to_string()
+}
+
+fn format_diff_value(value: &Value) -> String {
+    if value.is_null() {
+        return "null".to_string();
+    }
+    serde_json::to_string(value).unwrap_or_else(|_| "null".to_string())
+}
+
+fn update(
+    address: &str,
+    field_name: &str,
+    before: Value,
+    after: Value,
+    summary: String,
+    details: Option<Vec<String>>,
+    severity: &str,
+) -> Value {
+    let mut change = json!({
+        "kind": "resource.update",
+        "address": address,
+        "field": field_name,
+        "before": before,
+        "after": after,
+        "path": format!("resources.{address}.{field_name}"),
+        "summary": summary,
+        "severity": severity,
+        "deployEffect": if field_name == "config" || field_name == "groupId" { "none" } else { "deploy" },
+    });
+    if let Some(details) = details.filter(|details| !details.is_empty()) {
+        change["details"] = json!(details);
+    }
+    change
+}
+
+fn format_variable_diff_value(
+    value: Option<&Value>,
+    resources_by_address: &Map<String, Value>,
+    reveal_values: bool,
+) -> String {
+    let Some(value) = value else {
+        return "unset".to_string();
+    };
+    match field_str(value, "type") {
+        Some("preserve") => "preserve()".into(),
+        Some("reference") => {
+            let resource = field_str(value, "resource").unwrap_or("");
+            let name = resources_by_address
+                .get(resource)
+                .map(resource_name)
+                .unwrap_or_else(|| resource.split('.').nth(1).unwrap_or(resource));
+            format!("{name}.{}", field_str(value, "output").unwrap_or(""))
+        }
+        Some("sharedReference") => format!("shared.{}", field_str(value, "name").unwrap_or("")),
+        _ if !reveal_values => REDACTED_VARIABLE_VALUE.into(),
+        Some("literal") => format_diff_value(value.get("value").unwrap_or(&Value::Null)),
+        _ => format_diff_value(&normalize_variable_for_diff(
+            Some(value),
+            resources_by_address,
+        )),
+    }
+}
+
+fn normalize_variable_for_diff(
+    value: Option<&Value>,
+    resources_by_address: &Map<String, Value>,
+) -> Value {
+    let Some(value) = value else {
+        return Value::Null;
+    };
+    if field_str(value, "type") == Some("sharedReference") {
+        return json!({
+            "type": "literal",
+            "value": format!("${{{{shared.{}}}}}", field_str(value, "name").unwrap_or("")),
+        });
+    }
+    if field_str(value, "type") != Some("reference") {
+        return value.clone();
+    }
+    let resource = field_str(value, "resource").unwrap_or("");
+    let name = resources_by_address
+        .get(resource)
+        .map(resource_name)
+        .unwrap_or_else(|| resource.split('.').nth(1).unwrap_or(resource));
+    json!({
+        "type": "literal",
+        "value": format!("${{{{{}.{}}}}}", name, field_str(value, "output").unwrap_or("")),
+    })
+}
+
+fn is_managed_by_repo_config(resource: &Value) -> bool {
+    if !matches!(resource_type(resource), "service" | "database") {
+        return false;
+    }
+    field_str(resource, "configFile").is_some_and(|path| {
+        regex::Regex::new(r"railway\.(json|toml)$")
+            .unwrap()
+            .is_match(path)
+    })
+}
+
+fn bucket_region(resource: &Value) -> Option<String> {
+    field(resource, "config")
+        .and_then(|config| field_str(config, "region"))
+        .map(str::to_string)
+}
+
+fn database_region(resource: &Value) -> Option<String> {
+    let regions = field(resource, "deploy")
+        .and_then(|d| d.get("multiRegionConfig"))
+        .and_then(Value::as_object)?;
+    let present: Vec<_> = regions
+        .iter()
+        .filter(|(_, config)| !config.is_null())
+        .collect();
+    if present.len() != 1 {
+        return None;
+    }
+    Some(present[0].0.clone())
+}
+
+fn is_equivalent_database_source(previous: &Value, after: &Value) -> bool {
+    if resource_type(previous) != "database" || !after.is_object() {
+        return false;
+    }
+    field_str(after, "type") == Some("image")
+        && normalize_image_tag(field_str(after, "image").unwrap_or(""))
+            == normalize_image_tag(field_str(previous, "image").unwrap_or(""))
+}
+
+fn is_preserved_variable(value: &Value) -> bool {
+    field_str(value, "type") == Some("preserve")
+}
+
+fn is_unknown_current_variable(value: Option<&Value>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    field_str(value, "type") == Some("preserve")
+        || (field_str(value, "type") == Some("literal") && field_str(value, "value") == Some(""))
+}
+
+fn normalize_for_diff(field_name: &str, value: &Value) -> Value {
+    if !value.is_object() {
+        return value.clone();
+    }
+    let mut copy = value.as_object().cloned().unwrap();
+    if field_name == "source" {
+        if copy.get("checkSuites") == Some(&json!(false)) {
+            copy.remove("checkSuites");
+        }
+        if copy.get("branch") == Some(&json!("main")) {
+            copy.remove("branch");
+        }
+        copy.remove("commitSha");
+        copy.remove("upstreamUrl");
+        if copy.get("rootDirectory") == Some(&json!("")) {
+            copy.remove("rootDirectory");
+        }
+        if let Some(image) = copy.get("image").and_then(Value::as_str) {
+            copy.insert("image".into(), json!(normalize_image_tag(image)));
+        }
+    }
+    if field_name == "build" {
+        if copy.get("builder") == Some(&json!("RAILPACK")) {
+            copy.remove("builder");
+        }
+        if copy.get("buildEnvironment") == Some(&json!("V3")) {
+            copy.remove("buildEnvironment");
+        }
+        if copy.get("buildCommand") == Some(&json!("")) {
+            copy.remove("buildCommand");
+        }
+        if copy.get("dockerfilePath") == Some(&json!("Dockerfile")) {
+            copy.remove("dockerfilePath");
+        }
+    }
+    if field_name == "deploy" {
+        if copy.get("useLegacyStacker") == Some(&json!(false)) {
+            copy.remove("useLegacyStacker");
+        }
+        if copy.get("ipv6EgressEnabled") == Some(&json!(false)) {
+            copy.remove("ipv6EgressEnabled");
+        }
+        if copy.get("runtime") == Some(&json!("V2")) {
+            copy.remove("runtime");
+        }
+        if let Some(multi) = copy.remove("multiRegionConfig") {
+            let normalized = normalize_multi_region_config(&multi);
+            if !is_default_multi_region_config(&normalized)
+                && normalized.as_object().is_some_and(|obj| !obj.is_empty())
+            {
+                copy.insert("multiRegionConfig".into(), normalized);
+            }
+        }
+    }
+    if copy.is_empty() {
+        Value::Null
+    } else {
+        Value::Object(copy)
+    }
+}
+
+fn normalize_multi_region_config(value: &Value) -> Value {
+    let Some(obj) = value.as_object() else {
+        return value.clone();
+    };
+    Value::Object(
+        obj.iter()
+            .filter(|(_, config)| {
+                if !config.is_object() {
+                    return true;
+                }
+                !config.get("numReplicas").is_none_or(Value::is_null)
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    )
+}
+
+fn is_default_multi_region_config(value: &Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    if obj.len() != 1 {
+        return false;
+    }
+    let Some(config) = obj.values().next().and_then(Value::as_object) else {
+        return false;
+    };
+    config.iter().all(|(key, child)| {
+        (key == "numReplicas" && child == &json!(1))
+            || (key == "stackerAssignment" && child.is_null())
+    })
+}
+
+fn normalize_image_tag(image: &str) -> String {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"^(?:railwayapp/|ghcr\.io/railwayapp-templates/)?(redis|mysql|mongo|postgres)(?:-ssl)?:(\d+)(?:\.\d+)*$")
+            .unwrap()
+    });
+    if let Some(caps) = re.captures(image) {
+        format!("{}:{}", &caps[1], &caps[2])
+    } else {
+        image.to_string()
+    }
+}

--- a/src/iac/compiler.rs
+++ b/src/iac/compiler.rs
@@ -1,0 +1,957 @@
+use serde_json::{Map, Value, json};
+
+use super::graph::{
+    Edge, EnvironmentNode, ProjectNode, RAILWAY_GRAPH_VERSION, RailwayGraph, resource_addr,
+    resource_address, resource_name, resource_type,
+};
+use super::json::{field, field_str, prune_empty};
+
+#[derive(Debug, Clone, Default)]
+pub struct CompileOptions {
+    pub service_ids_by_name: Map<String, Value>,
+    pub existing_service_ids: Vec<String>,
+    pub volume_ids_by_service_name: Map<String, Value>,
+    pub volume_ids_by_name: Map<String, Value>,
+    pub bucket_ids_by_name: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EnvironmentConfigToGraphOptions {
+    pub project_name: Option<String>,
+    pub service_names_by_id: Map<String, Value>,
+    pub volume_names_by_id: Map<String, Value>,
+    pub volume_group_ids_by_id: Map<String, Value>,
+    pub bucket_names_by_id: Map<String, Value>,
+    pub bucket_group_ids_by_id: Map<String, Value>,
+    pub custom_domains_by_service_id: Map<String, Value>,
+}
+
+pub fn project_definition_to_graph(definition: &Value) -> RailwayGraph {
+    let mut resources = flatten_resources(
+        definition
+            .get("resources")
+            .or_else(|| definition.get("services")),
+    );
+    let mut seen: std::collections::HashSet<String> = resources.iter().map(resource_addr).collect();
+
+    for resource in resources.clone() {
+        if !matches!(resource_type(&resource), "service" | "database") {
+            continue;
+        }
+        let Some(attachments) = field(&resource, "volumeAttachments").and_then(Value::as_object)
+        else {
+            continue;
+        };
+        for attachment in attachments.values() {
+            let Some(volume) = field_str(attachment, "volume") else {
+                continue;
+            };
+            if seen.contains(volume) {
+                continue;
+            }
+            let volume_name = volume.split('.').skip(1).collect::<Vec<_>>().join(".");
+            let mut node = json!({
+                "address": volume,
+                "type": "volume",
+                "name": volume_name,
+            });
+            if let Some(config) = attachment.get("volumeConfig") {
+                node["config"] = config.clone();
+            }
+            seen.insert(volume.to_string());
+            resources.push(node);
+        }
+    }
+
+    let mut edges = Vec::new();
+    for resource in &resources {
+        if !matches!(resource_type(resource), "service" | "database") {
+            continue;
+        }
+        let from = resource_addr(resource);
+        if let Some(attachments) = field(resource, "volumeAttachments").and_then(Value::as_object) {
+            for attachment in attachments.values() {
+                if let (Some(volume), Some(mount)) = (
+                    field_str(attachment, "volume"),
+                    field_str(attachment, "mountPath"),
+                ) {
+                    edges.push(Edge {
+                        from: from.clone(),
+                        to: volume.to_string(),
+                        kind: "mount".to_string(),
+                        key: Some(mount.to_string()),
+                    });
+                }
+            }
+        }
+        if let Some(variables) = field(resource, "variables").and_then(Value::as_object) {
+            for (key, value) in variables {
+                if field_str(value, "type") == Some("reference") {
+                    if let Some(target) = field_str(value, "resource") {
+                        edges.push(Edge {
+                            from: from.clone(),
+                            to: target.to_string(),
+                            kind: "variable".to_string(),
+                            key: Some(key.clone()),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    let resources = resources
+        .into_iter()
+        .map(strip_runtime_helpers)
+        .map(drop_attachment_volume_config)
+        .collect();
+
+    RailwayGraph {
+        version: RAILWAY_GRAPH_VERSION,
+        project: ProjectNode {
+            name: field_str(definition, "name")
+                .unwrap_or("imported-project")
+                .to_string(),
+        },
+        environments: definition
+            .get("environments")
+            .and_then(Value::as_array)
+            .map(|names| {
+                names
+                    .iter()
+                    .filter_map(|name| {
+                        name.as_str().map(|name| EnvironmentNode {
+                            name: name.to_string(),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        resources,
+        edges,
+    }
+}
+
+fn flatten_resources(value: Option<&Value>) -> Vec<Value> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .flat_map(|item| flatten_resources(Some(item)))
+            .collect(),
+        other => vec![other.clone()],
+    }
+}
+
+fn drop_attachment_volume_config(mut resource: Value) -> Value {
+    let Some(attachments) = resource
+        .get_mut("volumeAttachments")
+        .and_then(Value::as_object_mut)
+    else {
+        return resource;
+    };
+    for attachment in attachments.values_mut() {
+        if let Some(obj) = attachment.as_object_mut() {
+            obj.remove("volumeConfig");
+        }
+    }
+    resource
+}
+
+fn strip_runtime_helpers(value: Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.into_iter().map(strip_runtime_helpers).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, child)| (key, strip_runtime_helpers(child)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+pub fn graph_to_environment_config(graph: &RailwayGraph, options: &CompileOptions) -> Value {
+    let mut config = json!({ "services": {} });
+    let names_by_id: Map<String, Value> = graph
+        .resources
+        .iter()
+        .map(|resource| (resource_addr(resource), json!(resource_name(resource))))
+        .collect();
+    let existing: std::collections::HashSet<String> =
+        options.existing_service_ids.iter().cloned().collect();
+
+    for resource in &graph.resources {
+        match resource_type(resource) {
+            "service" | "database" => {
+                let name = resource_name(resource);
+                let service_key = options
+                    .service_ids_by_name
+                    .get(name)
+                    .and_then(Value::as_str)
+                    .unwrap_or(name)
+                    .to_string();
+                let is_new = !existing.contains(&service_key);
+                let service = if resource_type(resource) == "database" {
+                    let volume_id = options
+                        .volume_ids_by_service_name
+                        .get(name)
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    database_to_environment_config(resource, is_new, volume_id.as_deref())
+                } else {
+                    service_to_environment_config(
+                        resource,
+                        &names_by_id,
+                        is_new,
+                        &options.volume_ids_by_name,
+                    )
+                };
+                config["services"][service_key.clone()] = service;
+
+                if resource_type(resource) == "database" {
+                    if let Some(volume_id) = options
+                        .volume_ids_by_service_name
+                        .get(name)
+                        .and_then(Value::as_str)
+                    {
+                        let mut volume = json!({ "isCreated": true });
+                        if let Some(region) = database_region(resource) {
+                            volume["region"] = json!(region);
+                        }
+                        config
+                            .as_object_mut()
+                            .unwrap()
+                            .entry("volumes")
+                            .or_insert_with(|| json!({}))[volume_id] = volume;
+                    }
+                }
+            }
+            "volume" => {
+                let volumes = config
+                    .as_object_mut()
+                    .unwrap()
+                    .entry("volumes")
+                    .or_insert_with(|| json!({}));
+                let existing_id = options
+                    .volume_ids_by_name
+                    .get(resource_name(resource))
+                    .and_then(Value::as_str);
+                let key = existing_id.unwrap_or_else(|| resource_name(resource));
+                let mut volume = resource.get("config").cloned().unwrap_or_else(|| json!({}));
+                if existing_id.is_none() {
+                    if let Some(obj) = volume.as_object_mut() {
+                        obj.insert("isCreated".to_string(), json!(true));
+                    }
+                }
+                volumes[key] = volume;
+            }
+            "bucket" => {
+                let buckets = config
+                    .as_object_mut()
+                    .unwrap()
+                    .entry("buckets")
+                    .or_insert_with(|| json!({}));
+                let existing_id = options
+                    .bucket_ids_by_name
+                    .get(resource_name(resource))
+                    .and_then(Value::as_str);
+                let key = existing_id.unwrap_or_else(|| resource_name(resource));
+                let mut bucket = resource.get("config").cloned().unwrap_or_else(|| json!({}));
+                if existing_id.is_none() {
+                    if let Some(obj) = bucket.as_object_mut() {
+                        obj.insert("isCreated".to_string(), json!(true));
+                    }
+                }
+                if let Some(group_id) = field_str(resource, "groupId") {
+                    bucket["groupId"] = json!(group_id);
+                }
+                buckets[key] = bucket;
+            }
+            "group" => {
+                let groups = config
+                    .as_object_mut()
+                    .unwrap()
+                    .entry("groups")
+                    .or_insert_with(|| json!({}));
+                groups[resource_name(resource)] = prune_empty(json!({
+                    "isCreated": true,
+                    "name": resource_name(resource),
+                    "color": resource.get("color").cloned().unwrap_or(Value::Null),
+                    "icon": resource.get("icon").cloned().unwrap_or(Value::Null),
+                    "isCollapsed": resource.get("isCollapsed").cloned().unwrap_or(Value::Null),
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    prune_empty(config)
+}
+
+fn database_region(database: &Value) -> Option<String> {
+    let regions = field(database, "deploy")
+        .and_then(|deploy| deploy.get("multiRegionConfig"))
+        .and_then(Value::as_object)?;
+    let present: Vec<_> = regions
+        .iter()
+        .filter(|(_, config)| !config.is_null())
+        .collect();
+    if present.len() != 1 {
+        return None;
+    }
+    Some(present[0].0.clone())
+}
+
+fn database_deploy(database: &Value, required_mount_path: &str) -> Value {
+    let mut deploy = json!({ "requiredMountPath": required_mount_path });
+    if let Some(multi) =
+        field(database, "deploy").and_then(|deploy| deploy.get("multiRegionConfig"))
+    {
+        deploy["multiRegionConfig"] = multi.clone();
+    }
+    deploy
+}
+
+fn database_to_environment_config(
+    database: &Value,
+    is_new: bool,
+    volume_id: Option<&str>,
+) -> Value {
+    let engine = field_str(database, "engine").unwrap_or("postgres");
+    let image = field_str(database, "image").unwrap_or("postgres:16");
+    if engine != "postgres" {
+        let mut config = json!({
+            "source": { "image": image },
+        });
+        if is_new {
+            config["isCreated"] = json!(true);
+        }
+        if let Some(mount) = field_str(database, "defaultMountPath") {
+            config["deploy"] = database_deploy(database, mount);
+            if let Some(volume_id) = volume_id {
+                config["volumeMounts"] = json!({ volume_id: { "mountPath": mount } });
+            }
+        }
+        return prune_empty(config);
+    }
+
+    let mut config = json!({
+        "source": { "image": image },
+        "deploy": database_deploy(database, "/var/lib/postgresql/data"),
+        "variables": {
+            "PGDATA": { "value": "/var/lib/postgresql/data/pgdata" },
+            "PGHOST": { "value": "${{RAILWAY_PRIVATE_DOMAIN}}" },
+            "PGPORT": { "value": "5432" },
+            "PGUSER": { "value": "${{POSTGRES_USER}}" },
+            "PGDATABASE": { "value": "${{POSTGRES_DB}}" },
+            "PGPASSWORD": { "value": "${{POSTGRES_PASSWORD}}" },
+            "POSTGRES_DB": { "value": "railway" },
+            "DATABASE_URL": { "value": "postgresql://${{PGUSER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_PRIVATE_DOMAIN}}:5432/${{PGDATABASE}}" },
+            "POSTGRES_USER": { "value": "postgres" },
+            "SSL_CERT_DAYS": { "value": "820" },
+            "POSTGRES_PASSWORD": { "generator": "secret(32, \"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\")" },
+            "DATABASE_PUBLIC_URL": { "value": "postgresql://${{PGUSER}}:${{POSTGRES_PASSWORD}}@${{RAILWAY_TCP_PROXY_DOMAIN}}:${{RAILWAY_TCP_PROXY_PORT}}/${{PGDATABASE}}" },
+            "RAILWAY_DEPLOYMENT_DRAINING_SECONDS": { "value": "60" },
+        },
+        "networking": { "tcpProxies": { "5432": {} } },
+    });
+    if is_new {
+        config["isCreated"] = json!(true);
+    }
+    if let Some(volume_id) = volume_id {
+        config["volumeMounts"] = json!({ volume_id: { "mountPath": "/var/lib/postgresql/data" } });
+    }
+    prune_empty(config)
+}
+
+fn service_to_environment_config(
+    service: &Value,
+    resource_names_by_id: &Map<String, Value>,
+    is_new: bool,
+    volume_ids_by_name: &Map<String, Value>,
+) -> Value {
+    let mut config = if is_new {
+        json!({ "isCreated": true })
+    } else {
+        json!({})
+    };
+    if let Some(source) = field(service, "source") {
+        let source_type = field_str(source, "type");
+        let mut out = json!({});
+        if source_type == Some("github") {
+            if let Some(repo) = source.get("repo") {
+                out["repo"] = repo.clone();
+            }
+            if let Some(branch) = source.get("branch") {
+                out["branch"] = branch.clone();
+            }
+        }
+        if source_type == Some("image") {
+            if let Some(image) = source.get("image") {
+                out["image"] = image.clone();
+            }
+        }
+        for key in [
+            "rootDirectory",
+            "commitSha",
+            "upstreamUrl",
+            "checkSuites",
+            "autoUpdates",
+        ] {
+            if let Some(value) = source.get(key) {
+                out[key] = value.clone();
+            }
+        }
+        let out = prune_empty(out);
+        if out.as_object().is_some_and(|obj| !obj.is_empty()) {
+            config["source"] = out;
+        }
+    }
+    if let Some(build) = field(service, "build") {
+        config["build"] = build.clone();
+    }
+    if let Some(deploy) = field(service, "deploy") {
+        config["deploy"] = deploy.clone();
+    }
+    if let Some(variables) = field(service, "variables") {
+        config["variables"] = variables_to_environment_config(variables, resource_names_by_id);
+    }
+    if let Some(networking) = field(service, "networking") {
+        config["networking"] = networking.clone();
+    }
+    let mut mounts = Map::new();
+    if let Some(attachments) = field(service, "volumeAttachments").and_then(Value::as_object) {
+        for attachment in attachments.values() {
+            let Some(volume) = field_str(attachment, "volume") else {
+                continue;
+            };
+            let volume_name = resource_names_by_id
+                .get(volume)
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| volume.split('.').skip(1).collect::<Vec<_>>().join("."));
+            let volume_id = volume_ids_by_name
+                .get(&volume_name)
+                .and_then(Value::as_str)
+                .unwrap_or(&volume_name);
+            let mut mount = json!({ "mountPath": attachment.get("mountPath") });
+            if let Some(schedules) = attachment.get("backupSchedules") {
+                mount["backupSchedules"] = schedules.clone();
+            }
+            mounts.insert(volume_id.to_string(), prune_empty(mount));
+        }
+    }
+    if let Some(existing) = field(service, "volumeMounts").and_then(Value::as_object) {
+        for (key, value) in existing {
+            mounts.insert(key.clone(), value.clone());
+        }
+    }
+    if !mounts.is_empty() {
+        config["volumeMounts"] = Value::Object(mounts);
+    }
+    for key in [
+        "configFile",
+        "parentServiceId",
+        "groupId",
+        "clusterRole",
+        "replicaConfig",
+        "clusterDisplay",
+    ] {
+        if let Some(value) = field(service, key) {
+            config[key] = value.clone();
+        }
+    }
+    prune_empty(config)
+}
+
+fn variables_to_environment_config(
+    variables: &Value,
+    resource_names_by_id: &Map<String, Value>,
+) -> Value {
+    let Some(map) = variables.as_object() else {
+        return json!({});
+    };
+    let mut out = Map::new();
+    for (key, value) in map {
+        if field_str(value, "type") == Some("preserve") {
+            continue;
+        }
+        out.insert(key.clone(), variable_to_config(value, resource_names_by_id));
+    }
+    Value::Object(out)
+}
+
+fn variable_to_config(value: &Value, resource_names_by_id: &Map<String, Value>) -> Value {
+    match field_str(value, "type") {
+        Some("literal") => {
+            let mut copy = value.clone();
+            if let Some(obj) = copy.as_object_mut() {
+                obj.remove("type");
+            }
+            copy
+        }
+        Some("raw") => value.get("value").cloned().unwrap_or(json!({})),
+        Some("sharedReference") => {
+            let name = field_str(value, "name").unwrap_or("");
+            json!({ "value": format!("${{{{shared.{name}}}}}") })
+        }
+        Some("reference") => {
+            let resource = field_str(value, "resource").unwrap_or("");
+            let name = resource_names_by_id
+                .get(resource)
+                .and_then(Value::as_str)
+                .unwrap_or(resource);
+            let output = field_str(value, "output").unwrap_or("");
+            json!({ "value": format!("${{{{{name}.{output}}}}}") })
+        }
+        _ => value.clone(),
+    }
+}
+
+pub fn environment_config_to_graph(
+    config: &Value,
+    options: &EnvironmentConfigToGraphOptions,
+) -> RailwayGraph {
+    let mut resources = Vec::new();
+    let groups = config
+        .get("groups")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let group_names_by_id: Map<String, Value> = groups
+        .iter()
+        .map(|(id, group)| {
+            (
+                id.clone(),
+                json!(group.get("name").and_then(Value::as_str).unwrap_or(id)),
+            )
+        })
+        .collect();
+
+    let mut referenced = std::collections::HashSet::new();
+    if let Some(services) = config.get("services").and_then(Value::as_object) {
+        for service in services.values() {
+            if let Some(group_id) = field_str(service, "groupId") {
+                referenced.insert(group_id.to_string());
+            }
+        }
+    }
+    for group_id in options
+        .volume_group_ids_by_id
+        .values()
+        .filter_map(Value::as_str)
+    {
+        referenced.insert(group_id.to_string());
+    }
+    if let Some(buckets) = config.get("buckets").and_then(Value::as_object) {
+        for (bucket_id, bucket) in buckets {
+            let group_id = options
+                .bucket_group_ids_by_id
+                .get(bucket_id)
+                .and_then(Value::as_str)
+                .or_else(|| field_str(bucket, "groupId"));
+            if let Some(group_id) = group_id {
+                referenced.insert(group_id.to_string());
+            }
+        }
+    }
+    for group_id in referenced.clone() {
+        let mut parent = groups
+            .get(&group_id)
+            .and_then(|group| field_str(group, "groupId"))
+            .map(str::to_string);
+        while let Some(parent_id) = parent {
+            if referenced.contains(&parent_id) {
+                break;
+            }
+            referenced.insert(parent_id.clone());
+            parent = groups
+                .get(&parent_id)
+                .and_then(|group| field_str(group, "groupId"))
+                .map(str::to_string);
+        }
+    }
+
+    for (group_id, group) in &groups {
+        if group.get("isDeleted").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        if !referenced.contains(group_id) {
+            continue;
+        }
+        let name = group
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or(group_id);
+        let mut node = prune_empty(json!({
+            "address": resource_address("group", name),
+            "type": "group",
+            "name": name,
+            "color": group.get("color").cloned().unwrap_or(Value::Null),
+            "icon": group.get("icon").cloned().unwrap_or(Value::Null),
+            "isCollapsed": group.get("isCollapsed").cloned().unwrap_or(Value::Null),
+        }));
+        if let Some(parent) = field_str(group, "groupId") {
+            let parent_name = group_names_by_id
+                .get(parent)
+                .and_then(Value::as_str)
+                .unwrap_or(parent);
+            node["groupId"] = json!(parent_name);
+        }
+        resources.push(node);
+    }
+
+    if let Some(services) = config.get("services").and_then(Value::as_object) {
+        for (service_id, service) in services {
+            if service.is_null() || service.get("isDeleted").and_then(Value::as_bool) == Some(true)
+            {
+                continue;
+            }
+            let name = options
+                .service_names_by_id
+                .get(service_id)
+                .and_then(Value::as_str)
+                .unwrap_or(service_id);
+            let image_name = service
+                .get("source")
+                .and_then(|source| field_str(source, "image"));
+            let looks_like_database = image_name.is_some_and(|image| {
+                image.contains("postgres")
+                    || image.contains("mysql")
+                    || image.contains("redis")
+                    || image.contains("mongo")
+            });
+            if looks_like_database {
+                let image = image_name.unwrap_or("postgres:16");
+                let engine = if image.contains("mysql") {
+                    "mysql"
+                } else if image.contains("redis") {
+                    "redis"
+                } else if image.contains("mongo") {
+                    "mongo"
+                } else {
+                    "postgres"
+                };
+                let output = match engine {
+                    "redis" => "REDIS_URL",
+                    "mysql" => "MYSQL_URL",
+                    "mongo" => "MONGO_URL",
+                    _ => "DATABASE_URL",
+                };
+                let mut node = prune_empty(json!({
+                    "address": resource_address("database", name),
+                    "type": "database",
+                    "kind": "database",
+                    "engine": engine,
+                    "name": name,
+                    "image": image,
+                    "output": output,
+                    "defaultMountPath": if service.get("volumeMounts").and_then(Value::as_object).is_some_and(|m| !m.is_empty()) {
+                        service.get("deploy").and_then(|d| d.get("requiredMountPath")).cloned().unwrap_or(Value::Null)
+                    } else {
+                        Value::Null
+                    },
+                    "deploy": service.get("deploy").cloned().unwrap_or(Value::Null),
+                    "volumeMounts": service.get("volumeMounts").cloned().unwrap_or(Value::Null),
+                }));
+                if let Some(group_id) = field_str(service, "groupId") {
+                    node["groupId"] = json!(
+                        group_names_by_id
+                            .get(group_id)
+                            .and_then(Value::as_str)
+                            .unwrap_or(group_id)
+                    );
+                }
+                resources.push(node);
+                continue;
+            }
+
+            let kind = if service.get("source").and_then(|s| s.get("repo")).is_some() {
+                "github"
+            } else if service.get("source").and_then(|s| s.get("image")).is_some() {
+                "docker-image"
+            } else if service
+                .get("deploy")
+                .and_then(|d| d.get("cronSchedule"))
+                .is_some()
+            {
+                "function"
+            } else {
+                "empty"
+            };
+            let mut node = json!({
+                "address": resource_address("service", name),
+                "type": "service",
+                "kind": kind,
+                "name": name,
+            });
+            if let Some(source) = service.get("source") {
+                let mut src = source.clone();
+                if let Some(obj) = src.as_object_mut() {
+                    obj.insert(
+                        "type".to_string(),
+                        json!(if source.get("image").is_some() {
+                            "image"
+                        } else {
+                            "github"
+                        }),
+                    );
+                }
+                node["source"] = src;
+            }
+            if let Some(build) = service.get("build") {
+                node["build"] = build.clone();
+            }
+            if let Some(deploy) = service.get("deploy") {
+                node["deploy"] = deploy.clone();
+            }
+            if let Some(variables) = service.get("variables") {
+                node["variables"] = variables_from_environment_config(variables);
+            }
+            let mut networking = service.get("networking").cloned().unwrap_or(json!({}));
+            if let Some(domains) = options.custom_domains_by_service_id.get(service_id) {
+                networking["customDomains"] = domains.clone();
+            } else if let Some(existing) = service
+                .get("networking")
+                .and_then(|n| n.get("customDomains"))
+            {
+                networking["customDomains"] = existing.clone();
+            }
+            let networking = prune_empty(networking);
+            if networking.as_object().is_some_and(|obj| !obj.is_empty())
+                || options
+                    .custom_domains_by_service_id
+                    .contains_key(service_id)
+            {
+                node["networking"] = networking;
+            }
+            let attachments = volume_attachments_from_environment_config(
+                service.get("volumeMounts"),
+                &options.volume_names_by_id,
+            );
+            if let Some(attachments) = attachments {
+                node["volumeAttachments"] = attachments;
+            }
+            if let Some(config_file) = service.get("configFile") {
+                node["configFile"] = config_file.clone();
+            }
+            if let Some(group_id) = field_str(service, "groupId") {
+                node["groupId"] = json!(
+                    group_names_by_id
+                        .get(group_id)
+                        .and_then(Value::as_str)
+                        .unwrap_or(group_id)
+                );
+            }
+            resources.push(node);
+        }
+    }
+
+    if let Some(volumes) = config.get("volumes").and_then(Value::as_object) {
+        for (volume_id, volume) in volumes {
+            if volume.is_null() || volume.get("isDeleted").and_then(Value::as_bool) == Some(true) {
+                continue;
+            }
+            let name = options
+                .volume_names_by_id
+                .get(volume_id)
+                .and_then(Value::as_str)
+                .unwrap_or(volume_id);
+            let mut node = json!({
+                "address": resource_address("volume", name),
+                "type": "volume",
+                "name": name,
+                "config": volume,
+            });
+            if let Some(group_id) = options
+                .volume_group_ids_by_id
+                .get(volume_id)
+                .and_then(Value::as_str)
+            {
+                node["groupId"] = json!(
+                    group_names_by_id
+                        .get(group_id)
+                        .and_then(Value::as_str)
+                        .unwrap_or(group_id)
+                );
+            }
+            resources.push(node);
+        }
+    }
+
+    if let Some(buckets) = config.get("buckets").and_then(Value::as_object) {
+        for (bucket_id, bucket) in buckets {
+            if bucket.is_null() || bucket.get("isDeleted").and_then(Value::as_bool) == Some(true) {
+                continue;
+            }
+            let name = options
+                .bucket_names_by_id
+                .get(bucket_id)
+                .and_then(Value::as_str)
+                .unwrap_or(bucket_id);
+            let mut node = json!({
+                "address": resource_address("bucket", name),
+                "type": "bucket",
+                "name": name,
+                "config": bucket,
+            });
+            let group_id = options
+                .bucket_group_ids_by_id
+                .get(bucket_id)
+                .and_then(Value::as_str)
+                .or_else(|| field_str(bucket, "groupId"));
+            if let Some(group_id) = group_id {
+                node["groupId"] = json!(
+                    group_names_by_id
+                        .get(group_id)
+                        .and_then(Value::as_str)
+                        .unwrap_or(group_id)
+                );
+            }
+            resources.push(node);
+        }
+    }
+
+    project_definition_to_graph(&json!({
+        "name": options.project_name.clone().unwrap_or_else(|| "imported-project".to_string()),
+        "resources": resources,
+    }))
+}
+
+fn variables_from_environment_config(variables: &Value) -> Value {
+    let Some(map) = variables.as_object() else {
+        return json!({});
+    };
+    let mut out = Map::new();
+    for (key, value) in map {
+        if value.is_null() {
+            continue;
+        }
+        let literal = value.get("value").and_then(Value::as_str);
+        out.insert(
+            key.clone(),
+            if literal.is_none() || literal == Some("") {
+                json!({ "type": "preserve" })
+            } else {
+                json!({ "type": "literal", "value": literal })
+            },
+        );
+    }
+    Value::Object(out)
+}
+
+fn volume_attachments_from_environment_config(
+    volume_mounts: Option<&Value>,
+    volume_names_by_id: &Map<String, Value>,
+) -> Option<Value> {
+    let mounts = volume_mounts.and_then(Value::as_object)?;
+    let mut attachments = Map::new();
+    for (volume_id, mount) in mounts {
+        let Some(path) = field_str(mount, "mountPath") else {
+            continue;
+        };
+        let name = volume_names_by_id
+            .get(volume_id)
+            .and_then(Value::as_str)
+            .unwrap_or(volume_id);
+        let mut attachment = json!({
+            "volume": resource_address("volume", name),
+            "mountPath": path,
+        });
+        if let Some(schedules) = mount.get("backupSchedules") {
+            attachment["backupSchedules"] = schedules.clone();
+        }
+        attachments.insert(name.to_string(), attachment);
+    }
+    if attachments.is_empty() {
+        None
+    } else {
+        Some(Value::Object(attachments))
+    }
+}
+
+pub fn compose_patch(current_config: &Value, desired_config: &Value) -> Value {
+    prune_empty(add_deletion_markers(current_config, desired_config))
+}
+
+fn add_deletion_markers(current_config: &Value, desired_config: &Value) -> Value {
+    let mut next = desired_config.clone();
+    if let Some(volumes) = current_config.get("volumes").and_then(Value::as_object) {
+        for (volume_id, current_volume) in volumes {
+            if current_volume.is_null()
+                || current_volume.get("isDeleted").and_then(Value::as_bool) == Some(true)
+            {
+                continue;
+            }
+            if desired_config
+                .get("volumes")
+                .and_then(|volumes| volumes.get(volume_id))
+                .is_some()
+            {
+                continue;
+            }
+            next.as_object_mut()
+                .unwrap()
+                .entry("volumes")
+                .or_insert_with(|| json!({}))[volume_id.clone()] = json!({ "isDeleted": true });
+        }
+    }
+    if let Some(services) = current_config.get("services").and_then(Value::as_object) {
+        for (service_id, current_service) in services {
+            if current_service.is_null()
+                || current_service.get("isDeleted").and_then(Value::as_bool) == Some(true)
+            {
+                continue;
+            }
+            let desired_service = desired_config
+                .get("services")
+                .and_then(|s| s.get(service_id));
+            if desired_service.is_none() {
+                next.as_object_mut()
+                    .unwrap()
+                    .entry("services")
+                    .or_insert_with(|| json!({}))[service_id.clone()] =
+                    json!({ "isDeleted": true });
+                continue;
+            }
+            if let Some(vars) = current_service.get("variables").and_then(Value::as_object) {
+                for (variable_name, current_variable) in vars {
+                    if current_variable.is_null() {
+                        continue;
+                    }
+                    if desired_service
+                        .and_then(|s| s.get("variables"))
+                        .and_then(|v| v.get(variable_name))
+                        .is_some()
+                    {
+                        continue;
+                    }
+                    let services = next
+                        .as_object_mut()
+                        .unwrap()
+                        .entry("services")
+                        .or_insert_with(|| json!({}));
+                    let service = services
+                        .as_object_mut()
+                        .unwrap()
+                        .entry(service_id.clone())
+                        .or_insert_with(|| json!({}));
+                    service
+                        .as_object_mut()
+                        .unwrap()
+                        .entry("variables")
+                        .or_insert_with(|| json!({}))[variable_name.clone()] = Value::Null;
+                }
+            }
+        }
+    }
+    next
+}
+
+pub fn map_from_str(map: &[(&str, &str)]) -> Map<String, Value> {
+    map.iter()
+        .map(|(k, v)| ((*k).to_string(), json!(*v)))
+        .collect()
+}

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -1,0 +1,416 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::time::sleep;
+
+use crate::{
+    client::{GQLClient, post_graphql_raw},
+    config::{Configs, LinkedProject},
+};
+
+use super::change_set::{DiffOptions, diff_graphs, render_change_set};
+use super::compiler::{EnvironmentConfigToGraphOptions, environment_config_to_graph};
+use super::eval::evaluate_file;
+use super::graph::validate_graph;
+use super::partial::needs_partial_claim_apply;
+
+#[derive(Debug, Deserialize)]
+struct EnvQuery {
+    environment: EnvNode,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EnvNode {
+    id: String,
+    name: Option<String>,
+    project_id: Option<String>,
+    config: Value,
+    config_etag: Option<String>,
+    canvas_group_refs: Option<Value>,
+    iac_partials: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NameQuery {
+    project: Option<NameNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NameNode {
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EdgesQuery<T> {
+    project: Option<Connection<T>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Connection<T> {
+    edges: Vec<Edge<T>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Edge<T> {
+    node: T,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Named {
+    id: String,
+    name: Option<String>,
+    #[serde(default)]
+    group_id: Option<String>,
+}
+
+pub struct NativeRun {
+    pub file: Option<std::path::PathBuf>,
+    pub decrypt_variables: bool,
+    pub show_values: bool,
+}
+
+pub async fn run(
+    args: &NativeRun,
+    configs: &Configs,
+    linked_project: &LinkedProject,
+    command: &str,
+) -> Result<Value> {
+    let cwd = std::env::current_dir()?;
+    let file = args
+        .file
+        .clone()
+        .or_else(|| find_authoring_file(&cwd))
+        .context("Could not find .railway/railway.ts, railway.py, or railway.go")?;
+    let evaluated = evaluate_file(&file)?;
+    let diagnostics: Vec<Value> = validate_graph(&evaluated.graph)
+        .into_iter()
+        .map(|message| json!({ "severity": "error", "path": "graph", "message": message }))
+        .collect();
+
+    let client = GQLClient::new_authorized(configs)?;
+    let endpoint = configs.get_backboard();
+    let environment_id = linked_project.environment_id()?;
+    let current =
+        fetch_current_environment(&client, &endpoint, environment_id, args.decrypt_variables)
+            .await?;
+    let mut options = EnvironmentConfigToGraphOptions {
+        project_name: linked_project
+            .name
+            .clone()
+            .or_else(|| Some(evaluated.graph.project.name.clone())),
+        ..Default::default()
+    };
+    if let Some(project_id) = current
+        .project_id
+        .clone()
+        .or_else(|| Some(linked_project.project.clone()))
+    {
+        fill_name_maps(
+            &client,
+            &endpoint,
+            &project_id,
+            current.id.as_str(),
+            &current,
+            &mut options,
+        )
+        .await?;
+    }
+    let current_graph = environment_config_to_graph(&current.config, &options);
+    let owners = parse_owners(current.iac_partials.as_ref());
+    let change_set = diff_graphs(DiffOptions {
+        current: &current_graph,
+        desired: &evaluated.graph,
+        reveal_values: args.show_values,
+        partial: evaluated.partial.as_deref(),
+        owners: owners.as_ref(),
+    });
+    let mut all_diagnostics = diagnostics;
+    for diagnostic in &change_set.diagnostics {
+        all_diagnostics.push(json!({
+            "severity": diagnostic.severity,
+            "path": diagnostic.path,
+            "message": diagnostic.message,
+        }));
+    }
+    let ok = all_diagnostics
+        .iter()
+        .all(|d| d.get("severity").and_then(Value::as_str) != Some("error"));
+    let claim = needs_partial_claim_apply(
+        &change_set.declared,
+        owners.as_ref(),
+        evaluated.partial.as_deref(),
+    );
+
+    let mut apply_result = None;
+    if command == "apply" && ok && (!change_set.changes.is_empty() || claim) {
+        apply_result = Some(
+            apply_change_set(
+                &client,
+                &endpoint,
+                &current.id,
+                &change_set,
+                current.config_etag.as_deref(),
+            )
+            .await?,
+        );
+    }
+
+    let serialized = serde_json::to_value(RunnerWire {
+        ok,
+        command: command.to_string(),
+        file: evaluated.file.to_string_lossy().to_string(),
+        current_environment: Some(json!({
+            "projectId": current.project_id,
+            "projectName": options.project_name,
+            "environmentId": current.id,
+            "environmentName": current.name,
+            "configEtag": current.config_etag,
+        })),
+        change_set: Some(change_set.clone()),
+        diff: Some(render_change_set(&change_set)),
+        diagnostics: all_diagnostics,
+        current_graph: Some(current_graph),
+        desired_graph: Some(evaluated.graph),
+        apply_result,
+        claim,
+    })?;
+    Ok(serialized)
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunnerWire {
+    ok: bool,
+    command: String,
+    file: String,
+    current_environment: Option<Value>,
+    change_set: Option<super::change_set::ChangeSet>,
+    diff: Option<String>,
+    diagnostics: Vec<Value>,
+    current_graph: Option<super::graph::RailwayGraph>,
+    desired_graph: Option<super::graph::RailwayGraph>,
+    apply_result: Option<Value>,
+    claim: bool,
+}
+
+async fn fetch_current_environment(
+    client: &reqwest::Client,
+    endpoint: &str,
+    environment_id: &str,
+    decrypt_variables: bool,
+) -> Result<EnvNode> {
+    let query_with_partials = r#"
+      query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
+        environment(id: $environmentId) {
+          id name projectId config(decryptVariables: $decryptVariables) configEtag canvasGroupRefs iacPartials
+        }
+      }
+    "#;
+    let vars = json!({ "environmentId": environment_id, "decryptVariables": decrypt_variables });
+    match post_graphql_raw::<EnvQuery, _>(client, endpoint, query_with_partials, vars.clone()).await
+    {
+        Ok(data) => Ok(data.environment),
+        Err(err) if err.to_string().contains("iacPartials") => {
+            let query = r#"
+              query IacEnvironmentConfig($environmentId: String!, $decryptVariables: Boolean) {
+                environment(id: $environmentId) {
+                  id name projectId config(decryptVariables: $decryptVariables) configEtag canvasGroupRefs
+                }
+              }
+            "#;
+            Ok(
+                post_graphql_raw::<EnvQuery, _>(client, endpoint, query, vars)
+                    .await?
+                    .environment,
+            )
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+async fn fill_name_maps(
+    client: &reqwest::Client,
+    endpoint: &str,
+    project_id: &str,
+    environment_id: &str,
+    current: &EnvNode,
+    options: &mut EnvironmentConfigToGraphOptions,
+) -> Result<()> {
+    if let Ok(data) = post_graphql_raw::<NameQuery, _>(
+        client,
+        endpoint,
+        "query IacProjectName($projectId: String!) { project(id: $projectId) { name } }",
+        json!({ "projectId": project_id }),
+    )
+    .await
+    {
+        if let Some(name) = data.project.and_then(|p| p.name) {
+            options.project_name = Some(name);
+        }
+    }
+    if let Ok(data) = post_graphql_raw::<EdgesQuery<Named>, _>(
+        client,
+        endpoint,
+        "query IacProjectServices($projectId: String!) { project(id: $projectId) { services(first: 1000) { edges { node { id name } } } } }",
+        json!({ "projectId": project_id }),
+    )
+    .await
+    {
+        for edge in data.project.unwrap_or(Connection { edges: vec![] }).edges {
+            if let Some(name) = edge.node.name {
+                options.service_names_by_id.insert(edge.node.id, json!(name));
+            }
+        }
+    }
+    if let Ok(data) = post_graphql_raw::<EdgesQuery<Named>, _>(
+        client,
+        endpoint,
+        "query IacProjectVolumes($projectId: String!) { project(id: $projectId) { volumes(first: 1000) { edges { node { id name } } } } }",
+        json!({ "projectId": project_id }),
+    )
+    .await
+    {
+        for edge in data.project.unwrap_or(Connection { edges: vec![] }).edges {
+            if let Some(name) = edge.node.name {
+                options.volume_names_by_id.insert(edge.node.id.clone(), json!(name));
+            }
+            if let Some(refs) = current.canvas_group_refs.as_ref().and_then(Value::as_object) {
+                if let Some(group_id) = refs.get(&edge.node.id) {
+                    options.volume_group_ids_by_id.insert(edge.node.id, group_id.clone());
+                }
+            }
+        }
+    }
+    if let Ok(data) = post_graphql_raw::<EdgesQuery<Named>, _>(
+        client,
+        endpoint,
+        "query IacProjectBuckets($projectId: String!) { project(id: $projectId) { buckets(first: 1000) { edges { node { id name groupId } } } } }",
+        json!({ "projectId": project_id }),
+    )
+    .await
+    {
+        for edge in data.project.unwrap_or(Connection { edges: vec![] }).edges {
+            if let Some(name) = edge.node.name {
+                options.bucket_names_by_id.insert(edge.node.id.clone(), json!(name));
+            }
+            if let Some(group_id) = edge.node.group_id {
+                options.bucket_group_ids_by_id.insert(edge.node.id, json!(group_id));
+            }
+        }
+    }
+    let _ = environment_id;
+    Ok(())
+}
+
+fn find_authoring_file(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    const NAMES: &[&str] = &["railway.ts", "railway.py", "railway.go"];
+    for directory in start.ancestors() {
+        let railway_dir =
+            if directory.file_name().and_then(|name| name.to_str()) == Some(".railway") {
+                directory.to_path_buf()
+            } else {
+                directory.join(".railway")
+            };
+        for name in NAMES {
+            let candidate = railway_dir.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn parse_owners(value: Option<&Value>) -> Option<super::partial::IacPartials> {
+    let object = value.and_then(Value::as_object)?;
+    let mut out = super::partial::IacPartials::new();
+    for (key, value) in object {
+        if let Some(owner) = value.as_str() {
+            out.insert(key.clone(), owner.to_string());
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+async fn apply_change_set(
+    client: &reqwest::Client,
+    endpoint: &str,
+    environment_id: &str,
+    change_set: &super::change_set::ChangeSet,
+    base_etag: Option<&str>,
+) -> Result<Value> {
+    let mut variables = json!({
+        "environmentId": environment_id,
+        "input": change_set,
+        "commitMessage": "Apply Railway configuration",
+        "waitForCompletion": false,
+    });
+    if let Some(etag) = base_etag {
+        variables["baseConfigEtag"] = json!(etag);
+    }
+    let mutation = r#"
+      mutation IacApplyChangeSet($environmentId: String!, $input: JSON!, $commitMessage: String, $baseConfigEtag: String, $waitForCompletion: Boolean) {
+        environmentApplyChangeSet(environmentId: $environmentId, input: $input, commitMessage: $commitMessage, baseConfigEtag: $baseConfigEtag, waitForCompletion: $waitForCompletion) {
+          id status deploymentId stagedPatchId diagnostics changes { kind path summary status outputs }
+        }
+      }
+    "#;
+    #[derive(Deserialize)]
+    struct ApplyQuery {
+        #[serde(rename = "environmentApplyChangeSet")]
+        result: ApplyResult,
+    }
+    #[derive(Deserialize)]
+    struct ApplyResult {
+        id: String,
+        status: String,
+        #[serde(flatten)]
+        rest: Value,
+    }
+    let applied = post_graphql_raw::<ApplyQuery, _>(client, endpoint, mutation, variables).await?;
+    if applied.result.status != "applying" {
+        let mut value = serde_json::to_value(&applied.result.rest)?;
+        value["id"] = json!(applied.result.id);
+        value["status"] = json!(applied.result.status);
+        return Ok(value);
+    }
+    wait_for_apply(client, endpoint, environment_id, &applied.result.id).await
+}
+
+async fn wait_for_apply(
+    client: &reqwest::Client,
+    endpoint: &str,
+    environment_id: &str,
+    id: &str,
+) -> Result<Value> {
+    let query = r#"
+      query IacChangeSetApplyStatus($environmentId: String!, $id: String!) {
+        environmentChangeSetApply(environmentId: $environmentId, id: $id) {
+          id status deploymentId stagedPatchId diagnostics changes { kind path summary status outputs }
+        }
+      }
+    "#;
+    #[derive(Deserialize)]
+    struct StatusQuery {
+        #[serde(rename = "environmentChangeSetApply")]
+        result: Value,
+    }
+    for _ in 0..120 {
+        let data = post_graphql_raw::<StatusQuery, _>(
+            client,
+            endpoint,
+            query,
+            json!({ "environmentId": environment_id, "id": id }),
+        )
+        .await?;
+        if data.result.get("status").and_then(Value::as_str) != Some("applying") {
+            return Ok(data.result);
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    bail!("Timed out waiting for Railway ChangeSet apply {id}")
+}

--- a/src/iac/eval.rs
+++ b/src/iac/eval.rs
@@ -1,0 +1,214 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+use serde_json::{Value, json};
+
+use super::compiler::project_definition_to_graph;
+use super::graph::RailwayGraph;
+use super::partial::parse_partial_name;
+
+pub struct EvaluatedFile {
+    pub file: PathBuf,
+    pub graph: RailwayGraph,
+    pub partial: Option<String>,
+}
+
+pub fn evaluate_file(file: &Path) -> Result<EvaluatedFile> {
+    let file = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+    let ext = file
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let payload = match ext.as_str() {
+        "py" => evaluate_python(&file)?,
+        "go" => evaluate_go(&file)?,
+        "ts" | "mts" | "cts" | "js" | "mjs" | "cjs" => evaluate_javascript(&file)?,
+        other => bail!("Unsupported IaC file extension: .{other}"),
+    };
+    let partial = parse_partial_name(payload.get("partial").and_then(Value::as_str))
+        .map_err(|err| anyhow::anyhow!(err))?;
+    let project = payload
+        .get("project")
+        .cloned()
+        .or_else(|| payload.get("graph").cloned())
+        .unwrap_or(payload.clone());
+    let graph = project_definition_to_graph(&normalize_project(project));
+    Ok(EvaluatedFile {
+        file,
+        graph,
+        partial,
+    })
+}
+
+fn normalize_project(mut project: Value) -> Value {
+    if project.get("resources").is_none() {
+        if let Some(resources) = project.get("Resources").cloned() {
+            project["resources"] = resources;
+        }
+    }
+    if let Some(resources) = project.get_mut("resources").and_then(Value::as_array_mut) {
+        for resource in resources {
+            if resource.get("address").is_none() {
+                let kind = resource
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .unwrap_or("service");
+                let name = resource
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("web");
+                resource["address"] = json!(format!("{kind}.{name}"));
+            }
+            if resource.get("kind").is_none()
+                && resource.get("type").and_then(Value::as_str) == Some("service")
+            {
+                resource["kind"] = json!("empty");
+            }
+            if let Some(start) = resource.get("start").cloned() {
+                if resource.get("deploy").is_none() {
+                    resource["deploy"] = json!({});
+                }
+                if resource["deploy"].get("startCommand").is_none() {
+                    resource["deploy"]["startCommand"] = start;
+                }
+            }
+            if let Some(build) = resource.get("build").cloned() {
+                if build.is_string() {
+                    resource["build"] = json!({ "buildCommand": build });
+                }
+            }
+        }
+    }
+    if project.get("name").is_none() {
+        project["name"] = json!("app");
+    }
+    project
+}
+
+fn evaluate_python(file: &Path) -> Result<Value> {
+    let script = r#"
+import importlib.util, json, sys
+path = sys.argv[1]
+spec = importlib.util.spec_from_file_location("railway_iac_user", path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+partial = getattr(mod, "PARTIAL", None) or getattr(mod, "Partial", None) or getattr(mod, "partial", None)
+candidate = getattr(mod, "main", None) or getattr(mod, "Railway", None) or getattr(mod, "default", None)
+project = candidate() if callable(candidate) else candidate
+if hasattr(project, "to_graph"):
+    project = project.to_graph()
+print(json.dumps({"partial": partial, "project": project}, default=str))
+"#;
+    let output = Command::new("python3")
+        .args(["-c", script, &file.to_string_lossy()])
+        .output()
+        .context("Failed to run python3 to evaluate .railway/railway.py")?;
+    decode_eval_output("python3", &output)
+}
+
+fn evaluate_go(file: &Path) -> Result<Value> {
+    let dir = file
+        .parent()
+        .context("Go IaC file has no parent directory")?;
+    let wrapper = dir.join(".railway-iac-eval.go");
+    let has_partial = fs::read_to_string(file)
+        .unwrap_or_default()
+        .contains("Partial");
+    let source = if has_partial {
+        r#"package main
+import ("encoding/json"; "os")
+func main() {
+  out, err := json.Marshal(map[string]any{"partial": Partial, "project": Railway().Graph()})
+  if err != nil { panic(err) }
+  os.Stdout.Write(out)
+}
+"#
+    } else {
+        r#"package main
+import ("encoding/json"; "os")
+func main() {
+  out, err := json.Marshal(map[string]any{"project": Railway().Graph()})
+  if err != nil { panic(err) }
+  os.Stdout.Write(out)
+}
+"#
+    };
+    fs::write(&wrapper, source)?;
+    let output = Command::new("go")
+        .args([
+            "run",
+            file.file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("railway.go"),
+            wrapper
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(".railway-iac-eval.go"),
+        ])
+        .current_dir(dir)
+        .output();
+    let _ = fs::remove_file(&wrapper);
+    decode_eval_output(
+        "go run",
+        &output.context("Failed to run go to evaluate .railway/railway.go")?,
+    )
+}
+
+fn evaluate_javascript(file: &Path) -> Result<Value> {
+    let script = r#"
+import { pathToFileURL } from "node:url";
+const file = process.argv[1];
+const mod = await import(`${pathToFileURL(file).href}?t=${Date.now()}`);
+const partial = mod.partial ?? mod.PARTIAL ?? mod.Partial ?? undefined;
+let exported = mod.default ?? mod.main ?? mod.Railway ?? mod;
+while (exported && typeof exported === "object" && "default" in exported && exported.name == null && exported.resources == null) {
+  exported = exported.default;
+}
+const project = typeof exported === "function" ? await exported({}) : exported;
+const graph = project && typeof project === "object" && "to_graph" in project ? project.to_graph() : project;
+process.stdout.write(JSON.stringify({ partial, project: graph }));
+"#;
+    let mut command = Command::new("node");
+    command.args([
+        "--experimental-strip-types",
+        "--disable-warning=ExperimentalWarning",
+        "--input-type=module",
+        "-e",
+        script,
+        "--",
+        &file.to_string_lossy(),
+    ]);
+    if let Some(modules) = nearest_node_modules(file) {
+        command.env("NODE_PATH", modules);
+    }
+    let output = command
+        .output()
+        .context("Failed to run node to evaluate the IaC file")?;
+    decode_eval_output("node", &output)
+}
+
+fn nearest_node_modules(start: &Path) -> Option<PathBuf> {
+    for dir in start.ancestors() {
+        let candidate = dir.join("node_modules");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn decode_eval_output(runtime: &str, output: &std::process::Output) -> Result<Value> {
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !output.status.success() {
+        bail!("{runtime} failed to evaluate IaC file.\n{stderr}\n{stdout}");
+    }
+    serde_json::from_str(&stdout).with_context(|| {
+        format!("{runtime} returned non-JSON output.\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    })
+}

--- a/src/iac/graph.rs
+++ b/src/iac/graph.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::json::field_str;
+
+pub const RAILWAY_GRAPH_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct RailwayGraph {
+    pub version: u32,
+    pub project: ProjectNode,
+    #[serde(default)]
+    pub environments: Vec<EnvironmentNode>,
+    #[serde(default)]
+    pub resources: Vec<Value>,
+    #[serde(default)]
+    pub edges: Vec<Edge>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ProjectNode {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct EnvironmentNode {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Edge {
+    pub from: String,
+    pub to: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+}
+
+pub fn resource_address(resource_type: &str, name: &str) -> String {
+    format!("{resource_type}.{name}")
+}
+
+pub fn resource_type(resource: &Value) -> &str {
+    field_str(resource, "type").unwrap_or("")
+}
+
+pub fn resource_name(resource: &Value) -> &str {
+    field_str(resource, "name").unwrap_or("")
+}
+
+pub fn resource_addr(resource: &Value) -> String {
+    field_str(resource, "address")
+        .map(str::to_string)
+        .unwrap_or_else(|| resource_address(resource_type(resource), resource_name(resource)))
+}
+
+pub fn validate_graph(graph: &RailwayGraph) -> Vec<String> {
+    let mut errors = Vec::new();
+    if graph.version != RAILWAY_GRAPH_VERSION {
+        errors.push(format!("Unsupported graph version: {}", graph.version));
+    }
+    let mut addresses = std::collections::HashSet::new();
+    for resource in &graph.resources {
+        let address = resource_addr(resource);
+        if !addresses.insert(address.clone()) {
+            errors.push(format!("Duplicate resource address: {address}"));
+        }
+    }
+    for edge in &graph.edges {
+        if !addresses.contains(&edge.from) {
+            errors.push(format!("Edge references missing source: {}", edge.from));
+        }
+        if !addresses.contains(&edge.to) {
+            errors.push(format!("Edge references missing target: {}", edge.to));
+        }
+    }
+    errors
+}

--- a/src/iac/json.rs
+++ b/src/iac/json.rs
@@ -1,0 +1,93 @@
+use serde_json::{Map, Value};
+
+pub fn clone_value(value: &Value) -> Value {
+    value.clone()
+}
+
+pub fn as_object(value: &Value) -> Option<&Map<String, Value>> {
+    value.as_object()
+}
+
+pub fn as_object_mut(value: &mut Value) -> Option<&mut Map<String, Value>> {
+    value.as_object_mut()
+}
+
+pub fn field<'a>(value: &'a Value, name: &str) -> Option<&'a Value> {
+    value.get(name)
+}
+
+pub fn field_str<'a>(value: &'a Value, name: &str) -> Option<&'a str> {
+    value.get(name).and_then(Value::as_str)
+}
+
+pub fn stable_stringify(value: &Value) -> String {
+    serde_json::to_string(&sort_for_json(value)).unwrap_or_else(|_| "null".to_string())
+}
+
+pub fn sort_for_json(value: &Value) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(sort_for_json).collect()),
+        Value::Object(map) => {
+            let mut keys: Vec<_> = map.keys().cloned().collect();
+            keys.sort();
+            let mut out = Map::new();
+            for key in keys {
+                if let Some(child) = map.get(&key) {
+                    out.insert(key, sort_for_json(child));
+                }
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
+pub fn prune_empty(value: Value) -> Value {
+    prune_empty_at(value, &[])
+}
+
+fn prune_empty_at(value: Value, path: &[&str]) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .map(|child| prune_empty_at(child, path))
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let mut out = Map::new();
+            for (key, child) in map {
+                let mut next_path = path.to_vec();
+                next_path.push(key.as_str());
+                let child = prune_empty_at(child, &next_path);
+                if child.is_null() {
+                    continue;
+                }
+                if let Value::Object(ref inner) = child {
+                    let keep_empty = matches!(
+                        path.last().copied(),
+                        Some("customDomains") | Some("serviceDomains") | Some("tcpProxies")
+                    );
+                    if inner.is_empty() && !keep_empty {
+                        continue;
+                    }
+                }
+                out.insert(key, child);
+            }
+            Value::Object(out)
+        }
+        other => other,
+    }
+}
+
+pub fn merge_objects(base: Value, extra: Value) -> Value {
+    match (base, extra) {
+        (Value::Object(mut left), Value::Object(right)) => {
+            for (key, value) in right {
+                left.insert(key, value);
+            }
+            Value::Object(left)
+        }
+        (_, extra) => extra,
+    }
+}

--- a/src/iac/mod.rs
+++ b/src/iac/mod.rs
@@ -1,0 +1,44 @@
+//! CLI-owned Infrastructure as Code engine.
+//!
+//! Language packages only author a project definition. This module evaluates
+//! those files, diffs against the live environment, and applies ChangeSets.
+//! `--runner` / `RAILWAY_IAC_TS_BIN` still invoke `railway-iac-ts` unchanged.
+
+mod change_set;
+mod compiler;
+mod engine;
+mod eval;
+mod graph;
+mod json;
+mod partial;
+
+#[allow(dead_code)]
+pub use change_set::{ChangeSet, RAILWAY_CHANGE_SET_VERSION, diff_graphs, render_change_set};
+#[allow(dead_code)]
+pub use compiler::{
+    CompileOptions, EnvironmentConfigToGraphOptions, environment_config_to_graph,
+    graph_to_environment_config, project_definition_to_graph,
+};
+pub use engine::{NativeRun, run as run_native};
+#[allow(dead_code)]
+pub use eval::{EvaluatedFile, evaluate_file};
+#[allow(dead_code)]
+pub use graph::{RAILWAY_GRAPH_VERSION, RailwayGraph, resource_address, validate_graph};
+#[allow(dead_code)]
+pub use partial::{needs_partial_claim_apply, parse_partial_name};
+
+pub fn use_legacy_ts_runner(explicit_runner: Option<&str>) -> bool {
+    if explicit_runner.is_some() {
+        return true;
+    }
+    if std::env::var("RAILWAY_IAC_TS_BIN").is_ok() {
+        return true;
+    }
+    matches!(
+        std::env::var("RAILWAY_IAC_ENGINE").as_deref(),
+        Ok("ts") | Ok("typescript") | Ok("legacy")
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/iac/partial.rs
+++ b/src/iac/partial.rs
@@ -1,0 +1,63 @@
+use std::collections::BTreeMap;
+
+pub const PROJECT_PARTIAL: &str = "*";
+const PARTIAL_NAME: &str = r"^[a-zA-Z0-9._-]{1,64}$";
+
+pub type IacPartials = BTreeMap<String, String>;
+
+pub fn parse_partial_name(value: Option<&str>) -> Result<Option<String>, String> {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    if value == PROJECT_PARTIAL || !regex_is_match(value) {
+        return Err(format!(
+            "Invalid partial export: {value:?}. Use a 1–64 character name matching [a-zA-Z0-9._-]+."
+        ));
+    }
+    Ok(Some(value.to_string()))
+}
+
+fn regex_is_match(value: &str) -> bool {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(PARTIAL_NAME).expect("partial name regex"))
+        .is_match(value)
+}
+
+pub fn has_named_partials(owners: Option<&IacPartials>) -> bool {
+    owners
+        .map(|owners| owners.values().any(|owner| owner != PROJECT_PARTIAL))
+        .unwrap_or(false)
+}
+
+pub fn owner_of<'a>(owners: Option<&'a IacPartials>, address: &str) -> Option<&'a str> {
+    owners
+        .and_then(|owners| owners.get(address))
+        .map(String::as_str)
+}
+
+pub fn effective_partial(partial: Option<&str>) -> &str {
+    partial.unwrap_or(PROJECT_PARTIAL)
+}
+
+pub fn foreign_resource_message(address: &str, owner: &str) -> String {
+    let (kind, name) = address
+        .split_once('.')
+        .map(|(kind, name)| (kind, name))
+        .unwrap_or(("resource", address));
+    format!("Cannot manage {kind} \"{name}\": already managed by partial \"{owner}\".")
+}
+
+pub fn nameless_file_message() -> String {
+    "This environment already has named IaC partials. Export `const partial = \"<name>\"` from this file instead of managing the whole project.".to_string()
+}
+
+pub fn needs_partial_claim_apply(
+    declared: &[String],
+    owners: Option<&IacPartials>,
+    partial: Option<&str>,
+) -> bool {
+    let p = effective_partial(partial);
+    declared
+        .iter()
+        .any(|address| owner_of(owners, address) != Some(p))
+}

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -1,0 +1,1030 @@
+use serde_json::{Value, json};
+
+use super::change_set::{DiffOptions, RAILWAY_CHANGE_SET_VERSION, diff_graphs, render_change_set};
+use super::compiler::{
+    CompileOptions, EnvironmentConfigToGraphOptions, environment_config_to_graph,
+    graph_to_environment_config, project_definition_to_graph,
+};
+use super::eval::evaluate_file;
+use super::graph::RAILWAY_GRAPH_VERSION;
+use super::partial::IacPartials;
+
+fn graph_from(resources: Vec<Value>) -> super::graph::RailwayGraph {
+    project_definition_to_graph(&json!({ "name": "app", "resources": resources }))
+}
+
+fn service(name: &str, extra: Value) -> Value {
+    let mut node = json!({
+        "address": format!("service.{name}"),
+        "type": "service",
+        "kind": "empty",
+        "name": name,
+    });
+    if let Some(obj) = extra.as_object() {
+        for (key, value) in obj {
+            node[key] = value.clone();
+        }
+    }
+    if node
+        .get("source")
+        .and_then(|s| s.get("type"))
+        .and_then(Value::as_str)
+        == Some("github")
+    {
+        node["kind"] = json!("github");
+    }
+    if node
+        .get("source")
+        .and_then(|s| s.get("type"))
+        .and_then(Value::as_str)
+        == Some("image")
+    {
+        node["kind"] = json!("docker-image");
+    }
+    node
+}
+
+fn github(repo: &str) -> Value {
+    json!({ "type": "github", "repo": repo, "branch": "main" })
+}
+
+fn image(name: &str) -> Value {
+    json!({ "type": "image", "image": name })
+}
+
+fn postgres(name: &str, region: Option<&str>) -> Value {
+    let mut node = json!({
+        "address": format!("database.{name}"),
+        "type": "database",
+        "kind": "database",
+        "engine": "postgres",
+        "name": name,
+        "image": "ghcr.io/railwayapp-templates/postgres-ssl:18",
+        "output": "DATABASE_URL",
+        "defaultMountPath": "/var/lib/postgresql/data",
+        "source": image("ghcr.io/railwayapp-templates/postgres-ssl:18"),
+    });
+    if let Some(region) = region {
+        node["deploy"] = json!({ "multiRegionConfig": { region: { "numReplicas": 1 } } });
+    }
+    node
+}
+
+fn redis(name: &str) -> Value {
+    json!({
+        "address": format!("database.{name}"),
+        "type": "database",
+        "kind": "database",
+        "engine": "redis",
+        "name": name,
+        "image": "railwayapp/redis:8.2",
+        "output": "REDIS_URL",
+        "defaultMountPath": "/bitnami",
+        "source": image("railwayapp/redis:8.2"),
+    })
+}
+
+fn volume(name: &str, config: Value) -> Value {
+    json!({
+        "address": format!("volume.{name}"),
+        "type": "volume",
+        "name": name,
+        "config": config,
+    })
+}
+
+fn bucket(name: &str, region: &str) -> Value {
+    json!({
+        "address": format!("bucket.{name}"),
+        "type": "bucket",
+        "name": name,
+        "config": { "region": region },
+    })
+}
+
+fn env_config(config: Value) -> super::graph::RailwayGraph {
+    environment_config_to_graph(
+        &config,
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            ..Default::default()
+        },
+    )
+}
+
+fn diff(
+    current: &super::graph::RailwayGraph,
+    desired: &super::graph::RailwayGraph,
+) -> super::change_set::ChangeSet {
+    diff_graphs(DiffOptions {
+        current,
+        desired,
+        reveal_values: false,
+        partial: None,
+        owners: None,
+    })
+}
+
+fn kinds(change_set: &super::change_set::ChangeSet) -> Vec<String> {
+    change_set
+        .changes
+        .iter()
+        .map(|change| {
+            change
+                .get("kind")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn emits_change_set_wire_version() {
+    let current = graph_from(vec![]);
+    let desired = graph_from(vec![service("web", json!({}))]);
+    assert_eq!(RAILWAY_CHANGE_SET_VERSION, 1);
+    assert_eq!(diff(&current, &desired).version, 1);
+    assert_eq!(RAILWAY_GRAPH_VERSION, 1);
+}
+
+#[test]
+fn numeric_replicas_are_count_only() {
+    let graph = graph_from(vec![service(
+        "web",
+        json!({ "deploy": { "numReplicas": 1 } }),
+    )]);
+    let web = graph
+        .resources
+        .iter()
+        .find(|r| r["address"] == "service.web")
+        .unwrap();
+    assert_eq!(web["deploy"], json!({ "numReplicas": 1 }));
+    let config = graph_to_environment_config(&graph, &CompileOptions::default());
+    assert_eq!(
+        config["services"]["web"]["deploy"],
+        json!({ "numReplicas": 1 })
+    );
+}
+
+#[test]
+fn count_only_replica_changes_keep_current_region() {
+    let current = graph_from(vec![service(
+        "web",
+        json!({ "deploy": { "multiRegionConfig": { "us-east4": { "numReplicas": 1 } } } }),
+    )]);
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "deploy": { "numReplicas": 2 } }),
+    )]);
+    let change_set = diff(&current, &desired);
+    assert_eq!(change_set.changes.len(), 1);
+    assert_eq!(change_set.changes[0]["kind"], "resource.update");
+    assert_eq!(change_set.changes[0]["field"], "deploy");
+}
+
+#[test]
+fn dockerfile_build_defaults_do_not_drift() {
+    let current = graph_from(vec![service(
+        "backend",
+        json!({ "build": { "builder": "DOCKERFILE", "dockerfilePath": "Dockerfile", "buildCommand": "" } }),
+    )]);
+    let desired = graph_from(vec![service(
+        "backend",
+        json!({ "build": { "builder": "DOCKERFILE" } }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn volume_upsize_is_safe_downsize_is_destructive() {
+    let small = graph_from(vec![volume("data", json!({ "sizeMB": 1024 }))]);
+    let large = graph_from(vec![volume("data", json!({ "sizeMB": 2048 }))]);
+    assert_eq!(diff(&small, &large).changes[0]["severity"], "safe");
+    assert_eq!(diff(&large, &small).changes[0]["severity"], "destructive");
+}
+
+#[test]
+fn shared_variable_references_compile() {
+    let graph = graph_from(vec![service(
+        "web",
+        json!({
+            "variables": {
+                "API_KEY": { "type": "sharedReference", "name": "API_KEY" },
+                "DASHED": { "type": "sharedReference", "name": "DASHED-KEY" }
+            }
+        }),
+    )]);
+    let config = graph_to_environment_config(&graph, &CompileOptions::default());
+    assert_eq!(
+        config["services"]["web"]["variables"],
+        json!({
+            "API_KEY": { "value": "${{shared.API_KEY}}" },
+            "DASHED": { "value": "${{shared.DASHED-KEY}}" }
+        })
+    );
+}
+
+#[test]
+fn database_region_maps_to_service_and_volume() {
+    let graph = graph_from(vec![postgres("db", Some("europe-west4"))]);
+    let config = graph_to_environment_config(
+        &graph,
+        &CompileOptions {
+            service_ids_by_name: super::compiler::map_from_str(&[("db", "service-id")]),
+            volume_ids_by_service_name: super::compiler::map_from_str(&[("db", "volume-id")]),
+            existing_service_ids: vec!["service-id".into()],
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        config["services"]["service-id"]["deploy"]["multiRegionConfig"],
+        json!({ "europe-west4": { "numReplicas": 1 } })
+    );
+    assert_eq!(config["volumes"]["volume-id"]["region"], "europe-west4");
+}
+
+#[test]
+fn database_region_change_is_destructive() {
+    let current = graph_from(vec![postgres("db", Some("us-west2"))]);
+    let desired = graph_from(vec![postgres("db", Some("europe-west4"))]);
+    let change = &diff(&current, &desired).changes[0];
+    assert_eq!(change["severity"], "destructive");
+    assert_eq!(change["summary"], "Move database db to europe-west4");
+}
+
+#[test]
+fn imported_database_without_explicit_region_is_clean() {
+    let current = environment_config_to_graph(
+        &json!({
+            "services": {
+                "db-id": {
+                    "source": { "image": "ghcr.io/railwayapp-templates/postgres-ssl:18" },
+                    "deploy": {
+                        "multiRegionConfig": { "us-east4-eqdc4a": { "numReplicas": 1 } },
+                        "requiredMountPath": "/var/lib/postgresql/data"
+                    },
+                    "volumeMounts": { "vol-id": { "mountPath": "/var/lib/postgresql/data" } }
+                }
+            }
+        }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            service_names_by_id: super::compiler::map_from_str(&[("db-id", "postgres")]),
+            ..Default::default()
+        },
+    );
+    let desired = graph_from(vec![postgres("postgres", None)]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn custom_domain_registration_is_diagnosed() {
+    let current = env_config(json!({ "services": {} }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "networking": { "customDomains": { "app.example.com": { "port": 8080 } } } }),
+    )]);
+    let result = diff(&current, &desired);
+    assert!(!result.changes.iter().any(|c| c["kind"] == "domain.create"));
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("not supported"))
+    );
+}
+
+#[test]
+fn existing_custom_domains_are_plan_clean() {
+    let current = environment_config_to_graph(
+        &json!({ "services": { "web": {} } }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            custom_domains_by_service_id: {
+                let mut map = serde_json::Map::new();
+                map.insert("web".into(), json!({ "app.example.com": {} }));
+                map
+            },
+            ..Default::default()
+        },
+    );
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "networking": { "customDomains": { "app.example.com": {} } } }),
+    )]);
+    let result = diff(&current, &desired);
+    assert!(result.changes.is_empty());
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn round_tripped_config_plans_no_changes() {
+    let desired = graph_from(vec![
+        service(
+            "web",
+            json!({
+                "source": github("railwayapp/demo"),
+                "variables": { "PUBLIC_FLAG": { "type": "literal", "value": "on" } }
+            }),
+        ),
+        service(
+            "worker",
+            json!({ "source": image("ghcr.io/acme/worker:1.2.3") }),
+        ),
+    ]);
+    let current = environment_config_to_graph(
+        &graph_to_environment_config(&desired, &CompileOptions::default()),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            ..Default::default()
+        },
+    );
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn template_database_start_command_does_not_churn() {
+    let current = env_config(json!({
+        "services": {
+            "cache": {
+                "source": { "image": "ghcr.io/railwayapp-templates/redis:8" },
+                "deploy": {
+                    "requiredMountPath": "/data",
+                    "startCommand": "/bin/sh -c \"exec docker-entrypoint.sh redis-server --requirepass $REDIS_PASSWORD\""
+                }
+            }
+        }
+    }));
+    let desired = graph_from(vec![redis("cache")]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn inline_volume_config_is_hoisted() {
+    let graph = project_definition_to_graph(&json!({
+        "name": "app",
+        "resources": [service("web", json!({
+            "volumeAttachments": {
+                "data": {
+                    "volume": "volume.data",
+                    "mountPath": "/data",
+                    "volumeConfig": { "sizeMB": 4096, "region": "europe-west4" }
+                }
+            }
+        }))]
+    }));
+    let vol = graph
+        .resources
+        .iter()
+        .find(|r| r["address"] == "volume.data")
+        .unwrap();
+    assert_eq!(
+        vol["config"],
+        json!({ "sizeMB": 4096, "region": "europe-west4" })
+    );
+    assert!(
+        !serde_json::to_string(&graph)
+            .unwrap()
+            .contains("volumeConfig")
+    );
+}
+
+#[test]
+fn platform_volume_alerts_do_not_churn() {
+    let current = environment_config_to_graph(
+        &json!({
+            "services": {
+                "web": {
+                    "source": { "image": "ghcr.io/acme/api:1.2.3" },
+                    "volumeMounts": { "vol-1": { "mountPath": "/data" } }
+                }
+            },
+            "volumes": {
+                "vol-1": {
+                    "sizeMB": 1024,
+                    "region": "us-west2",
+                    "alerts": { "usage": { "80": {}, "95": {}, "100": {} } },
+                    "allowOnlineResize": true
+                }
+            }
+        }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            volume_names_by_id: super::compiler::map_from_str(&[("vol-1", "data")]),
+            ..Default::default()
+        },
+    );
+    let desired = project_definition_to_graph(&json!({
+        "name": "app",
+        "resources": [service("web", json!({
+            "source": image("ghcr.io/acme/api:1.2.3"),
+            "volumeAttachments": {
+                "data": {
+                    "volume": "volume.data",
+                    "mountPath": "/data",
+                    "volumeConfig": { "sizeMB": 1024, "region": "us-west2" }
+                }
+            }
+        }))]
+    }));
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn authored_database_start_command_still_diffs() {
+    let node = |start: &str| {
+        let mut db = postgres("db", None);
+        db["deploy"] = json!({ "startCommand": start });
+        graph_from(vec![db])
+    };
+    assert_eq!(
+        diff(&node("old-start"), &node("new-start")).changes[0]["field"],
+        "deploy"
+    );
+}
+
+#[test]
+fn never_deletes_database_realized_volume() {
+    let current = environment_config_to_graph(
+        &json!({
+            "services": {
+                "db": {
+                    "source": { "image": "ghcr.io/railwayapp-templates/postgres-ssl:18" },
+                    "deploy": { "requiredMountPath": "/var/lib/postgresql/data" },
+                    "volumeMounts": { "vol-1": { "mountPath": "/var/lib/postgresql/data" } }
+                }
+            },
+            "volumes": { "vol-1": { "sizeMB": 50000, "region": "us-west2" } }
+        }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            volume_names_by_id: super::compiler::map_from_str(&[("vol-1", "postgres-volume")]),
+            ..Default::default()
+        },
+    );
+    let desired = graph_from(vec![postgres("db", None)]);
+    let result = diff(&current, &desired);
+    assert!(!kinds(&result).contains(&"resource.delete".to_string()));
+}
+
+#[test]
+fn warns_instead_of_deleting_mounted_volume() {
+    let current = environment_config_to_graph(
+        &json!({
+            "services": {
+                "web": {
+                    "source": { "image": "ghcr.io/acme/api:1.2.3" },
+                    "volumeMounts": { "vol-1": { "mountPath": "/data" } }
+                }
+            },
+            "volumes": { "vol-1": { "sizeMB": 1024, "region": "us-west2" } }
+        }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            volume_names_by_id: super::compiler::map_from_str(&[("vol-1", "data")]),
+            ..Default::default()
+        },
+    );
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "source": image("ghcr.io/acme/api:1.2.3") }),
+    )]);
+    let result = diff(&current, &desired);
+    assert!(!kinds(&result).contains(&"resource.delete".to_string()));
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("never deleted"))
+    );
+}
+
+#[test]
+fn removing_a_service_is_destructive() {
+    let current = env_config(json!({
+        "services": {
+            "web": { "source": { "repo": "railwayapp/demo" } },
+            "api": { "source": { "repo": "railwayapp/api" } }
+        }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "source": github("railwayapp/demo") }),
+    )]);
+    let deletion = diff(&current, &desired)
+        .changes
+        .into_iter()
+        .find(|c| c["kind"] == "resource.delete")
+        .unwrap();
+    assert_eq!(deletion["address"], "service.api");
+    assert_eq!(deletion["severity"], "destructive");
+}
+
+#[test]
+fn does_not_delete_resources_owned_by_another_partial() {
+    let current = env_config(json!({
+        "services": {
+            "api": { "source": { "repo": "acme/api" } },
+            "worker": { "source": { "repo": "acme/worker" } }
+        }
+    }));
+    let desired = graph_from(vec![service(
+        "api",
+        json!({ "source": github("acme/api") }),
+    )]);
+    let mut owners = IacPartials::new();
+    owners.insert("service.api".into(), "api".into());
+    owners.insert("service.worker".into(), "worker".into());
+    let result = diff_graphs(DiffOptions {
+        current: &current,
+        desired: &desired,
+        reveal_values: false,
+        partial: Some("api"),
+        owners: Some(&owners),
+    });
+    assert!(!kinds(&result).contains(&"resource.delete".to_string()));
+    assert_eq!(result.declared, vec!["service.api"]);
+}
+
+#[test]
+fn errors_when_partial_declares_foreign_resource() {
+    let current =
+        env_config(json!({ "services": { "api": { "source": { "repo": "acme/api" } } } }));
+    let desired = graph_from(vec![service(
+        "api",
+        json!({ "source": github("acme/api") }),
+    )]);
+    let mut owners = IacPartials::new();
+    owners.insert("service.api".into(), "api".into());
+    let result = diff_graphs(DiffOptions {
+        current: &current,
+        desired: &desired,
+        reveal_values: false,
+        partial: Some("worker"),
+        owners: Some(&owners),
+    });
+    assert!(result.changes.is_empty());
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("already managed by partial \"api\""))
+    );
+}
+
+#[test]
+fn errors_when_nameless_file_meets_named_partials() {
+    let current =
+        env_config(json!({ "services": { "api": { "source": { "repo": "acme/api" } } } }));
+    let desired = graph_from(vec![service(
+        "api",
+        json!({ "source": github("acme/api") }),
+    )]);
+    let mut owners = IacPartials::new();
+    owners.insert("service.api".into(), "api".into());
+    let result = diff_graphs(DiffOptions {
+        current: &current,
+        desired: &desired,
+        reveal_values: false,
+        partial: None,
+        owners: Some(&owners),
+    });
+    assert!(result.diagnostics.iter().any(|d| d.path == "partial"));
+}
+
+#[test]
+fn whole_project_owner_still_deletes() {
+    let current = env_config(json!({
+        "services": {
+            "web": { "source": { "repo": "railwayapp/demo" } },
+            "api": { "source": { "repo": "railwayapp/api" } }
+        }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "source": github("railwayapp/demo") }),
+    )]);
+    let mut owners = IacPartials::new();
+    owners.insert("service.web".into(), "*".into());
+    owners.insert("service.api".into(), "*".into());
+    let result = diff_graphs(DiffOptions {
+        current: &current,
+        desired: &desired,
+        reveal_values: false,
+        partial: None,
+        owners: Some(&owners),
+    });
+    assert!(
+        result
+            .changes
+            .iter()
+            .any(|c| c["address"] == "service.api" && c["kind"] == "resource.delete")
+    );
+}
+
+#[test]
+fn deletes_a_partials_own_omitted_service() {
+    let current = env_config(json!({
+        "services": {
+            "api": { "source": { "repo": "acme/api" } },
+            "extra": { "source": { "repo": "acme/extra" } }
+        }
+    }));
+    let desired = graph_from(vec![service(
+        "api",
+        json!({ "source": github("acme/api") }),
+    )]);
+    let mut owners = IacPartials::new();
+    owners.insert("service.api".into(), "api".into());
+    owners.insert("service.extra".into(), "api".into());
+    let result = diff_graphs(DiffOptions {
+        current: &current,
+        desired: &desired,
+        reveal_values: false,
+        partial: Some("api"),
+        owners: Some(&owners),
+    });
+    assert!(
+        result
+            .changes
+            .iter()
+            .any(|c| c["address"] == "service.extra" && c["kind"] == "resource.delete")
+    );
+}
+
+#[test]
+fn variable_removal_is_destructive() {
+    let current = env_config(json!({
+        "services": { "web": { "source": { "repo": "r" }, "variables": { "OLD": { "value": "1" } } } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": github("r"),
+            "variables": { "NEW": { "type": "literal", "value": "2" } }
+        }),
+    )]);
+    let changes = diff(&current, &desired).changes;
+    assert!(changes.iter().any(|c| c["kind"] == "variable.delete"
+        && c["variable"] == "OLD"
+        && c["severity"] == "destructive"));
+    assert!(
+        changes.iter().any(|c| c["kind"] == "variable.set"
+            && c["variable"] == "NEW"
+            && c["severity"] == "safe")
+    );
+}
+
+#[test]
+fn preserve_variable_never_plans() {
+    let current = env_config(json!({
+        "services": { "web": { "source": { "repo": "r" }, "variables": { "SECRET": { "value": "existing" } } } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": github("r"),
+            "variables": { "SECRET": { "type": "preserve" } }
+        }),
+    )]);
+    assert!(
+        diff(&current, &desired)
+            .changes
+            .iter()
+            .all(|c| { !c["kind"].as_str().unwrap_or("").starts_with("variable") })
+    );
+}
+
+#[test]
+fn redacts_variable_values_in_plan_output() {
+    let secret = "sk-super-secret-value-123";
+    let current = env_config(json!({ "services": { "web": { "source": { "repo": "r" } } } }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": github("r"),
+            "variables": { "API_KEY": { "type": "literal", "value": secret } }
+        }),
+    )]);
+    let change_set = diff(&current, &desired);
+    let change = change_set
+        .changes
+        .iter()
+        .find(|c| c["variable"] == "API_KEY")
+        .unwrap();
+    let rendered = format!(
+        "{}{:?}{:?}",
+        render_change_set(&change_set),
+        change.get("summary"),
+        change.get("details")
+    );
+    assert!(!rendered.contains(secret));
+    assert!(rendered.contains("«hidden»"));
+    assert_eq!(change["after"]["value"], secret);
+}
+
+#[test]
+fn reveal_values_prints_secrets() {
+    let secret = "sk-super-secret-value-123";
+    let current = env_config(json!({ "services": { "web": { "source": { "repo": "r" } } } }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": github("r"),
+            "variables": { "API_KEY": { "type": "literal", "value": secret } }
+        }),
+    )]);
+    let change_set = diff_graphs(DiffOptions {
+        current: &current,
+        desired: &desired,
+        reveal_values: true,
+        partial: None,
+        owners: None,
+    });
+    let details = change_set.changes[0]["details"][0].as_str().unwrap();
+    assert!(details.contains(secret));
+    assert!(!details.contains("«hidden»"));
+}
+
+#[test]
+fn registry_credentials_first_apply_plans_and_redacts() {
+    let password = "hunter2-secret";
+    let current = env_config(
+        json!({ "services": { "web": { "source": { "image": "ghcr.io/acme/api:1.2.3" } } } }),
+    );
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/api:1.2.3"),
+            "deploy": { "registryCredentials": { "username": "robot", "password": password } }
+        }),
+    )]);
+    let changes = diff(&current, &desired).changes;
+    assert_eq!(changes[0]["field"], "deploy");
+    assert!(!format!("{:?}", changes[0]["details"]).contains(password));
+}
+
+#[test]
+fn masked_registry_credentials_do_not_churn() {
+    let current = env_config(json!({
+        "services": { "web": {
+            "source": { "image": "ghcr.io/acme/api:1.2.3" },
+            "deploy": { "registryCredentials": { "username": "*****", "password": "*****" } }
+        } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/api:1.2.3"),
+            "deploy": { "registryCredentials": { "username": "robot", "password": "hunter2-secret" } }
+        }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn null_registry_credentials_do_not_churn() {
+    let current = env_config(json!({
+        "services": { "web": {
+            "source": { "image": "ghcr.io/acme/api:1.2.3" },
+            "deploy": { "registryCredentials": null }
+        } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/api:1.2.3"),
+            "deploy": { "registryCredentials": { "username": "robot", "password": "hunter2-secret" } }
+        }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn omitting_credentials_does_not_plan_removal() {
+    let current = env_config(json!({
+        "services": { "web": {
+            "source": { "image": "ghcr.io/acme/api:1.2.3" },
+            "deploy": { "registryCredentials": { "username": "*****", "password": "*****" } }
+        } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "source": image("ghcr.io/acme/api:1.2.3") }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn decrypted_credential_rotation_plans_without_leaking() {
+    let password = "hunter2-secret";
+    let current = env_config(json!({
+        "services": { "web": {
+            "source": { "image": "ghcr.io/acme/api:1.2.3" },
+            "deploy": { "registryCredentials": { "username": "robot", "password": "old-password" } }
+        } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/api:1.2.3"),
+            "deploy": { "registryCredentials": { "username": "robot", "password": password } }
+        }),
+    )]);
+    let changes = diff(&current, &desired).changes;
+    let rendered = format!(
+        "{:?}{:?}",
+        changes[0].get("summary"),
+        changes[0].get("details")
+    );
+    assert!(rendered.contains("registryCredentials"));
+    assert!(!rendered.contains(password));
+    assert!(!rendered.contains("old-password"));
+}
+
+#[test]
+fn rotate_one_field_when_remote_is_masked() {
+    let password = "hunter2-secret";
+    let current = env_config(json!({
+        "services": { "web": {
+            "source": { "image": "ghcr.io/acme/api:1.2.3" },
+            "deploy": { "registryCredentials": { "username": "*****", "password": "*****" } }
+        } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/api:1.2.3"),
+            "deploy": { "registryCredentials": { "username": "*****", "password": password } }
+        }),
+    )]);
+    assert_eq!(
+        diff(&current, &desired).changes[0]["after"],
+        json!({ "registryCredentials": { "password": password } })
+    );
+}
+
+#[test]
+fn image_to_github_clears_credentials() {
+    let current = env_config(json!({
+        "services": { "web": {
+            "source": { "image": "ghcr.io/acme/api:1.2.3" },
+            "deploy": { "registryCredentials": { "username": "*****", "password": "*****" } }
+        } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "source": github("railwayapp/api") }),
+    )]);
+    let changes = diff(&current, &desired).changes;
+    assert!(changes.iter().any(|c| c["field"] == "source"));
+    assert!(changes.iter().any(|c| c["field"] == "deploy" && c["after"] == json!({ "registryCredentials": null })));
+}
+
+#[test]
+fn stale_auto_updates_on_github_source_do_not_drift() {
+    let current = env_config(json!({
+        "services": { "web": { "source": { "repo": "acme/api", "branch": "main", "autoUpdates": { "type": "patch", "schedule": [] } } } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({ "source": github("acme/api") }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn refuses_repo_config_owned_service() {
+    let current = env_config(json!({
+        "services": { "web": { "source": { "repo": "r" }, "configFile": "railway.json" } }
+    }));
+    let desired = graph_from(vec![service("web", json!({ "source": github("r") }))]);
+    let result = diff(&current, &desired);
+    assert!(result.changes.is_empty());
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("railway.json"))
+    );
+}
+
+#[test]
+fn restores_volume_group_membership() {
+    let graph = environment_config_to_graph(
+        &json!({
+            "groups": { "group-id": { "name": "Storage" } },
+            "volumes": { "volume-id": { "region": "us-west2", "sizeMB": 1024 } }
+        }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            volume_names_by_id: super::compiler::map_from_str(&[("volume-id", "data")]),
+            volume_group_ids_by_id: super::compiler::map_from_str(&[("volume-id", "group-id")]),
+            ..Default::default()
+        },
+    );
+    assert!(
+        graph
+            .resources
+            .iter()
+            .any(|r| r["address"] == "volume.data" && r["groupId"] == "Storage")
+    );
+}
+
+#[test]
+fn omits_unreferenced_canvas_groups() {
+    let graph = env_config(json!({
+        "groups": {
+            "production": { "name": "Production" },
+            "test": { "name": "Test-only Sandbox" }
+        },
+        "services": { "web": { "source": { "image": "nginx:latest" }, "groupId": "production" } }
+    }));
+    assert!(
+        graph
+            .resources
+            .iter()
+            .any(|r| r["address"] == "group.Production")
+    );
+    assert!(
+        !graph
+            .resources
+            .iter()
+            .any(|r| r["address"] == "group.Test-only Sandbox")
+    );
+}
+
+#[test]
+fn bucket_region_change_is_an_error() {
+    let current = env_config(json!({ "buckets": { "assets": { "region": "sjc" } } }));
+    let desired = graph_from(vec![bucket("assets", "ams")]);
+    assert!(
+        diff(&current, &desired)
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("region"))
+    );
+}
+
+#[test]
+fn evaluates_typescript_default_export() {
+    let dir = tempfile_dir("railway-iac-ts-");
+    let file = dir.join("railway.ts");
+    std::fs::write(
+        &file,
+        r#"
+export const partial = "api";
+export default () => ({
+  name: "app",
+  resources: [{ address: "service.api", type: "service", name: "api" }],
+});
+"#,
+    )
+    .unwrap();
+    let evaluated = evaluate_file(&file).expect("node should evaluate railway.ts");
+    assert_eq!(evaluated.partial.as_deref(), Some("api"));
+    assert!(
+        evaluated
+            .graph
+            .resources
+            .iter()
+            .any(|r| r["address"] == "service.api")
+    );
+}
+
+#[test]
+fn evaluates_python_partial_and_graph() {
+    let dir = tempfile_dir("railway-iac-py-");
+    let file = dir.join("railway.py");
+    std::fs::write(
+        &file,
+        r#"
+PARTIAL = "api"
+def main(ctx=None):
+    return {"name": "app", "resources": [{"type": "service", "name": "api", "start": "echo api"}]}
+"#,
+    )
+    .unwrap();
+    let evaluated = evaluate_file(&file).expect("python3 should evaluate railway.py");
+    assert_eq!(evaluated.partial.as_deref(), Some("api"));
+    assert!(
+        evaluated
+            .graph
+            .resources
+            .iter()
+            .any(|r| r["address"] == "service.api")
+    );
+}
+
+fn tempfile_dir(prefix: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("{prefix}{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn legacy_runner_only_when_explicitly_requested() {
+    assert!(!super::use_legacy_ts_runner(None));
+    assert!(super::use_legacy_ts_runner(Some("railway-iac-ts")));
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use clap::error::ErrorKind;
 
 mod commands;
+mod iac;
 use commands::*;
 use config::Configs;
 use errors::RailwayError;


### PR DESCRIPTION
## Summary
- `railway config plan` / `apply` / `current` now run the IaC engine in the CLI: evaluate `.railway/railway.ts|py|go` with that language's runtime, then diff and apply from Rust.
- Existing TypeScript runner behavior is unchanged when `--runner`, `RAILWAY_IAC_TS_BIN`, or `RAILWAY_IAC_ENGINE=ts` is set — those still spawn `railway-iac-ts`.
- Diff/compiler coverage is ported from the TS SDK (`tests/iac.test.ts`): replicas, volumes, partials, credentials, CaC ownership, round-trip plan-clean, plus TS/Python file eval.

## Test plan
- [x] `cargo test --bin railway -- iac::tests` (43 tests)
- [ ] `railway config plan` on an existing `.railway/railway.ts` project **without** `RAILWAY_IAC_TS_BIN` (native path)
- [ ] Same project with `RAILWAY_IAC_TS_BIN` or `--runner` still uses the TS binary
- [ ] `railway config plan` on a `.railway/railway.py` file does not require `railway-iac-ts`
- [ ] Empty plan / apply skip still matches previous CLI output


Made with [Cursor](https://cursor.com)