### PR TITLE
Fix Go IaC eval: go run ignores the wrapper file

### DIFF
--- a/src/commands/config/authoring.rs
+++ b/src/commands/config/authoring.rs
@@ -37,7 +37,7 @@ impl AuthoringLang {
 
     pub(super) fn helper(self, name: &str) -> String {
         match self {
-            Self::Go => format!("iac.{}", go_helper_ident(name)),
+            Self::Go => format!("railway.{}", go_helper_ident(name)),
             _ => name.to_string(),
         }
     }

--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -147,6 +147,24 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
         "Wrote".green().bold(),
         railway_file.display().to_string().cyan()
     );
+    match args.lang.as_str() {
+        "go" => {
+            let gomod = railway_dir.join("go.mod");
+            if !gomod.exists() {
+                fs::write(
+                    &gomod,
+                    "module railway-config\n\ngo 1.22\n\nrequire github.com/railwayapp/railway-go-sdk v0.2.0\n",
+                )?;
+            }
+        }
+        "py" => {
+            let req = railway_dir.join("requirements.txt");
+            if !req.exists() {
+                fs::write(&req, "railway-sdk>=0.2.0\n")?;
+            }
+        }
+        _ => {}
+    }
 
     clear_railway_config_file_on_linked_service().await?;
 
