### PR TITLE
Restore IaC eval context in the native CLI engine

### DIFF
--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -280,7 +280,8 @@ import "github.com/railwayapp/railway-go-sdk"
 // project and drop this if you later combine services into that file.
 const Partial = {name}
 
-func Railway() railway.Project {{
+func Railway(ctx railway.Context) railway.Project {{
+	ctx = railway.NewContext(ctx)
 	web := railway.ServiceNamed({name}, {config})
 	return railway.ProjectNamed({name}, []any{{web}})
 }}

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -832,7 +832,7 @@ fn render_preamble(lang: AuthoringLang, imports: &[&str]) -> String {
                 .join(", ")
         ),
         AuthoringLang::Go => {
-            "package main\n\nimport \"github.com/railwayapp/railway-go-sdk\"\n\nfunc Railway() railway.Project {\n"
+            "package main\n\nimport \"github.com/railwayapp/railway-go-sdk\"\n\nfunc Railway(ctx railway.Context) railway.Project {\n  ctx = railway.NewContext(ctx)\n"
                 .to_string()
         }
     }
@@ -2223,7 +2223,7 @@ mod tests {
         };
         let rendered = render_graph_as_railway(&graph, true, AuthoringLang::Go);
         assert!(rendered.contains("github.com/railwayapp/railway-go-sdk"));
-        assert!(rendered.contains("func Railway()"));
+        assert!(rendered.contains("func Railway(ctx railway.Context)"));
         assert!(rendered.contains("railway.Github(\"org/app\")"));
         assert!(rendered.contains("\"start\": \"./app\""));
         assert!(rendered.contains("railway.ServiceNamed"));

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::change_set::{ChangeSetTelemetry, DiffOptions, diff_graphs, render_change_set};
 use super::compiler::{EnvironmentConfigToGraphOptions, environment_config_to_graph};
-use super::eval::evaluate_file;
+use super::eval::{EvalContext, evaluate_file_with_context};
 use super::graph::validate_graph;
 use super::partial::needs_partial_claim_apply;
 
@@ -157,7 +157,10 @@ pub async fn run(
         .clone()
         .or_else(|| find_authoring_file(&cwd))
         .context("Could not find .railway/railway.ts, railway.py, or railway.go")?;
-    let evaluated = evaluate_file(&file)?;
+    let evaluated = evaluate_file_with_context(
+        &file,
+        &EvalContext::from_linked_project(linked_project, command),
+    )?;
     let diagnostics: Vec<Value> = validate_graph(&evaluated.graph)
         .into_iter()
         .map(|message| json!({ "severity": "error", "path": "graph", "message": message }))

--- a/src/iac/eval.rs
+++ b/src/iac/eval.rs
@@ -7,6 +7,8 @@ use std::{
 use anyhow::{Context, Result, bail};
 use serde_json::{Value, json};
 
+use crate::config::LinkedProject;
+
 use super::compiler::project_definition_to_graph;
 use super::graph::RailwayGraph;
 use super::partial::parse_partial_name;
@@ -17,17 +19,58 @@ pub struct EvaluatedFile {
     pub partial: Option<String>,
 }
 
+/// Linked project + command, matching the JSON the legacy TS runner sent as `context`.
+#[derive(Clone, Debug, Default)]
+pub struct EvalContext {
+    pub command: Option<String>,
+    pub project_id: Option<String>,
+    pub project_name: Option<String>,
+    pub environment_id: Option<String>,
+    pub environment: Option<String>,
+    pub environment_name: Option<String>,
+}
+
+impl EvalContext {
+    pub fn from_linked_project(linked: &LinkedProject, command: &str) -> Self {
+        let environment = linked.environment_name.clone();
+        Self {
+            command: Some(command.to_string()),
+            project_id: Some(linked.project.clone()),
+            project_name: linked.name.clone(),
+            environment_id: linked.environment.clone(),
+            environment: environment.clone(),
+            environment_name: environment,
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "command": self.command,
+            "projectId": self.project_id,
+            "projectName": self.project_name,
+            "environmentId": self.environment_id,
+            "environment": self.environment,
+            "environmentName": self.environment_name,
+        })
+    }
+}
+
 pub fn evaluate_file(file: &Path) -> Result<EvaluatedFile> {
+    evaluate_file_with_context(file, &EvalContext::default())
+}
+
+pub fn evaluate_file_with_context(file: &Path, ctx: &EvalContext) -> Result<EvaluatedFile> {
     let file = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+    let context_json = ctx.to_json().to_string();
     let ext = file
         .extension()
         .and_then(|ext| ext.to_str())
         .unwrap_or("")
         .to_ascii_lowercase();
     let payload = match ext.as_str() {
-        "py" => evaluate_python(&file)?,
-        "go" => evaluate_go(&file)?,
-        "ts" | "mts" | "cts" | "js" | "mjs" | "cjs" => evaluate_javascript(&file)?,
+        "py" => evaluate_python(&file, &context_json)?,
+        "go" => evaluate_go(&file, &context_json)?,
+        "ts" | "mts" | "cts" | "js" | "mjs" | "cjs" => evaluate_javascript(&file, &context_json)?,
         other => bail!("Unsupported IaC file extension: .{other}"),
     };
     let partial = parse_partial_name(payload.get("partial").and_then(Value::as_str))
@@ -90,28 +133,69 @@ fn normalize_project(mut project: Value) -> Value {
     project
 }
 
-fn evaluate_python(file: &Path) -> Result<Value> {
+fn with_eval_context(command: &mut Command, context_json: &str) {
+    command.env("RAILWAY_IAC_CONTEXT", context_json);
+}
+
+fn evaluate_python(file: &Path, context_json: &str) -> Result<Value> {
     let script = r#"
-import importlib.util, json, sys
+import importlib.util, inspect, json, os, sys
 path = sys.argv[1]
+payload = json.loads(os.environ.get("RAILWAY_IAC_CONTEXT") or "{}")
+
+def make_ctx(payload):
+    try:
+        from railway_sdk import create_railway_context
+        return create_railway_context(payload)
+    except Exception:
+        class _Shared:
+            def __getattr__(self, name):
+                if name.startswith("_"):
+                    raise AttributeError(name)
+                return {"type": "sharedReference", "name": name}
+        class _Ctx(dict):
+            def __init__(self, p):
+                super().__init__(p)
+                env = p.get("environment") or p.get("environmentName")
+                self.environment = env
+                self.environmentName = env
+                self.shared = _Shared()
+            def is_environment(self, name):
+                return self.environment == name
+            def random_string(self, label="random", bytes=12):
+                import hashlib
+                seed = f"railway-iac:{self.environment or 'default'}:{label}"
+                return hashlib.sha256(seed.encode()).hexdigest()[: bytes * 2]
+        return _Ctx(payload)
+
+ctx = make_ctx(payload)
 spec = importlib.util.spec_from_file_location("railway_sdk_user", path)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 partial = getattr(mod, "PARTIAL", None) or getattr(mod, "Partial", None) or getattr(mod, "partial", None)
 candidate = getattr(mod, "main", None) or getattr(mod, "Railway", None) or getattr(mod, "default", None)
-project = candidate() if callable(candidate) else candidate
+if callable(candidate):
+    try:
+        params = list(inspect.signature(candidate).parameters.values())
+    except (TypeError, ValueError):
+        params = [None]
+    project = candidate() if not params else candidate(ctx)
+else:
+    project = candidate
 if hasattr(project, "to_graph"):
     project = project.to_graph()
 print(json.dumps({"partial": partial, "project": project}, default=str))
 "#;
-    let output = Command::new("python3")
-        .args(["-c", script, &file.to_string_lossy()])
+    let mut command = Command::new("python3");
+    command.args(["-c", script, &file.to_string_lossy()]);
+    with_eval_context(&mut command, context_json);
+    let output = command
         .output()
         .context("Failed to run python3 to evaluate .railway/railway.py")?;
     decode_eval_output("python3", &output)
 }
 
-fn evaluate_go(file: &Path) -> Result<Value> {
+fn evaluate_go(file: &Path, context_json: &str) -> Result<Value> {
     let dir = file
         .parent()
         .context("Go IaC file has no parent directory")?;
@@ -119,27 +203,9 @@ fn evaluate_go(file: &Path) -> Result<Value> {
     let has_partial = fs::read_to_string(file)
         .unwrap_or_default()
         .contains("Partial");
-    let source = if has_partial {
-        r#"package main
-import ("encoding/json"; "os")
-func main() {
-  out, err := json.Marshal(map[string]any{"partial": Partial, "project": Railway().Graph()})
-  if err != nil { panic(err) }
-  os.Stdout.Write(out)
-}
-"#
-    } else {
-        r#"package main
-import ("encoding/json"; "os")
-func main() {
-  out, err := json.Marshal(map[string]any{"project": Railway().Graph()})
-  if err != nil { panic(err) }
-  os.Stdout.Write(out)
-}
-"#
-    };
-    fs::write(&wrapper, source)?;
-    let output = Command::new("go")
+    fs::write(&wrapper, go_eval_wrapper(has_partial))?;
+    let mut command = Command::new("go");
+    command
         .args([
             "run",
             file.file_name()
@@ -150,8 +216,9 @@ func main() {
                 .and_then(|n| n.to_str())
                 .unwrap_or("railway_iac_eval_main.go"),
         ])
-        .current_dir(dir)
-        .output();
+        .current_dir(dir);
+    with_eval_context(&mut command, context_json);
+    let output = command.output();
     let _ = fs::remove_file(&wrapper);
     decode_eval_output(
         "go run",
@@ -159,17 +226,139 @@ func main() {
     )
 }
 
-fn evaluate_javascript(file: &Path) -> Result<Value> {
+fn go_eval_wrapper(include_partial: bool) -> String {
+    let payload = if include_partial {
+        r#"map[string]any{"partial": Partial, "project": railwayIacGraph(result)}"#
+    } else {
+        r#"map[string]any{"project": railwayIacGraph(result)}"#
+    };
+    format!(
+        r#"package main
+import (
+  "encoding/json"
+  "os"
+  "reflect"
+  "strings"
+)
+
+func railwayIacContextValue(fnType reflect.Type) reflect.Value {{
+  raw := os.Getenv("RAILWAY_IAC_CONTEXT")
+  var payload map[string]any
+  _ = json.Unmarshal([]byte(raw), &payload)
+  in := fnType.In(0)
+  arg := reflect.New(in).Elem()
+  railwayIacFillValue(arg, payload)
+  return arg
+}}
+
+func railwayIacFillValue(v reflect.Value, payload map[string]any) {{
+  if v.Kind() == reflect.Pointer {{
+    if v.IsNil() {{
+      v.Set(reflect.New(v.Type().Elem()))
+    }}
+    railwayIacFillValue(v.Elem(), payload)
+    return
+  }}
+  if v.Kind() != reflect.Struct {{
+    return
+  }}
+  t := v.Type()
+  for i := 0; i < t.NumField(); i++ {{
+    field := t.Field(i)
+    if !field.IsExported() || field.Type.Kind() != reflect.String {{
+      continue
+    }}
+    name := strings.ToLower(field.Name)
+    keys := []string{{field.Name, name}}
+    switch name {{
+    case "command":
+      keys = append(keys, "command")
+    case "projectid":
+      keys = append(keys, "projectId")
+    case "projectname":
+      keys = append(keys, "projectName")
+    case "environmentid":
+      keys = append(keys, "environmentId")
+    case "environment":
+      keys = append(keys, "environment", "environmentName")
+    case "environmentname":
+      keys = append(keys, "environmentName", "environment")
+    }}
+    for _, key := range keys {{
+      if text, ok := payload[key].(string); ok && text != "" {{
+        v.Field(i).SetString(text)
+        break
+      }}
+    }}
+  }}
+}}
+
+func railwayIacGraph(project reflect.Value) any {{
+  if method := project.MethodByName("Graph"); method.IsValid() {{
+    return method.Call(nil)[0].Interface()
+  }}
+  return project.Interface()
+}}
+
+func main() {{
+  fn := reflect.ValueOf(Railway)
+  var result reflect.Value
+  if fn.Type().NumIn() == 0 {{
+    result = fn.Call(nil)[0]
+  }} else {{
+    result = fn.Call([]reflect.Value{{railwayIacContextValue(fn.Type())}})[0]
+  }}
+  out, err := json.Marshal({payload})
+  if err != nil {{ panic(err) }}
+  os.Stdout.Write(out)
+}}
+"#
+    )
+}
+
+fn evaluate_javascript(file: &Path, context_json: &str) -> Result<Value> {
     let script = r#"
+import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
 const file = process.argv[1];
+const input = JSON.parse(process.env.RAILWAY_IAC_CONTEXT || "{}");
+const environment = input.environment ?? input.environmentName ?? undefined;
+function fallbackContext(payload) {
+  return {
+    ...payload,
+    ...(environment ? { environment, environmentName: environment } : {}),
+    isEnvironment: (name) => environment === name,
+    randomString: (label = "random", bytes = 12) =>
+      createHash("sha256")
+        .update(`railway-iac:${environment ?? "default"}:${label}`)
+        .digest("hex")
+        .slice(0, bytes * 2),
+    shared: new Proxy({}, {
+      get: (_target, name) => {
+        if (typeof name !== "string" || name.startsWith("_")) return undefined;
+        return { type: "sharedReference", name };
+      },
+    }),
+  };
+}
+let ctx = fallbackContext(input);
+try {
+  const iac = await import("railway/iac");
+  if (typeof iac.createRailwayContext === "function") {
+    ctx = iac.createRailwayContext(input);
+  }
+} catch {}
 const mod = await import(`${pathToFileURL(file).href}?t=${Date.now()}`);
 const partial = mod.partial ?? mod.PARTIAL ?? mod.Partial ?? undefined;
 let exported = mod.default ?? mod.main ?? mod.Railway ?? mod;
 while (exported && typeof exported === "object" && "default" in exported && exported.name == null && exported.resources == null) {
   exported = exported.default;
 }
-const project = typeof exported === "function" ? await exported({}) : exported;
+const projectFactory = (name, definition = {}) => {
+  const resources = (definition.resources ?? definition.services ?? []).flat?.() ?? definition.resources ?? [];
+  return { name, ...definition, resources };
+};
+const project = typeof exported === "function" ? await exported(ctx, projectFactory) : exported;
 const graph = project && typeof project === "object" && "to_graph" in project ? project.to_graph() : project;
 process.stdout.write(JSON.stringify({ partial, project: graph }));
 "#;
@@ -183,6 +372,7 @@ process.stdout.write(JSON.stringify({ partial, project: graph }));
         "--",
         &file.to_string_lossy(),
     ]);
+    with_eval_context(&mut command, context_json);
     if let Some(modules) = nearest_node_modules(file) {
         command.env("NODE_PATH", modules);
     }

--- a/src/iac/mod.rs
+++ b/src/iac/mod.rs
@@ -22,7 +22,7 @@ pub use compiler::{
 };
 pub use engine::{NativeRun, run as run_native};
 #[allow(dead_code)]
-pub use eval::{EvaluatedFile, evaluate_file};
+pub use eval::{EvalContext, EvaluatedFile, evaluate_file, evaluate_file_with_context};
 #[allow(dead_code)]
 pub use graph::{RAILWAY_GRAPH_VERSION, RailwayGraph, resource_address, validate_graph};
 #[allow(dead_code)]

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -5,7 +5,7 @@ use super::compiler::{
     CompileOptions, EnvironmentConfigToGraphOptions, environment_config_to_graph,
     graph_to_environment_config, project_definition_to_graph,
 };
-use super::eval::evaluate_file;
+use super::eval::{EvalContext, evaluate_file, evaluate_file_with_context};
 use super::graph::RAILWAY_GRAPH_VERSION;
 use super::partial::IacPartials;
 
@@ -1058,6 +1058,121 @@ func Railway() graph {
             .resources
             .iter()
             .any(|r| r["address"] == "service.api")
+    );
+}
+
+fn eval_context_production() -> EvalContext {
+    EvalContext {
+        command: Some("plan".into()),
+        project_id: Some("proj_123".into()),
+        project_name: Some("acme".into()),
+        environment_id: Some("env_123".into()),
+        environment: Some("production".into()),
+        environment_name: Some("production".into()),
+    }
+}
+
+#[test]
+fn evaluates_typescript_with_cli_context() {
+    let dir = tempfile_dir("railway-iac-ts-ctx-");
+    let file = dir.join("railway.ts");
+    std::fs::write(
+        &file,
+        r#"
+export default (ctx) => ({
+  name: "app",
+  resources: [{
+    address: "service.api",
+    type: "service",
+    name: ctx.isEnvironment("production") ? "prod-api" : "dev-api",
+  }],
+});
+"#,
+    )
+    .unwrap();
+    let evaluated = evaluate_file_with_context(&file, &eval_context_production())
+        .expect("node should evaluate railway.ts with context");
+    assert!(
+        evaluated
+            .graph
+            .resources
+            .iter()
+            .any(|r| r["name"] == "prod-api")
+    );
+}
+
+#[test]
+fn evaluates_python_with_cli_context() {
+    if which::which("python3").is_err() {
+        return;
+    }
+    let dir = tempfile_dir("railway-iac-py-ctx-");
+    let file = dir.join("railway.py");
+    std::fs::write(
+        &file,
+        r#"
+def main(ctx=None):
+    name = "prod-api" if ctx.is_environment("production") else "dev-api"
+    return {"name": "app", "resources": [{"type": "service", "name": name, "start": "echo api"}]}
+"#,
+    )
+    .unwrap();
+    let evaluated = evaluate_file_with_context(&file, &eval_context_production())
+        .expect("python3 should evaluate railway.py with context");
+    assert!(
+        evaluated
+            .graph
+            .resources
+            .iter()
+            .any(|r| r["name"] == "prod-api")
+    );
+}
+
+#[test]
+fn evaluates_go_with_cli_context() {
+    if which::which("go").is_err() {
+        return;
+    }
+    let dir = tempfile_dir("railway-iac-go-ctx-");
+    let file = dir.join("railway.go");
+    std::fs::write(dir.join("go.mod"), "module railway-eval\n\ngo 1.22\n").unwrap();
+    std::fs::write(
+        &file,
+        r#"
+package main
+
+type graph map[string]any
+
+func (g graph) Graph() map[string]any { return g }
+
+type evalCtx struct {
+	Environment     string
+	EnvironmentName string
+}
+
+func Railway(ctx evalCtx) graph {
+	name := "dev-api"
+	if ctx.Environment == "production" {
+		name = "prod-api"
+	}
+	return graph{
+		"name": "app",
+		"resources": []any{
+			map[string]any{"type": "service", "name": name, "start": "echo api"},
+		},
+	}
+}
+"#,
+    )
+    .unwrap();
+    let evaluated = evaluate_file_with_context(&file, &eval_context_production())
+        .expect("go should evaluate railway.go with context");
+    assert!(
+        evaluated
+            .graph
+            .resources
+            .iter()
+            .any(|r| r["name"] == "prod-api")
     );
 }
 


### PR DESCRIPTION
## Summary
- Native `config plan`/`apply` now pass the linked project and command into TypeScript, Python, and Go eval (the same `context` payload the legacy `railway-iac-ts` runner sent).
- TS gets `createRailwayContext` when `railway/iac` is importable, plus `isEnvironment`/`shared` fallbacks; Python calls `main(ctx)`; Go fills `Railway(ctx railway.Context)` via reflection. Zero-arg entrypoints still evaluate.
- Pull/migrate Go files now take `railway.Context` so new authoring can branch on the environment.

## Test plan
- [x] `cargo test --bin railway evaluates_` (including production-branching cases for TS/Py/Go)
- [ ] `railway config plan` against a `.railway/railway.ts` that uses `ctx.environment === "production"` / `ctx.shared.NAME` on a linked production environment
- [ ] Same for `railway.py` `main(ctx)` and `railway.go` `func Railway(ctx railway.Context)`
- [ ] Confirm a zero-arg `func Railway()` file still plans


Made with [Cursor](https://cursor.com)