### PR TITLE
Emit named IaC partial from migrate as a last resort

### DIFF
--- a/assets/iac/README.md
+++ b/assets/iac/README.md
@@ -40,6 +40,7 @@ railway config apply
 - `railway config apply` previews changes and asks before applying unless you pass `--yes`.
 - Destructive changes in non-interactive or agent sessions require `railway config apply --confirm-destructive` after reviewing the plan.
 - Services already managed by `railway.json` must be migrated before `.railway/railway.ts` can manage them.
+- Keep one `.railway` file for the whole project. A named `export const partial` (or `PARTIAL` / `const Partial`) is a last resort for separate repos that cannot share that file. Do not add it unless omit=delete across repos is a blocker.
 - Use `replicas` for scaling; advanced placement can still specify region names.
 - Use `group("Name", [resources])` to keep large projects organized on the Railway canvas.
 - Secrets imported from Railway are rendered as `preserve()` so existing values are retained without writing secret values to source. Use `railway config pull --omit-preserved-variables` for a smaller import.

--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -223,6 +223,9 @@ fn emit_railway_py(service_name: &str, cac: &CacFile) -> String {
     format!(
         r#"from railway_iac import define_railway, project, service
 
+# Last resort for a per-service CaC repo. Prefer one .railway file for the
+# project and drop this if you later combine services into that file.
+PARTIAL = {project}
 
 @define_railway
 def main(ctx=None):
@@ -254,6 +257,10 @@ fn emit_railway_go(service_name: &str, cac: &CacFile) -> String {
         r#"package main
 
 import "github.com/railwayapp/railway-go-iac/iac"
+
+// Last resort for a per-service CaC repo. Prefer one .railway file for the
+// project and drop this if you later combine services into that file.
+const Partial = {name}
 
 func Railway() iac.Project {{
 	web := iac.ServiceNamed({name}, {config})
@@ -328,6 +335,10 @@ fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
 
     format!(
         r#"import {{ defineRailway, project, service }} from "railway/iac";
+
+// Last resort for a per-service CaC repo. Prefer one .railway file for the
+// project and drop this if you later combine services into that file.
+export const partial = {project};
 
 export default defineRailway(() => {{
 {body}
@@ -441,6 +452,7 @@ mod tests {
         assert!(out.contains("start: \"pnpm start\""));
         assert!(out.contains("healthcheck: \"/health\""));
         assert!(out.contains("service(\"api\""));
+        assert!(out.contains("export const partial = \"api\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `railway config migrate` writes `export const partial` / `PARTIAL` / `const Partial` using the linked service name so a per-service CaC repo does not own the whole environment on apply.
- `.railway/README.md` tells agents to keep one file and treat a named partial as a last resort.

Engine, claim apply, and unit tests already landed in #1113. This replaces the stale stacked #1112.

## Test plan
- [ ] `railway config migrate` (ts/py/go) includes the sibling constant and the last-resort comment
- [ ] Cargo tests for migrate still pass


Made with [Cursor](https://cursor.com)