@@ -221,7 +239,7 @@ fn emit_railway_py(service_name: &str, cac: &CacFile) -> String {
         )
     };
     format!(
-        r#"from railway_iac import define_railway, project, service
+        r#"from railway_sdk import define_railway, project, service
 
 # Last resort for a per-service CaC repo. Prefer one .railway file for the
 # project and drop this if you later combine services into that file.
@@ -251,20 +269,20 @@ fn emit_railway_go(service_name: &str, cac: &CacFile) -> String {
     let config_block = if fields.is_empty() {
         "nil".to_string()
     } else {
-        format!("iac.ServiceConfig{{\n{}\n\t}}", fields.join("\n"))
+        format!("railway.ServiceConfig{{\n{}\n\t}}", fields.join("\n"))
     };
     format!(
         r#"package main
 
-import "github.com/railwayapp/railway-go-iac/iac"
+import "github.com/railwayapp/railway-go-sdk"
 
 // Last resort for a per-service CaC repo. Prefer one .railway file for the
 // project and drop this if you later combine services into that file.
 const Partial = {name}
 
-func Railway() iac.Project {{
-	web := iac.ServiceNamed({name}, {config})
-	return iac.ProjectNamed({name}, []any{{web}})
+func Railway() railway.Project {{
+	web := railway.ServiceNamed({name}, {config})
+	return railway.ProjectNamed({name}, []any{{web}})
 }}
 "#,
         name = js_string(service_name),
@@ -453,6 +471,13 @@ mod tests {
         assert!(out.contains("healthcheck: \"/health\""));
         assert!(out.contains("service(\"api\""));
         assert!(out.contains("export const partial = \"api\""));
+        let py = emit_railway_py("api", &cac);
+        assert!(py.contains("from railway_sdk import"));
+        assert!(py.contains("PARTIAL = \"api\""));
+        let go = emit_railway_go("api", &cac);
+        assert!(go.contains("github.com/railwayapp/railway-go-sdk"));
+        assert!(go.contains("railway.ServiceNamed"));
+        assert!(go.contains("const Partial = \"api\""));
     }
 
     #[test]

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -370,7 +370,10 @@ fn write_language_support_files(lang: AuthoringLang, railway_dir: &Path) -> Resu
             )?;
         }
         AuthoringLang::Python => {
-            write_asset_if_missing(&railway_dir.join("requirements.txt"), "railway-sdk>=0.2.0\n")?;
+            write_asset_if_missing(
+                &railway_dir.join("requirements.txt"),
+                "railway-sdk>=0.2.0\n",
+            )?;
         }
         AuthoringLang::TypeScript => {}
     }

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -310,6 +310,7 @@ async fn init_config(args: InitArgs) -> Result<()> {
         )?,
     }
     write_new(&readme_file, &iac_readme(lang), args.force)?;
+    write_language_support_files(lang, &railway_dir)?;
 
     println!("{}", "Railway configuration initialized".green().bold());
     println!(
@@ -360,6 +361,22 @@ fn create_parent(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn write_language_support_files(lang: AuthoringLang, railway_dir: &Path) -> Result<()> {
+    match lang {
+        AuthoringLang::Go => {
+            write_asset_if_missing(
+                &railway_dir.join("go.mod"),
+                "module railway-config\n\ngo 1.22\n\nrequire github.com/railwayapp/railway-go-sdk v0.2.0\n",
+            )?;
+        }
+        AuthoringLang::Python => {
+            write_asset_if_missing(&railway_dir.join("requirements.txt"), "railway-sdk>=0.2.0\n")?;
+        }
+        AuthoringLang::TypeScript => {}
+    }
+    Ok(())
+}
+
 fn write_asset_if_missing(path: &Path, contents: &str) -> Result<bool> {
     if path.exists() {
         return Ok(false);
@@ -400,6 +417,7 @@ async fn pull_config(args: PullArgs) -> Result<()> {
     )
     .await?;
     let wrote_readme = write_asset_if_missing(&readme_file, &iac_readme(lang))?;
+    write_language_support_files(lang, cwd.join(".railway").as_path())?;
 
     println!("{}", "Railway configuration imported".green().bold());
     println!(
@@ -776,7 +794,7 @@ fn render_preamble(lang: AuthoringLang, imports: &[&str]) -> String {
             imports.join(", ")
         ),
         AuthoringLang::Python => format!(
-            "from railway_iac import {}\n\n\n@define_railway\ndef main(ctx=None):\n",
+            "from railway_sdk import {}\n\n\n@define_railway\ndef main(ctx=None):\n",
             imports
                 .iter()
                 .map(|name| match *name {
@@ -787,7 +805,7 @@ fn render_preamble(lang: AuthoringLang, imports: &[&str]) -> String {
                 .join(", ")
         ),
         AuthoringLang::Go => {
-            "package main\n\nimport \"github.com/railwayapp/railway-go-iac/iac\"\n\nfunc Railway() iac.Project {\n"
+            "package main\n\nimport \"github.com/railwayapp/railway-go-sdk\"\n\nfunc Railway() railway.Project {\n"
                 .to_string()
         }
     }
@@ -831,7 +849,7 @@ fn service_call(lang: AuthoringLang, name: &str, body: &str) -> String {
         AuthoringLang::TypeScript => format!("service({name}, {body})"),
         AuthoringLang::Python => format!("service(\n        {name},\n{body}\n    )"),
         AuthoringLang::Go => format!(
-            "{}({name}, iac.ServiceConfig{{\n{body}\n  }})",
+            "{}({name}, railway.ServiceConfig{{\n{body}\n  }})",
             lang.helper("service")
         ),
     }
@@ -2121,7 +2139,7 @@ mod tests {
         let railway_dir = root.path().join(".railway");
         fs::create_dir_all(&railway_dir).unwrap();
         let py = railway_dir.join("railway.py");
-        fs::write(&py, "from railway_iac import project\n").unwrap();
+        fs::write(&py, "from railway_sdk import project\n").unwrap();
 
         assert_eq!(authoring_file_for_write(root.path()).unwrap(), py);
     }
@@ -2152,7 +2170,7 @@ mod tests {
             )],
         };
         let rendered = render_graph_as_railway(&graph, true, AuthoringLang::Python);
-        assert!(rendered.contains("from railway_iac import"));
+        assert!(rendered.contains("from railway_sdk import"));
         assert!(rendered.contains("def main(ctx=None):"));
         assert!(rendered.contains("source=github(\"org/app\")"));
         assert!(rendered.contains("start=\"./app\""));
@@ -2172,10 +2190,10 @@ mod tests {
             )],
         };
         let rendered = render_graph_as_railway(&graph, true, AuthoringLang::Go);
-        assert!(rendered.contains("github.com/railwayapp/railway-go-iac/iac"));
+        assert!(rendered.contains("github.com/railwayapp/railway-go-sdk"));
         assert!(rendered.contains("func Railway()"));
-        assert!(rendered.contains("iac.Github(\"org/app\")"));
+        assert!(rendered.contains("railway.Github(\"org/app\")"));
         assert!(rendered.contains("\"start\": \"./app\""));
-        assert!(rendered.contains("iac.ServiceNamed"));
+        assert!(rendered.contains("railway.ServiceNamed"));
     }
 }

--- a/src/iac/eval.rs
+++ b/src/iac/eval.rs
@@ -94,7 +94,7 @@ fn evaluate_python(file: &Path) -> Result<Value> {
     let script = r#"
 import importlib.util, json, sys
 path = sys.argv[1]
-spec = importlib.util.spec_from_file_location("railway_iac_user", path)
+spec = importlib.util.spec_from_file_location("railway_sdk_user", path)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 partial = getattr(mod, "PARTIAL", None) or getattr(mod, "Partial", None) or getattr(mod, "partial", None)
@@ -115,7 +115,7 @@ fn evaluate_go(file: &Path) -> Result<Value> {
     let dir = file
         .parent()
         .context("Go IaC file has no parent directory")?;
-    let wrapper = dir.join(".railway-iac-eval.go");
+    let wrapper = dir.join("railway_iac_eval_main.go");
     let has_partial = fs::read_to_string(file)
         .unwrap_or_default()
         .contains("Partial");
@@ -148,7 +148,7 @@ func main() {
             wrapper
                 .file_name()
                 .and_then(|n| n.to_str())
-                .unwrap_or(".railway-iac-eval.go"),
+                .unwrap_or("railway_iac_eval_main.go"),
         ])
         .current_dir(dir)
         .output();

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -1017,6 +1017,48 @@ def main(ctx=None):
     );
 }
 
+#[test]
+fn evaluates_go_partial_and_graph() {
+    let dir = tempfile_dir("railway-iac-go-");
+    let file = dir.join("railway.go");
+    std::fs::write(
+        dir.join("go.mod"),
+        "module railway-eval\n\ngo 1.22\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &file,
+        r#"
+package main
+
+const Partial = "api"
+
+type graph map[string]any
+
+func (g graph) Graph() map[string]any { return g }
+
+func Railway() graph {
+	return graph{
+		"name": "app",
+		"resources": []any{
+			map[string]any{"type": "service", "name": "api", "start": "echo api"},
+		},
+	}
+}
+"#,
+    )
+    .unwrap();
+    let evaluated = evaluate_file(&file).expect("go should evaluate railway.go");
+    assert_eq!(evaluated.partial.as_deref(), Some("api"));
+    assert!(
+        evaluated
+            .graph
+            .resources
+            .iter()
+            .any(|r| r["address"] == "service.api")
+    );
+}
+
 fn tempfile_dir(prefix: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!("{prefix}{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -995,6 +995,9 @@ export default () => ({
 
 #[test]
 fn evaluates_python_partial_and_graph() {
+    if which::which("python3").is_err() {
+        return;
+    }
     let dir = tempfile_dir("railway-iac-py-");
     let file = dir.join("railway.py");
     std::fs::write(
@@ -1019,13 +1022,12 @@ def main(ctx=None):
 
 #[test]
 fn evaluates_go_partial_and_graph() {
+    if which::which("go").is_err() {
+        return;
+    }
     let dir = tempfile_dir("railway-iac-go-");
     let file = dir.join("railway.go");
-    std::fs::write(
-        dir.join("go.mod"),
-        "module railway-eval\n\ngo 1.22\n",
-    )
-    .unwrap();
+    std::fs::write(dir.join("go.mod"), "module railway-eval\n\ngo 1.22\n").unwrap();
     std::fs::write(
         &file,
         r#"


### PR DESCRIPTION
## Summary
- Nightly Go plan still fails with `function main is undeclared in the main package` ([report](https://report-server-production-4d2b.up.railway.app/#/?file=-341451238&test=-341451238_0_1)).
- The CLI writes `.railway-iac-eval.go` as the `go run` companion. **`go run` ignores files that start with `.`**, so only `railway.go` is compiled and there is no `main`.
- This was fixed on the #1123 branch *after* that PR merged, so it never reached `master` / 5.44.0. Python plan works because it does not use that wrapper.
- Also lands the missed `railway_sdk` / `github.com/railwayapp/railway-go-sdk` emit names from that same commit.

Needs a **patch release** so `@railway/cli@latest` (the nightly runner) picks it up.

## Test plan
- [x] `cargo test evaluates_go_partial` (local; wrapper is `railway_iac_eval_main.go`)
- [ ] After release, languages.test.ts Go case on the report server

Made with [Cursor](https://cursor.com)