### PR TITLE
fix(cloud-agent): seed SHELL=/bin/bash on newly created agents

### DIFF
--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -2151,9 +2151,11 @@ async fn resolve_agent(
         configs.remove_code_agent(environment_id);
     }
 
-    let variables = variables_to_input(&args.env_files, &args.variables)?
-        .map(serde_json::to_value)
-        .transpose()?;
+    let variables = crate::controllers::cloud_agent::with_default_variables(
+        variables_to_input(&args.env_files, &args.variables)?
+            .map(serde_json::to_value)
+            .transpose()?,
+    );
     progress.step("Creating a cloud agent");
     let create_started = std::time::Instant::now();
     let create = post_graphql::<mutations::CloudAgentCreate, _>(

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -194,6 +194,30 @@ pub async fn list_in_environment(
         .collect())
 }
 
+/// Layer the CLI's default variables under the caller's, for a new agent.
+///
+/// `SHELL` is a stopgap: the VM's session runner wraps every command in
+/// `bash -c`, and bash self-assigns `$SHELL` without exporting it — so the
+/// variable reads as set from a shell prompt but is invisible to child
+/// processes. Codex desktop's remote bootstrap probes it from a `sh -c`
+/// wrapper and refuses to start when it's empty, which a GUI surfaces as a
+/// bare "SSH connection failed". A create-time variable lands in the VM's
+/// real environment, so it is exported everywhere. Only at create: variables
+/// don't reach an agent that already exists. A caller-supplied SHELL wins.
+/// Remove once vm-init exports SHELL itself.
+pub fn with_default_variables(variables: Option<serde_json::Value>) -> Option<serde_json::Value> {
+    let mut map = match variables {
+        None => serde_json::Map::new(),
+        Some(serde_json::Value::Object(map)) => map,
+        // Never produced by our callers (variables come from string maps);
+        // reshaping someone else's value is worse than leaving it alone.
+        Some(other) => return Some(other),
+    };
+    map.entry("SHELL")
+        .or_insert_with(|| serde_json::Value::String("/bin/bash".to_owned()));
+    Some(serde_json::Value::Object(map))
+}
+
 /// Create an agent. The VM only — no harness, no credential, no session.
 /// Provisioning belongs to whatever opens a session on it, so an agent created
 /// here works with any of them.
@@ -211,7 +235,7 @@ pub async fn create(
             input: mutations::cloud_agent_create::CloudAgentCreateInput {
                 environment_id: environment_id.to_owned(),
                 name,
-                variables,
+                variables: with_default_variables(variables),
             },
         },
     )
@@ -571,6 +595,25 @@ mod tests {
         assert!(!Status::Failed.is_live());
         assert!(!Status::Deleting.is_live());
         assert!(!Status::Unknown("wat".into()).is_live());
+    }
+
+    #[test]
+    fn shell_is_seeded_when_absent() {
+        // No variables at all still yields SHELL — Codex's remote bootstrap
+        // dies without it, and this is the only moment it can be set.
+        let vars = with_default_variables(None).unwrap();
+        assert_eq!(vars["SHELL"], "/bin/bash");
+
+        let vars = with_default_variables(Some(serde_json::json!({ "FOO": "bar" }))).unwrap();
+        assert_eq!(vars["SHELL"], "/bin/bash");
+        assert_eq!(vars["FOO"], "bar");
+    }
+
+    #[test]
+    fn a_callers_shell_wins_over_the_default() {
+        let vars =
+            with_default_variables(Some(serde_json::json!({ "SHELL": "/bin/zsh" }))).unwrap();
+        assert_eq!(vars["SHELL"], "/bin/zsh");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

- `railway ca desktop --codex` fails in Codex with "SSH connection failed"
- Actual error (from Codex's logs): its remote bootstrap exits 127 with "Codex remote SSH requires SHELL to point to an executable login shell"
- Agent exec sessions never export `SHELL`: vm-init wraps every command in `bash -c`, and bash self-assigns `$SHELL` **without exporting it** — `echo $SHELL` looks fine, but Codex's `sh -c` bootstrap wrapper sees it empty
- No client-side fix: the SSH relay drops all client-sent env (`SetEnv` is ignored except the two durable-session keys)

## Solution

- Seed `SHELL=/bin/bash` as a create-time variable on every new agent, landing it in the VM's real (exported) environment
- New `with_default_variables()` in `controllers/cloud_agent.rs`, applied in `ca::create` and in the `railway code` launch pipeline's direct create
- Caller-supplied `SHELL` (`--variable SHELL=...`) wins over the default
- Stopgap until vm-init exports `SHELL` itself (`buildShellCmd`/`buildExecCmd` defaults); create-time only, so existing agents need a recreate

## Validation

- Created an agent with the patched CLI, ran Codex's exact bootstrap probe over the relay: passes, `env` shows `SHELL=/bin/bash` exported
- `cargo test`: 1205 passed; clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)