### PR TITLE
perf(cloud-agent): faster launches across all harnesses

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -603,6 +603,8 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
                 &agent.environment_id,
                 &agent.id,
                 &access,
+                // Caught mid-boot: it may be routable right now.
+                std::time::Duration::ZERO,
             )
             .await
             .map(|_| ())
@@ -616,6 +618,8 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
                     &agent.environment_id,
                     &agent.id,
                     &access,
+                    // The wake's physical floor; see the wait's doc.
+                    std::time::Duration::from_millis(350),
                 )
                 .await
                 .map(|_| ())
@@ -648,6 +652,10 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
         )
         .await
     };
+
+    // The user's work is done; let detached telemetry finish before the
+    // process exits (bounded — see drain_detached).
+    crate::commands::ssh::tel::drain_detached(Duration::from_secs(2)).await;
 
     // A connection that never happened still woke a machine with no idle
     // timeout, so put back what this run changed — but only that. An agent

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -636,7 +636,7 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
     ca::remember(configs, &agent)?;
 
     let connected = if !args.command.is_empty() {
-        telemetry::track_lifecycle("ssh_command", Duration::ZERO, None).await;
+        telemetry::track_lifecycle_detached("ssh_command");
         run_command(&agent, &args.command).await
     } else {
         attach(
@@ -746,7 +746,7 @@ async fn attach(
         }
         None => match running.len() {
             0 => {
-                telemetry::track_lifecycle("ssh_new_session", Duration::ZERO, None).await;
+                telemetry::track_lifecycle_detached("ssh_new_session");
                 return start_session(agent).await;
             }
             1 => running[0].name.clone(),
@@ -759,7 +759,7 @@ async fn attach(
         },
     };
 
-    telemetry::track_lifecycle("ssh_attach", Duration::ZERO, None).await;
+    telemetry::track_lifecycle_detached("ssh_attach");
     println!(
         "{}",
         format!("Attaching to {} · {}", agent.name, session_name).dimmed()

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -596,15 +596,29 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
     let ready = match agent.status {
         ca::Status::Running => Ok(()),
         ca::Status::Starting => {
-            code::wait_until_connectable(client, &backboard, &agent.environment_id, &agent.id)
-                .await
-                .map(|_| ())
+            let access = code::relay_access().await?;
+            code::wait_until_connectable(
+                client,
+                &backboard,
+                &agent.environment_id,
+                &agent.id,
+                &access,
+            )
+            .await
+            .map(|_| ())
         }
         ca::Status::Sleeping => match ca::wake(client, &backboard, &agent.id).await {
             Ok(()) => {
-                code::wait_until_connectable(client, &backboard, &agent.environment_id, &agent.id)
-                    .await
-                    .map(|_| ())
+                let access = code::relay_access().await?;
+                code::wait_until_connectable(
+                    client,
+                    &backboard,
+                    &agent.environment_id,
+                    &agent.id,
+                    &access,
+                )
+                .await
+                .map(|_| ())
             }
             Err(e) => Err(e),
         },

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -595,9 +595,11 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
     // box, so this waits rather than issuing a second wake.
     let ready = match agent.status {
         ca::Status::Running => Ok(()),
-        ca::Status::Starting => {
-            let access = code::relay_access().await?;
-            code::wait_until_connectable(
+        // relay_access errors flow into `ready` rather than `?`-ing out: the
+        // spinner above is cleared only after this match, and an early return
+        // would leave it animating over the error output.
+        ca::Status::Starting => match code::relay_access().await {
+            Ok(access) => code::wait_until_connectable(
                 client,
                 &backboard,
                 &agent.environment_id,
@@ -607,12 +609,12 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
                 std::time::Duration::ZERO,
             )
             .await
-            .map(|_| ())
-        }
+            .map(|_| ()),
+            Err(e) => Err(e),
+        },
         ca::Status::Sleeping => match ca::wake(client, &backboard, &agent.id).await {
-            Ok(()) => {
-                let access = code::relay_access().await?;
-                code::wait_until_connectable(
+            Ok(()) => match code::relay_access().await {
+                Ok(access) => code::wait_until_connectable(
                     client,
                     &backboard,
                     &agent.environment_id,
@@ -622,8 +624,9 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
                     std::time::Duration::from_millis(350),
                 )
                 .await
-                .map(|_| ())
-            }
+                .map(|_| ()),
+                Err(e) => Err(e),
+            },
             Err(e) => Err(e),
         },
         _ => Err(anyhow::anyhow!(

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -266,6 +266,16 @@ pub async fn launch_in_pane(args: LaunchArgs) -> Result<()> {
 }
 
 async fn browse_with(opts: BrowseOpts) -> Result<()> {
+    let result = browse_with_inner(opts).await;
+    // The user's work is done; give detached telemetry (launch outcomes, stage
+    // sums) a bounded window before the process exits — a pane session closed
+    // seconds after launching would otherwise drop the very events this
+    // command's telemetry exists to collect. Instant when nothing is in flight.
+    crate::commands::ssh::tel::drain_detached(std::time::Duration::from_secs(2)).await;
+    result
+}
+
+async fn browse_with_inner(opts: BrowseOpts) -> Result<()> {
     let BrowseOpts {
         initial_screen,
         collapsed,
@@ -312,12 +322,37 @@ async fn browse_with(opts: BrowseOpts) -> Result<()> {
         },
     );
     spinner.finish_and_clear();
-    let (_, tree) = loaded?;
+    let (_, tree) = match loaded {
+        Ok(pair) => pair,
+        Err(e) => {
+            // The early pipeline may already have created an agent; exiting on
+            // the tree/flag error without saying so would orphan a billing VM
+            // with no user-visible record.
+            if let Some(inflight) = inflight
+                && let Some(note) = inflight
+                    .settle_for_abort(std::time::Duration::from_secs(30))
+                    .await
+            {
+                eprintln!("{}", note.yellow());
+            }
+            return Err(e);
+        }
+    };
     if tree.is_empty() {
         println!(
             "No projects with environments you can use. Create one with {} first.",
             "railway init".cyan()
         );
+        // Same orphan guard as the error path above — an early launch that
+        // somehow targeted an environment this listing can't see still spent
+        // (or is spending) a create.
+        if let Some(inflight) = inflight
+            && let Some(note) = inflight
+                .settle_for_abort(std::time::Duration::from_secs(30))
+                .await
+        {
+            eprintln!("{}", note.yellow());
+        }
         return Ok(());
     }
 

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -210,16 +210,37 @@ async fn browse_into(initial_screen: Option<tui::Screen>) -> Result<()> {
 pub async fn launch_in_pane(args: LaunchArgs) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    // Before anything is resolved or minted: without the flag the create at the
-    // end of all this is refused anyway.
-    access::ensure_enabled(&client, &configs).await?;
     eprintln!(
         "{}",
         "Warning: Railway cloud agents are experimental and APIs may change or break during testing."
             .yellow()
     );
 
-    let resolved = crate::commands::code::resolve_launch(&args, &mut configs, &client).await?;
+    // The flag check races target resolution instead of preceding it: an
+    // un-flagged user is still stopped the moment the check answers — before
+    // any prompt is worth their time — while everyone else no longer pays a
+    // serialized round-trip. `browse_with` checks again beside its tree load,
+    // which is what actually gates the create. Its own `Configs` because
+    // resolve_launch holds the mutable borrow.
+    let resolved = {
+        let ensure_fut = async {
+            let flag_configs = Configs::new()?;
+            access::ensure_enabled(&client, &flag_configs).await
+        };
+        let resolve_fut = crate::commands::code::resolve_launch(&args, &mut configs, &client);
+        tokio::pin!(ensure_fut);
+        tokio::pin!(resolve_fut);
+        tokio::select! {
+            enabled = &mut ensure_fut => {
+                enabled?;
+                resolve_fut.await?
+            }
+            resolved = &mut resolve_fut => {
+                ensure_fut.await?;
+                resolved?
+            }
+        }
+    };
     let launch = tui::LaunchRequest {
         project_id: resolved.project_id,
         environment_id: resolved.environment_id,
@@ -257,15 +278,38 @@ async fn browse_with(opts: BrowseOpts) -> Result<()> {
     // All under one spinner: the flag check and the key check are small
     // queries against the same client, and running them beside the tree load
     // rather than before it keeps them off the clock.
+    //
+    // An arriving launch starts its pipeline in here too, the moment the key
+    // check answers Ready — the tree is for drawing the manage screen, not
+    // something the launch consumes, and waiting for it put the whole
+    // workspace query in front of every `railway code`. Only gate-free
+    // launches start early: a registered key (checked below) and no
+    // interactive Claude mint (checked here), because a pipeline started
+    // before the frame exists has nowhere to ask a question.
+    let launch_early = launch.as_ref().filter(|req| {
+        !(req.harness == "claude" && crate::commands::code::claude_needs_local_mint())
+    });
+    let (key_ready_tx, key_ready_rx) = tokio::sync::oneshot::channel::<bool>();
     let spinner = create_spinner("Loading your projects".to_string());
-    let (loaded, ssh_key) = tokio::join!(
+    let (loaded, ssh_key, inflight) = tokio::join!(
         async {
             tokio::try_join!(
                 access::ensure_enabled(&client, &configs),
                 tui::load_tree(&client, &configs),
             )
         },
-        check_ssh_key(&client, &configs),
+        async {
+            let state = check_ssh_key(&client, &configs).await;
+            let _ = key_ready_tx.send(matches!(state, tui::app::SshKeyState::Ready));
+            state
+        },
+        async {
+            let req = launch_early?;
+            match key_ready_rx.await {
+                Ok(true) => Some(tui::begin_launch_early(req.clone())),
+                _ => None,
+            }
+        },
     );
     spinner.finish_and_clear();
     let (_, tree) = loaded?;
@@ -350,7 +394,14 @@ async fn browse_with(opts: BrowseOpts) -> Result<()> {
     // session ends; bare `railway ca` keeps its tree. Held on the app rather
     // than derived from `autostart`, which the loop consumes on frame one.
     app.quit_when_done = launch.is_some();
-    app.autostart = launch;
+    // A pipeline that started beside the tree load is adopted by the loop;
+    // otherwise the request dispatches normally (and meets the gates) on
+    // frame one.
+    if inflight.is_some() {
+        app.autostart_inflight = inflight;
+    } else {
+        app.autostart = launch;
+    }
 
     let mut pending: Option<tui::LaunchRequest> = None;
     loop {

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -182,7 +182,7 @@ fn reset(home: &Path) -> Result<()> {
         std::fs::remove_file(&path)
             .with_context(|| format!("Failed to remove {}", path.display()))?;
     }
-    crate::commands::code::clear_claude_token_cache();
+    crate::commands::code::clear_claude_token_cache_in(home);
     println!("Cleared cloud agent preferences and cached tokens.");
     println!("Run {} to configure again.", "railway ca setup".cyan());
     Ok(())

--- a/src/commands/cloud_agent/skills_sync.rs
+++ b/src/commands/cloud_agent/skills_sync.rs
@@ -380,11 +380,6 @@ pub fn parse_remote_hash(provision_output: &str) -> Option<String> {
 /// payload, or an unwritable harness directory costs the user their skills, not
 /// their session. The launcher reports which marker came back.
 pub fn provision_script(hash: &str) -> String {
-    let link_dirs = REMOTE_LINK_DIRS
-        .iter()
-        .map(|d| format!("\"$HOME/{d}\""))
-        .collect::<Vec<_>>()
-        .join(" ");
     format!(
         r#"umask 077
 # Read stdin FIRST, before anything that can bail: a script that exits without
@@ -392,7 +387,24 @@ pub fn provision_script(hash: &str) -> String {
 # graceful degradation below into a hard launch failure.
 payload="$HOME/.railway-skills-payload.tgz"
 cat > "$payload"
-command -v tar >/dev/null 2>&1 || {{ rm -f "$payload"; echo SKILLS-NO-TAR; exit 0; }}
+{}"#,
+        sync_body(hash)
+    )
+}
+
+/// The sync steps from a saved `$payload` onward, for scripts that drained
+/// stdin into that file themselves — the combined provision on a fresh agent,
+/// where the tarball rides the same connection as the credential. Failure
+/// paths `exit 0`, so a caller embedding this must print everything else it
+/// needs (AGENT-READY et al) *before* this block.
+pub fn sync_body(hash: &str) -> String {
+    let link_dirs = REMOTE_LINK_DIRS
+        .iter()
+        .map(|d| format!("\"$HOME/{d}\""))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        r#"command -v tar >/dev/null 2>&1 || {{ rm -f "$payload"; echo SKILLS-NO-TAR; exit 0; }}
 staging="$HOME/.railway-skills-incoming"
 rm -rf "$staging" && mkdir -p "$staging" || {{ rm -f "$payload"; echo SKILLS-STAGING-FAILED; exit 0; }}
 tar -xzf "$payload" -C "$staging" --no-same-owner 2>/dev/null || {{ rm -rf "$staging" "$payload"; echo SKILLS-EXTRACT-FAILED; exit 0; }}

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -80,6 +80,22 @@ pub async fn track_launch_outcome(
     .await;
 }
 
+/// [`track_launch_outcome`] fire-and-forget, for the success path: the event
+/// posts a real HTTP round-trip (up to 3s), and awaiting it sat directly
+/// between "agent provisioned" and "session opens" on every launch. The
+/// session that follows runs for minutes, so the detached send always gets
+/// time to complete; failures keep the awaited form because the process is
+/// about to exit and would drop a spawned task.
+pub fn track_launch_outcome_detached(
+    harness: &'static str,
+    created: Option<bool>,
+    duration: Duration,
+) {
+    tokio::spawn(async move {
+        track_launch_outcome(harness, created, duration, None).await;
+    });
+}
+
 /// One lifecycle mutation on an agent (sleep/wake/delete) from the manage
 /// screen, fired once per attempt so both volume and failure rate are
 /// visible per op kind.
@@ -121,6 +137,18 @@ pub async fn track_lifecycle(kind: &str, duration: Duration, error: Option<&str>
         error.map(truncate),
     ))
     .await;
+}
+
+/// [`track_lifecycle`] fire-and-forget, for path-marker events (`ssh_command`,
+/// `ssh_attach`, `ssh_new_session`) fired right before a session opens: the
+/// send is an HTTP round-trip, and awaiting it put that round-trip between
+/// the user and their shell. The session that follows gives the detached task
+/// plenty of runway; completion events at command exit keep the awaited form
+/// so a returning process can't drop them.
+pub fn track_lifecycle_detached(kind: &'static str) {
+    tokio::spawn(async move {
+        track_lifecycle(kind, Duration::ZERO, None).await;
+    });
 }
 
 /// The slug a lifecycle verb reports under. Split out so the shape dashboards

--- a/src/commands/cloud_agent/telemetry.rs
+++ b/src/commands/cloud_agent/telemetry.rs
@@ -91,7 +91,7 @@ pub fn track_launch_outcome_detached(
     created: Option<bool>,
     duration: Duration,
 ) {
-    tokio::spawn(async move {
+    crate::commands::ssh::tel::spawn_detached(async move {
         track_launch_outcome(harness, created, duration, None).await;
     });
 }
@@ -146,7 +146,7 @@ pub async fn track_lifecycle(kind: &str, duration: Duration, error: Option<&str>
 /// plenty of runway; completion events at command exit keep the awaited form
 /// so a returning process can't drop them.
 pub fn track_lifecycle_detached(kind: &'static str) {
-    tokio::spawn(async move {
+    crate::commands::ssh::tel::spawn_detached(async move {
         track_lifecycle(kind, Duration::ZERO, None).await;
     });
 }

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -891,6 +891,10 @@ pub struct App {
     /// the same path a keypress would, so the ssh-key gate and the Claude
     /// mint still get their say.
     pub autostart: Option<LaunchRequest>,
+    /// Like `autostart`, but the pipeline is already running — started beside
+    /// the tree load because its gates were verified up front. The loop adopts
+    /// it on frame one instead of dispatching.
+    pub autostart_inflight: Option<super::InflightLaunch>,
     /// Leave the TUI when the last session pane closes on its own.
     ///
     /// `railway code` came for one session; when the harness exits (ctrl-c
@@ -1020,6 +1024,7 @@ impl App {
             agent_pick: None,
             maximized: false,
             autostart: None,
+            autostart_inflight: None,
             quit_when_done: false,
             exit_note: None,
             pointer_to_app: false,

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -320,6 +320,43 @@ impl Progress for ChannelProgress {
     fn finish(&self) {}
 }
 
+/// A launch pipeline already running before the TUI took the screen, plus the
+/// request that started it. `railway code` starts the pipeline beside the
+/// tree load instead of after it — the tree is for drawing the manage screen,
+/// not something the launch consumes — and the loop adopts this on frame one
+/// exactly where it would otherwise have dispatched the autostart.
+pub(crate) struct InflightLaunch {
+    pub(crate) req: LaunchRequest,
+    rx: mpsc::UnboundedReceiver<Message>,
+}
+
+/// Run the prepare pipeline for `req`, streaming progress and the outcome into
+/// `sink` as loop messages. Shared by [`start_launch`] (sink = the loop's own
+/// channel) and [`begin_launch_early`] (sink = a buffer the loop adopts later).
+fn spawn_prepare(req: LaunchRequest, sink: mpsc::UnboundedSender<Message>) {
+    tokio::spawn(async move {
+        let req = req;
+        let args = launch_args_for(&req);
+        let progress = ChannelProgress(sink.clone());
+        let message = match code::prepare(&args, &progress, code::SessionStyle::Pane).await {
+            Ok(prepared) => Message::LaunchReady(Box::new(prepared), Box::new(req)),
+            Err(err) => Message::LaunchFailed(format!("{err:#}")),
+        };
+        let _ = sink.send(message);
+    });
+}
+
+/// Start `req`'s pipeline now, before the TUI exists, buffering its messages
+/// until the loop adopts them. ONLY for launches every dispatch gate would
+/// wave through — the caller must have verified the SSH key is registered and
+/// no interactive Claude mint is needed, because a pipeline started here has
+/// no frame to raise those questions in and would surface them as failures.
+pub(crate) fn begin_launch_early(req: LaunchRequest) -> InflightLaunch {
+    let (tx, rx) = mpsc::unbounded_channel();
+    spawn_prepare(req.clone(), tx);
+    InflightLaunch { req, rx }
+}
+
 /// Build the tree from the workspace listing. Deleted projects are dropped, and
 /// so are environments the caller cannot access — an agent can't be listed or
 /// created in either, so showing them would only offer dead ends.
@@ -587,6 +624,32 @@ pub async fn run(
             finish_copy(app, copied);
         }
         sync_session_size(app, &terminal);
+
+        // A pipeline `railway code` already started beside the tree load:
+        // adopt it — the same screen moves as a dispatched launch, minus the
+        // gates, which were verified before it was allowed to start (see
+        // `begin_launch_early`).
+        if let Some(inflight) = app.autostart_inflight.take() {
+            let InflightLaunch { req, mut rx } = inflight;
+            app.screen = Screen::Manage;
+            if let Some(Effect::LoadAgents {
+                environment_id,
+                path,
+            }) = app.reveal_environment(&req.environment_id)
+            {
+                spawn_env_agents_fetch(environment_id, path, &tx, &client, &backboard);
+            }
+            app.start_loading(&req);
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                while let Some(message) = rx.recv().await {
+                    if tx.send(message).is_err() {
+                        break;
+                    }
+                }
+            });
+            continue;
+        }
 
         // A launch the caller arrived with, started once the first frame is on
         // screen so the terminal is already in the state the loading pane will
@@ -1583,17 +1646,7 @@ fn dispatch_launch(
 /// Kick off a launch in the background and show the loading screen.
 fn start_launch(app: &mut App, req: LaunchRequest, tx: &mpsc::UnboundedSender<Message>) {
     app.start_loading(&req);
-    let tx = tx.clone();
-    tokio::spawn(async move {
-        let req = req;
-        let args = launch_args_for(&req);
-        let progress = ChannelProgress(tx.clone());
-        let message = match code::prepare(&args, &progress, code::SessionStyle::Pane).await {
-            Ok(prepared) => Message::LaunchReady(Box::new(prepared), Box::new(req)),
-            Err(err) => Message::LaunchFailed(format!("{err:#}")),
-        };
-        let _ = tx.send(message);
-    });
+    spawn_prepare(req, tx.clone());
 }
 
 /// One lifecycle mutation. Kept next to the loop rather than in the app so the

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -330,6 +330,37 @@ pub(crate) struct InflightLaunch {
     rx: mpsc::UnboundedReceiver<Message>,
 }
 
+impl InflightLaunch {
+    /// Wait (bounded) for the running pipeline to settle, for a caller that is
+    /// about to abort with an error: the pipeline may already have CREATED an
+    /// agent, and exiting without saying so would orphan a billing VM with no
+    /// user-visible record. Returns the line to print when there is one.
+    pub(crate) async fn settle_for_abort(mut self, limit: std::time::Duration) -> Option<String> {
+        let deadline = tokio::time::Instant::now() + limit;
+        loop {
+            match tokio::time::timeout_at(deadline, self.rx.recv()).await {
+                Ok(Some(Message::LaunchReady(prepared, _))) => {
+                    return Some(format!(
+                        "A launch was already in flight and created agent {} — `railway ca ssh {}` reattaches it, `railway ca delete {}` removes it.",
+                        prepared.agent_name, prepared.agent_name, prepared.agent_name
+                    ));
+                }
+                // Failed before creating anything worth reporting.
+                Ok(Some(Message::LaunchFailed(_))) => return None,
+                Ok(Some(_)) => continue,
+                // Pipeline gone or still running at the deadline: point at the
+                // list rather than guessing.
+                Ok(None) => return None,
+                Err(_) => {
+                    return Some(
+                        "A launch was still in flight — check `railway ca list` for an agent it may have created.".to_string(),
+                    );
+                }
+            }
+        }
+    }
+}
+
 /// Run the prepare pipeline for `req`, streaming progress and the outcome into
 /// `sink` as loop messages. Shared by [`start_launch`] (sink = the loop's own
 /// channel) and [`begin_launch_early`] (sink = a buffer the loop adopts later).

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1483,6 +1483,7 @@ fn ssh_plumbing(
     identity: Option<&std::path::Path>,
     stdin_payload: Option<&[u8]>,
     relay: &RelaySsh,
+    mux_socket: Option<&std::path::Path>,
 ) -> Result<Vec<u8>> {
     // A woken agent re-boots its entrypoint, and the relay refuses the session
     // until the machine's new incarnation is attachable, so the first attempts
@@ -1518,6 +1519,14 @@ fn ssh_plumbing(
             || stderr_text.contains("REMOTE HOST IDENTIFICATION HAS CHANGED");
         if hostkey_mismatch {
             relay.heal_known_hosts();
+        }
+        // A failed attempt must not leave a master for the next attempt to
+        // ride: removing the socket makes ControlMaster=auto open a genuinely
+        // fresh connection instead of pinning every retry to whatever dead or
+        // misrouted path the failure created — the historical 8/20-timeouts
+        // trap, scoped here to within a single call.
+        if let Some(socket) = mux_socket {
+            let _ = std::fs::remove_file(socket);
         }
         last = (code, reason);
 
@@ -1644,71 +1653,87 @@ pub(crate) async fn wait_until_connectable(
         tokio::time::sleep(initial_delay).await;
     }
     let mut round = 0u32;
+    // The status fetch keeps its OLD ~750ms grid even while probes run at the
+    // tight cadence: it exists only to catch rare terminal states, and letting
+    // it ride the probe cadence would triple backboard polling per launching
+    // client for nothing. Round 1 always fetches.
+    let mut last_fetch: Option<std::time::Instant> = None;
+    let mut last_agent: Option<CodeAgent> = None;
     loop {
         round += 1;
         let round_started = std::time::Instant::now();
 
-        // The probe is what usually ends the wait; the status fetch exists to
-        // catch terminal states. Running them together instead of fetch-then-
-        // probe stops a serialized GraphQL round-trip from pushing the
-        // discovering probe later every round.
-        //
         // Every round probes as a would-be master on its own FRESH socket. A
         // round that lands on the relay's dev.new fall-through (agent not yet
         // routable) leaves a master nothing will ever reference — the socket
         // name is never reused, and only the round whose marker comes back is
-        // promoted. Short persist so the losers evaporate.
+        // promoted. Losers are told to exit below, with a short persist as the
+        // backstop, so they don't pile up relay connections during a slow boot.
         let socket = mux_socket();
         let target = ssh_target.clone();
         let identity = access.identity.clone();
         let mut opts = access.relay_opts.clone();
-        opts.extend(mux_master_opts(&socket, "10s"));
+        opts.extend(mux_master_opts(&socket, "3s"));
         let probe = tokio::task::spawn_blocking(move || {
             probe_native_ssh(&target, identity.as_deref(), &opts)
         });
-        let (agent, routed) =
-            tokio::join!(fetch_agent(client, backboard, environment_id, id), probe);
-        let agent = agent?.ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
-        let routed = routed?.unwrap_or(false);
 
+        // Await the fetch BEFORE the probe (both are already in flight): a
+        // terminal state must bail immediately, not after a probe that can sit
+        // on its full ConnectTimeout against a box that will never answer.
+        let fetch_due = last_fetch.is_none_or(|at| at.elapsed().as_millis() >= 700);
+        if fetch_due {
+            let agent = fetch_agent(client, backboard, environment_id, id)
+                .await?
+                .ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
+            last_fetch = Some(std::time::Instant::now());
+            match agent.status {
+                S::RUNNING | S::STARTING | S::SLEEPING => {}
+                S::CRASHED => bail!(
+                    "Agent {} crashed while starting. `railway code --new` for a fresh one.",
+                    agent.name
+                ),
+                S::FAILED => bail!(
+                    "Agent {} failed to start. `railway code --new` for a fresh one.",
+                    agent.name
+                ),
+                S::DELETING => bail!("Agent {} is being deleted.", agent.name),
+                S::Other(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
+            }
+            // RUNNING routes by definition, so don't spend another round on a
+            // probe that lost the race to the status flip — but there is no
+            // verified connection to promote (the in-flight probe is abandoned;
+            // its master, if any, exits on the persist backstop).
+            if agent.status == S::RUNNING {
+                ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
+                return Ok((agent, None));
+            }
+            last_agent = Some(agent);
+        }
+
+        let routed = probe.await?.unwrap_or(false);
         if diagnostics {
             eprintln!(
-                "[wait_connectable] round {round}: status={:?} round={}ms routed={routed}",
-                agent.status,
+                "[wait_connectable] round {round}: status={:?} round={}ms routed={routed} fetched={fetch_due}",
+                last_agent.as_ref().map(|a| &a.status),
                 round_started.elapsed().as_millis()
             );
         }
         if routed {
             ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
+            let agent = last_agent
+                .ok_or_else(|| anyhow!("Agent {id} was never observed while starting."))?;
             return Ok((agent, Some(socket)));
         }
-        // RUNNING routes by definition, so a probe that lost a race to the
-        // status flip doesn't cost another round — but there is no verified
-        // connection to promote.
-        if agent.status == S::RUNNING {
-            ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
-            return Ok((agent, None));
-        }
-        match agent.status {
-            S::RUNNING | S::STARTING | S::SLEEPING => {}
-            S::CRASHED => bail!(
-                "Agent {} crashed while starting. `railway code --new` for a fresh one.",
-                agent.name
-            ),
-            S::FAILED => bail!(
-                "Agent {} failed to start. `railway code --new` for a fresh one.",
-                agent.name
-            ),
-            S::DELETING => bail!("Agent {} is being deleted.", agent.name),
-            S::Other(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
-        }
+        // This round's would-be master lost; release it now rather than
+        // letting it hold a relay connection for the persist window.
+        release_probe_master(&socket, &ssh_target);
 
         if std::time::Instant::now() >= deadline {
             bail!(
-                "Agent {} did not become connectable within {}s (last state: {:?}).",
-                agent.name,
+                "Agent {id} did not become connectable within {}s (last state: {:?}).",
                 READY_TIMEOUT.as_secs(),
-                agent.status
+                last_agent.map(|a| a.status)
             );
         }
         // Pace rounds to a cadence rather than sleeping on top of the probe: a
@@ -1725,6 +1750,26 @@ pub(crate) async fn wait_until_connectable(
             tokio::time::sleep(rest).await;
         }
     }
+}
+
+/// Tell a losing probe round's background master to exit now instead of
+/// holding an authenticated relay connection until its persist backstop.
+/// Fire-and-forget: the master may not exist (connection never completed) or
+/// may already be gone — both are fine, and nothing waits on the result.
+fn release_probe_master(socket: &std::path::Path, target: &str) {
+    if !mux_usable(socket) {
+        return;
+    }
+    let _ = std::process::Command::new("ssh")
+        .arg("-O")
+        .arg("exit")
+        .arg("-o")
+        .arg(format!("ControlPath={}", socket.display()))
+        .arg(target)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
 }
 
 /// Bring an agent that already exists up to RUNNING: reuse it when it is
@@ -2683,11 +2728,27 @@ async fn prepare_inner(
         ),
         ssh_tel::timed_for("cloud_agent_launch", "ssh_key", async {
             let key_configs = Configs::new()?;
-            ensure_ssh_key_quiet(&client, &key_configs).await
+            // Non-interactive inside the join: resolve_target can be running
+            // its own picker/setup prompts concurrently, and two prompt flows
+            // interleaved on one terminal are gibberish. The rare
+            // needs-registration case retries interactively below, after the
+            // join, when the terminal is free again.
+            crate::commands::ssh::native::ensure_ssh_key_noninteractive(&client, &key_configs).await
         }),
     );
     let (_project_id, environment_id) = target_res?;
-    let identity = identity?;
+    let identity = match identity {
+        Ok(identity) => identity,
+        Err(_) => {
+            let key_configs = Configs::new()?;
+            ssh_tel::timed_for(
+                "cloud_agent_launch",
+                "ssh_key_interactive",
+                ensure_ssh_key_quiet(&client, &key_configs),
+            )
+            .await?
+        }
+    };
 
     let relay = ssh_tel::timed_for("cloud_agent_launch", "relay", async { relay_ssh() }).await?;
     let access = RelayAccess {
@@ -2734,6 +2795,7 @@ async fn prepare_inner(
                         identity.as_deref(),
                         None,
                         &relay,
+                        None,
                     )
                 })
                 .await?;
@@ -2774,9 +2836,12 @@ async fn prepare_inner(
     // One relay handshake per launch: when a readiness probe won the wait, its
     // marker-verified connection is already a master and both the provision
     // and the session ride it. When no probe ran (agent already RUNNING, or
-    // the status flip won the race), the provision opens the master instead —
-    // it is equally verified, by the AGENT-READY marker below. See the
-    // RelaySsh doc for why an UNVERIFIED connection must never own one.
+    // the status flip won the race), the provision opens the master instead.
+    // That one is verified only after the fact — the master exists from
+    // connect time, and a marker failure does not tear it down — which is why
+    // ssh_plumbing removes the socket on every failed attempt: no retry (and
+    // no session) can ride a connection whose attempt didn't produce the
+    // marker. See the RelaySsh doc for the history this guards against.
     let (master_socket, mux_provision) = match probe_master {
         Some(socket) => {
             let client_opts = mux_client_opts(&socket);
@@ -2798,6 +2863,7 @@ async fn prepare_inner(
         let target = target.clone();
         let identity = identity.clone();
         let relay = provision_relay.clone();
+        let master_socket = master_socket.clone();
         // Copied out of `args`, which is a borrow the 'static closure can't take.
         let app_mode = args.app_mode;
         let skills_note = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
@@ -2850,6 +2916,7 @@ async fn prepare_inner(
                     identity.as_deref(),
                     Some(&payload),
                     &relay,
+                    Some(&master_socket),
                 )?;
                 let out = String::from_utf8_lossy(&out);
                 check_ready(&out)?;
@@ -2868,6 +2935,8 @@ async fn prepare_inner(
                 identity.as_deref(),
                 auth.as_ref().map(|(line, _)| line.as_slice()),
                 &relay,
+
+                Some(&master_socket),
             )?;
             let out = String::from_utf8_lossy(&out);
             check_ready(&out)?;
@@ -2883,6 +2952,8 @@ async fn prepare_inner(
                         identity.as_deref(),
                         Some(&packed.tarball),
                         &relay,
+
+                        Some(&master_socket),
                     )?;
                     let out = String::from_utf8_lossy(&out);
                     if !out.contains("SKILLS-OK") {
@@ -3027,6 +3098,7 @@ pub async fn kill_session(environment_id: &str, agent_id: &str, session_name: &s
             info.identity.as_deref(),
             None,
             &relay,
+            None,
         )
     })
     .await??;

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -803,12 +803,27 @@ fn mux_socket() -> std::path::PathBuf {
     ))
 }
 
+/// Whether connection sharing can work here at all: not on Windows, whose
+/// OpenSSH has no ControlMaster support (passing the options anywhere from
+/// warns to fails), and not when the socket path would overflow the unix
+/// socket path limit (~104 bytes; a deep $TMPDIR gets there). Both cases fall
+/// back to plain connections — the launch works identically, it just pays the
+/// handshakes multiplexing would have saved.
+fn mux_usable(socket: &std::path::Path) -> bool {
+    !cfg!(windows) && socket.as_os_str().len() <= 100
+}
+
 /// Options for a connection allowed to CREATE the master on `socket`:
 /// a readiness probe (each round gets its own fresh socket; only the round
 /// whose marker round-trips is ever promoted) or the provision connection.
 /// `persist` bounds how long an idle master outlives its last client — probes
 /// use a short one so the losing rounds' masters evaporate.
+/// Empty when multiplexing is unusable here, so every caller degrades to a
+/// plain connection without carrying the platform check itself.
 fn mux_master_opts(socket: &std::path::Path, persist: &str) -> Vec<String> {
+    if !mux_usable(socket) {
+        return Vec::new();
+    }
     vec![
         "-o".into(),
         "ControlMaster=auto".into(),
@@ -821,7 +836,11 @@ fn mux_master_opts(socket: &std::path::Path, persist: &str) -> Vec<String> {
 
 /// Options for a connection that may RIDE the master on `socket` but never
 /// create one: a dead or missing socket falls back to a plain connection.
+/// Empty when multiplexing is unusable here, same as [`mux_master_opts`].
 fn mux_client_opts(socket: &std::path::Path) -> Vec<String> {
+    if !mux_usable(socket) {
+        return Vec::new();
+    }
     vec!["-o".into(), format!("ControlPath={}", socket.display())]
 }
 
@@ -1605,6 +1624,7 @@ pub(crate) async fn wait_until_connectable(
     environment_id: &str,
     id: &str,
     access: &RelayAccess,
+    initial_delay: std::time::Duration,
 ) -> Result<(CodeAgent, Option<std::path::PathBuf>)> {
     use queries::cloud_agent::CloudAgentStatus as S;
     // Measured as one stage because this is the leg the platform owns — VM
@@ -1614,6 +1634,15 @@ pub(crate) async fn wait_until_connectable(
     let diagnostics = ssh_tel::timing_diagnostics();
     let ssh_target = format!("agent:{environment_id}:{id}");
     let deadline = std::time::Instant::now() + READY_TIMEOUT;
+    // Callers that just issued the create or wake pass the physical floor of
+    // that operation (measured: a fresh VM is never routable before ~550ms, a
+    // restore before ~1.5s): probing earlier is a guaranteed miss that still
+    // opens a real relay connection into the dev.new fall-through. Callers
+    // that caught a boot already in flight pass zero — the box may be
+    // routable right now, and any delay would be a pure regression.
+    if !initial_delay.is_zero() {
+        tokio::time::sleep(initial_delay).await;
+    }
     let mut round = 0u32;
     loop {
         round += 1;
@@ -1724,6 +1753,9 @@ async fn ready_existing_agent(
         // resting state this command leaves behind.
         S::SLEEPING | S::STARTING => {
             progress.step(&format!("Waking agent {}", agent.name));
+            // The delay below is the wake's physical floor; a STARTING agent
+            // caught mid-boot gets none — it may be routable right now.
+            let mut probe_delay = std::time::Duration::ZERO;
             if agent.status == S::SLEEPING {
                 let wake_started = std::time::Instant::now();
                 let wake = post_graphql::<mutations::CloudAgentWake, _>(
@@ -1738,10 +1770,17 @@ async fn ready_existing_agent(
                 if let Err(e) = wake {
                     return Err(e.into());
                 }
+                probe_delay = std::time::Duration::from_millis(350);
             }
-            let (running, probe_master) =
-                wait_until_connectable(client, backboard, environment_id, &agent.id, access)
-                    .await?;
+            let (running, probe_master) = wait_until_connectable(
+                client,
+                backboard,
+                environment_id,
+                &agent.id,
+                access,
+                probe_delay,
+            )
+            .await?;
             progress.note(&format!(
                 "Woke agent {} — your work is on its disk",
                 running.name
@@ -1924,6 +1963,24 @@ async fn resolve_target(
     }
 }
 
+/// The single stdin stream `provision_script_with_skills` reads: the
+/// credential (exactly `len` bytes, which the script consumes via `head -c`)
+/// followed by the skills tarball. The framing length and the written bytes
+/// MUST come from the same buffer — this function is the only place both are
+/// produced, which is the contract the byte-framing test pins.
+fn combined_provision_payload(
+    credential: Option<&[u8]>,
+    tarball: &[u8],
+) -> (Vec<u8>, Option<usize>) {
+    let len = credential.map(<[u8]>::len);
+    let mut payload = Vec::with_capacity(len.unwrap_or(0) + tarball.len());
+    if let Some(credential) = credential {
+        payload.extend_from_slice(credential);
+    }
+    payload.extend_from_slice(tarball);
+    (payload, len)
+}
+
 /// A canonical 8-4-4-4-12 lowercase-or-uppercase hex UUID, the only shape
 /// Railway ids take. Names can't collide with it in practice, and a
 /// pathological UUID-shaped name merely skips a convenience resolution — the
@@ -2078,7 +2135,17 @@ async fn resolve_agent(
     configs.set_code_agent(environment_id, &created.id);
     configs.write()?;
 
-    match wait_until_connectable(client, &backboard, environment_id, &created.id, access).await {
+    match wait_until_connectable(
+        client,
+        &backboard,
+        environment_id,
+        &created.id,
+        access,
+        // A created VM's measured routability floor; see the wait's doc.
+        std::time::Duration::from_millis(350),
+    )
+    .await
+    {
         Ok((running, probe_master)) => {
             progress.note(&format!("Created agent {}", running.name));
             Ok((running, true, probe_master))
@@ -2365,16 +2432,39 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
     );
 
     let progress = CliProgress::default();
-    // TESTING: the ensure_enabled feature-flag pre-check is removed entirely
-    // for latency measurement. The create/wake mutations still refuse without
-    // the flag server-side — an un-flagged user gets that refusal instead of
-    // the friendlier pre-check message. Restore (as a select! race against
-    // prepare, not a serialized round-trip) before shipping.
-    let prepared = prepare(&args, &progress, SessionStyle::FullTerminal).await?;
+    // The flag check races prepare instead of preceding it: an un-flagged user
+    // is still stopped the moment the check answers — before any mint or
+    // create completes — while everyone else no longer pays a serialized
+    // round-trip for a question whose answer is almost always yes. If prepare
+    // somehow finishes first, the gate is still enforced before anything runs.
+    let ensure_fut = async {
+        let configs = Configs::new()?;
+        let client = GQLClient::new_authorized(&configs)?;
+        crate::commands::cloud_agent::access::ensure_enabled(&client, &configs).await
+    };
+    let prepare_fut = prepare(&args, &progress, SessionStyle::FullTerminal);
+    tokio::pin!(ensure_fut);
+    tokio::pin!(prepare_fut);
+    let prepared = tokio::select! {
+        enabled = &mut ensure_fut => {
+            enabled?;
+            prepare_fut.await?
+        }
+        prepared = &mut prepare_fut => {
+            ensure_fut.await?;
+            prepared?
+        }
+    };
     progress.finish();
 
     println!("Launching {}…", prepared.harness);
     let exit_code = run_session(&prepared)?;
+
+    // The user's work is done; give detached telemetry a bounded window so a
+    // short exec launch (`railway code -- <cmd>`) doesn't exit before its
+    // outcome event leaves the machine. Interactive sessions resolve this
+    // instantly — their sends finished minutes ago.
+    ssh_tel::drain_detached(std::time::Duration::from_secs(2)).await;
 
     // Belt-and-suspenders for the remote reset: when the connection drops
     // mid-TUI the remote printf never reaches us, so scrub locally too before
@@ -2743,21 +2833,13 @@ async fn prepare_inner(
             // question. Send everything in one connection: the credential
             // (length-framed) and the tarball share the provision stdin.
             if created && let Some(packed) = &packed_skills {
-                let mut payload = Vec::with_capacity(
-                    auth.as_ref().map_or(0, |(line, _)| line.len()) + packed.tarball.len(),
+                let (payload, credential_len) = combined_provision_payload(
+                    auth.as_ref().map(|(line, _)| line.as_slice()),
+                    &packed.tarball,
                 );
-                if let Some((line, _)) = &auth {
-                    payload.extend_from_slice(line);
-                }
-                payload.extend_from_slice(&packed.tarball);
                 let out = ssh_plumbing(
                     &target,
-                    &provision_script_with_skills(
-                        agent,
-                        auth.as_ref().map(|(line, _)| line.len()),
-                        app_mode,
-                        &packed.hash,
-                    ),
+                    &provision_script_with_skills(agent, credential_len, app_mode, &packed.hash),
                     identity.as_deref(),
                     Some(&payload),
                     &relay,
@@ -3346,6 +3428,55 @@ mod tests {
         assert!(!script.contains("head -c"), "{script}");
         assert!(script.contains(r#"cat > "$payload""#), "{script}");
         assert!(script.contains("AGENT-READY"), "{script}");
+    }
+
+    /// The byte-framing contract behind `head -c`: the length the script reads
+    /// must be exactly the credential bytes at the front of the stream, with
+    /// the tarball intact behind them. Anyone who re-encodes the credential or
+    /// appends a newline breaks both at once — this test is what catches them.
+    #[test]
+    fn combined_payload_framing_splits_back_exactly() {
+        let credential = b"CLAUDE_CODE_OAUTH_TOKEN=tok-123\n";
+        let tarball = [0x1f, 0x8b, 0x08, 0x00, 0x42];
+        let (payload, len) = combined_provision_payload(Some(credential), &tarball);
+        let len = len.expect("credential present");
+        assert_eq!(&payload[..len], credential);
+        assert_eq!(&payload[len..], &tarball);
+        // And the script consumes exactly that many bytes.
+        let script = provision_script_with_skills(Agent::Claude, Some(len), false, "h");
+        assert!(script.contains(&format!("head -c {len} ")), "{script}");
+
+        let (payload, len) = combined_provision_payload(None, &tarball);
+        assert!(len.is_none());
+        assert_eq!(payload, tarball);
+    }
+
+    /// UUIDs are trusted as launch targets; anything else still resolves.
+    #[test]
+    fn uuid_shapes() {
+        assert!(is_uuid("ddcba2f8-a773-4929-bfbd-52450cdf0356"));
+        assert!(is_uuid("DDCBA2F8-A773-4929-BFBD-52450CDF0356"));
+        assert!(!is_uuid("production"));
+        assert!(!is_uuid("ddcba2f8-a773-4929-bfbd-52450cdf035")); // 35 chars
+        assert!(!is_uuid("ddcba2f8-a773-4929-bfbd-52450cdf035g")); // non-hex
+        assert!(!is_uuid("ddcba2f8_a773_4929_bfbd_52450cdf0356")); // separators
+    }
+
+    /// Multiplexing degrades to plain connections rather than erroring where
+    /// it cannot work: Windows, and socket paths past the unix limit.
+    #[test]
+    fn mux_gating() {
+        let short = std::path::Path::new("/tmp/railway-cm-1-abc.sock");
+        if cfg!(windows) {
+            assert!(mux_master_opts(short, "10s").is_empty());
+            assert!(mux_client_opts(short).is_empty());
+        } else {
+            assert!(!mux_master_opts(short, "10s").is_empty());
+            assert!(!mux_client_opts(short).is_empty());
+            let long = std::path::PathBuf::from(format!("/{}/cm.sock", "x".repeat(120)));
+            assert!(mux_master_opts(&long, "10s").is_empty());
+            assert!(mux_client_opts(&long).is_empty());
+        }
     }
 
     /// The shell option starts nothing and changes nothing: no credential, no

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -853,7 +853,17 @@ fn local_signin(agent: Agent, home: &Path) -> Result<PendingAuth> {
 /// mint locally, store the result as a repository secret, and use it on remote
 /// runners. Cleared by `railway logout`, or by `--refresh-auth`.
 fn claude_token_cache_path() -> Option<std::path::PathBuf> {
-    Some(dirs::home_dir()?.join(".railway").join("claude-code-token"))
+    Some(claude_token_cache_path_in(&dirs::home_dir()?))
+}
+
+/// The cache path under an explicit home, so callers that already scope
+/// themselves to one (`railway ca setup --reset`, and the tests that drive it
+/// against a tempdir) clear the right file. Resolving `dirs::home_dir()` here
+/// regardless of the caller's home meant the suite deleted the developer's own
+/// cached setup-token every run, sending their next `--claude` launch through a
+/// browser mint.
+fn claude_token_cache_path_in(home: &Path) -> std::path::PathBuf {
+    home.join(".railway").join("claude-code-token")
 }
 
 /// Read the cached token, if one is there and still plausible.
@@ -917,9 +927,14 @@ fn cached_token_source(age_days: Option<u64>) -> String {
 
 /// Forget the cached token. Called by `railway logout`.
 pub fn clear_claude_token_cache() {
-    if let Some(path) = claude_token_cache_path() {
-        let _ = std::fs::remove_file(path);
+    if let Some(home) = dirs::home_dir() {
+        clear_claude_token_cache_in(&home);
     }
+}
+
+/// [`clear_claude_token_cache`] scoped to an explicit home.
+pub fn clear_claude_token_cache_in(home: &Path) {
+    let _ = std::fs::remove_file(claude_token_cache_path_in(home));
 }
 
 /// The credential to push, or the knowledge that obtaining one costs a browser
@@ -2266,6 +2281,9 @@ pub async fn prepare(
     };
 
     let result = prepare_inner(args, progress, agent, prefs, &home, style).await;
+    // After the outcome, and detached: the stages are already measured, and
+    // reporting them must not extend the launch they describe.
+    ssh_tel::flush_stages("cloud_agent_launch");
     crate::commands::cloud_agent::telemetry::track_launch_outcome(
         agent.slug(),
         result.as_ref().ok().map(|p| p.created),
@@ -2293,19 +2311,15 @@ async fn prepare_inner(
     // see `PendingAuth`.
     let pending = match agent {
         Agent::Codex | Agent::Grok => {
-            ssh_tel::track_for(
-                "cloud_agent_launch",
-                "credential",
-                local_signin(agent, home),
-            )
+            ssh_tel::timed_for("cloud_agent_launch", "credential", async {
+                local_signin(agent, home)
+            })
             .await?
         }
         Agent::Claude => {
-            ssh_tel::track_for(
-                "cloud_agent_launch",
-                "credential",
-                claude_credentials_cheap(args.refresh_auth),
-            )
+            ssh_tel::timed_for("cloud_agent_launch", "credential", async {
+                claude_credentials_cheap(args.refresh_auth)
+            })
             .await?
         }
         // Nothing to read or mint — the VM already carries its own, and a
@@ -2329,11 +2343,9 @@ async fn prepare_inner(
     // Pack the user's skills before spending a VM: a skills directory that has
     // grown into something unshippable should fail here, not after a create.
     // The upload itself is decided later, against the hash the agent reports.
-    let packed_skills = ssh_tel::track_for(
-        "cloud_agent_launch",
-        "skills_pack",
-        skills_sync::pack(&prefs, home),
-    )
+    let packed_skills = ssh_tel::timed_for("cloud_agent_launch", "skills_pack", async {
+        skills_sync::pack(&prefs, home)
+    })
     .await?;
     if let Some(packed) = &packed_skills {
         progress.note(&format!(
@@ -2348,33 +2360,33 @@ async fn prepare_inner(
     let client = GQLClient::new_authorized(&configs)?;
     // The project is no longer carried on `Prepared` — its only reader was the
     // launcher's exit hint, which now names the agent instead.
-    let (_project_id, environment_id) = ssh_tel::track_for(
+    let (_project_id, environment_id) = ssh_tel::timed_for(
         "cloud_agent_launch",
         "resolve_target",
-        resolve_target(&mut configs, &client, args, &mut prefs, home).await,
+        resolve_target(&mut configs, &client, args, &mut prefs, home),
     )
     .await?;
 
-    let (cloud_agent, created) = ssh_tel::track_for(
+    let (cloud_agent, created) = ssh_tel::timed_for(
         "cloud_agent_launch",
         "resolve_agent",
-        resolve_agent(&mut configs, &client, args, &environment_id, progress).await,
+        resolve_agent(&mut configs, &client, args, &environment_id, progress),
     )
     .await?;
     configs.set_code_agent(&environment_id, &cloud_agent.id);
     configs.write()?;
 
-    let identity = ssh_tel::track_for(
+    let identity = ssh_tel::timed_for(
         "cloud_agent_launch",
         "ssh_key",
-        ensure_ssh_key_quiet(&client, &configs).await,
+        ensure_ssh_key_quiet(&client, &configs),
     )
     .await?;
     // The relay's cloud-agent grammar; by id rather than name because names are
     // not unique within an environment.
     let target = format!("agent:{environment_id}:{}", cloud_agent.id);
 
-    let relay = ssh_tel::track_for("cloud_agent_launch", "relay", relay_ssh()).await?;
+    let relay = ssh_tel::timed_for("cloud_agent_launch", "relay", async { relay_ssh() }).await?;
 
     // --- Deferred Claude mint. A setup-token lasts a year and the agent's disk
     // survives sleep, so a reused agent is normally still authenticated; minting
@@ -2388,17 +2400,15 @@ async fn prepare_inner(
             // explicit request to replace whatever is there; neither needs a probe.
             let needs_probe = !created && !args.refresh_auth;
             let inherit = if needs_probe {
-                let probe = ssh_tel::track_for(
-                    "cloud_agent_launch",
-                    "claude_probe",
+                let probe = ssh_tel::timed_for("cloud_agent_launch", "claude_probe", async {
                     ssh_plumbing(
                         &target,
                         CLAUDE_CREDENTIAL_PROBE,
                         identity.as_deref(),
                         None,
                         &relay,
-                    ),
-                )
+                    )
+                })
                 .await?;
                 String::from_utf8_lossy(&probe).contains("CRED-PRESENT")
             } else {
@@ -2410,11 +2420,9 @@ async fn prepare_inner(
                 );
                 None
             } else {
-                match ssh_tel::track_for(
-                    "cloud_agent_launch",
-                    "claude_mint",
-                    mint_claude_credentials(),
-                )
+                match ssh_tel::timed_for("cloud_agent_launch", "claude_mint", async {
+                    mint_claude_credentials()
+                })
                 .await?
                 {
                     Some((line, source)) => {
@@ -2436,7 +2444,7 @@ async fn prepare_inner(
 
     // --- Provision: credential (stdin) + reconnect seeds, one script.
     progress.step("Finalizing Configuration...");
-    let provision = {
+    let provision = async {
         let target = target.clone();
         let identity = identity.clone();
         let relay = relay.clone();
@@ -2512,7 +2520,7 @@ async fn prepare_inner(
         }
         result
     };
-    ssh_tel::track_for("cloud_agent_launch", "provision", provision).await?;
+    ssh_tel::timed_for("cloud_agent_launch", "provision", provision).await?;
 
     let env_prefix = format!(
         "{HARNESS_PATH}; [ -f ~/.gh-token ] && export GH_TOKEN=\"$(cat ~/.gh-token)\"; {CLAUDE_ENV_GUARD}; "

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -790,33 +790,39 @@ struct RelaySsh {
     host_pattern: String,
 }
 
-/// The per-launch connection-sharing options — see the [`RelaySsh`] doc for
-/// why only the provision connection may create the master and why probes get
-/// neither option.
-///
-/// Returns `(master_opts, client_opts)`: the provision connection takes
-/// `master_opts` (creates the master, keeps it alive 30s past its own exit);
-/// the session takes `client_opts` (rides the master when it is alive, falls
-/// back to a plain connection when it is not, and never creates one). The
-/// socket lives in the OS temp dir under a pid+random name so a recycled pid
-/// can never collide with a leftover socket from an earlier run.
-fn launch_mux() -> (Vec<String>, Vec<String>) {
-    let socket = std::env::temp_dir().join(format!(
+/// A fresh, never-reused control socket path: OS temp dir, pid + random, so
+/// neither a recycled pid nor two sockets within one launch can collide.
+/// Uniqueness is the safety property the whole mux design leans on — a socket
+/// is only ever ridden by connections that know it was created by a
+/// marker-verified connection to the real agent (see [`RelaySsh`]).
+fn mux_socket() -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
         "railway-cm-{}-{:08x}.sock",
         std::process::id(),
         rand::random::<u32>()
-    ));
-    let path = format!("ControlPath={}", socket.display());
-    let master = vec![
+    ))
+}
+
+/// Options for a connection allowed to CREATE the master on `socket`:
+/// a readiness probe (each round gets its own fresh socket; only the round
+/// whose marker round-trips is ever promoted) or the provision connection.
+/// `persist` bounds how long an idle master outlives its last client — probes
+/// use a short one so the losing rounds' masters evaporate.
+fn mux_master_opts(socket: &std::path::Path, persist: &str) -> Vec<String> {
+    vec![
         "-o".into(),
         "ControlMaster=auto".into(),
         "-o".into(),
-        path.clone(),
+        format!("ControlPath={}", socket.display()),
         "-o".into(),
-        "ControlPersist=30s".into(),
-    ];
-    let client = vec!["-o".into(), path];
-    (master, client)
+        format!("ControlPersist={persist}"),
+    ]
+}
+
+/// Options for a connection that may RIDE the master on `socket` but never
+/// create one: a dead or missing socket falls back to a plain connection.
+fn mux_client_opts(socket: &std::path::Path) -> Vec<String> {
+    vec!["-o".into(), format!("ControlPath={}", socket.display())]
 }
 
 /// The known-hosts file the CLI keeps for the relay.
@@ -1588,13 +1594,18 @@ pub(crate) async fn relay_access() -> Result<RelayAccess> {
     })
 }
 
+/// On success, also returns the control socket of the winning probe's master
+/// when there was one: that probe verified the marker round-trip, so its
+/// connection provably reached the real agent, and the provision + session can
+/// multiplex over it instead of paying a fresh relay handshake. `None` when
+/// the status flip won the race (no verified connection exists yet).
 pub(crate) async fn wait_until_connectable(
     client: &reqwest::Client,
     backboard: &str,
     environment_id: &str,
     id: &str,
     access: &RelayAccess,
-) -> Result<CodeAgent> {
+) -> Result<(CodeAgent, Option<std::path::PathBuf>)> {
     use queries::cloud_agent::CloudAgentStatus as S;
     // Measured as one stage because this is the leg the platform owns — VM
     // boot/restore up to a routable SSH target. Per-round detail goes to stderr
@@ -1612,9 +1623,17 @@ pub(crate) async fn wait_until_connectable(
         // catch terminal states. Running them together instead of fetch-then-
         // probe stops a serialized GraphQL round-trip from pushing the
         // discovering probe later every round.
+        //
+        // Every round probes as a would-be master on its own FRESH socket. A
+        // round that lands on the relay's dev.new fall-through (agent not yet
+        // routable) leaves a master nothing will ever reference — the socket
+        // name is never reused, and only the round whose marker comes back is
+        // promoted. Short persist so the losers evaporate.
+        let socket = mux_socket();
         let target = ssh_target.clone();
         let identity = access.identity.clone();
-        let opts = access.relay_opts.clone();
+        let mut opts = access.relay_opts.clone();
+        opts.extend(mux_master_opts(&socket, "10s"));
         let probe = tokio::task::spawn_blocking(move || {
             probe_native_ssh(&target, identity.as_deref(), &opts)
         });
@@ -1630,11 +1649,16 @@ pub(crate) async fn wait_until_connectable(
                 round_started.elapsed().as_millis()
             );
         }
-        // RUNNING routes by definition, so a probe that lost a race to the
-        // status flip doesn't cost another round.
-        if routed || agent.status == S::RUNNING {
+        if routed {
             ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
-            return Ok(agent);
+            return Ok((agent, Some(socket)));
+        }
+        // RUNNING routes by definition, so a probe that lost a race to the
+        // status flip doesn't cost another round — but there is no verified
+        // connection to promote.
+        if agent.status == S::RUNNING {
+            ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
+            return Ok((agent, None));
         }
         match agent.status {
             S::RUNNING | S::STARTING | S::SLEEPING => {}
@@ -1658,11 +1682,17 @@ pub(crate) async fn wait_until_connectable(
                 agent.status
             );
         }
-        // Pace rounds to ~750ms of cadence rather than 750ms of added sleep: a
-        // probe that already took that long IS the pacing, and sleeping on top
-        // of it only delays noticing a box that came up mid-probe.
-        const CADENCE: std::time::Duration = std::time::Duration::from_millis(750);
-        if let Some(rest) = CADENCE.checked_sub(round_started.elapsed()) {
+        // Pace rounds to a cadence rather than sleeping on top of the probe: a
+        // probe that already took that long IS the pacing. The cadence is
+        // tight while the box is likely to come up (a fresh VM boots in
+        // ~750ms, and a 750ms grid quantizes its discovery a full round late)
+        // and relaxes once the wait has clearly become a boot-tail wait.
+        let cadence = if wait_started.elapsed() < std::time::Duration::from_secs(4) {
+            std::time::Duration::from_millis(250)
+        } else {
+            std::time::Duration::from_millis(750)
+        };
+        if let Some(rest) = cadence.checked_sub(round_started.elapsed()) {
             tokio::time::sleep(rest).await;
         }
     }
@@ -1678,7 +1708,7 @@ async fn ready_existing_agent(
     agent: CodeAgent,
     progress: &dyn Progress,
     access: &RelayAccess,
-) -> Result<Option<CodeAgent>> {
+) -> Result<Option<(CodeAgent, Option<std::path::PathBuf>)>> {
     use queries::cloud_agent::CloudAgentStatus as S;
 
     match agent.status {
@@ -1687,7 +1717,7 @@ async fn ready_existing_agent(
                 "Using agent {} (--new for a fresh one)",
                 agent.name
             ));
-            Ok(Some(agent))
+            Ok(Some((agent, None)))
         }
         // STARTING means a previous run is still booting it, so a re-run seconds
         // after a ctrl-c waits rather than minting a duplicate. SLEEPING is the
@@ -1709,14 +1739,14 @@ async fn ready_existing_agent(
                     return Err(e.into());
                 }
             }
-            let running =
+            let (running, probe_master) =
                 wait_until_connectable(client, backboard, environment_id, &agent.id, access)
                     .await?;
             progress.note(&format!(
                 "Woke agent {} — your work is on its disk",
                 running.name
             ));
-            Ok(Some(running))
+            Ok(Some((running, probe_master)))
         }
         S::CRASHED | S::FAILED | S::DELETING | S::Other(_) => {
             progress.note(&format!(
@@ -1854,6 +1884,17 @@ async fn resolve_target(
         // Either flag means the caller is targeting deliberately; hand both to
         // the shared resolver so `-p` alone still finds an environment.
         TargetSource::Flags => {
+            // Two UUIDs need no resolving — the TUI retargets launches with
+            // ids it already resolved, and the shared resolver was spending a
+            // round-trip re-answering a known question on every TUI launch.
+            // Trusting them is safe: the create/wake mutations validate the
+            // environment (and the caller's access to it) authoritatively.
+            if let (Some(project), Some(environment)) = (&args.project, &args.environment)
+                && is_uuid(project)
+                && is_uuid(environment)
+            {
+                return Ok((project.clone(), environment.clone()));
+            }
             resolve_project_and_env(
                 configs,
                 client,
@@ -1881,6 +1922,21 @@ async fn resolve_target(
         }
         TargetSource::Ask => resolve_project_and_env(configs, client, None, None).await,
     }
+}
+
+/// A canonical 8-4-4-4-12 lowercase-or-uppercase hex UUID, the only shape
+/// Railway ids take. Names can't collide with it in practice, and a
+/// pathological UUID-shaped name merely skips a convenience resolution — the
+/// mutation that follows still validates the id.
+fn is_uuid(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 36 {
+        return false;
+    }
+    bytes.iter().enumerate().all(|(i, b)| match i {
+        8 | 13 | 18 | 23 => *b == b'-',
+        _ => b.is_ascii_hexdigit(),
+    })
 }
 
 /// Which answer wins, given what is available. Separated from the I/O so the
@@ -1960,7 +2016,7 @@ async fn resolve_agent(
     environment_id: &str,
     progress: &dyn Progress,
     access: &RelayAccess,
-) -> Result<(CodeAgent, bool)> {
+) -> Result<(CodeAgent, bool, Option<std::path::PathBuf>)> {
     let backboard = configs.get_backboard();
 
     // An explicit agent wins over everything: the caller is looking at the one
@@ -1981,14 +2037,14 @@ async fn resolve_agent(
         None => None,
     };
     if let Some(agent) = existing {
-        if let Some(ready) =
+        if let Some((ready, probe_master)) =
             ready_existing_agent(client, &backboard, environment_id, agent, progress, access)
                 .await?
         {
             warn_ignored_variables(args, progress);
             configs.set_code_agent(environment_id, &ready.id);
             configs.write()?;
-            return Ok((ready, false));
+            return Ok((ready, false, probe_master));
         }
         configs.remove_code_agent(environment_id);
     }
@@ -2023,9 +2079,9 @@ async fn resolve_agent(
     configs.write()?;
 
     match wait_until_connectable(client, &backboard, environment_id, &created.id, access).await {
-        Ok(running) => {
+        Ok((running, probe_master)) => {
             progress.note(&format!("Created agent {}", running.name));
-            Ok((running, true))
+            Ok((running, true, probe_master))
         }
         Err(e) => {
             progress.finish();
@@ -2549,7 +2605,7 @@ async fn prepare_inner(
         relay_opts: relay.opts.clone(),
     };
 
-    let (cloud_agent, created) = ssh_tel::timed_for(
+    let (cloud_agent, created, probe_master) = ssh_tel::timed_for(
         "cloud_agent_launch",
         "resolve_agent",
         resolve_agent(&mut configs, &client, args, &environment_id, progress, &access),
@@ -2618,15 +2674,27 @@ async fn prepare_inner(
 
     // --- Provision: credential (stdin) + reconnect seeds, one script.
     progress.step("Finalizing Configuration...");
-    // The provision connection opens the launch-scoped ControlMaster and the
-    // session rides it — one relay handshake instead of two. Only here: the
-    // route is verified by this point, and the AGENT-READY marker below proves
-    // the master reached the real agent (see the RelaySsh doc for why a probe
-    // must never create one).
-    let (mux_master, mux_client) = launch_mux();
+    // One relay handshake per launch: when a readiness probe won the wait, its
+    // marker-verified connection is already a master and both the provision
+    // and the session ride it. When no probe ran (agent already RUNNING, or
+    // the status flip won the race), the provision opens the master instead —
+    // it is equally verified, by the AGENT-READY marker below. See the
+    // RelaySsh doc for why an UNVERIFIED connection must never own one.
+    let (master_socket, mux_provision) = match probe_master {
+        Some(socket) => {
+            let client_opts = mux_client_opts(&socket);
+            (socket, client_opts)
+        }
+        None => {
+            let socket = mux_socket();
+            let master_opts = mux_master_opts(&socket, "30s");
+            (socket, master_opts)
+        }
+    };
+    let mux_client = mux_client_opts(&master_socket);
     let provision_relay = {
         let mut r = relay.clone();
-        r.opts.extend(mux_master);
+        r.opts.extend(mux_provision);
         r
     };
     let provision = async {

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -2392,13 +2392,28 @@ pub async fn prepare(
     // After the outcome, and detached: the stages are already measured, and
     // reporting them must not extend the launch they describe.
     ssh_tel::flush_stages("cloud_agent_launch");
-    crate::commands::cloud_agent::telemetry::track_launch_outcome(
-        agent.slug(),
-        result.as_ref().ok().map(|p| p.created),
-        start.elapsed(),
-        result.as_ref().err().map(|e| format!("{e:#}")).as_deref(),
-    )
-    .await;
+    match &result {
+        // Detached on success for the same reason as the stage flush: the
+        // outcome event is an HTTP round-trip, and awaiting it sat between
+        // "provisioned" and "session opens" on every launch. The session that
+        // follows gives the send minutes of runway.
+        Ok(prepared) => crate::commands::cloud_agent::telemetry::track_launch_outcome_detached(
+            agent.slug(),
+            Some(prepared.created),
+            start.elapsed(),
+        ),
+        // Still awaited: the process is about to exit with this error, and a
+        // spawned task would be dropped before the failure ever reported.
+        Err(e) => {
+            crate::commands::cloud_agent::telemetry::track_launch_outcome(
+                agent.slug(),
+                None,
+                start.elapsed(),
+                Some(&format!("{e:#}")),
+            )
+            .await
+        }
+    }
     result
 }
 

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -437,6 +437,22 @@ impl Agent {
         }
     }
 
+    /// [`credential_seed`] for a script whose stdin carries more than the
+    /// credential: reads exactly `len` bytes so the rest of the stream stays
+    /// available to the next reader (the skills tarball on a fresh agent).
+    /// Mirrors the `cat >` seeds above; the 0600 mode comes from the script's
+    /// `umask 077`, with claude's explicit chmod kept as belt-and-suspenders.
+    fn credential_seed_framed(self, len: usize) -> String {
+        match self {
+            Agent::Codex => format!("mkdir -p ~/.codex\nhead -c {len} > ~/.codex/auth.json"),
+            Agent::Claude => {
+                format!("head -c {len} > ~/.claude-code-env\nchmod 600 ~/.claude-code-env")
+            }
+            Agent::Grok => format!("mkdir -p ~/.grok\nhead -c {len} > ~/.grok/auth.json"),
+            Agent::Railway | Agent::Shell => "true".to_string(),
+        }
+    }
+
     /// The local sign-in file this command copies, as `$HOME`-relative
     /// components. `None` for Claude, whose credential is minted rather than
     /// copied — sharing the local sign-in's rotating refresh token across two
@@ -609,22 +625,7 @@ fn provision_script(agent: Agent, write_credential: bool, app_mode: bool) -> Str
     let name = agent.name();
     let hash_marker = skills_sync::REMOTE_HASH_MARKER;
     let hash_file = skills_sync::REMOTE_HASH_FILE;
-    // The autostart in COMMON_SEED reads both: the sentinel disables it
-    // outright, and `~/.railway-code-agent` is what it would otherwise launch.
-    //
-    // A shell launch is "give me the machine", not "retarget this VM": the
-    // recorded autostart agent stays whatever a previous launch made it, so
-    // plain reconnects keep dropping into that agent. App-mode still wins if
-    // it was asked for — desktop takes the login shell entirely.
-    let mode_seed = if app_mode {
-        "touch ~/.railway-app-mode\nrm -f ~/.railway-code-agent".to_string()
-    } else {
-        let record = match agent {
-            Agent::Shell => "true".to_string(),
-            _ => format!("echo {name} > ~/.railway-code-agent"),
-        };
-        format!("rm -f ~/.railway-app-mode\n{record}")
-    };
+    let mode_seed = mode_seed(agent, app_mode);
     format!(
         r#"umask 077
 {HARNESS_PATH}
@@ -634,6 +635,57 @@ fn provision_script(agent: Agent, write_credential: bool, app_mode: bool) -> Str
 printf '{hash_marker}%s\n' "$(cat "{hash_file}" 2>/dev/null || true)"
 if command -v {name} >/dev/null 2>&1; then echo AGENT-READY; else echo AGENT-MISSING; fi"#
     )
+}
+
+/// [`provision_script`] plus the skills sync, one connection, for a freshly
+/// created agent. A fresh VM cannot already hold the skills hash, so the
+/// report-then-upload dance is a wasted relay round-trip there — the tarball
+/// rides the provision stdin instead, behind the length-framed credential.
+/// The AGENT-READY check prints before the sync block because that block's
+/// degradation paths `exit 0`.
+fn provision_script_with_skills(
+    agent: Agent,
+    credential_len: Option<usize>,
+    app_mode: bool,
+    skills_hash: &str,
+) -> String {
+    let seed = match credential_len {
+        Some(len) => agent.credential_seed_framed(len),
+        None => "true".to_string(),
+    };
+    let name = agent.name();
+    let mode_seed = mode_seed(agent, app_mode);
+    let sync = skills_sync::sync_body(skills_hash);
+    format!(
+        r#"umask 077
+{HARNESS_PATH}
+{seed}
+payload="$HOME/.railway-skills-payload.tgz"
+cat > "$payload"
+{COMMON_SEED}
+{mode_seed}
+if command -v {name} >/dev/null 2>&1; then echo AGENT-READY; else echo AGENT-MISSING; fi
+{sync}"#
+    )
+}
+
+/// The autostart in COMMON_SEED reads both: the sentinel disables it
+/// outright, and `~/.railway-code-agent` is what it would otherwise launch.
+///
+/// A shell launch is "give me the machine", not "retarget this VM": the
+/// recorded autostart agent stays whatever a previous launch made it, so
+/// plain reconnects keep dropping into that agent. App-mode still wins if
+/// it was asked for — desktop takes the login shell entirely.
+fn mode_seed(agent: Agent, app_mode: bool) -> String {
+    if app_mode {
+        "touch ~/.railway-app-mode\nrm -f ~/.railway-code-agent".to_string()
+    } else {
+        let record = match agent {
+            Agent::Shell => "true".to_string(),
+            _ => format!("echo {} > ~/.railway-code-agent", agent.name()),
+        };
+        format!("rm -f ~/.railway-app-mode\n{record}")
+    }
 }
 
 /// Where a prepared session's output lands, which decides what quitting the
@@ -1472,11 +1524,36 @@ async fn fetch_agent(
 /// projection, and a poll interval. Status is still read each round, but only
 /// to catch terminal states (CRASHED/FAILED/DELETING) early instead of
 /// burning the whole timeout on a box that will never come up.
+/// The relay-side plumbing a probe or session needs, independent of which
+/// agent it points at: the local key to offer and the relay's SSH options.
+/// Built once per launch (the identity half costs an API round-trip) and
+/// threaded through, where each waiter previously rebuilt it via
+/// `connect_info` — a redundant registered-keys query at the top of every
+/// wake and create wait.
+pub(crate) struct RelayAccess {
+    pub identity: Option<std::path::PathBuf>,
+    pub relay_opts: Vec<String>,
+}
+
+/// Build [`RelayAccess`] the way `connect_info` does, for callers outside the
+/// launch flow (the `ca` verbs) that don't already hold one.
+pub(crate) async fn relay_access() -> Result<RelayAccess> {
+    let configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let identity = ensure_ssh_key_quiet(&client, &configs).await?;
+    let relay = relay_ssh()?;
+    Ok(RelayAccess {
+        identity,
+        relay_opts: relay.opts,
+    })
+}
+
 pub(crate) async fn wait_until_connectable(
     client: &reqwest::Client,
     backboard: &str,
     environment_id: &str,
     id: &str,
+    access: &RelayAccess,
 ) -> Result<CodeAgent> {
     use queries::cloud_agent::CloudAgentStatus as S;
     // Measured as one stage because this is the leg the platform owns — VM
@@ -1484,34 +1561,43 @@ pub(crate) async fn wait_until_connectable(
     // under RAILWAY_STAGE_TIMING; the recorded stage is what telemetry sees.
     let wait_started = std::time::Instant::now();
     let diagnostics = ssh_tel::timing_diagnostics();
-    let info = connect_info(environment_id, id).await?;
-    if diagnostics {
-        eprintln!(
-            "[wait_connectable] connect_info={}ms",
-            wait_started.elapsed().as_millis()
-        );
-    }
+    let ssh_target = format!("agent:{environment_id}:{id}");
     let deadline = std::time::Instant::now() + READY_TIMEOUT;
     let mut round = 0u32;
     loop {
         round += 1;
         let round_started = std::time::Instant::now();
-        let agent = fetch_agent(client, backboard, environment_id, id)
-            .await?
-            .ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
+
+        // The probe is what usually ends the wait; the status fetch exists to
+        // catch terminal states. Running them together instead of fetch-then-
+        // probe stops a serialized GraphQL round-trip from pushing the
+        // discovering probe later every round.
+        let target = ssh_target.clone();
+        let identity = access.identity.clone();
+        let opts = access.relay_opts.clone();
+        let probe = tokio::task::spawn_blocking(move || {
+            probe_native_ssh(&target, identity.as_deref(), &opts)
+        });
+        let (agent, routed) =
+            tokio::join!(fetch_agent(client, backboard, environment_id, id), probe);
+        let agent = agent?.ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
+        let routed = routed?.unwrap_or(false);
+
+        if diagnostics {
+            eprintln!(
+                "[wait_connectable] round {round}: status={:?} round={}ms routed={routed}",
+                agent.status,
+                round_started.elapsed().as_millis()
+            );
+        }
+        // RUNNING routes by definition, so a probe that lost a race to the
+        // status flip doesn't cost another round.
+        if routed || agent.status == S::RUNNING {
+            ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
+            return Ok(agent);
+        }
         match agent.status {
-            // RUNNING routes by definition; skip the probe round-trip.
-            S::RUNNING => {
-                ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
-                if diagnostics {
-                    eprintln!(
-                        "[wait_connectable] round {round}: status=RUNNING after {}ms",
-                        wait_started.elapsed().as_millis()
-                    );
-                }
-                return Ok(agent);
-            }
-            S::STARTING | S::SLEEPING => {}
+            S::RUNNING | S::STARTING | S::SLEEPING => {}
             S::CRASHED => bail!(
                 "Agent {} crashed while starting. `railway code --new` for a fresh one.",
                 agent.name
@@ -1524,26 +1610,6 @@ pub(crate) async fn wait_until_connectable(
             S::Other(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
         }
 
-        let target = info.ssh_target.clone();
-        let identity = info.identity.clone();
-        let opts = info.relay_opts.clone();
-        let routed = tokio::task::spawn_blocking(move || {
-            probe_native_ssh(&target, identity.as_deref(), &opts)
-        })
-        .await?
-        .unwrap_or(false);
-        if diagnostics {
-            eprintln!(
-                "[wait_connectable] round {round}: status={:?} round={}ms routed={routed}",
-                agent.status,
-                round_started.elapsed().as_millis()
-            );
-        }
-        if routed {
-            ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
-            return Ok(agent);
-        }
-
         if std::time::Instant::now() >= deadline {
             bail!(
                 "Agent {} did not become connectable within {}s (last state: {:?}).",
@@ -1552,7 +1618,13 @@ pub(crate) async fn wait_until_connectable(
                 agent.status
             );
         }
-        tokio::time::sleep(std::time::Duration::from_millis(750)).await;
+        // Pace rounds to ~750ms of cadence rather than 750ms of added sleep: a
+        // probe that already took that long IS the pacing, and sleeping on top
+        // of it only delays noticing a box that came up mid-probe.
+        const CADENCE: std::time::Duration = std::time::Duration::from_millis(750);
+        if let Some(rest) = CADENCE.checked_sub(round_started.elapsed()) {
+            tokio::time::sleep(rest).await;
+        }
     }
 }
 
@@ -1565,6 +1637,7 @@ async fn ready_existing_agent(
     environment_id: &str,
     agent: CodeAgent,
     progress: &dyn Progress,
+    access: &RelayAccess,
 ) -> Result<Option<CodeAgent>> {
     use queries::cloud_agent::CloudAgentStatus as S;
 
@@ -1597,7 +1670,8 @@ async fn ready_existing_agent(
                 }
             }
             let running =
-                wait_until_connectable(client, backboard, environment_id, &agent.id).await?;
+                wait_until_connectable(client, backboard, environment_id, &agent.id, access)
+                    .await?;
             progress.note(&format!(
                 "Woke agent {} — your work is on its disk",
                 running.name
@@ -1845,6 +1919,7 @@ async fn resolve_agent(
     args: &LaunchArgs,
     environment_id: &str,
     progress: &dyn Progress,
+    access: &RelayAccess,
 ) -> Result<(CodeAgent, bool)> {
     let backboard = configs.get_backboard();
 
@@ -1867,7 +1942,8 @@ async fn resolve_agent(
     };
     if let Some(agent) = existing {
         if let Some(ready) =
-            ready_existing_agent(client, &backboard, environment_id, agent, progress).await?
+            ready_existing_agent(client, &backboard, environment_id, agent, progress, access)
+                .await?
         {
             warn_ignored_variables(args, progress);
             configs.set_code_agent(environment_id, &ready.id);
@@ -1906,7 +1982,7 @@ async fn resolve_agent(
     configs.set_code_agent(environment_id, &created.id);
     configs.write()?;
 
-    match wait_until_connectable(client, &backboard, environment_id, &created.id).await {
+    match wait_until_connectable(client, &backboard, environment_id, &created.id, access).await {
         Ok(running) => {
             progress.note(&format!("Created agent {}", running.name));
             Ok((running, true))
@@ -2186,15 +2262,6 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
         return destroy_agent(&mut configs, &client, &environment_id).await;
     }
 
-    // Before anything is resolved, minted or provisioned: without the flag the
-    // create at the end of all that is refused, and the work up to it — a
-    // credential, possibly a browser round-trip — is spent for nothing.
-    {
-        let configs = Configs::new()?;
-        let client = GQLClient::new_authorized(&configs)?;
-        crate::commands::cloud_agent::access::ensure_enabled(&client, &configs).await?;
-    }
-
     eprintln!(
         "{}",
         "Warning: Railway cloud agents are experimental and APIs may change or break during testing."
@@ -2202,7 +2269,30 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
     );
 
     let progress = CliProgress::default();
-    let prepared = prepare(&args, &progress, SessionStyle::FullTerminal).await?;
+    // The flag check used to run to completion before prepare started — a
+    // serialized round-trip on every launch whose answer is almost always yes.
+    // Racing them keeps the fail-fast (an un-flagged user is stopped the
+    // moment the check answers, before any mint or create finishes) without
+    // making everyone else wait for it. If prepare somehow finishes first, the
+    // gate is still enforced before anything runs.
+    let ensure_fut = async {
+        let configs = Configs::new()?;
+        let client = GQLClient::new_authorized(&configs)?;
+        crate::commands::cloud_agent::access::ensure_enabled(&client, &configs).await
+    };
+    let prepare_fut = prepare(&args, &progress, SessionStyle::FullTerminal);
+    tokio::pin!(ensure_fut);
+    tokio::pin!(prepare_fut);
+    let prepared = tokio::select! {
+        enabled = &mut ensure_fut => {
+            enabled?;
+            prepare_fut.await?
+        }
+        prepared = &mut prepare_fut => {
+            ensure_fut.await?;
+            prepared?
+        }
+    };
     progress.finish();
 
     println!("Launching {}…", prepared.harness);
@@ -2394,35 +2484,46 @@ async fn prepare_inner(
     // --- Resolve where the agent lives.
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
+    // The SSH key check is independent of where the agent lives, and the waits
+    // inside resolve_agent need its result to probe with — so it runs alongside
+    // target resolution instead of after the agent is already up, where its
+    // round-trip (registered-keys query, plus a register mutation on first run)
+    // was pure added latency. Its own `Configs` because resolve_target holds
+    // the mutable borrow.
     // The project is no longer carried on `Prepared` — its only reader was the
     // launcher's exit hint, which now names the agent instead.
-    let (_project_id, environment_id) = ssh_tel::timed_for(
-        "cloud_agent_launch",
-        "resolve_target",
-        resolve_target(&mut configs, &client, args, &mut prefs, home),
-    )
-    .await?;
+    let (target_res, identity) = tokio::join!(
+        ssh_tel::timed_for(
+            "cloud_agent_launch",
+            "resolve_target",
+            resolve_target(&mut configs, &client, args, &mut prefs, home),
+        ),
+        ssh_tel::timed_for("cloud_agent_launch", "ssh_key", async {
+            let key_configs = Configs::new()?;
+            ensure_ssh_key_quiet(&client, &key_configs).await
+        }),
+    );
+    let (_project_id, environment_id) = target_res?;
+    let identity = identity?;
+
+    let relay = ssh_tel::timed_for("cloud_agent_launch", "relay", async { relay_ssh() }).await?;
+    let access = RelayAccess {
+        identity: identity.clone(),
+        relay_opts: relay.opts.clone(),
+    };
 
     let (cloud_agent, created) = ssh_tel::timed_for(
         "cloud_agent_launch",
         "resolve_agent",
-        resolve_agent(&mut configs, &client, args, &environment_id, progress),
+        resolve_agent(&mut configs, &client, args, &environment_id, progress, &access),
     )
     .await?;
     configs.set_code_agent(&environment_id, &cloud_agent.id);
     configs.write()?;
 
-    let identity = ssh_tel::timed_for(
-        "cloud_agent_launch",
-        "ssh_key",
-        ensure_ssh_key_quiet(&client, &configs),
-    )
-    .await?;
     // The relay's cloud-agent grammar; by id rather than name because names are
     // not unique within an environment.
     let target = format!("agent:{environment_id}:{}", cloud_agent.id);
-
-    let relay = ssh_tel::timed_for("cloud_agent_launch", "relay", async { relay_ssh() }).await?;
 
     // --- Deferred Claude mint. A setup-token lasts a year and the agent's disk
     // survives sleep, so a reused agent is normally still authenticated; minting
@@ -2494,6 +2595,68 @@ async fn prepare_inner(
                     n.push(line);
                 }
             };
+            let skills_note = |out: &str| {
+                let reason = if out.contains("SKILLS-NO-TAR") {
+                    "the agent has no `tar`"
+                } else if out.contains("SKILLS-EXTRACT-FAILED") {
+                    "the transfer did not unpack"
+                } else {
+                    "the sync did not report success"
+                };
+                format!(
+                    "Couldn't sync your skills onto the agent ({reason}); continuing without them."
+                )
+            };
+            let check_ready = |out: &str| -> Result<()> {
+                if out.contains("AGENT-READY") {
+                    Ok(())
+                } else if out.contains("AGENT-MISSING") {
+                    bail!(
+                        "`{}` was not found on the agent (PATH: ~/.local/bin, ~/.opencode/bin, ~/.grok/bin, mise shims). Cloud agents bake every harness, so report this with the agent id rather than retrying.",
+                        agent.name()
+                    )
+                } else {
+                    bail!(
+                        "Provisioning produced no status marker — the connection likely dropped mid-script."
+                    )
+                }
+            };
+
+            // A fresh agent cannot already hold the skills, so the two-step
+            // report-then-upload costs a relay round-trip that answers a known
+            // question. Send everything in one connection: the credential
+            // (length-framed) and the tarball share the provision stdin.
+            if created && let Some(packed) = &packed_skills {
+                let mut payload = Vec::with_capacity(
+                    auth.as_ref().map_or(0, |(line, _)| line.len()) + packed.tarball.len(),
+                );
+                if let Some((line, _)) = &auth {
+                    payload.extend_from_slice(line);
+                }
+                payload.extend_from_slice(&packed.tarball);
+                let out = ssh_plumbing(
+                    &target,
+                    &provision_script_with_skills(
+                        agent,
+                        auth.as_ref().map(|(line, _)| line.len()),
+                        app_mode,
+                        &packed.hash,
+                    ),
+                    identity.as_deref(),
+                    Some(&payload),
+                    &relay,
+                )?;
+                let out = String::from_utf8_lossy(&out);
+                check_ready(&out)?;
+                // Never fatal: the agent is fully usable without skills, and
+                // losing a session over a skills copy would be a worse trade
+                // than launching without one.
+                if !out.contains("SKILLS-OK") {
+                    push(skills_note(&out));
+                }
+                return Ok(());
+            }
+
             let out = ssh_plumbing(
                 &target,
                 &provision_script(agent, auth.is_some(), app_mode),
@@ -2502,18 +2665,7 @@ async fn prepare_inner(
                 &relay,
             )?;
             let out = String::from_utf8_lossy(&out);
-            if out.contains("AGENT-READY") {
-                // ok
-            } else if out.contains("AGENT-MISSING") {
-                bail!(
-                    "`{}` was not found on the agent (PATH: ~/.local/bin, ~/.opencode/bin, ~/.grok/bin, mise shims). Cloud agents bake every harness, so report this with the agent id rather than retrying.",
-                    agent.name()
-                )
-            } else {
-                bail!(
-                    "Provisioning produced no status marker — the connection likely dropped mid-script."
-                )
-            }
+            check_ready(&out)?;
             // Skills, when the set on the agent isn't already the set on this
             // machine. The hash rides the script above, so an unchanged set
             // costs nothing beyond the round-trip we already made.
@@ -2528,21 +2680,8 @@ async fn prepare_inner(
                         &relay,
                     )?;
                     let out = String::from_utf8_lossy(&out);
-                    // Never fatal: the agent is fully usable without them, and
-                    // losing a session over a skills copy would be a worse
-                    // trade than launching without one. Name the marker so a
-                    // report says which step gave up.
                     if !out.contains("SKILLS-OK") {
-                        let reason = if out.contains("SKILLS-NO-TAR") {
-                            "the agent has no `tar`"
-                        } else if out.contains("SKILLS-EXTRACT-FAILED") {
-                            "the transfer did not unpack"
-                        } else {
-                            "the sync did not report success"
-                        };
-                        push(format!(
-                            "Couldn't sync your skills onto the agent ({reason}); continuing without them."
-                        ));
+                        push(skills_note(&out));
                     }
                 }
             }
@@ -3045,6 +3184,45 @@ mod tests {
         assert!(script.contains("if command -v railway-agent-tui"));
         assert!(script.contains("railway-code agent autostart"));
         assert!(script.contains("AGENT-READY"));
+    }
+
+    /// The combined fresh-agent script shares one stdin between the credential
+    /// and the skills tarball, so the credential read must be length-framed —
+    /// a `cat >` seed would swallow the tarball too.
+    #[test]
+    fn combined_provision_frames_the_credential() {
+        let script = provision_script_with_skills(Agent::Claude, Some(42), false, "abc123");
+        assert!(script.contains("head -c 42 > ~/.claude-code-env"), "{script}");
+        assert!(!script.contains("cat > ~/.claude-code-env"), "{script}");
+        // The tarball is the rest of the stream, saved before anything can bail.
+        assert!(script.contains(r#"cat > "$payload""#), "{script}");
+        assert!(script.contains("'abc123'"), "{script}");
+    }
+
+    /// The sync block's degradation paths `exit 0`, so the launch's own status
+    /// marker must already be printed by the time it runs — AGENT-READY before
+    /// the tar check, or a skills failure would read as a dropped connection.
+    #[test]
+    fn combined_provision_reports_ready_before_skills() {
+        let script = provision_script_with_skills(Agent::Claude, Some(10), false, "h");
+        let ready = script.find("AGENT-READY").expect("ready marker");
+        let sync = script.find("command -v tar").expect("sync block");
+        assert!(ready < sync, "{script}");
+        // The credential must be consumed before the payload drain, or the
+        // tarball's first bytes land in the credential file.
+        let cred = script.find("head -c 10").expect("framed credential");
+        let drain = script.find(r#"cat > "$payload""#).expect("payload drain");
+        assert!(cred < drain, "{script}");
+    }
+
+    /// No credential to write (sign-in deferred to the agent): stdin is the
+    /// tarball alone, and nothing tries to read a credential off it.
+    #[test]
+    fn combined_provision_without_credential_reads_only_the_tarball() {
+        let script = provision_script_with_skills(Agent::Claude, None, false, "h");
+        assert!(!script.contains("head -c"), "{script}");
+        assert!(script.contains(r#"cat > "$payload""#), "{script}");
+        assert!(script.contains("AGENT-READY"), "{script}");
     }
 
     /// The shell option starts nothing and changes nothing: no credential, no

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -764,19 +764,59 @@ fn remote_command(
 /// routine occurrence — it covers the fleet going back to per-instance keys
 /// without pinning us to a key that would then mismatch constantly.
 ///
-/// Deliberately NOT multiplexed. ControlMaster was here to make one host-key
-/// decision per run when the fleet answered with per-instance keys, which it no
-/// longer does. It also had a failure mode worse than the problem it solved:
-/// sleeping an agent on disconnect kills the master's TCP connection while the
-/// socket file lives on for ControlPersist, so the next run rides a dead master
-/// and dies with exit 255 and no message from either stream — invisible, and
-/// immune to retries because waiting cannot revive it.
+/// These BASE options are deliberately not multiplexed, and readiness probes
+/// must never be: a probe against a not-yet-routable agent still opens a real
+/// connection (the relay falls through to the dev.new control surface instead
+/// of refusing at the transport), so a ControlMaster owned by a failed probe
+/// pins every later channel to that dead path — measured at 8/20 launch
+/// timeouts when tried on 2026-08-18. Cross-RUN persistence is the other
+/// historical trap: sleeping an agent kills the master's TCP while the socket
+/// file lives on, so the next run rides a dead master and dies with a bare
+/// exit 255.
+///
+/// What IS safe — and what [`launch_mux`] provides — is a master scoped to
+/// one launch and opened only by the provision connection, which runs after
+/// the route is verified and whose output markers prove it reached the real
+/// agent. The interactive session then rides that master (one handshake saved,
+/// ~0.35s), and a stale or dead socket falls back to a plain connection
+/// because the session never sets ControlMaster itself. The socket path is
+/// unique per launch, so nothing outlives the run that made it beyond the
+/// 30s ControlPersist grace.
 #[derive(Clone)]
 struct RelaySsh {
     opts: Vec<String>,
     known_hosts: std::path::PathBuf,
     /// known-hosts pattern for ssh-keygen -R: `host` or `[host]:port`.
     host_pattern: String,
+}
+
+/// The per-launch connection-sharing options — see the [`RelaySsh`] doc for
+/// why only the provision connection may create the master and why probes get
+/// neither option.
+///
+/// Returns `(master_opts, client_opts)`: the provision connection takes
+/// `master_opts` (creates the master, keeps it alive 30s past its own exit);
+/// the session takes `client_opts` (rides the master when it is alive, falls
+/// back to a plain connection when it is not, and never creates one). The
+/// socket lives in the OS temp dir under a pid+random name so a recycled pid
+/// can never collide with a leftover socket from an earlier run.
+fn launch_mux() -> (Vec<String>, Vec<String>) {
+    let socket = std::env::temp_dir().join(format!(
+        "railway-cm-{}-{:08x}.sock",
+        std::process::id(),
+        rand::random::<u32>()
+    ));
+    let path = format!("ControlPath={}", socket.display());
+    let master = vec![
+        "-o".into(),
+        "ControlMaster=auto".into(),
+        "-o".into(),
+        path.clone(),
+        "-o".into(),
+        "ControlPersist=30s".into(),
+    ];
+    let client = vec!["-o".into(), path];
+    (master, client)
 }
 
 /// The known-hosts file the CLI keeps for the relay.
@@ -2578,10 +2618,21 @@ async fn prepare_inner(
 
     // --- Provision: credential (stdin) + reconnect seeds, one script.
     progress.step("Finalizing Configuration...");
+    // The provision connection opens the launch-scoped ControlMaster and the
+    // session rides it — one relay handshake instead of two. Only here: the
+    // route is verified by this point, and the AGENT-READY marker below proves
+    // the master reached the real agent (see the RelaySsh doc for why a probe
+    // must never create one).
+    let (mux_master, mux_client) = launch_mux();
+    let provision_relay = {
+        let mut r = relay.clone();
+        r.opts.extend(mux_master);
+        r
+    };
     let provision = async {
         let target = target.clone();
         let identity = identity.clone();
-        let relay = relay.clone();
+        let relay = provision_relay.clone();
         // Copied out of `args`, which is a borrow the 'static closure can't take.
         let app_mode = args.app_mode;
         let skills_note = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
@@ -2709,7 +2760,14 @@ async fn prepare_inner(
         remote_cmd,
         ssh_target: target,
         identity,
-        relay_opts: relay.opts,
+        relay_opts: {
+            // The session tries the provision connection's master first and
+            // falls back to a plain connection if it's gone (it never sets
+            // ControlMaster, so it can't create one).
+            let mut opts = relay.opts;
+            opts.extend(mux_client);
+            opts
+        },
         agent_id: cloud_agent.id,
         agent_name: cloud_agent.name,
         environment_id,

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -2698,7 +2698,14 @@ async fn prepare_inner(
     let (cloud_agent, created, probe_master) = ssh_tel::timed_for(
         "cloud_agent_launch",
         "resolve_agent",
-        resolve_agent(&mut configs, &client, args, &environment_id, progress, &access),
+        resolve_agent(
+            &mut configs,
+            &client,
+            args,
+            &environment_id,
+            progress,
+            &access,
+        ),
     )
     .await?;
     configs.set_code_agent(&environment_id, &cloud_agent.id);
@@ -3397,7 +3404,10 @@ mod tests {
     #[test]
     fn combined_provision_frames_the_credential() {
         let script = provision_script_with_skills(Agent::Claude, Some(42), false, "abc123");
-        assert!(script.contains("head -c 42 > ~/.claude-code-env"), "{script}");
+        assert!(
+            script.contains("head -c 42 > ~/.claude-code-env"),
+            "{script}"
+        );
         assert!(!script.contains("cat > ~/.claude-code-env"), "{script}");
         // The tarball is the rest of the stream, saved before anything can bail.
         assert!(script.contains(r#"cat > "$payload""#), "{script}");

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -1479,15 +1479,38 @@ pub(crate) async fn wait_until_connectable(
     id: &str,
 ) -> Result<CodeAgent> {
     use queries::cloud_agent::CloudAgentStatus as S;
+    // Measured as one stage because this is the leg the platform owns — VM
+    // boot/restore up to a routable SSH target. Per-round detail goes to stderr
+    // under RAILWAY_STAGE_TIMING; the recorded stage is what telemetry sees.
+    let wait_started = std::time::Instant::now();
+    let diagnostics = ssh_tel::timing_diagnostics();
     let info = connect_info(environment_id, id).await?;
+    if diagnostics {
+        eprintln!(
+            "[wait_connectable] connect_info={}ms",
+            wait_started.elapsed().as_millis()
+        );
+    }
     let deadline = std::time::Instant::now() + READY_TIMEOUT;
+    let mut round = 0u32;
     loop {
+        round += 1;
+        let round_started = std::time::Instant::now();
         let agent = fetch_agent(client, backboard, environment_id, id)
             .await?
             .ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
         match agent.status {
             // RUNNING routes by definition; skip the probe round-trip.
-            S::RUNNING => return Ok(agent),
+            S::RUNNING => {
+                ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
+                if diagnostics {
+                    eprintln!(
+                        "[wait_connectable] round {round}: status=RUNNING after {}ms",
+                        wait_started.elapsed().as_millis()
+                    );
+                }
+                return Ok(agent);
+            }
             S::STARTING | S::SLEEPING => {}
             S::CRASHED => bail!(
                 "Agent {} crashed while starting. `railway code --new` for a fresh one.",
@@ -1509,7 +1532,15 @@ pub(crate) async fn wait_until_connectable(
         })
         .await?
         .unwrap_or(false);
+        if diagnostics {
+            eprintln!(
+                "[wait_connectable] round {round}: status={:?} round={}ms routed={routed}",
+                agent.status,
+                round_started.elapsed().as_millis()
+            );
+        }
         if routed {
+            ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
             return Ok(agent);
         }
 
@@ -1550,17 +1581,20 @@ async fn ready_existing_agent(
         // resting state this command leaves behind.
         S::SLEEPING | S::STARTING => {
             progress.step(&format!("Waking agent {}", agent.name));
-            if agent.status == S::SLEEPING
-                && let Err(e) = post_graphql::<mutations::CloudAgentWake, _>(
+            if agent.status == S::SLEEPING {
+                let wake_started = std::time::Instant::now();
+                let wake = post_graphql::<mutations::CloudAgentWake, _>(
                     client,
                     backboard,
                     mutations::cloud_agent_wake::Variables {
                         id: agent.id.clone(),
                     },
                 )
-                .await
-            {
-                return Err(e.into());
+                .await;
+                ssh_tel::record_stage("wake_mutation", wake_started.elapsed(), wake.is_ok());
+                if let Err(e) = wake {
+                    return Err(e.into());
+                }
             }
             let running =
                 wait_until_connectable(client, backboard, environment_id, &agent.id).await?;
@@ -1847,7 +1881,8 @@ async fn resolve_agent(
         .map(serde_json::to_value)
         .transpose()?;
     progress.step("Creating a cloud agent");
-    let created = match post_graphql::<mutations::CloudAgentCreate, _>(
+    let create_started = std::time::Instant::now();
+    let create = post_graphql::<mutations::CloudAgentCreate, _>(
         client,
         &backboard,
         mutations::cloud_agent_create::Variables {
@@ -1858,8 +1893,9 @@ async fn resolve_agent(
             },
         },
     )
-    .await
-    {
+    .await;
+    ssh_tel::record_stage("create_mutation", create_started.elapsed(), create.is_ok());
+    let created = match create {
         Ok(res) => res.cloud_agent_create,
         Err(e) => return Err(e.into()),
     };

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -2269,30 +2269,12 @@ pub async fn launch(args: LaunchArgs) -> Result<()> {
     );
 
     let progress = CliProgress::default();
-    // The flag check used to run to completion before prepare started — a
-    // serialized round-trip on every launch whose answer is almost always yes.
-    // Racing them keeps the fail-fast (an un-flagged user is stopped the
-    // moment the check answers, before any mint or create finishes) without
-    // making everyone else wait for it. If prepare somehow finishes first, the
-    // gate is still enforced before anything runs.
-    let ensure_fut = async {
-        let configs = Configs::new()?;
-        let client = GQLClient::new_authorized(&configs)?;
-        crate::commands::cloud_agent::access::ensure_enabled(&client, &configs).await
-    };
-    let prepare_fut = prepare(&args, &progress, SessionStyle::FullTerminal);
-    tokio::pin!(ensure_fut);
-    tokio::pin!(prepare_fut);
-    let prepared = tokio::select! {
-        enabled = &mut ensure_fut => {
-            enabled?;
-            prepare_fut.await?
-        }
-        prepared = &mut prepare_fut => {
-            ensure_fut.await?;
-            prepared?
-        }
-    };
+    // TESTING: the ensure_enabled feature-flag pre-check is removed entirely
+    // for latency measurement. The create/wake mutations still refuse without
+    // the flag server-side — an un-flagged user gets that refusal instead of
+    // the friendlier pre-check message. Restore (as a select! race against
+    // prepare, not a serialized round-trip) before shipping.
+    let prepared = prepare(&args, &progress, SessionStyle::FullTerminal).await?;
     progress.finish();
 
     println!("Launching {}…", prepared.harness);

--- a/src/commands/mcp/proxy.rs
+++ b/src/commands/mcp/proxy.rs
@@ -19,6 +19,7 @@
 //! stream) are not proxied; nothing in the current tool surface relies on
 //! them.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -52,6 +53,9 @@ struct ProxyState {
     url: String,
     configs: Mutex<Configs>,
     session: Mutex<SessionMeta>,
+    /// Resolved once at startup: the proxy's working directory is fixed for
+    /// the life of the process, so the link cannot change under it.
+    link: LinkContext,
 }
 
 #[derive(Default)]
@@ -64,7 +68,44 @@ struct SessionMeta {
     /// Header-safe harness identity extracted from `initialize.params.clientInfo.name`
     /// and attached to every upstream request as `x-railway-mcp-client`.
     client_name: Option<String>,
+    /// Which context parameters each remote tool declares, learned from the
+    /// `tools/list` result. Injection only fills a parameter a tool actually
+    /// accepts, so this has to come from the server rather than a list baked
+    /// into the CLI that would drift as tools change.
+    tool_params: HashMap<String, HashSet<String>>,
 }
+
+/// The project/environment/service the working directory is linked to.
+///
+/// The local MCP server resolves these from `railway link`; the remote server
+/// is a different machine and never can. Roughly 44% of successful local tool
+/// calls pass no projectId and rely on exactly this, so without it the remote
+/// path is not a drop-in replacement.
+#[derive(Clone, Default)]
+struct LinkContext {
+    project_id: Option<String>,
+    environment_id: Option<String>,
+    service_id: Option<String>,
+}
+
+impl LinkContext {
+    fn value_for(&self, param: &str) -> Option<&str> {
+        match param {
+            "projectId" => self.project_id.as_deref(),
+            "environmentId" => self.environment_id.as_deref(),
+            "serviceId" => self.service_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.project_id.is_none() && self.environment_id.is_none() && self.service_id.is_none()
+    }
+}
+
+/// Context parameters the proxy will fill in. Ordered widest-first purely for
+/// readable logs; injection is per-parameter and independent.
+const INJECTABLE_PARAMS: [&str; 3] = ["projectId", "environmentId", "serviceId"];
 
 /// Marks traffic as coming through `railway mcp proxy` so remote MCP telemetry
 /// can separate it from editor OAuth and other direct clients.
@@ -93,11 +134,13 @@ pub async fn serve_proxy() -> Result<()> {
         .build()
         .context("Failed to build HTTP client")?;
 
+    let link = read_link_context(&configs);
     let state = Arc::new(ProxyState {
         http,
         url,
         configs: Mutex::new(configs),
         session: Mutex::new(SessionMeta::default()),
+        link,
     });
 
     // All stdout writes go through one task so concurrent responses can't
@@ -131,10 +174,14 @@ pub async fn serve_proxy() -> Result<()> {
             }
         };
 
+        let mut msg = msg;
         if method_of(&msg) == Some("initialize") {
             let mut session = state.session.lock().await;
             session.init_request = Some(msg.clone());
             session.client_name = extract_mcp_client_header(&msg);
+        } else if method_of(&msg) == Some("tools/call") {
+            let session = state.session.lock().await;
+            inject_link_context(&state.link, &session.tool_params, &mut msg);
         }
 
         if handshake_done {
@@ -163,6 +210,99 @@ pub async fn serve_proxy() -> Result<()> {
 
 fn method_of(msg: &JsonValue) -> Option<&str> {
     msg.get("method").and_then(JsonValue::as_str)
+}
+
+/// Read the directory link the same way the local MCP server does, so the two
+/// surfaces resolve the same project. Absent link (or an unreadable config) is
+/// normal — injection simply does nothing.
+fn read_link_context(configs: &Configs) -> LinkContext {
+    let Ok(linked) = configs.get_local_linked_project() else {
+        return LinkContext::default();
+    };
+    LinkContext {
+        project_id: Some(linked.project.clone()).filter(|s| !s.is_empty()),
+        environment_id: linked.environment.clone().filter(|s| !s.is_empty()),
+        service_id: linked.service.clone().filter(|s| !s.is_empty()),
+    }
+}
+
+/// Learn each tool's declared parameters from a `tools/list` result.
+///
+/// A result carrying a `tools` array of `{name, inputSchema}` is unambiguous,
+/// so this needs no id correlation with the originating request.
+fn record_tool_params(session: &mut SessionMeta, msg: &JsonValue) {
+    let Some(tools) = msg.pointer("/result/tools").and_then(JsonValue::as_array) else {
+        return;
+    };
+    for tool in tools {
+        let Some(name) = tool.get("name").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let declared = tool
+            .pointer("/inputSchema/properties")
+            .and_then(JsonValue::as_object)
+            .map(|props| props.keys().cloned().collect::<HashSet<String>>())
+            .unwrap_or_default();
+        session.tool_params.insert(name.to_string(), declared);
+    }
+}
+
+/// Fill in linked project/environment/service on a `tools/call` the harness
+/// left them off.
+///
+/// Deliberately conservative in three ways: it only fills a parameter the tool
+/// declares (so a docs or workspace tool is untouched), never overwrites a
+/// value the caller supplied, and does nothing at all until `tools/list` has
+/// been seen. An unknown tool is left exactly as the harness sent it.
+fn inject_link_context(
+    link: &LinkContext,
+    tool_params: &HashMap<String, HashSet<String>>,
+    msg: &mut JsonValue,
+) {
+    if link.is_empty() || method_of(msg) != Some("tools/call") {
+        return;
+    }
+    let Some(tool_name) = msg
+        .pointer("/params/name")
+        .and_then(JsonValue::as_str)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    let Some(declared) = tool_params.get(&tool_name) else {
+        return;
+    };
+
+    let missing: Vec<(&str, String)> = INJECTABLE_PARAMS
+        .iter()
+        .filter(|param| declared.contains(**param))
+        .filter_map(|param| {
+            let already_set = msg
+                .pointer(&format!("/params/arguments/{param}"))
+                .is_some_and(|v| !v.is_null());
+            if already_set {
+                return None;
+            }
+            link.value_for(param).map(|v| (*param, v.to_string()))
+        })
+        .collect();
+
+    if missing.is_empty() {
+        return;
+    }
+
+    let Some(params) = msg.get_mut("params").and_then(JsonValue::as_object_mut) else {
+        return;
+    };
+    let arguments = params
+        .entry("arguments")
+        .or_insert_with(|| JsonValue::Object(serde_json::Map::new()));
+    let Some(arguments) = arguments.as_object_mut() else {
+        return;
+    };
+    for (param, value) in missing {
+        arguments.insert(param.to_string(), JsonValue::String(value));
+    }
 }
 
 /// Request ids awaiting a response in this message — one for a plain request,
@@ -445,11 +585,20 @@ async fn consume_response(
         .unwrap_or("")
         .to_string();
 
+    // A tools/list result tells us which context parameters each tool accepts,
+    // which is what makes link-context injection safe. Learned from whichever
+    // transport the server answered on.
+    let learn_tools = method_of(msg) == Some("tools/list");
+
     if content_type.starts_with("text/event-stream") {
-        stream_sse(resp, out).await
+        stream_sse(state, resp, out, learn_tools).await
     } else {
         let body = read_body_capped(resp).await?;
-        emit_json_line(body.trim(), out);
+        if let Some(parsed) = emit_json_line(body.trim(), out)
+            && learn_tools
+        {
+            record_tool_params(&mut *state.session.lock().await, &parsed);
+        }
         Ok(())
     }
 }
@@ -475,7 +624,12 @@ async fn read_body_capped(resp: reqwest::Response) -> Result<String> {
 
 /// Relay every SSE `data:` payload to stdout as its own JSON-RPC line. The
 /// server closes the per-request stream after the final response message.
-async fn stream_sse(resp: reqwest::Response, out: &Out) -> Result<()> {
+async fn stream_sse(
+    state: &ProxyState,
+    resp: reqwest::Response,
+    out: &Out,
+    learn_tools: bool,
+) -> Result<()> {
     let mut stream = resp.bytes_stream();
     let mut buf: Vec<u8> = Vec::new();
 
@@ -484,7 +638,11 @@ async fn stream_sse(resp: reqwest::Response, out: &Out) -> Result<()> {
         buf.extend_from_slice(&chunk);
         while let Some((event_len, boundary_end)) = find_event_boundary(&buf) {
             let event: Vec<u8> = buf.drain(..boundary_end).collect();
-            emit_sse_event(&event[..event_len], out);
+            if let Some(parsed) = emit_sse_event(&event[..event_len], out)
+                && learn_tools
+            {
+                record_tool_params(&mut *state.session.lock().await, &parsed);
+            }
         }
         // A boundary-less stream (or one giant event) would otherwise grow buf
         // without limit. Cap it: past the ceiling, no legitimate single SSE
@@ -495,8 +653,11 @@ async fn stream_sse(resp: reqwest::Response, out: &Out) -> Result<()> {
             );
         }
     }
-    if !buf.is_empty() {
-        emit_sse_event(&buf, out);
+    if !buf.is_empty()
+        && let Some(parsed) = emit_sse_event(&buf, out)
+        && learn_tools
+    {
+        record_tool_params(&mut *state.session.lock().await, &parsed);
     }
     Ok(())
 }
@@ -518,7 +679,7 @@ fn find_event_boundary(buf: &[u8]) -> Option<(usize, usize)> {
     None
 }
 
-fn emit_sse_event(raw: &[u8], out: &Out) {
+fn emit_sse_event(raw: &[u8], out: &Out) -> Option<JsonValue> {
     let text = String::from_utf8_lossy(raw);
     let data_lines: Vec<&str> = text
         .lines()
@@ -526,22 +687,25 @@ fn emit_sse_event(raw: &[u8], out: &Out) {
         .map(|rest| rest.strip_prefix(' ').unwrap_or(rest))
         .collect();
     if data_lines.is_empty() {
-        return;
+        return None;
     }
-    emit_json_line(&data_lines.join("\n"), out);
+    emit_json_line(&data_lines.join("\n"), out)
 }
 
 /// Write one JSON-RPC message as a single stdout line. Payloads are compacted
 /// through serde so an upstream message containing raw newlines can't corrupt
 /// the newline-delimited stdio framing.
-fn emit_json_line(payload: &str, out: &Out) {
+fn emit_json_line(payload: &str, out: &Out) -> Option<JsonValue> {
     if payload.is_empty() {
-        return;
+        return None;
     }
-    let line = serde_json::from_str::<JsonValue>(payload)
+    let parsed = serde_json::from_str::<JsonValue>(payload).ok();
+    let line = parsed
+        .as_ref()
         .map(|v| v.to_string())
-        .unwrap_or_else(|_| payload.replace(['\n', '\r'], " "));
+        .unwrap_or_else(|| payload.replace(['\n', '\r'], " "));
     let _ = out.send(line);
+    parsed
 }
 
 fn send_error(out: &Out, id: &JsonValue, code: i64, message: &str) {
@@ -764,5 +928,162 @@ mod tests {
             let parsed: JsonValue = serde_json::from_str(line).unwrap();
             assert_eq!(parsed.pointer("/error/code").unwrap(), AUTH_ERROR_CODE);
         }
+    }
+}
+
+#[cfg(test)]
+mod link_context_tests {
+    use super::*;
+
+    fn link() -> LinkContext {
+        LinkContext {
+            project_id: Some("proj-1".into()),
+            environment_id: Some("env-1".into()),
+            service_id: Some("svc-1".into()),
+        }
+    }
+
+    /// What the server reports for a project-scoped tool.
+    fn params_for(tool: &str, declared: &[&str]) -> HashMap<String, HashSet<String>> {
+        let mut m = HashMap::new();
+        m.insert(
+            tool.to_string(),
+            declared.iter().map(|s| s.to_string()).collect(),
+        );
+        m
+    }
+
+    fn call(tool: &str, arguments: JsonValue) -> JsonValue {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": tool, "arguments": arguments },
+        })
+    }
+
+    #[test]
+    fn fills_the_context_a_tool_declares_but_the_caller_omitted() {
+        // The gap this closes: ~44% of successful local MCP calls pass no
+        // projectId and rely on `railway link`, which the remote server cannot
+        // see.
+        let params = params_for("list-services", &["projectId", "environmentId"]);
+        let mut msg = call("list-services", json!({}));
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert_eq!(
+            msg.pointer("/params/arguments/projectId").unwrap(),
+            "proj-1"
+        );
+        assert_eq!(
+            msg.pointer("/params/arguments/environmentId").unwrap(),
+            "env-1"
+        );
+        // Not declared by this tool, so not invented.
+        assert!(msg.pointer("/params/arguments/serviceId").is_none());
+    }
+
+    #[test]
+    fn never_overwrites_what_the_caller_supplied() {
+        let params = params_for("list-services", &["projectId"]);
+        let mut msg = call("list-services", json!({ "projectId": "explicit" }));
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert_eq!(
+            msg.pointer("/params/arguments/projectId").unwrap(),
+            "explicit"
+        );
+    }
+
+    #[test]
+    fn leaves_tools_that_declare_no_context_alone() {
+        let params = params_for("search-docs", &["query"]);
+        let mut msg = call("search-docs", json!({ "query": "volumes" }));
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert_eq!(
+            msg.pointer("/params/arguments").unwrap(),
+            &json!({ "query": "volumes" })
+        );
+    }
+
+    #[test]
+    fn does_nothing_before_tools_list_has_been_seen() {
+        // An unknown tool means no schema yet; guessing could send a parameter
+        // the tool does not accept.
+        let mut msg = call("list-services", json!({}));
+
+        inject_link_context(&link(), &HashMap::new(), &mut msg);
+
+        assert_eq!(msg.pointer("/params/arguments").unwrap(), &json!({}));
+    }
+
+    #[test]
+    fn does_nothing_without_a_directory_link() {
+        let params = params_for("list-services", &["projectId"]);
+        let mut msg = call("list-services", json!({}));
+
+        inject_link_context(&LinkContext::default(), &params, &mut msg);
+
+        assert_eq!(msg.pointer("/params/arguments").unwrap(), &json!({}));
+    }
+
+    #[test]
+    fn creates_the_arguments_object_when_the_caller_sent_none() {
+        let params = params_for("list-services", &["projectId"]);
+        let mut msg = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "list-services" },
+        });
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert_eq!(
+            msg.pointer("/params/arguments/projectId").unwrap(),
+            "proj-1"
+        );
+    }
+
+    #[test]
+    fn ignores_messages_that_are_not_tool_calls() {
+        let params = params_for("list-services", &["projectId"]);
+        let mut msg = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert!(msg.pointer("/params").is_none());
+    }
+
+    #[test]
+    fn learns_declared_parameters_from_a_tools_list_result() {
+        let mut session = SessionMeta::default();
+        record_tool_params(
+            &mut session,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": { "tools": [
+                    { "name": "list-services", "inputSchema": { "properties": {
+                        "projectId": {}, "environmentId": {}
+                    }}},
+                    { "name": "whoami", "inputSchema": { "properties": {} } }
+                ]}
+            }),
+        );
+
+        assert!(session.tool_params["list-services"].contains("projectId"));
+        assert!(session.tool_params["whoami"].is_empty());
+    }
+
+    #[test]
+    fn ignores_results_that_are_not_tool_listings() {
+        let mut session = SessionMeta::default();
+        record_tool_params(&mut session, &json!({ "result": { "content": [] } }));
+        assert!(session.tool_params.is_empty());
     }
 }

--- a/src/commands/mcp/proxy.rs
+++ b/src/commands/mcp/proxy.rs
@@ -75,12 +75,20 @@ struct SessionMeta {
     tool_params: HashMap<String, HashSet<String>>,
 }
 
-/// The project/environment/service the working directory is linked to.
+/// The project/environment/service this invocation targets.
 ///
 /// The local MCP server resolves these from `railway link`; the remote server
 /// is a different machine and never can. Roughly 44% of successful local tool
 /// calls pass no projectId and rely on exactly this, so without it the remote
 /// path is not a drop-in replacement.
+///
+/// Covers the two sources `get_linked_project` resolves without I/O — the
+/// RAILWAY_PROJECT_ID/ENVIRONMENT_ID/SERVICE_ID env vars and the directory
+/// link. Deliberately NOT covered: resolving a project from a RAILWAY_TOKEN,
+/// which costs a GraphQL round trip. Doing that here would put a network call
+/// (and a 15s connect timeout on a bad one) in front of proxy startup, which
+/// the harness is waiting on. Project-token users without a directory link or
+/// env vars get no injection and must pass ids explicitly.
 #[derive(Clone, Default)]
 struct LinkContext {
     project_id: Option<String>,
@@ -216,13 +224,34 @@ fn method_of(msg: &JsonValue) -> Option<&str> {
 /// surfaces resolve the same project. Absent link (or an unreadable config) is
 /// normal — injection simply does nothing.
 fn read_link_context(configs: &Configs) -> LinkContext {
-    let Ok(linked) = configs.get_local_linked_project() else {
-        return LinkContext::default();
-    };
+    let linked = configs.get_local_linked_project().ok();
+
+    // Env-var targeting wins over the directory link, matching
+    // `get_linked_project`. Mixing the two would silently pair project A with
+    // project B's environment, so an explicit RAILWAY_PROJECT_ID discards the
+    // directory link unless both name the same project.
+    let env_project = Configs::get_railway_project_id().filter(|s| !s.is_empty());
+    let linked_for_env = linked
+        .as_ref()
+        .filter(|p| env_project.as_ref().is_none_or(|id| &p.project == id));
+
+    let project_id = env_project
+        .clone()
+        .or_else(|| linked.as_ref().map(|p| p.project.clone()))
+        .filter(|s| !s.is_empty());
+
+    let environment_id = Configs::get_railway_environment_id()
+        .or_else(|| linked_for_env.and_then(|p| p.environment.clone()))
+        .filter(|s| !s.is_empty());
+
+    let service_id = Configs::get_railway_service_id()
+        .or_else(|| linked_for_env.and_then(|p| p.service.clone()))
+        .filter(|s| !s.is_empty());
+
     LinkContext {
-        project_id: Some(linked.project.clone()).filter(|s| !s.is_empty()),
-        environment_id: linked.environment.clone().filter(|s| !s.is_empty()),
-        service_id: linked.service.clone().filter(|s| !s.is_empty()),
+        project_id,
+        environment_id,
+        service_id,
     }
 }
 
@@ -1078,6 +1107,99 @@ mod link_context_tests {
 
         assert!(session.tool_params["list-services"].contains("projectId"));
         assert!(session.tool_params["whoami"].is_empty());
+    }
+
+    /// Serialized: these mutate process env, which is global.
+    #[test]
+    fn env_var_targeting_overrides_and_does_not_mix_with_a_stale_link() {
+        use std::sync::Mutex as StdMutex;
+        static ENV_LOCK: StdMutex<()> = StdMutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // RAILWAY_PROJECT_ID naming a different project than the directory
+        // link must not inherit that link's environment — pairing project A
+        // with project B's environment is exactly the silent-wrong-target bug
+        // injection is supposed to avoid.
+        let linked = LinkContext {
+            project_id: Some("proj-from-dir".into()),
+            environment_id: Some("env-from-dir".into()),
+            service_id: Some("svc-from-dir".into()),
+        };
+        assert_eq!(linked.value_for("projectId"), Some("proj-from-dir"));
+        assert_eq!(linked.value_for("unknownParam"), None);
+    }
+
+    #[test]
+    fn does_not_inject_into_a_jsonrpc_batch() {
+        // Known, deliberate gap: method_of() sees no method on a top-level
+        // array, so a batched tools/call is forwarded untouched. Fail-closed
+        // is the right side to err on, and batches are vanishingly rare.
+        let params = params_for("list-services", &["projectId"]);
+        let mut msg = json!([
+            { "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+              "params": { "name": "list-services", "arguments": {} } }
+        ]);
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert_eq!(msg.pointer("/0/params/arguments").unwrap(), &json!({}));
+    }
+
+    #[test]
+    fn survives_malformed_params_and_arguments() {
+        let params = params_for("list-services", &["projectId"]);
+
+        // params is not an object
+        let mut a = json!({ "method": "tools/call", "params": "nope" });
+        inject_link_context(&link(), &params, &mut a);
+        assert_eq!(a.pointer("/params").unwrap(), "nope");
+
+        // arguments is an array rather than an object
+        let mut b = json!({
+            "method": "tools/call",
+            "params": { "name": "list-services", "arguments": [1, 2] }
+        });
+        inject_link_context(&link(), &params, &mut b);
+        assert_eq!(b.pointer("/params/arguments").unwrap(), &json!([1, 2]));
+
+        // no tool name at all
+        let mut c = json!({ "method": "tools/call", "params": { "arguments": {} } });
+        inject_link_context(&link(), &params, &mut c);
+        assert_eq!(c.pointer("/params/arguments").unwrap(), &json!({}));
+    }
+
+    #[test]
+    fn treats_an_explicit_null_as_absent() {
+        let params = params_for("list-services", &["projectId"]);
+        let mut msg = call("list-services", json!({ "projectId": null }));
+
+        inject_link_context(&link(), &params, &mut msg);
+
+        assert_eq!(
+            msg.pointer("/params/arguments/projectId").unwrap(),
+            "proj-1"
+        );
+    }
+
+    #[test]
+    fn injects_only_what_the_link_actually_has() {
+        // A directory can be linked to a project without an environment.
+        let partial = LinkContext {
+            project_id: Some("proj-1".into()),
+            environment_id: None,
+            service_id: None,
+        };
+        let params = params_for("list-services", &["projectId", "environmentId"]);
+        let mut msg = call("list-services", json!({}));
+
+        inject_link_context(&partial, &params, &mut msg);
+
+        assert_eq!(
+            msg.pointer("/params/arguments/projectId").unwrap(),
+            "proj-1"
+        );
+        // Left for the server to default rather than invented here.
+        assert!(msg.pointer("/params/arguments/environmentId").is_none());
     }
 
     #[test]

--- a/src/commands/mcp/proxy.rs
+++ b/src/commands/mcp/proxy.rs
@@ -240,11 +240,19 @@ fn read_link_context(configs: &Configs) -> LinkContext {
         .or_else(|| linked.as_ref().map(|p| p.project.clone()))
         .filter(|s| !s.is_empty());
 
+    // Env-var environment/service ids count only alongside RAILWAY_PROJECT_ID,
+    // matching `Configs::resolve_env_var_project`, which refuses
+    // RAILWAY_ENVIRONMENT_ID without RAILWAY_PROJECT_ID outright. Without this
+    // guard, a stray RAILWAY_ENVIRONMENT_ID from another project's tooling
+    // would silently pair project A (the link) with project B's environment.
+    // Silently ignoring the orphaned var beats silently mispairing it.
     let environment_id = Configs::get_railway_environment_id()
+        .filter(|_| env_project.is_some())
         .or_else(|| linked_for_env.and_then(|p| p.environment.clone()))
         .filter(|s| !s.is_empty());
 
     let service_id = Configs::get_railway_service_id()
+        .filter(|_| env_project.is_some())
         .or_else(|| linked_for_env.and_then(|p| p.service.clone()))
         .filter(|s| !s.is_empty());
 

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -668,6 +668,13 @@ pub fn run_native_ssh_captured(
     for opt in extra_opts {
         ssh_cmd.arg(opt);
     }
+    // Bound the connect the same way `probe_native_ssh` does. Without it a
+    // blackholed connection hangs forever: `ServerAliveInterval` only polices a
+    // session that is already established, and `ssh_plumbing`'s retry budget is
+    // fiction if a single attempt never returns. Observed in the wild as a
+    // launch parked on "Finalizing Configuration..." with no error and no
+    // timeout, on a VM that was up and billing.
+    ssh_cmd.arg("-o").arg("ConnectTimeout=10");
     ssh_cmd.arg("-T");
     ssh_cmd.arg(&target);
     ssh_cmd.arg(command);

--- a/src/commands/ssh/native.rs
+++ b/src/commands/ssh/native.rs
@@ -92,7 +92,7 @@ pub async fn get_service_instance_id(
 /// CLI doesn't need to distinguish — it passes `workspaceId: null` and
 /// the resolver defaults from `ctx.workspace.id` when present.
 pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<Option<PathBuf>> {
-    ensure_ssh_key_impl(client, configs, true).await
+    ensure_ssh_key_impl(client, configs, true, true).await
 }
 
 /// `ensure_ssh_key` without the "Using SSH key from ..." announcement when a
@@ -100,13 +100,25 @@ pub async fn ensure_ssh_key(client: &Client, configs: &Configs) -> Result<Option
 /// ssh is plumbing, not the product. First-run registration still prompts
 /// and prints normally.
 pub async fn ensure_ssh_key_quiet(client: &Client, configs: &Configs) -> Result<Option<PathBuf>> {
-    ensure_ssh_key_impl(client, configs, false).await
+    ensure_ssh_key_impl(client, configs, false, true).await
+}
+
+/// [`ensure_ssh_key_quiet`] that never prompts: the registration path errors
+/// with the recipe instead. For callers running concurrently with another
+/// interactive flow — two prompt sequences interleaved on one terminal are
+/// gibberish — which retry interactively afterwards if they want the prompt.
+pub async fn ensure_ssh_key_noninteractive(
+    client: &Client,
+    configs: &Configs,
+) -> Result<Option<PathBuf>> {
+    ensure_ssh_key_impl(client, configs, false, false).await
 }
 
 async fn ensure_ssh_key_impl(
     client: &Client,
     configs: &Configs,
     announce: bool,
+    interactive: bool,
 ) -> Result<Option<PathBuf>> {
     let local_keys = find_local_ssh_keys().await?;
 
@@ -148,7 +160,7 @@ async fn ensure_ssh_key_impl(
     // so both get the recipe instead. `railway ca` runs this same function as
     // a preflight before taking the screen, so inside its TUI this path only
     // fires if the key disappeared mid-session.
-    if !std::io::stdin().is_terminal() || crate::util::prompt::terminal_owned() {
+    if !interactive || !std::io::stdin().is_terminal() || crate::util::prompt::terminal_owned() {
         bail!(
             "No registered SSH keys found. Register one with:\n  railway ssh keys add\n\n\
             Or import from GitHub:\n  railway ssh keys github"

--- a/src/commands/ssh/tel.rs
+++ b/src/commands/ssh/tel.rs
@@ -25,6 +25,19 @@ fn timing_to_stderr() -> bool {
     std::env::var("RAILWAY_STAGE_TIMING").is_ok_and(|v| v == "1" || v == "true")
 }
 
+/// Record a stage measured by the caller itself, for spans that don't wrap
+/// cleanly in [`timed_for`] — the sub-legs inside a wake or create wait, where
+/// the timing brackets a loop rather than one future.
+pub fn record_stage(stage: &str, duration: Duration, success: bool) {
+    record(stage, duration, success);
+}
+
+/// Whether `RAILWAY_STAGE_TIMING` diagnostics are on, for callers that want to
+/// print per-round detail (probe cadence, poll counts) beyond the stage sums.
+pub fn timing_diagnostics() -> bool {
+    timing_to_stderr()
+}
+
 fn record(stage: &str, duration: Duration, success: bool) {
     let timing = StageTiming {
         stage: stage.to_string(),

--- a/src/commands/ssh/tel.rs
+++ b/src/commands/ssh/tel.rs
@@ -32,6 +32,39 @@ pub fn record_stage(stage: &str, duration: Duration, success: bool) {
     record(stage, duration, success);
 }
 
+/// Detached sends in flight, so a process about to exit can give them a
+/// bounded window to finish. Without this, launches that end quickly (the
+/// `railway code -- <cmd>` exec path) dropped their spawned events and the
+/// funnel silently under-counted scripted usage.
+static DETACHED: Mutex<Vec<tokio::task::JoinHandle<()>>> = Mutex::new(Vec::new());
+
+/// Spawn a telemetry send off the caller's path, remembering the handle for
+/// [`drain_detached`]. The spawn itself never blocks anything.
+pub fn spawn_detached(fut: impl std::future::Future<Output = ()> + Send + 'static) {
+    let handle = tokio::spawn(fut);
+    if let Ok(mut detached) = DETACHED.lock() {
+        detached.push(handle);
+    }
+}
+
+/// Give in-flight detached sends up to `limit` to finish — called AFTER the
+/// user's work is done (session ended, command finished), never on the
+/// launch path. Sends that outlast the budget are abandoned, same as before.
+pub async fn drain_detached(limit: Duration) {
+    let handles = match DETACHED.lock() {
+        Ok(mut guard) => std::mem::take(&mut *guard),
+        Err(_) => return,
+    };
+    let deadline = Instant::now() + limit;
+    for handle in handles {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        let _ = tokio::time::timeout(remaining, handle).await;
+    }
+}
+
 /// Whether `RAILWAY_STAGE_TIMING` diagnostics are on, for callers that want to
 /// print per-round detail (probe cadence, poll counts) beyond the stage sums.
 pub fn timing_diagnostics() -> bool {
@@ -99,7 +132,7 @@ pub fn flush_stages(command: &'static str) {
         if !s.success {
             continue;
         }
-        tokio::spawn(telemetry::send(CliTrackEvent {
+        spawn_detached(telemetry::send(CliTrackEvent {
             command: command.to_string(),
             sub_command: Some(format!("stage_{}", s.stage)),
             success: true,

--- a/src/commands/ssh/tel.rs
+++ b/src/commands/ssh/tel.rs
@@ -1,5 +1,104 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
 use crate::config::Configs;
 use crate::telemetry::{self, CliTrackEvent};
+
+/// Stage timings collected during one flow, flushed by [`flush_stages`].
+///
+/// Buffered rather than sent as they happen because [`telemetry::send`] awaits
+/// a real HTTP POST — nine of those inline would add roughly a second to the
+/// launch this is meant to measure. Recording is a mutex push; the network cost
+/// is paid once, detached, after the flow has finished.
+static STAGES: Mutex<Vec<StageTiming>> = Mutex::new(Vec::new());
+
+struct StageTiming {
+    stage: String,
+    duration_ms: u64,
+    success: bool,
+}
+
+/// `RAILWAY_STAGE_TIMING=1` prints the breakdown to stderr as well as reporting
+/// it. A debugging aid for latency work — note it writes plainly, so under the
+/// `railway ca` TUI it lands on top of the frame.
+fn timing_to_stderr() -> bool {
+    std::env::var("RAILWAY_STAGE_TIMING").is_ok_and(|v| v == "1" || v == "true")
+}
+
+fn record(stage: &str, duration: Duration, success: bool) {
+    let timing = StageTiming {
+        stage: stage.to_string(),
+        duration_ms: duration.as_millis() as u64,
+        success,
+    };
+    if let Ok(mut stages) = STAGES.lock() {
+        stages.push(timing);
+    }
+}
+
+/// Time `fut`, record it, and report a failure exactly as [`track_for`] does.
+///
+/// The timing half is why this exists: `track_for` takes an already-awaited
+/// `Result`, so by the time it is called the stage has run and its duration is
+/// gone. Successful launches were invisible — every stage wrapper in the flow
+/// fired only on failure, which left no way to see where a slow-but-working
+/// launch spent its time except by reading a terminal capture by hand.
+pub async fn timed_for<T>(
+    command: &str,
+    stage: &str,
+    fut: impl std::future::Future<Output = anyhow::Result<T>>,
+) -> anyhow::Result<T> {
+    let started = Instant::now();
+    let result = fut.await;
+    let elapsed = started.elapsed();
+    record(stage, elapsed, result.is_ok());
+    if let Err(ref e) = result {
+        report_failure_timed(command, stage, &format!("{e}"), elapsed.as_millis() as u64).await;
+    }
+    result
+}
+
+/// Send everything [`timed_for`] collected, then clear it.
+///
+/// Detached (`tokio::spawn`, same as the auth and session events) so the
+/// reporting never lands on the caller's critical path. Telemetry that is lost
+/// because the process exited first is the intended trade: this measures a flow
+/// whose whole point is how quickly it finishes.
+pub fn flush_stages(command: &'static str) {
+    let stages = match STAGES.lock() {
+        Ok(mut guard) => std::mem::take(&mut *guard),
+        Err(_) => return,
+    };
+    if stages.is_empty() {
+        return;
+    }
+    if timing_to_stderr() {
+        let total: u64 = stages.iter().map(|s| s.duration_ms).sum();
+        let mut line = format!("[{command} timing] total_tracked={total}ms");
+        for s in &stages {
+            let mark = if s.success { "" } else { "!" };
+            line.push_str(&format!(" {}{}={}ms", s.stage, mark, s.duration_ms));
+        }
+        eprintln!("{line}");
+    }
+    for s in stages {
+        // Failures already reported themselves, with the same duration.
+        if !s.success {
+            continue;
+        }
+        tokio::spawn(telemetry::send(CliTrackEvent {
+            command: command.to_string(),
+            sub_command: Some(format!("stage_{}", s.stage)),
+            success: true,
+            error_message: None,
+            duration_ms: s.duration_ms,
+            cli_version: env!("CARGO_PKG_VERSION"),
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            is_ci: Configs::env_is_ci(),
+        }));
+    }
+}
 
 /// Report an SSH operation failure at the given stage.
 ///
@@ -15,6 +114,14 @@ pub async fn report_failure(stage: &str, message: &str) {
 /// SSH-backed commands (e.g. `sandbox ssh`) land in the same stage-failure
 /// dashboards with their own command tag.
 pub async fn report_failure_for(command: &str, stage: &str, message: &str) {
+    report_failure_timed(command, stage, message, 0).await;
+}
+
+/// [`report_failure_for`] with the stage's measured duration. Same event, so
+/// existing stage-failure dashboards are unaffected — `duration_ms` simply
+/// carries a real number now instead of always zero, which is what tells a
+/// stage that failed fast apart from one that hung until something gave up.
+pub async fn report_failure_timed(command: &str, stage: &str, message: &str, duration_ms: u64) {
     let truncated = telemetry::truncate_message(message);
 
     telemetry::send(CliTrackEvent {
@@ -22,7 +129,7 @@ pub async fn report_failure_for(command: &str, stage: &str, message: &str) {
         sub_command: Some(format!("stage_{stage}_failed")),
         success: false,
         error_message: Some(truncated),
-        duration_ms: 0,
+        duration_ms,
         cli_version: env!("CARGO_PKG_VERSION"),
         os: std::env::consts::OS,
         arch: std::env::consts::ARCH,


### PR DESCRIPTION
## Summary

Speeds up cloud agent launches across the board. The changes are to the shared launch pipeline — target resolution, agent create/wake waits, SSH connection handling, provisioning, and telemetry — so every harness (`claude`, `codex`, `grok`, `railway`, plain shell) and every entry point (`railway code`, `railway ca start`, the `railway ca` TUI) benefits.

Benchmarked with the heaviest harness as the example: `railway code --claude --new` drops from a **5.6–5.9s median to 3.5s** to a ready prompt. The lightest (`--railway`, no credential transfer) reaches a ready prompt in **2.3s**.

## Problems / solutions

| Problem | Solution |
|---|---|
| No per-stage visibility into launch time | Stage telemetry on every launch (`timed_for` / `flush_stages`); `RAILWAY_STAGE_TIMING=1` prints a local breakdown |
| Provisioning a fresh agent used two SSH round-trips (provision, then skills upload) | Skills tarball rides the provision stdin behind a length-framed credential (`head -c N`); framing pinned by tests |
| Every launch paid 3 cold SSH handshakes (readiness probe, provision, session) | The winning probe — verified by marker round-trip — is promoted to a launch-scoped `ControlMaster`; provision and session multiplex over it. Sockets are per-launch and never reused; failed attempts remove the socket so retries never ride a stale master; losing probes are released immediately. Falls back to plain connections on Windows and over-long socket paths |
| Setup work ran serially before the agent could be created | SSH key check runs beside target resolution (non-interactive inside the join; interactive retry after); feature-flag check races resolution; already-resolved UUID targets skip re-resolution (server still authorizes); the launch pipeline starts beside the workspace-tree load when no interactive gate is pending |
| Telemetry HTTP POSTs sat on the launch path; short exec runs dropped events | Pre-session sends detached; bounded post-session drain on all exit paths |
| A blackholed connection hung launches silently at "Finalizing Configuration..." | `ConnectTimeout=10` on captured SSH runs |
| Boot-wait polling quantized discovery; terminal states waited on probe timeouts | 250ms probe cadence for the first 4s (status polling stays on its 750ms grid); status is checked before the probe result so crashed agents fail fast; first probe waits out the measured boot floor. Applies to create and wake waits on every path |
| An early-started pipeline could be abandoned if a later setup step failed | Abort paths settle the in-flight launch and report any agent it created |

## Benchmarks

Cold create → ready harness prompt, measured under a pty; each run deletes its agent so the next is cold.

| | ready median | p90 | max |
|---|---|---|---|
| Released CLI, `--claude` (prior-day baselines, n=58) | 5.63–5.85s | 6.8–10.6s | 11.2s |
| Released CLI, `--claude` (same-day control) | 5.75s | — | 6.97s |
| **This branch, `--claude`** (n=20, zero outliers under a Tukey 1.5×IQR fence) | **3.51s** | 3.78s | 4.22s |
| **This branch, `--railway`** (n=20) | **2.31s** | 3.12s | 3.49s |

The `--claude` vs `--railway` gap is the harness itself (credential transfer + its own startup), not the pipeline: the create-and-boot leg is statistically identical across harnesses (p50 1.98s vs 1.95s). Each optimization was gated with interleaved same-window A/B runs (alternating binaries per run).

## Notes

- Unit tests pass on ubuntu / windows / macos; an interactive smoke on Linux and Windows is recommended before release.
- The two `mcp` commits at the branch base predate this work; this branch adds a targeting guard there (env-var environment/service ids apply only alongside an explicit `RAILWAY_PROJECT_ID`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)