### PR TITLE
fix: restore default SIGPIPE disposition so piped output does not abort

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,8 +239,37 @@ async fn background_stage_update(version: &str) -> Result<()> {
     result
 }
 
+/// Restore the default disposition for `SIGPIPE`.
+///
+/// Rust's standard library sets `SIGPIPE` to `SIG_IGN` before `main` runs, so
+/// writing to a closed pipe returns `EPIPE` instead of terminating the
+/// process. The `print!`/`println!` macros panic on write errors, and because
+/// this crate is built with `panic = "abort"` (see `Cargo.toml`), that panic
+/// becomes a `SIGABRT` and a core dump.
+///
+/// The practical effect is that ordinary shell usage such as
+/// `railway logs | head -n 5` crashes the CLI once the reader exits, leaving
+/// a core dump behind on systems that collect them. Restoring `SIG_DFL` makes
+/// the process terminate silently on `SIGPIPE`, which is the conventional
+/// behaviour for a Unix command line tool.
+fn restore_default_sigpipe() {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{SigHandler, Signal, signal};
+        // SAFETY: `SIG_DFL` is the kernel's default disposition; installing
+        // it allocates nothing and runs no user code. This executes once at
+        // the top of `main` before the CLI writes any output, and nothing
+        // else in the process installs a handler for `SIGPIPE`.
+        unsafe {
+            let _ = signal(Signal::SIGPIPE, SigHandler::SigDfl);
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    restore_default_sigpipe();
+
     // Internal: detached background download spawned by a prior invocation.
     if let Ok(version) = std::env::var(consts::RAILWAY_STAGE_UPDATE_ENV) {
         return background_stage_update(&version).await;


### PR DESCRIPTION
## Problem

The CLI dies with `SIGABRT` and leaves a core dump behind whenever its stdout pipe
is closed before it finishes writing — ordinary shell usage like `railway logs | head -n 5`
or piping into a pager the user then quits.

```
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

On Linux distributions that collect core dumps (anything running `systemd-coredump`,
which is the default on Arch, Fedora, and others) each occurrence writes a ~220 KB
core to `/var/lib/systemd/coredump/`. Because a core is a verbatim copy of process
memory, those files can contain the user's Railway API token. On the machine where
I hit this, six cores had accumulated before I noticed.

## Reproduction

Close the read end of the pipe before the CLI writes:

```python
import subprocess, os, signal
r, w = os.pipe()
p = subprocess.Popen(["railway", "--help"], stdout=w, stderr=subprocess.PIPE)
os.close(w); os.close(r)
_, err = p.communicate()
print(p.returncode, signal.Signals(-p.returncode).name)  # -6 SIGABRT
```

Note that `railway --help | head -1` does *not* reproduce it — the help text fits
in the 64 KB pipe buffer, so the write never fails. The reader has to go away
before the write lands.

## Cause

Two things combine:

1. Rust's standard library sets `SIGPIPE` to `SIG_IGN` before `main` runs, so a
   write to a closed pipe returns `EPIPE` instead of terminating the process.
   Nothing in this crate restores the default disposition — `grep -rn "SIGPIPE"
   src/` returns no hits.
2. `print!`/`println!` panic on write errors, and `Cargo.toml` sets
   `panic = "abort"` for the release profile, so that panic becomes a `SIGABRT`
   with a core dump rather than a quiet exit.

## Fix

Restore `SIG_DFL` for `SIGPIPE` at the top of `main`, so the process terminates
silently on a broken pipe — the conventional behaviour for a Unix CLI, and what
users' shells already expect from `| head`.

This uses `nix`, which is already a dependency with the `signal` feature enabled,
so it adds no new crates. The change is `#[cfg(unix)]`-gated and is a no-op on
Windows, which has no `SIGPIPE`.

## Verification

- `cargo check` passes; no new warnings
- `cargo fmt --all -- --check` passes
- Built `--release` and ran the reproduction above against both binaries under
  identical conditions:

  | binary | result | stderr |
  | --- | --- | --- |
  | stock 5.44.0 | killed by `SIGABRT` (6), core dumped | panic message |
  | patched | killed by `SIGPIPE` (13), no core | empty |

- `railway --help | head -3` now exits 141 (128+13), matching the conventional
  behaviour of `yes | head`. Normal non-piped invocations are unaffected:
  `railway --version` and `railway status` behave exactly as before.

Tested on Linux x86_64 with rustc 1.98.0, against `master` at 5.44.0.

## Note for maintainers

CI's label check requires a release label — `release/patch` seems right for this.
