### PR TITLE
Pin IaC plans so CI applies the reviewed change set

### DIFF
--- a/assets/iac/README.md
+++ b/assets/iac/README.md
@@ -39,6 +39,7 @@ railway config apply
 - `railway config plan` is safe and does not change Railway.
 - `railway config apply` previews changes and asks before applying unless you pass `--yes`.
 - Destructive changes in non-interactive or agent sessions require `railway config apply --confirm-destructive` after reviewing the plan.
+- CI should pin a plan (`railway config plan --out railway-plan.json`) and apply that file on merge (`railway config apply --plan railway-plan.json --yes --confirm-destructive`) so the reviewed change set is what lands.
 - Services already managed by `railway.json` must be migrated before `.railway/railway.ts` can manage them.
 - Keep one `.railway` file for the whole project. A named `export const partial` (or `PARTIAL` / `const Partial`) is a last resort for separate repos that cannot share that file. Do not add it unless omit=delete across repos is a blocker.
 - Use `replicas` for scaling; advanced placement can still specify region names.

--- a/examples/github/railway-config.yml
+++ b/examples/github/railway-config.yml
@@ -1,0 +1,96 @@
+# Plan .railway/ on every PR, apply that exact artifact on merge.
+# Requires RAILWAY_TOKEN (project token) in repo secrets.
+# Merge does not re-plan: a drifted environment or a different .railway/
+# tree fails instead of applying a new diff.
+
+name: Railway config
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - ".railway/**"
+      - ".github/workflows/railway-config.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+env:
+  RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+
+jobs:
+  plan:
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+      - name: Plan
+        run: railway config plan --out railway-plan.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: railway-plan
+          path: railway-plan.json
+      - name: Comment plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = JSON.parse(fs.readFileSync('railway-plan.json', 'utf8'));
+            const diff = (plan.diff || 'already up to date').trimEnd();
+            const banner = plan.destructive
+              ? '> **Destructive:** this plan removes Railway resources or variables.\n\n'
+              : '';
+            const body = `<!-- railway-config-plan -->
+            ## Railway config plan
+
+            ${banner}Pinned to \`.railway/\` tree \`${plan.sourceTree}\` against etag \`${plan.configEtag}\`.
+
+            Merge applies **this** change set. If the environment moves or \`.railway/\` changes, apply fails and you re-plan.
+
+            \`\`\`
+            ${diff}
+            \`\`\`
+            `.replace(/^            /gm, '');
+            const { owner, repo } = context.repo;
+            const number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: number,
+            });
+            const existing = comments.find((c) => (c.body || '').includes('<!-- railway-config-plan -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: number, body,
+              });
+            }
+
+  apply:
+    if: github.event.action == 'closed' && github.event.pull_request.merged && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+      - name: Download pinned plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          RUN_ID="$(gh run list --workflow "Railway config" --commit "$HEAD_SHA" --json databaseId,conclusion --jq '[.[] | select(.conclusion=="success")][0].databaseId')"
+          if [ -z "${RUN_ID}" ] || [ "${RUN_ID}" = "null" ]; then
+            echo "No successful plan run for ${HEAD_SHA}. Re-open the PR and wait for plan."
+            exit 1
+          fi
+          gh run download "${RUN_ID}" -n railway-plan
+      - name: Apply pinned plan
+        run: railway config apply --plan railway-plan.json --yes --confirm-destructive

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -90,6 +90,18 @@ struct SharedArgs {
     /// Print variable values in the plan instead of redacting them.
     #[clap(long)]
     show_values: bool,
+
+    /// Write a pinned plan artifact. Plan only.
+    #[clap(long)]
+    out: Option<PathBuf>,
+
+    /// Apply this pinned plan without re-evaluating the authoring file. Apply only.
+    #[clap(long)]
+    plan: Option<PathBuf>,
+
+    /// Tree written into `--out`. Defaults to `git rev-parse HEAD:.railway`.
+    #[clap(long)]
+    source_tree: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -165,6 +177,9 @@ pub async fn command(args: Args) -> Result<()> {
             if args.confirm_destructive {
                 bail!("--confirm-destructive is only valid with `railway config apply`.");
             }
+            if args.plan.is_some() {
+                bail!("--plan is only valid with `railway config apply`.");
+            }
             run_sync(args, false, false).await
         }
         Command::Stage(_args) => bail!(
@@ -173,6 +188,12 @@ pub async fn command(args: Args) -> Result<()> {
         Command::Apply(args) => {
             if args.detailed_exit_code {
                 bail!("--detailed-exit-code is only valid with `railway config plan`.");
+            }
+            if args.out.is_some() {
+                bail!("--out is only valid with `railway config plan`.");
+            }
+            if args.source_tree.is_some() {
+                bail!("--source-tree is only valid with `railway config plan`.");
             }
             run_sync(args, false, true).await
         }
@@ -508,6 +529,9 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         verbose: false,
         detailed_exit_code: false,
         show_values: false,
+        out: None,
+        plan: None,
+        source_tree: None,
     };
     let response = runner::run(&args, "current").await?;
     // `temp_dir` cleans itself up on drop, including on the error paths below.
@@ -1734,7 +1758,9 @@ fn detect_package_manager(cwd: &Path) -> String {
 }
 
 async fn run_sync(args: SharedArgs, stage: bool, apply: bool) -> Result<()> {
-    ensure_config_initialized(&args).await?;
+    if args.plan.is_none() {
+        ensure_config_initialized(&args).await?;
+    }
 
     runner::run_command(runner::Args {
         file: args.file,
@@ -1749,6 +1775,9 @@ async fn run_sync(args: SharedArgs, stage: bool, apply: bool) -> Result<()> {
         verbose: args.verbose,
         detailed_exit_code: args.detailed_exit_code,
         show_values: args.show_values,
+        out: args.out,
+        plan: args.plan,
+        source_tree: args.source_tree,
     })
     .await
 }

--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -63,6 +63,18 @@ pub struct Args {
     /// Print variable values in the plan instead of redacting them.
     #[clap(long)]
     pub(super) show_values: bool,
+
+    /// Write a pinned plan artifact (plan only).
+    #[clap(long)]
+    pub(super) out: Option<PathBuf>,
+
+    /// Apply a pinned plan artifact without re-evaluating the authoring file.
+    #[clap(long)]
+    pub(super) plan: Option<PathBuf>,
+
+    /// Tree hash written into `--out`. Defaults to `git rev-parse HEAD:.railway`.
+    #[clap(long)]
+    pub(super) source_tree: Option<String>,
 }
 
 #[derive(Deserialize, serde::Serialize)]
@@ -90,6 +102,7 @@ struct CurrentEnvironment {
     project_name: Option<String>,
     environment_id: String,
     environment_name: Option<String>,
+    config_etag: Option<String>,
 }
 
 #[derive(Deserialize, serde::Serialize)]
@@ -171,10 +184,16 @@ struct StagedPatch {
 
 pub(super) async fn run(args: &Args, command: &str) -> Result<RunnerResponse> {
     let (configs, linked_project, token, auth_type) = ensure_config_context().await?;
-    invoke_runner(args, &configs, &linked_project, &token, auth_type, command).await
+    let (response, _) =
+        invoke_runner(args, &configs, &linked_project, &token, auth_type, command).await?;
+    Ok(response)
 }
 
 pub(super) async fn run_command(args: Args) -> Result<()> {
+    if let Some(path) = &args.plan {
+        return apply_pinned_plan(&args, path).await;
+    }
+
     let (configs, linked_project, token, auth_type) = ensure_config_context().await?;
     let command = if args.stage {
         "stage"
@@ -189,7 +208,7 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
             !args.json && std::io::stdout().is_terminal(),
             "Checking proposed changes".into(),
         );
-        let preview =
+        let (preview, _) =
             invoke_runner(&args, &configs, &linked_project, &token, auth_type, "plan").await?;
         if let Some(spinner) = &mut spinner {
             if preview.ok {
@@ -243,8 +262,13 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
         !args.json && std::io::stdout().is_terminal(),
         runner_message(command).into(),
     );
-    let output =
+    let (output, raw) =
         invoke_runner(&args, &configs, &linked_project, &token, auth_type, command).await?;
+    if output.ok {
+        if let Some(path) = &args.out {
+            write_pinned_plan(&args, &raw, path)?;
+        }
+    }
     if let Some(spinner) = &mut spinner {
         if output.ok {
             success_spinner(spinner, runner_done_message(command).into());
@@ -305,7 +329,8 @@ async fn preview_before_apply(
         !args.json && std::io::stdout().is_terminal(),
         "Checking Railway configuration".into(),
     );
-    let preview = invoke_runner(args, configs, linked_project, token, auth_type, "plan").await?;
+    let (preview, _) =
+        invoke_runner(args, configs, linked_project, token, auth_type, "plan").await?;
     if let Some(spinner) = &mut spinner {
         if preview.ok {
             success_spinner(spinner, "Checked Railway configuration".into());
@@ -377,6 +402,62 @@ fn get_runner_token(configs: &Configs) -> Result<(String, &'static str)> {
         )
 }
 
+fn write_pinned_plan(args: &Args, raw: &serde_json::Value, path: &PathBuf) -> Result<()> {
+    let cwd = env::current_dir().context("Unable to get current working directory")?;
+    let tree = crate::iac::saved_plan::source_tree(&cwd, args.source_tree.as_deref())?;
+    let plan = crate::iac::saved_plan::from_runner_json(raw, tree)?;
+    crate::iac::saved_plan::write_plan(path, &plan)?;
+    if !args.json {
+        eprintln!("{} {}", "Wrote".dimmed(), path.display());
+    }
+    Ok(())
+}
+
+async fn apply_pinned_plan(args: &Args, path: &PathBuf) -> Result<()> {
+    if !args.yes && !args.json && !std::io::stdout().is_terminal() {
+        bail!(
+            "Run `railway config apply --plan {} --yes` to apply a pinned plan non-interactively.",
+            path.display()
+        );
+    }
+    let cwd = env::current_dir().context("Unable to get current working directory")?;
+    let plan = crate::iac::saved_plan::read_plan(path)?;
+    crate::iac::saved_plan::assert_source_tree(&plan, &cwd)?;
+    guard_destructive_apply(args, plan.destructive)?;
+
+    if !args.yes && !args.json {
+        if let Some(diff) = &plan.diff {
+            println!("{diff}");
+        }
+        println!();
+        let prompt = if plan.destructive {
+            "Apply this pinned plan? This will remove Railway resources or variables."
+        } else {
+            "Apply this pinned plan to Railway?"
+        };
+        if !prompt_confirm_with_default(prompt, false)? {
+            bail!("No changes applied.");
+        }
+        println!();
+    }
+
+    let (configs, _, _, _) = ensure_config_context().await?;
+    let result = crate::iac::saved_plan::apply_saved_plan(&configs, &plan).await?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+    if result.get("status").and_then(Value::as_str) == Some("noop") {
+        println!(
+            "{}",
+            "✓ Your Railway configuration is already up to date.".green()
+        );
+        return Ok(());
+    }
+    println!("{}", "Applied pinned Railway configuration.".green());
+    Ok(())
+}
+
 async fn invoke_runner(
     args: &Args,
     configs: &Configs,
@@ -384,7 +465,7 @@ async fn invoke_runner(
     token: &str,
     auth_type: &str,
     command: &str,
-) -> Result<RunnerResponse> {
+) -> Result<(RunnerResponse, Value)> {
     let cwd_path = env::current_dir().context("Unable to get current working directory")?;
     if !crate::iac::use_legacy_ts_runner(args.runner.as_deref()) {
         let value = crate::iac::run_native(
@@ -398,8 +479,9 @@ async fn invoke_runner(
             command,
         )
         .await?;
-        return serde_json::from_value(value)
-            .context("Native IaC engine returned a response the CLI could not parse");
+        let response = serde_json::from_value(value.clone())
+            .context("Native IaC engine returned a response the CLI could not parse")?;
+        return Ok((response, value));
     }
     let runner = resolve_runner(args.runner.as_deref(), &cwd_path);
 
@@ -453,11 +535,13 @@ async fn invoke_runner(
     let stdout = String::from_utf8(output.stdout).context("Runner stdout was not valid UTF-8")?;
     let stderr = String::from_utf8(output.stderr).context("Runner stderr was not valid UTF-8")?;
 
-    let response: RunnerResponse = serde_json::from_str(&stdout).with_context(|| {
+    let value: Value = serde_json::from_str(&stdout).with_context(|| {
         format!("IaC runner returned non-JSON output.\nstdout:\n{stdout}\nstderr:\n{stderr}")
     })?;
+    let response: RunnerResponse = serde_json::from_value(value.clone())
+        .context("IaC runner returned a response the CLI could not parse")?;
 
-    Ok(response)
+    Ok((response, value))
 }
 
 struct ResolvedRunner {

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -475,11 +475,21 @@ async fn preview_change_set(
     Ok(data.result)
 }
 
-async fn apply_change_set(
+pub(crate) async fn fetch_config_etag(
+    configs: &Configs,
+    environment_id: &str,
+) -> Result<Option<String>> {
+    let client = GQLClient::new_authorized(configs)?;
+    let endpoint = configs.get_backboard();
+    let current = fetch_current_environment(&client, &endpoint, environment_id, false).await?;
+    Ok(current.config_etag)
+}
+
+pub(crate) async fn apply_change_set(
     client: &reqwest::Client,
     endpoint: &str,
     environment_id: &str,
-    change_set: &super::change_set::ChangeSet,
+    change_set: &impl serde::Serialize,
     base_etag: Option<&str>,
 ) -> Result<Value> {
     let mut variables = json!({

--- a/src/iac/mod.rs
+++ b/src/iac/mod.rs
@@ -11,6 +11,7 @@ mod eval;
 mod graph;
 mod json;
 mod partial;
+pub mod saved_plan;
 
 #[allow(dead_code)]
 pub use change_set::{ChangeSet, RAILWAY_CHANGE_SET_VERSION, diff_graphs, render_change_set};

--- a/src/iac/saved_plan.rs
+++ b/src/iac/saved_plan.rs
@@ -1,0 +1,368 @@
+//! Pinned IaC plan artifacts for CI.
+//!
+//! `railway config plan --out` writes the evaluated change set, the
+//! environment etag it was computed against, and the git tree of `.railway/`.
+//! `railway config apply --plan` applies that change set as-is. It does not
+//! re-evaluate the authoring file. A drifted environment or a different
+//! `.railway/` tree fails instead of silently planning something new.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::{client::GQLClient, config::Configs};
+
+use super::engine::{apply_change_set, fetch_config_etag};
+use super::json::stable_stringify;
+
+pub const KIND: &str = "railway.config.plan";
+pub const VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SavedPlan {
+    pub kind: String,
+    pub version: u32,
+    pub cli_version: String,
+    pub source_tree: String,
+    pub environment_id: String,
+    pub config_etag: String,
+    pub change_set_hash: String,
+    pub change_set: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<String>,
+    pub destructive: bool,
+}
+
+pub fn change_set_hash(change_set: &Value) -> String {
+    let digest = Sha256::digest(stable_stringify(change_set).as_bytes());
+    format!("sha256:{digest:x}")
+}
+
+pub fn is_destructive_change_set(change_set: &Value) -> bool {
+    change_set
+        .get("changes")
+        .and_then(Value::as_array)
+        .map(|changes| {
+            changes
+                .iter()
+                .any(|change| change.get("severity").and_then(Value::as_str) == Some("destructive"))
+        })
+        .unwrap_or(false)
+}
+
+pub fn source_tree(cwd: &Path, override_tree: Option<&str>) -> Result<String> {
+    if let Some(tree) = override_tree {
+        if tree.trim().is_empty() {
+            bail!("--source-tree must not be empty");
+        }
+        return Ok(tree.trim().to_string());
+    }
+    detect_source_tree(cwd)
+}
+
+pub fn detect_source_tree(cwd: &Path) -> Result<String> {
+    if let Some(tree) = git_railway_tree(cwd) {
+        return Ok(tree);
+    }
+    hash_railway_dir(&cwd.join(".railway"))
+}
+
+fn git_railway_tree(cwd: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD:.railway"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let tree = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if tree.is_empty() { None } else { Some(tree) }
+}
+
+fn hash_railway_dir(dir: &Path) -> Result<String> {
+    if !dir.is_dir() {
+        bail!(
+            "Could not pin .railway/: {} is not a directory and git has no HEAD:.railway tree",
+            dir.display()
+        );
+    }
+    let mut files = Vec::new();
+    collect_files(dir, dir, &mut files)?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    for (relative, path) in files {
+        hasher.update(relative.as_bytes());
+        hasher.update([0]);
+        hasher.update(fs::read(path)?);
+        hasher.update([0]);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn collect_files(root: &Path, dir: &Path, out: &mut Vec<(String, PathBuf)>) -> Result<()> {
+    let mut entries: Vec<_> = fs::read_dir(dir)
+        .with_context(|| format!("Failed to read {}", dir.display()))?
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(|entry| entry.file_name());
+    for entry in entries {
+        let path = entry.path();
+        let name = entry.file_name();
+        if name == ".DS_Store" {
+            continue;
+        }
+        if path.is_dir() {
+            collect_files(root, &path, out)?;
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        out.push((relative, path));
+    }
+    Ok(())
+}
+
+pub fn from_runner_json(raw: &Value, source_tree: String) -> Result<SavedPlan> {
+    let environment = raw
+        .get("currentEnvironment")
+        .context("Plan JSON is missing currentEnvironment")?;
+    let environment_id = environment
+        .get("environmentId")
+        .and_then(Value::as_str)
+        .context("Plan JSON is missing currentEnvironment.environmentId")?
+        .to_string();
+    let config_etag = environment
+        .get("configEtag")
+        .and_then(Value::as_str)
+        .context(
+            "Plan JSON is missing currentEnvironment.configEtag; re-run `railway config plan --out`",
+        )?
+        .to_string();
+    let change_set = raw
+        .get("changeSet")
+        .cloned()
+        .context("Plan JSON is missing changeSet")?;
+    Ok(SavedPlan {
+        kind: KIND.to_string(),
+        version: VERSION,
+        cli_version: env!("CARGO_PKG_VERSION").to_string(),
+        source_tree,
+        environment_id,
+        config_etag,
+        change_set_hash: change_set_hash(&change_set),
+        change_set,
+        diff: raw.get("diff").and_then(Value::as_str).map(str::to_string),
+        destructive: is_destructive_change_set(raw.get("changeSet").unwrap_or(&Value::Null)),
+    })
+}
+
+pub fn write_plan(path: &Path, plan: &SavedPlan) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+        }
+    }
+    let body = serde_json::to_string_pretty(plan)?;
+    fs::write(path, body).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+pub fn read_plan(path: &Path) -> Result<SavedPlan> {
+    let body = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read saved plan {}", path.display()))?;
+    let plan: SavedPlan = serde_json::from_str(&body).with_context(|| {
+        format!(
+            "Saved plan {} is not a railway.config.plan file",
+            path.display()
+        )
+    })?;
+    if plan.kind != KIND {
+        bail!(
+            "Saved plan {} has kind {:?}, expected {KIND}",
+            path.display(),
+            plan.kind
+        );
+    }
+    if plan.version != VERSION {
+        bail!(
+            "Saved plan {} has version {}, this CLI reads version {VERSION}",
+            path.display(),
+            plan.version
+        );
+    }
+    let actual = change_set_hash(&plan.change_set);
+    if actual != plan.change_set_hash {
+        bail!(
+            "Saved plan {} is corrupt: changeSetHash is {} but the change set hashes to {actual}",
+            path.display(),
+            plan.change_set_hash
+        );
+    }
+    Ok(plan)
+}
+
+pub fn assert_source_tree(plan: &SavedPlan, cwd: &Path) -> Result<()> {
+    let current = detect_source_tree(cwd)?;
+    if current != plan.source_tree {
+        bail!(
+            "Merged .railway/ tree {current} does not match the planned tree {}. Re-run `railway config plan` on this revision; do not apply an unreviewed combination.",
+            plan.source_tree
+        );
+    }
+    Ok(())
+}
+
+pub async fn apply_saved_plan(configs: &Configs, plan: &SavedPlan) -> Result<Value> {
+    let live = fetch_config_etag(configs, &plan.environment_id).await?;
+    match live.as_deref() {
+        Some(etag) if etag == plan.config_etag => {}
+        Some(etag) => bail!(
+            "The environment changed since this plan was computed (etag {etag}, plan {}). Re-run `railway config plan` and review the new diff.",
+            plan.config_etag
+        ),
+        None => {
+            bail!("The environment no longer reports a config etag. Re-run `railway config plan`.")
+        }
+    }
+
+    let empty = plan
+        .change_set
+        .get("changes")
+        .and_then(Value::as_array)
+        .map(Vec::is_empty)
+        .unwrap_or(true);
+    if empty {
+        return Ok(serde_json::json!({
+            "id": null,
+            "status": "noop",
+            "changes": [],
+        }));
+    }
+
+    let client = GQLClient::new_authorized(configs)?;
+    let endpoint = configs.get_backboard();
+    apply_change_set(
+        &client,
+        &endpoint,
+        &plan.environment_id,
+        &plan.change_set,
+        Some(&plan.config_etag),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hashes_are_stable_under_key_reorder() {
+        let a = json!({"version": 1, "changes": [{"path": "service.api", "kind": "update"}]});
+        let b = json!({"changes": [{"kind": "update", "path": "service.api"}], "version": 1});
+        assert_eq!(change_set_hash(&a), change_set_hash(&b));
+    }
+
+    #[test]
+    fn detects_destructive_severity() {
+        let set = json!({
+            "changes": [
+                {"summary": "add", "severity": "info"},
+                {"summary": "delete service", "severity": "destructive"}
+            ]
+        });
+        assert!(is_destructive_change_set(&set));
+        assert!(!is_destructive_change_set(&json!({"changes": []})));
+    }
+
+    #[test]
+    fn from_runner_json_requires_etag() {
+        let raw = json!({
+            "currentEnvironment": { "environmentId": "env_1" },
+            "changeSet": { "version": 1, "changes": [] }
+        });
+        assert!(from_runner_json(&raw, "tree".into()).is_err());
+    }
+
+    #[test]
+    fn from_runner_json_round_trips() {
+        let raw = json!({
+            "currentEnvironment": {
+                "environmentId": "env_1",
+                "configEtag": "etag_1"
+            },
+            "changeSet": { "version": 1, "changes": [] },
+            "diff": "already up to date"
+        });
+        let plan = from_runner_json(&raw, "abc".into()).unwrap();
+        assert_eq!(plan.kind, KIND);
+        assert_eq!(plan.source_tree, "abc");
+        assert_eq!(plan.config_etag, "etag_1");
+        assert!(!plan.destructive);
+        let encoded = serde_json::to_string(&plan).unwrap();
+        let parsed: SavedPlan = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(parsed.change_set_hash, plan.change_set_hash);
+    }
+
+    #[test]
+    fn read_plan_rejects_tampered_hash() {
+        let dir = tempfile_dir("saved-plan");
+        let path = dir.join("plan.json");
+        let mut plan = from_runner_json(
+            &json!({
+                "currentEnvironment": {
+                    "environmentId": "env_1",
+                    "configEtag": "etag_1"
+                },
+                "changeSet": { "version": 1, "changes": [] }
+            }),
+            "tree".into(),
+        )
+        .unwrap();
+        plan.change_set_hash = "sha256:deadbeef".into();
+        write_plan(&path, &plan).unwrap();
+        assert!(
+            read_plan(&path)
+                .unwrap_err()
+                .to_string()
+                .contains("corrupt")
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn hashes_railway_dir_when_git_tree_is_missing() {
+        let dir = tempfile_dir("saved-plan-tree");
+        fs::create_dir_all(dir.join(".railway")).unwrap();
+        fs::write(dir.join(".railway").join("railway.ts"), "export default {}").unwrap();
+        let tree = detect_source_tree(&dir).unwrap();
+        assert!(tree.starts_with("sha256:"));
+        assert_eq!(detect_source_tree(&dir).unwrap(), tree);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    fn tempfile_dir(prefix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}

--- a/src/iac/saved_plan.rs
+++ b/src/iac/saved_plan.rs
@@ -39,6 +39,10 @@ pub struct SavedPlan {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diff: Option<String>,
     pub destructive: bool,
+    /// A named partial claiming ownership must apply even with zero changes,
+    /// mirroring the live apply path.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub claim: bool,
 }
 
 pub fn change_set_hash(change_set: &Value) -> String {
@@ -76,6 +80,16 @@ pub fn detect_source_tree(cwd: &Path) -> Result<String> {
 }
 
 fn git_railway_tree(cwd: &Path) -> Option<String> {
+    // A dirty .railway/ means HEAD's tree is not what the plan evaluated;
+    // fall back to hashing the working tree instead of pinning a lie.
+    let status = Command::new("git")
+        .args(["status", "--porcelain", "--", ".railway"])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !status.status.success() || !status.stdout.is_empty() {
+        return None;
+    }
     let output = Command::new("git")
         .args(["rev-parse", "HEAD:.railway"])
         .current_dir(cwd)
@@ -164,6 +178,7 @@ pub fn from_runner_json(raw: &Value, source_tree: String) -> Result<SavedPlan> {
         change_set,
         diff: raw.get("diff").and_then(Value::as_str).map(str::to_string),
         destructive: is_destructive_change_set(raw.get("changeSet").unwrap_or(&Value::Null)),
+        claim: raw.get("claim").and_then(Value::as_bool).unwrap_or(false),
     })
 }
 
@@ -182,7 +197,7 @@ pub fn write_plan(path: &Path, plan: &SavedPlan) -> Result<()> {
 pub fn read_plan(path: &Path) -> Result<SavedPlan> {
     let body = fs::read_to_string(path)
         .with_context(|| format!("Failed to read saved plan {}", path.display()))?;
-    let plan: SavedPlan = serde_json::from_str(&body).with_context(|| {
+    let mut plan: SavedPlan = serde_json::from_str(&body).with_context(|| {
         format!(
             "Saved plan {} is not a railway.config.plan file",
             path.display()
@@ -210,6 +225,9 @@ pub fn read_plan(path: &Path) -> Result<SavedPlan> {
             plan.change_set_hash
         );
     }
+    // The destructive guard must derive from the hash-verified change set, not
+    // a stored flag an edited artifact could clear.
+    plan.destructive = is_destructive_change_set(&plan.change_set);
     Ok(plan)
 }
 
@@ -243,7 +261,7 @@ pub async fn apply_saved_plan(configs: &Configs, plan: &SavedPlan) -> Result<Val
         .and_then(Value::as_array)
         .map(Vec::is_empty)
         .unwrap_or(true);
-    if empty {
+    if empty && !plan.claim {
         return Ok(serde_json::json!({
             "id": null,
             "status": "noop",
@@ -340,6 +358,51 @@ mod tests {
                 .contains("corrupt")
         );
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn read_plan_recomputes_destructive_from_hashed_change_set() {
+        let dir = tempfile_dir("saved-plan-destructive");
+        let path = dir.join("plan.json");
+        let mut plan = from_runner_json(
+            &json!({
+                "currentEnvironment": {
+                    "environmentId": "env_1",
+                    "configEtag": "etag_1"
+                },
+                "changeSet": {
+                    "version": 1,
+                    "changes": [{"summary": "delete service", "severity": "destructive"}]
+                }
+            }),
+            "tree".into(),
+        )
+        .unwrap();
+        assert!(plan.destructive);
+        // An edited artifact clearing the flag must not bypass the guard.
+        plan.destructive = false;
+        write_plan(&path, &plan).unwrap();
+        assert!(read_plan(&path).unwrap().destructive);
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn claim_defaults_to_false_and_round_trips() {
+        let raw = json!({
+            "currentEnvironment": { "environmentId": "env_1", "configEtag": "etag_1" },
+            "changeSet": { "version": 1, "changes": [] },
+            "claim": true
+        });
+        let plan = from_runner_json(&raw, "tree".into()).unwrap();
+        assert!(plan.claim);
+        let encoded = serde_json::to_string(&plan).unwrap();
+        let parsed: SavedPlan = serde_json::from_str(&encoded).unwrap();
+        assert!(parsed.claim);
+        // Old artifacts without the field still parse.
+        let mut trimmed: Value = serde_json::from_str(&encoded).unwrap();
+        trimmed.as_object_mut().unwrap().remove("claim");
+        let old: SavedPlan = serde_json::from_value(trimmed).unwrap();
+        assert!(!old.claim);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1053,5 +1053,26 @@ mod cli_tests {
             assert_parses(&["mcp", "install", "--oauth"]);
             assert_parses(&["mcp", "install", "--oauth", "--agent", "cursor"]);
         }
+
+        #[test]
+        fn config_pinned_plan_flags() {
+            assert_parses(&["config", "plan", "--out", "railway-plan.json"]);
+            assert_parses(&[
+                "config",
+                "plan",
+                "--out",
+                "railway-plan.json",
+                "--source-tree",
+                "abc123",
+            ]);
+            assert_parses(&[
+                "config",
+                "apply",
+                "--plan",
+                "railway-plan.json",
+                "--yes",
+                "--confirm-destructive",
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `railway config plan --out` writes a pinned plan (change set, `configEtag`, `.railway/` tree).
- `railway config apply --plan` applies that artifact as-is — no re-eval — and fails if the live etag or checkout tree drifted.
- Adds an example GitHub Actions workflow that comments the plan on the PR and applies the artifact on merge.

## Test plan
- [ ] `railway config plan --out railway-plan.json` writes `kind: railway.config.plan` with etag + tree
- [ ] `railway config apply --plan railway-plan.json` applies without re-planning
- [ ] Apply fails after a dashboard edit (etag drift)
- [ ] Apply fails if `.railway/` differs from the planned tree
- [ ] Destructive apply still requires `--confirm-destructive`
- [ ] Empty change set is a noop
- [ ] `cargo test saved_plan` and `cargo test config_pinned_plan`


Made with [Cursor](https://cursor.com)