### PR TITLE
feat(mcp): make `railway mcp` start the proxy, move the in-process server to `railway mcp local`

### DIFF
--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -20,8 +20,8 @@ pub struct Args {
     #[clap(long, conflicts_with = "local")]
     remote: bool,
 
-    /// Configure the local GraphQL-backed MCP server (`railway mcp`) instead of the
-    /// remote CLI proxy default.
+    /// Configure the local GraphQL-backed MCP server (`railway mcp local`) instead of
+    /// the remote CLI proxy default.
     #[clap(long, conflicts_with_all = ["remote", "oauth"])]
     local: bool,
 
@@ -34,10 +34,11 @@ pub struct Args {
 /// Which flavor of the Railway MCP server an install writes into a harness config.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum McpTransport {
-    /// `railway mcp` — local stdio server backed by GraphQL.
+    /// `railway mcp local` — in-process stdio server backed by GraphQL.
     Local,
-    /// `railway mcp proxy` — local stdio bridge to mcp.railway.com that
-    /// authenticates with the CLI's stored login.
+    /// `railway mcp proxy` — stdio bridge to mcp.railway.com that
+    /// authenticates with the CLI's stored login. Also what a bare
+    /// `railway mcp` starts.
     RemoteProxy,
     /// Plain mcp.railway.com URL — the editor authenticates via its own OAuth flow.
     RemoteOauth,
@@ -61,7 +62,10 @@ impl McpTransport {
 /// The argv written into harness configs for the stdio transports.
 fn stdio_args(transport: McpTransport) -> Vec<&'static str> {
     match transport {
-        McpTransport::Local => vec!["mcp"],
+        McpTransport::Local => vec!["mcp", "local"],
+        // Written explicitly rather than as a bare `mcp`, even though that is
+        // now the default: an installed config should not change meaning if
+        // the default ever moves again.
         McpTransport::RemoteProxy => vec!["mcp", "proxy"],
         // RemoteOauth entries are URL-based; callers never ask for its argv.
         McpTransport::RemoteOauth => unreachable!("RemoteOauth has no stdio argv"),
@@ -249,15 +253,26 @@ pub(crate) fn mcp_configured_for_slug(home: &Path, slug: &str, transport: McpTra
     }
 }
 
-/// Distinguish `railway mcp` (local) from `railway mcp proxy`: a bare
-/// "contains mcp" check would classify a proxy entry as a local install.
+/// Classify an installed `railway mcp …` entry by which server it starts.
+///
+/// Three-way since the cutover. `mcp local` is the in-process server; `mcp
+/// proxy` is the remote one; and a bare `mcp` — what installs written before
+/// the cutover contain — now starts the proxy too, so it classifies as remote
+/// rather than as the local install it used to be.
 fn stdio_argv_matches<'a>(
     args: impl Iterator<Item = &'a str> + Clone,
     transport: McpTransport,
 ) -> bool {
-    let has_mcp = args.clone().any(|a| a == "mcp");
-    let has_proxy = args.clone().any(|a| a == "proxy");
-    has_mcp && (has_proxy == matches!(transport, McpTransport::RemoteProxy))
+    if !args.clone().any(|a| a == "mcp") {
+        return false;
+    }
+    let has_local = args.clone().any(|a| a == "local");
+    match transport {
+        McpTransport::Local => has_local,
+        McpTransport::RemoteProxy => !has_local,
+        // URL-based; callers match it before narrowing to a stdio transport.
+        McpTransport::RemoteOauth => false,
+    }
 }
 
 fn json_mcp_entry_matches(entry: &JsonValue, transport: McpTransport) -> bool {
@@ -591,7 +606,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detects_existing_cursor_local_mcp() {
+    fn detects_existing_cursor_bare_mcp_as_remote() {
         let home = tempfile::tempdir().unwrap();
         let path = home.path().join(".cursor").join("mcp.json");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -606,6 +621,42 @@ mod tests {
         )
         .unwrap();
 
+        // A bare `mcp` argv started the in-process server before the
+        // cutover and starts the proxy after it, so an untouched
+        // pre-cutover config now reads as a remote install.
+        assert!(mcp_configured_for_slug(
+            home.path(),
+            "cursor",
+            McpTransport::RemoteProxy
+        ));
+        assert!(!mcp_configured_for_slug(
+            home.path(),
+            "cursor",
+            McpTransport::Local
+        ));
+        assert!(!mcp_configured_for_slug(
+            home.path(),
+            "cursor",
+            McpTransport::RemoteOauth
+        ));
+    }
+
+    #[test]
+    fn local_installs_are_written_explicitly() {
+        let home = tempfile::tempdir().unwrap();
+        let path = home.path().join(".cursor").join("mcp.json");
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        install_for("cursor", &path, McpTransport::Local).unwrap();
+
+        let root: JsonValue =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // Must be `mcp local`, not a bare `mcp` — that starts the proxy now.
+        assert_eq!(
+            root.pointer("/mcpServers/railway/args").unwrap(),
+            &serde_json::json!(["mcp", "local"])
+        );
+
         assert!(mcp_configured_for_slug(
             home.path(),
             "cursor",
@@ -616,11 +667,26 @@ mod tests {
             "cursor",
             McpTransport::RemoteProxy
         ));
-        assert!(!mcp_configured_for_slug(
-            home.path(),
-            "cursor",
-            McpTransport::RemoteOauth
-        ));
+    }
+
+    #[test]
+    fn argv_classification_is_three_way() {
+        let cases: [(&[&str], McpTransport, bool); 6] = [
+            (&["mcp", "local"], McpTransport::Local, true),
+            (&["mcp", "local"], McpTransport::RemoteProxy, false),
+            (&["mcp", "proxy"], McpTransport::RemoteProxy, true),
+            (&["mcp", "proxy"], McpTransport::Local, false),
+            // Pre-cutover config: bare `mcp` starts the proxy now.
+            (&["mcp"], McpTransport::RemoteProxy, true),
+            (&["mcp"], McpTransport::Local, false),
+        ];
+        for (argv, transport, expected) in cases {
+            assert_eq!(
+                stdio_argv_matches(argv.iter().copied(), transport),
+                expected,
+                "{argv:?} against {transport:?}"
+            );
+        }
     }
 
     #[test]
@@ -730,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn detects_existing_codex_local_mcp() {
+    fn detects_existing_codex_bare_mcp_as_remote() {
         let home = tempfile::tempdir().unwrap();
         let path = home.path().join(".codex").join("config.toml");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -744,15 +810,18 @@ mod tests {
         )
         .unwrap();
 
+        // A bare `mcp` argv started the in-process server before the
+        // cutover and starts the proxy after it, so an untouched
+        // pre-cutover config now reads as a remote install.
         assert!(mcp_configured_for_slug(
             home.path(),
             "codex",
-            McpTransport::Local
+            McpTransport::RemoteProxy
         ));
         assert!(!mcp_configured_for_slug(
             home.path(),
             "codex",
-            McpTransport::RemoteProxy
+            McpTransport::Local
         ));
         assert!(!mcp_configured_for_slug(
             home.path(),

--- a/src/commands/mcp/install.rs
+++ b/src/commands/mcp/install.rs
@@ -63,10 +63,11 @@ impl McpTransport {
 fn stdio_args(transport: McpTransport) -> Vec<&'static str> {
     match transport {
         McpTransport::Local => vec!["mcp", "local"],
-        // Written explicitly rather than as a bare `mcp`, even though that is
-        // now the default: an installed config should not change meaning if
-        // the default ever moves again.
-        McpTransport::RemoteProxy => vec!["mcp", "proxy"],
+        // A bare `mcp` — the canonical invocation now that it starts the
+        // proxy. `mcp proxy` still works and still classifies as remote, so
+        // configs written before the cutover keep running; new ones just say
+        // it the short way.
+        McpTransport::RemoteProxy => vec!["mcp"],
         // RemoteOauth entries are URL-based; callers never ask for its argv.
         McpTransport::RemoteOauth => unreachable!("RemoteOauth has no stdio argv"),
     }
@@ -674,6 +675,8 @@ mod tests {
         let cases: [(&[&str], McpTransport, bool); 6] = [
             (&["mcp", "local"], McpTransport::Local, true),
             (&["mcp", "local"], McpTransport::RemoteProxy, false),
+            // No longer written by `install`, but pre-cutover configs contain
+            // it and must keep resolving to the remote server.
             (&["mcp", "proxy"], McpTransport::RemoteProxy, true),
             (&["mcp", "proxy"], McpTransport::Local, false),
             // Pre-cutover config: bare `mcp` starts the proxy now.
@@ -690,7 +693,7 @@ mod tests {
     }
 
     #[test]
-    fn proxy_entry_is_not_mistaken_for_local() {
+    fn remote_installs_are_written_as_a_bare_mcp() {
         let home = tempfile::tempdir().unwrap();
         let path = home.path().join(".cursor").join("mcp.json");
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -700,10 +703,7 @@ mod tests {
         let written = std::fs::read_to_string(&path).unwrap();
         let root: JsonValue = serde_json::from_str(&written).unwrap();
         let railway = root.pointer("/mcpServers/railway").unwrap();
-        assert_eq!(
-            railway.get("args").unwrap(),
-            &serde_json::json!(["mcp", "proxy"])
-        );
+        assert_eq!(railway.get("args").unwrap(), &serde_json::json!(["mcp"]));
 
         assert!(mcp_configured_for_slug(
             home.path(),
@@ -780,7 +780,7 @@ mod tests {
         let railway = root.pointer("/mcp/railway").unwrap();
         assert_eq!(
             railway.get("command").unwrap(),
-            &serde_json::json!(["railway", "mcp", "proxy"])
+            &serde_json::json!(["railway", "mcp"])
         );
 
         assert!(mcp_configured_for_slug(
@@ -846,8 +846,8 @@ mod tests {
             .and_then(|railway| railway.get("args"))
             .and_then(toml::Value::as_array)
             .unwrap();
-        assert_eq!(args.len(), 2);
-        assert_eq!(args[1].as_str(), Some("proxy"));
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str(), Some("mcp"));
 
         assert!(mcp_configured_for_slug(
             home.path(),

--- a/src/commands/mcp/mod.rs
+++ b/src/commands/mcp/mod.rs
@@ -8,7 +8,7 @@ mod proxy;
 mod tools;
 use handler::RailwayMcp;
 
-/// Starts a local MCP server for AI-agent access, or installs the MCP config into AI coding tools.
+/// Connects AI agents to Railway's MCP server, or installs the MCP config into AI coding tools.
 #[derive(Parser)]
 pub struct Args {
     #[clap(subcommand)]
@@ -19,15 +19,26 @@ pub struct Args {
 enum Commands {
     /// Install Railway's MCP server config into AI coding tools (Claude Code, Cursor, OpenCode, Codex)
     Install(install::Args),
-    /// Proxy the remote MCP server (mcp.railway.com) over stdio, authenticating with your CLI login
+    /// Serve the in-process MCP server over stdio, without reaching mcp.railway.com
+    Local,
+    /// Proxy the remote MCP server over stdio — what a bare `railway mcp` now does
     Proxy,
 }
 
 pub async fn command(args: Args) -> Result<()> {
     match args.command {
-        None => serve_stdio().await,
+        // A bare `railway mcp` bridges to mcp.railway.com. The remote surface
+        // is the one that gets new tools, and it fails at a lower rate than
+        // the in-process server; the proxy reproduces the in-process server's
+        // one real advantage by completing a `railway link` project on calls
+        // that name no scope of their own.
+        //
+        // `mcp local` keeps the in-process server for anything that cannot
+        // reach mcp.railway.com, and `mcp proxy` still resolves here so
+        // configs written before the cutover keep working.
+        None | Some(Commands::Proxy) => proxy::serve_proxy().await,
+        Some(Commands::Local) => serve_stdio().await,
         Some(Commands::Install(install_args)) => install::command(install_args).await,
-        Some(Commands::Proxy) => proxy::serve_proxy().await,
     }
 }
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -42,8 +42,8 @@ pub struct AgentArgs {
     #[clap(long, conflicts_with = "local")]
     remote: bool,
 
-    /// Configure the local GraphQL-backed MCP server (`railway mcp`) instead of the
-    /// remote CLI proxy default.
+    /// Configure the local GraphQL-backed MCP server (`railway mcp local`) instead of
+    /// the remote CLI proxy default.
     #[clap(long, conflicts_with_all = ["remote", "oauth"])]
     local: bool,
 
@@ -95,7 +95,7 @@ impl fmt::Display for McpChoice {
             McpChoice::Local => write!(
                 f,
                 "Local            {}",
-                "— runs `railway mcp` as a stdio server".dimmed()
+                "— runs `railway mcp local` as a stdio server".dimmed()
             ),
             McpChoice::RemoteOauth => write!(
                 f,


### PR DESCRIPTION
## Problem

`railway mcp` starts the in-process MCP server. The remote server at mcp.railway.com is where new tools and fixes land, but reaching it requires opting in with `railway mcp proxy` — 2,141 users have, against 18,054 still on the in-process server.

## Changes

| Command | Before | After |
|---|---|---|
| `railway mcp` | in-process server | proxy to mcp.railway.com |
| `railway mcp local` | — | in-process server |
| `railway mcp proxy` | proxy | unchanged |

- `install` writes a bare `["mcp"]` for the remote transport and `["mcp", "local"]` for local.
- `stdio_argv_matches` is now three-way. A config containing a bare `mcp` classifies as **remote**, since that is what it now starts — including pre-cutover configs written by `install --local`.
- `mcp proxy` is untouched as a command and still classifies as remote, so pre-cutover configs keep running. `install` just no longer generates that form.
- Help text corrected in three places that would otherwise say `railway mcp` for the local server: `mcp install --local`, `setup --local`, and the interactive setup picker.