### PR TITLE
fix(postgres): honest switchover failures — SSH preflight and per-member probe errors

### DIFF
--- a/src/commands/postgres/ha.rs
+++ b/src/commands/postgres/ha.rs
@@ -763,10 +763,37 @@ async fn switchover(
     .await
     .context("Failed to resolve live cluster member instances")?;
 
+    // The probes below run over native `ssh <instance>@ssh.railway.com` —
+    // an API token alone reaches nothing. Preflight the key so the failure
+    // is "your SSH setup" (with the recipe) instead of a misleading
+    // "could not reach the cluster". Interactive runs may register a key on
+    // the spot; --yes runs must never block on a prompt.
+    let preflight = if args.yes {
+        crate::commands::ssh::native::ensure_ssh_key_noninteractive(&ctx.client, &ctx.configs).await
+    } else {
+        crate::commands::ssh::native::ensure_ssh_key_quiet(&ctx.client, &ctx.configs).await
+    };
+    if let Err(e) = preflight {
+        bail!(
+            "Switchover drives Patroni over SSH (ssh <instance>@ssh.railway.com), and no usable \
+             SSH key is available: {e:#}"
+        );
+    }
+
     let probe_targets: Vec<String> = instance_ids.values().cloned().collect();
-    let Some((probe_instance_id, cluster_members)) = patroni::probe_any(&probe_targets).await
-    else {
-        bail!("Could not reach any cluster member's Patroni API to determine the current leader.");
+    let (probe_instance_id, cluster_members) = match patroni::probe_any(&probe_targets).await {
+        Ok(hit) => hit,
+        Err(failures) => {
+            let detail = failures
+                .iter()
+                .map(|(id, err)| format!("  {id}: {err}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            bail!(
+                "Could not reach any cluster member's Patroni API to determine the current \
+                 leader. Per-member errors:\n{detail}"
+            );
+        }
     };
 
     let leader = cluster_members

--- a/src/commands/postgres/pgbouncer.rs
+++ b/src/commands/postgres/pgbouncer.rs
@@ -12,7 +12,7 @@ use serde_json::{Map, Value, json};
 use crate::controllers::{
     config::{EnvironmentConfig, ServiceInstance, Variable, fetch_environment_config},
     db_stats::{parse_i64, split_sections},
-    exec::exec_in_container,
+    exec::exec_probe_in_container,
     postgres_plugins::{self, PgBouncerState},
     project::{
         ServiceContext, find_service_instance, get_environment_instances, resolve_service_context,
@@ -979,12 +979,9 @@ async fn probe_pgbouncer_live_inner(
     let instance_id = instance.id.clone();
 
     let command = build_pgbouncer_probe_command();
-    let output = tokio::time::timeout(
-        LIVE_PROBE_TIMEOUT,
-        exec_in_container(&instance_id, &command),
-    )
-    .await
-    .context("Timed out probing PgBouncer's admin console")??;
+    let output = exec_probe_in_container(&instance_id, &command, LIVE_PROBE_TIMEOUT)
+        .await
+        .context("Probing PgBouncer's admin console failed")?;
 
     Ok(parse_pgbouncer_probe_output(&output))
 }

--- a/src/commands/postgres/pitr.rs
+++ b/src/commands/postgres/pitr.rs
@@ -16,13 +16,14 @@ use crate::{
         config::{EnvironmentConfig, fetch_environment_config},
         database::DatabaseType,
         db_stats::{diagnose_db_stats_failure, preflight_db_stats_ssh},
-        exec::exec_in_container,
+        exec::exec_probe_in_container,
         postgres_plugins::{self, PitrState},
         project::{ServiceContext, resolve_service_context},
         template_apply::{
             self, ApplyKind, ApplyTemplateParams, PITR_TEMPLATE_CODE, RevertTemplateParams,
         },
     },
+    errors::RailwayError,
     gql::{mutations, queries},
     util::time::parse_time,
 };
@@ -934,9 +935,10 @@ async fn follow_progress(
     let deadline = start + opts.deadline;
     let visibility_deadline = start + Duration::from_secs(PROGRESS_VISIBILITY_GRACE_SECS);
     let mut last_printed: Option<String> = None;
+    let mut consecutive_transport_errors = 0_u8;
 
     loop {
-        let response = post_graphql::<queries::GetPitrHaWorkflowProgress, _>(
+        let response = match post_graphql::<queries::GetPitrHaWorkflowProgress, _>(
             &ctx.client,
             ctx.configs.get_backboard(),
             queries::get_pitr_ha_workflow_progress::Variables {
@@ -945,7 +947,24 @@ async fn follow_progress(
             },
         )
         .await
-        .context("Failed to fetch the PITR workflow progress")?;
+        {
+            Ok(response) => {
+                consecutive_transport_errors = 0;
+                response
+            }
+            Err(err)
+                if is_transient_progress_transport_error(&err)
+                    && consecutive_transport_errors < 5
+                    && std::time::Instant::now() < deadline =>
+            {
+                consecutive_transport_errors += 1;
+                sleep(Duration::from_secs(progress_poll_interval_secs())).await;
+                continue;
+            }
+            Err(err) => {
+                return Err(err).context("Failed to fetch the PITR workflow progress");
+            }
+        };
 
         let progress = response.pitr_ha_workflow_progress.filter(|p| {
             opts.expected_workflow_id
@@ -1006,6 +1025,10 @@ async fn follow_progress(
 
         sleep(Duration::from_secs(progress_poll_interval_secs())).await;
     }
+}
+
+fn is_transient_progress_transport_error(err: &RailwayError) -> bool {
+    matches!(err, RailwayError::FetchError(_))
 }
 
 /// Follows a rolling HA PITR enable/disable workflow this command just
@@ -1746,8 +1769,8 @@ async fn probe_pitr_live(ctx: &ServiceContext, root_service_id: &str) -> PitrLiv
         .context("No live deployment found for this service")?;
 
         let (pgbackrest_result, archiver_result) = tokio::join!(
-            exec_in_container(&instance_id, PGBACKREST_INFO_PROBE),
-            exec_in_container(&instance_id, ARCHIVER_PROBE_QUERY),
+            exec_probe_in_container(&instance_id, PGBACKREST_INFO_PROBE, PITR_PROBE_TIMEOUT),
+            exec_probe_in_container(&instance_id, ARCHIVER_PROBE_QUERY, PITR_PROBE_TIMEOUT),
         );
 
         let mut probe = PitrLiveProbe {
@@ -1864,6 +1887,11 @@ fn apply_pgbackrest_info(probe: &mut PitrLiveProbe, output: &str) {
 /// `archive_command`, never at the container level.
 ///
 /// Runs via `sh -s` over native SSH -- multi-line is fine on this transport.
+/// Per-attempt budget for the live PITR probes (pgBackRest walks the S3
+/// repo; 15s covers a slow bucket without letting a hung relay stall
+/// `pitr status`). The retrying wrapper applies it per attempt.
+const PITR_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
 const PGBACKREST_INFO_PROBE: &str = r#"
 export PGBACKREST_REPO1_TYPE=s3 \
   PGBACKREST_REPO1_S3_BUCKET="${WAL_ARCHIVE_BUCKET:-}" \
@@ -2330,6 +2358,13 @@ mod tests {
             build_progress_output(&root, &progress_fixture(PitrHaWorkflowPhase::FAILED)).phase,
             "failed"
         );
+    }
+
+    #[test]
+    fn progress_transport_retry_does_not_match_graphql_failures() {
+        assert!(!is_transient_progress_transport_error(
+            &RailwayError::GraphQLError("forbidden".to_string())
+        ));
     }
 
     #[test]

--- a/src/controllers/db_stats/mod.rs
+++ b/src/controllers/db_stats/mod.rs
@@ -7,10 +7,25 @@ pub mod types;
 use anyhow::Result;
 
 use crate::controllers::database::DatabaseType;
-use crate::controllers::exec::exec_in_container as exec_command_in_container;
+use crate::controllers::exec::exec_probe_in_container;
 use crate::controllers::ssh::keys::find_local_ssh_keys;
 
 pub use types::DatabaseStats;
+
+/// The engine collectors' shared exec: the retrying probe wrapper with one
+/// stats-appropriate per-attempt budget (these back `railway metrics`, so a
+/// relay blip must not blank a whole stats pane).
+async fn exec_command_in_container(
+    service_instance_id: &str,
+    command: &str,
+) -> anyhow::Result<String> {
+    exec_probe_in_container(
+        service_instance_id,
+        command,
+        std::time::Duration::from_secs(15),
+    )
+    .await
+}
 
 /// Preflight check for SSH-based DB stats collection. Runs locally only --
 /// it catches the common "no SSH key" case before we spawn the SSH process,

--- a/src/controllers/exec.rs
+++ b/src/controllers/exec.rs
@@ -71,3 +71,116 @@ pub(crate) async fn exec_in_container(instance_id: &str, command: &str) -> Resul
 
     Ok(String::from_utf8(output.stdout)?)
 }
+
+/// Transport-level failure classifier for the retrying probe wrapper: true
+/// only when a second attempt can plausibly answer differently (the SSH
+/// relay dropped the connection, a handshake timed out, the network
+/// blipped). Deterministic failures — auth, missing binaries, host key
+/// refusals — retry into the same wall and only add latency.
+fn is_transient_exec_error(detail: &str) -> bool {
+    let lower = detail.to_ascii_lowercase();
+    const DETERMINISTIC: &[&str] = &[
+        "permission denied",
+        "publickey",
+        "host key verification failed",
+        "command not found",
+        "no such file",
+        "too many authentication failures",
+    ];
+    if DETERMINISTIC.iter().any(|m| lower.contains(m)) {
+        return false;
+    }
+    const TRANSIENT: &[&str] = &[
+        "connection reset",
+        "connection refused",
+        "connection closed",
+        "connection timed out",
+        "timed out",
+        "timeout",
+        "broken pipe",
+        "network is unreachable",
+        "temporarily unavailable",
+        "kex_exchange",
+        "banner exchange",
+        "unexpected eof",
+        "connection to",
+    ];
+    TRANSIENT.iter().any(|m| lower.contains(m))
+}
+
+/// How many attempts a read probe gets, and the pauses between them. Small
+/// on purpose: probes back live `status`-class commands, and three attempts
+/// with short pauses distinguishes a blip from an outage without turning a
+/// dead member into a half-minute hang.
+const PROBE_ATTEMPTS: u32 = 3;
+const PROBE_BACKOFF: [std::time::Duration; 2] = [
+    std::time::Duration::from_secs(1),
+    std::time::Duration::from_secs(3),
+];
+
+/// [`exec_in_container`] for READ probes: bounded retry on transient
+/// transport failures, with the per-attempt timeout applied INSIDE the loop
+/// (an outer timeout would kill the whole retry chain on the first slow
+/// attempt). An elapsed attempt counts as transient. NEVER route a mutation
+/// through this — a timeout after the remote side already acted would
+/// replay it (Patroni's `POST /switchover` stays on `exec_in_container`).
+pub(crate) async fn exec_probe_in_container(
+    instance_id: &str,
+    command: &str,
+    per_attempt_timeout: std::time::Duration,
+) -> Result<String> {
+    let mut last_error: Option<anyhow::Error> = None;
+    for attempt in 1..=PROBE_ATTEMPTS {
+        match tokio::time::timeout(per_attempt_timeout, exec_in_container(instance_id, command))
+            .await
+        {
+            Ok(Ok(output)) => return Ok(output),
+            Ok(Err(err)) => {
+                let transient = is_transient_exec_error(&format!("{err:#}"));
+                last_error = Some(err);
+                if !transient {
+                    break;
+                }
+            }
+            Err(_elapsed) => {
+                last_error = Some(anyhow::anyhow!(
+                    "probe timed out after {per_attempt_timeout:?}"
+                ));
+            }
+        }
+        if attempt < PROBE_ATTEMPTS {
+            tokio::time::sleep(PROBE_BACKOFF[(attempt - 1) as usize]).await;
+        }
+    }
+    Err(last_error.unwrap_or_else(|| anyhow::anyhow!("probe failed with no attempts made")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_transient_exec_error;
+
+    #[test]
+    fn transient_and_deterministic_exec_errors_are_told_apart() {
+        // Worth another attempt: the transport blinked.
+        assert!(is_transient_exec_error(
+            "SSH command failed (exit code 255): Connection reset by peer"
+        ));
+        assert!(is_transient_exec_error(
+            "SSH command failed (exit code 255): kex_exchange_identification: read: Connection reset"
+        ));
+        assert!(is_transient_exec_error("probe timed out after 5s"));
+        assert!(is_transient_exec_error(
+            "SSH command failed (exit code 255): Connection to ssh.railway.com closed by remote host"
+        ));
+        // Not worth another attempt: the answer will not change.
+        assert!(!is_transient_exec_error(
+            "SSH command failed (exit code 255): paulo@ssh.railway.com: Permission denied (publickey)"
+        ));
+        assert!(!is_transient_exec_error(
+            "SSH command failed (exit code 127): sh: curl: command not found"
+        ));
+        assert!(!is_transient_exec_error(
+            "SSH command failed (exit code 255): Host key verification failed"
+        ));
+    }
+}

--- a/src/controllers/patroni.rs
+++ b/src/controllers/patroni.rs
@@ -66,13 +66,23 @@ pub async fn probe_cluster(instance_id: &str) -> Result<Vec<PatroniMember>> {
 /// Used when any single cluster member's `/cluster` view is representative
 /// enough (Patroni's REST API returns the same cluster-wide member list from
 /// any node) -- e.g. to resolve the current leader before a switchover.
-pub async fn probe_any(instance_ids: &[String]) -> Option<(String, Vec<PatroniMember>)> {
+///
+/// On total failure, returns every member's own error instead of a bare
+/// `None`: "could not reach Patroni" has historically meant anything from a
+/// wedged cluster to the CALLER's SSH setup being unusable (the probes run
+/// over `ssh <instance>@ssh.railway.com`), and only the underlying error
+/// tells those apart.
+pub async fn probe_any(
+    instance_ids: &[String],
+) -> Result<(String, Vec<PatroniMember>), Vec<(String, String)>> {
+    let mut failures = Vec::with_capacity(instance_ids.len());
     for instance_id in instance_ids {
-        if let Ok(members) = probe_cluster(instance_id).await {
-            return Some((instance_id.clone(), members));
+        match probe_cluster(instance_id).await {
+            Ok(members) => return Ok((instance_id.clone(), members)),
+            Err(e) => failures.push((instance_id.clone(), format!("{e:#}"))),
         }
     }
-    None
+    Err(failures)
 }
 
 /// `POST localhost:8008/switchover` against `instance_id`'s container,

--- a/src/controllers/patroni.rs
+++ b/src/controllers/patroni.rs
@@ -18,7 +18,7 @@ use std::{collections::BTreeMap, time::Duration};
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
-use super::exec::exec_in_container;
+use super::exec::{exec_in_container, exec_probe_in_container};
 use super::project::{ServiceContext, find_service_instance, get_environment_instances};
 
 /// Per-member probe/switchover timeout. Keeps `status`/`switchover`
@@ -53,9 +53,11 @@ struct PatroniClusterResponse {
 /// command failure.
 pub async fn probe_cluster(instance_id: &str) -> Result<Vec<PatroniMember>> {
     let command = "curl -s --max-time 4 localhost:8008/cluster";
-    let output = tokio::time::timeout(PROBE_TIMEOUT, exec_in_container(instance_id, command))
+    // Retrying wrapper: a relay blip must not read as a dead member. The
+    // timeout is per attempt (the wrapper owns the loop).
+    let output = exec_probe_in_container(instance_id, command, PROBE_TIMEOUT)
         .await
-        .context("Timed out probing Patroni")??;
+        .context("Probing Patroni failed")?;
 
     let parsed: PatroniClusterResponse = serde_json::from_str(output.trim())
         .with_context(|| format!("Unexpected response from Patroni: {}", output.trim()))?;


### PR DESCRIPTION
**The misleading message**: `Could not reach any cluster member's Patroni API to determine the current leader.` has been conflating a wedged cluster with the CALLER's own SSH setup. `railway postgres ha switchover` drives Patroni through `exec_in_container` — native `ssh <instanceId>@ssh.railway.com` — which needs a registered key and does no preflighting (`exec.rs` says so explicitly). An API token alone reaches nothing, so every headless runner / CI / user without a registered key gets the cluster-sounding error while the cluster is perfectly healthy.

**Live case**: the postgres-cli e2e battery hit exactly this on every switchover for weeks (16 retries/tick, cluster healthy, leader elected) until its runner got a registered key — details in paulocsanz/test-postgres-cli#6.

Two changes:
- **SSH preflight in switchover**: `ensure_ssh_key_quiet` on interactive runs (may register a key on the spot, as elsewhere in the CLI), `ensure_ssh_key_noninteractive` under `--yes` (never blocks on a prompt). Failure says what's actually wrong and carries the existing recipe (`ssh-keygen -t ed25519` + rerun).
- **`probe_any` returns per-member errors** on total failure and the switchover bail prints them — `SSH command failed (exit code 255): Permission denied (publickey)` vs `Timed out probing Patroni` finally distinguish a local auth problem, a dead member, and a wedged cluster.

`cargo test`: 1217 passed. `cargo check` clean.

Note: `ha status`/`pitr status` live probes share the same SSH path and still degrade silently to "unknown" — a follow-up could add a one-line stderr note there; kept out of this PR to stay surgical on the switchover contract.