### PR TITLE
feat(cli): report IaC authoring language on change sets

### DIFF
--- a/src/iac/change_set.rs
+++ b/src/iac/change_set.rs
@@ -25,13 +25,14 @@ pub struct ChangeSet {
     pub telemetry: Option<ChangeSetTelemetry>,
 }
 
+/// Authoring language is the only adoption dimension the server cannot observe
+/// on its own: CLI version arrives in the request headers, the engine is
+/// implied by the change set API, and CI is already on the `config` command
+/// event.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeSetTelemetry {
     pub language: String,
-    pub engine: String,
-    pub cli_version: String,
-    pub is_ci: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/iac/change_set.rs
+++ b/src/iac/change_set.rs
@@ -21,6 +21,17 @@ pub struct ChangeSet {
     pub partial: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub declared: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub telemetry: Option<ChangeSetTelemetry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeSetTelemetry {
+    pub language: String,
+    pub engine: String,
+    pub cli_version: String,
+    pub is_ci: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -218,6 +229,7 @@ fn change_set_result(
         diagnostics,
         partial: partial.map(str::to_string),
         declared,
+        telemetry: None,
     }
 }
 

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -202,9 +202,6 @@ pub async fn run(
     });
     change_set.telemetry = Some(ChangeSetTelemetry {
         language: authoring_language(&evaluated.file).to_string(),
-        engine: "native".to_string(),
-        cli_version: env!("CARGO_PKG_VERSION").to_string(),
-        is_ci: Configs::env_is_ci(),
     });
     let mut all_diagnostics = diagnostics;
     for diagnostic in &change_set.diagnostics {

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -10,7 +10,7 @@ use crate::{
     config::{Configs, LinkedProject},
 };
 
-use super::change_set::{DiffOptions, diff_graphs, render_change_set};
+use super::change_set::{ChangeSetTelemetry, DiffOptions, diff_graphs, render_change_set};
 use super::compiler::{EnvironmentConfigToGraphOptions, environment_config_to_graph};
 use super::eval::evaluate_file;
 use super::graph::validate_graph;
@@ -131,6 +131,20 @@ pub struct NativeRun {
     pub show_values: bool,
 }
 
+fn authoring_language(file: &std::path::Path) -> &'static str {
+    match file
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "py" => "python",
+        "go" => "go",
+        _ => "typescript",
+    }
+}
+
 pub async fn run(
     args: &NativeRun,
     configs: &Configs,
@@ -185,6 +199,12 @@ pub async fn run(
         reveal_values: args.show_values,
         partial: evaluated.partial.as_deref(),
         owners: owners.as_ref(),
+    });
+    change_set.telemetry = Some(ChangeSetTelemetry {
+        language: authoring_language(&evaluated.file).to_string(),
+        engine: "native".to_string(),
+        cli_version: env!("CARGO_PKG_VERSION").to_string(),
+        is_ci: Configs::env_is_ci(),
     });
     let mut all_diagnostics = diagnostics;
     for diagnostic in &change_set.diagnostics {
@@ -606,6 +626,22 @@ mod tests {
         assert!(
             broken.is_err(),
             "the live GraphQL payload is not {{ project: {{ edges }} }}"
+        );
+    }
+
+    #[test]
+    fn authoring_language_normalizes_supported_extensions() {
+        assert_eq!(
+            authoring_language(std::path::Path::new(".railway/railway.ts")),
+            "typescript"
+        );
+        assert_eq!(
+            authoring_language(std::path::Path::new(".railway/railway.py")),
+            "python"
+        );
+        assert_eq!(
+            authoring_language(std::path::Path::new(".railway/railway.go")),
+            "go"
         );
     }
 }


### PR DESCRIPTION
## Summary
Stamps native IaC change sets with the authoring language (`typescript` / `python` / `go`, from the evaluated file extension) so backboard can tell which SDK teams actually author in.

This is deliberately the *only* field sent. Everything else about the client is already observable server-side, and adding it here would mean the metric only covers users who upgrade:

- CLI version — already in the `x-source` / `user-agent` header on every request.
- Engine — the change set API only has the native path.
- CI — already on the existing `config` command event (`is_ci`).

Pairs with railwayapp/mono#36367, which reads `telemetry.language` and derives the rest. The field is optional there, so this can ship in either order.

## Test plan
- [x] `cargo test --bin railway iac::` (47 passed)
- [ ] Plan a `.railway/railway.ts` project and confirm the change set payload carries `telemetry.language=typescript`
- [ ] Repeat against a `.py` entrypoint and confirm `python`