### PR TITLE
fix(ca): click focuses the session, stale rows validate away, unasked deaths respawn

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -3319,6 +3319,65 @@ impl App {
         None
     }
 
+    /// A reconnect aimed at a session the agent no longer has — it closed, or
+    /// the machine died and came back without it. Connecting was the ask, so
+    /// the answer is a fresh session on that agent, not an error: the stale
+    /// row goes now (the platform just said it does not exist), and the
+    /// replacement runs the harness the row named where it still names one.
+    pub fn reattach_target_gone(
+        &mut self,
+        agent_id: &str,
+        agent_name: &str,
+        session_name: &str,
+    ) -> Option<Effect> {
+        self.connecting.remove(session_name);
+        let harness = self
+            .remove_session_row(agent_id, session_name)
+            .unwrap_or_default();
+        if let Some(effect) = self.respawn_on(agent_id, &harness) {
+            self.toast(format!(
+                "Session {session_name} is gone — starting a new one"
+            ));
+            return Some(effect);
+        }
+        // No replacement to offer — the agent stopped running underneath the
+        // reconnect. Say what happened and re-ask for the list, so the tree
+        // settles on the truth rather than the row that just misled us.
+        self.toast_error(format!(
+            "Session {session_name} is gone, and {agent_name} isn't running"
+        ));
+        self.refresh_agent_sessions(agent_id)
+    }
+
+    /// Drop one session row from the tree — the platform just said the
+    /// session does not exist — returning the harness it claimed to run, for
+    /// a replacement to launch.
+    fn remove_session_row(&mut self, agent_id: &str, session_name: &str) -> Option<String> {
+        let mut harness = None;
+        'search: for ws in &mut self.tree {
+            for project in &mut ws.projects {
+                for env in &mut project.envs {
+                    let Load::Loaded(agents) = &mut env.agents else {
+                        continue;
+                    };
+                    let Some(agent) = agents.iter_mut().find(|agent| agent.id == agent_id) else {
+                        continue;
+                    };
+                    let LoadSessions::Loaded(sessions) = &mut agent.sessions else {
+                        break 'search;
+                    };
+                    let Some(i) = sessions.iter().position(|s| s.name == session_name) else {
+                        break 'search;
+                    };
+                    harness = sessions.remove(i).harness_slug().map(str::to_string);
+                    break 'search;
+                }
+            }
+        }
+        self.clamp_cursor();
+        harness
+    }
+
     /// A pane whose connection just DIED (rather than finished) pulls the
     /// keyboard to itself, once: its banner says "r reconnects", and r has to
     /// mean that immediately — not the tree's refresh — without needing a
@@ -8536,6 +8595,62 @@ mod tests {
 
         a.on_mouse(MouseAction::Down, 5, 3 + row);
         assert_eq!(a.focus, ManageFocus::Session, "a second click keeps it");
+    }
+
+    /// A reconnect whose target session turns out not to exist launches a
+    /// replacement on the same agent — same harness, stale row dropped —
+    /// instead of failing. Connecting was the ask; a dead name must not
+    /// answer it with an error.
+    #[test]
+    fn a_reconnect_to_a_gone_session_starts_a_new_one() {
+        let mut a = loaded_app();
+        if let Load::Loaded(agents) = &mut a.tree[0].projects[0].envs[0].agents {
+            agents[0].expanded = true;
+            agents[0].sessions = LoadSessions::Loaded(vec![ConsoleSession {
+                name: "claude-one".into(),
+                kind: "SHELL".into(),
+                command: Some("claude --resume".into()),
+                running: true,
+                attached: false,
+                created_at: None,
+            }]);
+        }
+
+        let Some(Effect::Launch(req)) =
+            a.reattach_target_gone("ca_1", "nimble-otter", "claude-one")
+        else {
+            panic!("expected a replacement launch");
+        };
+        assert_eq!(req.agent_id.as_deref(), Some("ca_1"));
+        assert!(req.force_new, "the dead name must not be redialed");
+        assert_eq!(req.harness, "claude", "same harness the dead session ran");
+        assert_eq!(req.prompt, None);
+        assert!(
+            !a.rows().iter().any(|r| r.label.contains("claude-one")),
+            "the stale row is gone"
+        );
+
+        // The agent stopped running underneath the reconnect: nothing to
+        // launch onto — the truth gets refetched instead.
+        let mut b = loaded_app();
+        if let Load::Loaded(agents) = &mut b.tree[0].projects[0].envs[0].agents {
+            agents[0].expanded = true;
+            agents[0].status = "sleeping".into();
+            agents[0].sessions = LoadSessions::Loaded(vec![ConsoleSession {
+                name: "claude-one".into(),
+                kind: "SHELL".into(),
+                command: None,
+                running: true,
+                attached: false,
+                created_at: None,
+            }]);
+        }
+        let effect = b.reattach_target_gone("ca_1", "nimble-otter", "claude-one");
+        assert!(
+            matches!(effect, Some(Effect::LoadSessions { .. })),
+            "{effect:?}"
+        );
+        assert!(!b.toast.as_ref().unwrap().ok, "announced as a failure");
     }
 
     /// A refresh that finds an agent no longer running drops its session

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -53,8 +53,9 @@ pub const KEY_HELP: &[(&str, &[(&str, &str)])] = &[
             ("enter", "connect and type in it"),
             ("⌥f", "give it the whole screen · again to restore"),
             ("⌥enter / f", "leave the TUI and connect full screen"),
+            ("⌥⇧[ ⌥⇧]", "previous / next session"),
             ("c", "copy an ssh command for it"),
-            ("⌥/⇧esc / ^] / esc esc", "stop typing in it"),
+            ("⌥⇧esc / ^]", "stop typing in it"),
             ("wheel", "scroll its output"),
             ("click a link", "open it in your browser"),
             ("shift+pgup/pgdn", "scroll without the mouse"),
@@ -320,12 +321,6 @@ pub const SLEEP_PATIENCE: std::time::Duration = std::time::Duration::from_secs(6
 /// How often to ask again while waiting.
 pub const WATCH_TICK: std::time::Duration = std::time::Duration::from_millis(1500);
 
-/// How close together two Escapes must land to count as the double-tap that
-/// releases a focused session back to the tree. Wide enough for a deliberate
-/// tap-tap, tight enough that two Escapes meant for the harness (dismissing
-/// two of its menus, say) rarely fall inside it.
-const DOUBLE_ESC: std::time::Duration = std::time::Duration::from_millis(500);
-
 /// How many background attaches may be in flight at once. Startup wants the
 /// whole tree green, but each attach is a relay ssh, a reader thread, and a
 /// scrollback replay — a fleet's worth at once is a thundering herd.
@@ -472,8 +467,8 @@ pub struct PaneRects {
     /// The new-session prompt box, borders included.
     pub prompt: PaneBox,
     /// The header's session tabs, drawn only while the pane is maximized. A
-    /// fixed array so this stays `Copy`; sessions past the cap keep their ⌥[
-    /// ⌥] keys but aren't clickable.
+    /// fixed array so this stays `Copy`; sessions past the cap keep their
+    /// ⌥⇧[ ⌥⇧] keys but aren't clickable.
     pub tabs: [PaneBox; MAX_TABS],
 }
 
@@ -935,9 +930,6 @@ pub struct App {
     /// to its pane — once per drop, so Esc-ing away sticks. Cleared when the
     /// name reattaches, so a second drop announces itself the same way.
     drop_seen: std::collections::HashSet<String>,
-    /// When the last bare Escape went into a focused session, for spotting
-    /// the double-tap that releases the keyboard to the tree.
-    session_esc_at: Option<std::time::Instant>,
     /// First-run setup, when there are no preferences yet.
     pub wizard: Option<super::wizard::Wizard>,
     /// The ⌥s settings card, while it is open.
@@ -1052,7 +1044,6 @@ impl App {
             connecting: std::collections::HashSet::new(),
             auto_attempted: std::collections::HashSet::new(),
             drop_seen: std::collections::HashSet::new(),
-            session_esc_at: None,
             wizard: None,
             settings: None,
             skills_source: None,
@@ -2076,19 +2067,21 @@ impl App {
                 return None;
             }
             // A few chords are taken from the agent, all because the moment
-            // you want them is while you are using it: ⌥f for room, ⌥] and ⌥[
-            // to move between panes, ⌥n and ⌥p to start more work — the
-            // thought "this needs its own session" arrives while reading one,
-            // and going out to the tree first to act on it is the friction
-            // they exist to remove. ⌥r joins them for the same reason: a
-            // refresh that only worked with the tree focused would be a chord
-            // that silently does nothing half the time you press it. The
-            // costs, all in a shell: ⌥f is Meta-f (forward-word), ⌥n and ⌥p
-            // are Meta-n / Meta-p (the non-incremental history searches, which
-            // few people bind and both harnesses ignore), and ⌥r is Meta-r
-            // (revert-line). Readline leaves Meta-] and Meta-[ unbound, and
-            // `^]` (character-search) is untouched because only the Meta forms
-            // are claimed. Nothing else is intercepted — ⌥s still reaches the
+            // you want them is while you are using it: ⌥f for room, ⌥⇧] and
+            // ⌥⇧[ (with their unshifted aliases) to move between panes, ⌥n
+            // and ⌥p to start more work — the thought "this needs its own
+            // session" arrives while reading one, and going out to the tree
+            // first to act on it is the friction they exist to remove. ⌥r
+            // joins them for the same reason: a refresh that only worked with
+            // the tree focused would be a chord that silently does nothing
+            // half the time you press it. The costs, all in a shell: ⌥f is
+            // Meta-f (forward-word), ⌥n and ⌥p are Meta-n / Meta-p (the
+            // non-incremental history searches, which few people bind and
+            // both harnesses ignore), and ⌥r is Meta-r (revert-line).
+            // Readline leaves Meta-] and Meta-[ unbound, bash binds Meta-{
+            // only to the rarely-reached complete-into-braces, and `^]`
+            // (character-search) is untouched because only the Meta forms are
+            // claimed. Nothing else is intercepted — ⌥s still reaches the
             // agent from here.
             if let Some(chord) = alt_chord(&key)
                 && matches!(chord, 'f' | 'n' | 'p' | 'r' | ']' | '[')
@@ -2116,27 +2109,12 @@ impl App {
                 if dead && scroll.is_none() {
                     return self.dead_pane_key(i, key);
                 }
-                // Esc twice in quick succession releases the keyboard to the
-                // tree. One Esc belongs to the harness — it dismisses menus
-                // and cancels prompts in there — so the first still goes
-                // through; the double-tap is the reflex for "get me out",
-                // and only the second press is taken.
-                if key.code == KeyCode::Esc && key.modifiers.is_empty() {
-                    let now = std::time::Instant::now();
-                    if self
-                        .session_esc_at
-                        .take()
-                        .is_some_and(|at| now.duration_since(at) <= DOUBLE_ESC)
-                    {
-                        self.focus = ManageFocus::Tree;
-                        // Releasing means "show me the tree", same as ⇧esc.
-                        self.maximized = false;
-                        return None;
-                    }
-                    self.session_esc_at = Some(now);
-                } else {
-                    self.session_esc_at = None;
-                }
+                // Every bare Escape belongs to the harness — including two in
+                // a row. There used to be a double-tap release here, but the
+                // first tap always went through, and in Claude Code a single
+                // Esc cancels the running turn: the release gesture cost the
+                // user their work on its way out. ⌥⇧esc (and ⇧esc, ^], ^o)
+                // release without sending anything.
                 if let Some(session) = self.sessions.get_mut(i) {
                     match scroll {
                         // No pointer for a keyboard scroll; report it over the
@@ -3886,7 +3864,7 @@ impl App {
     /// Scoped to panes that are already open rather than every session in the
     /// tree, and that is the whole design: waking a sleeping agent is a cold
     /// boot — seconds of wall clock and a VM that starts billing — so holding
-    /// `⌥]` or `⌥[` must never fan out wakes across agents you were only
+    /// `⌥⇧]` or `⌥⇧[` must never fan out wakes across agents you were only
     /// passing through. Opening something new stays the deliberate `enter` on
     /// a row.
     fn cycle_session(&mut self, forward: bool) -> Option<Effect> {
@@ -5123,16 +5101,28 @@ fn project_agent_count(project: &ProjectNode) -> usize {
 /// everywhere. ⌥[ under Meta is the two bytes `ESC [` — byte-identical to the
 /// CSI prefix that starts every arrow key — so a legacy terminal can never
 /// deliver it; the parser eats the bytes as an unfinished escape sequence and
-/// no key event exists to match. `[` is still in the table for the terminals
-/// that can say it unambiguously: under the kitty keyboard protocol (pushed at
-/// startup) it arrives as a genuine ALT+`[` event, and composed-mode macOS
-/// sends it as a curly double quote. Everywhere else the reverse chord is
-/// simply absent — it can go dead, but never misfire.
+/// no key event exists to match, and a terminal or window manager that binds
+/// ⌥[ itself never lets it through at all. That is why the ADVERTISED chords
+/// are the shifted pair: ⌥⇧[ is `ESC {`, which no escape sequence begins with
+/// and nothing conventionally binds, so it arrives everywhere Meta does. The
+/// unshifted forms stay in the table as silent aliases for the terminals that
+/// can say them unambiguously: under the kitty keyboard protocol (pushed at
+/// startup) they arrive as genuine ALT+bracket events, and composed-mode
+/// macOS folds both shift states into the same curly quotes anyway.
+/// Everywhere else the unshifted chord is simply absent — it can go dead, but
+/// never misfire.
 fn alt_chord(key: &KeyEvent) -> Option<char> {
     const ACTIONS: &[char] = &['f', 's', 'n', 'p', 'r', ']', '['];
     if key.modifiers.contains(KeyModifiers::ALT) {
         if let KeyCode::Char(c) = key.code {
-            let c = c.to_ascii_lowercase();
+            let c = match c.to_ascii_lowercase() {
+                // ⌥⇧[ arrives as ALT+`{` where shift reaches us as the
+                // character; fold the braces onto the bracket chords, the
+                // same way the letters fold their capitals.
+                '{' => '[',
+                '}' => ']',
+                c => c,
+            };
             return ACTIONS.contains(&c).then_some(c);
         }
         return None;
@@ -6429,43 +6419,31 @@ mod tests {
         );
     }
 
-    /// Esc-Esc inside a live session steps back out to the tree. A single
-    /// Esc belongs to the harness (menus, cancels), so only the quick second
-    /// tap is taken — and two slow Escapes are just two Escapes.
+    /// Every bare Escape belongs to the harness — even two quick ones. The
+    /// old double-tap release cost the user their running turn (a single Esc
+    /// cancels Claude mid-run, and the first tap always went through).
+    /// ⌥⇧esc releases without sending anything.
     #[test]
-    fn double_esc_releases_a_focused_session() {
+    fn bare_escapes_belong_to_the_harness_and_alt_shift_esc_releases() {
         let mut a = loaded_app();
         a.attach_session(session("ca_1", "nimble-otter"), "ca_1".into());
         assert_eq!(a.focus, ManageFocus::Session);
 
         assert_eq!(a.on_key(key(KeyCode::Esc)), None);
+        assert_eq!(a.on_key(key(KeyCode::Esc)), None);
         assert_eq!(
             a.focus,
             ManageFocus::Session,
-            "a single esc stays in the session"
+            "two quick escapes are the harness's, not a release"
         );
 
-        // The quick second tap releases — and unfolds a maximized layout,
-        // since focus on an invisible tree helps nobody.
+        // ⌥⇧esc steps out — and unfolds a maximized layout, since focus on
+        // an invisible tree helps nobody.
         a.maximized = true;
-        assert_eq!(a.on_key(key(KeyCode::Esc)), None);
-        assert_eq!(a.focus, ManageFocus::Tree, "the double-tap steps out");
+        let chord = KeyEvent::new(KeyCode::Esc, KeyModifiers::ALT | KeyModifiers::SHIFT);
+        assert_eq!(a.on_key(chord), None);
+        assert_eq!(a.focus, ManageFocus::Tree, "⌥⇧esc steps out");
         assert!(!a.maximized, "and brings the tree back");
-
-        // Spaced-out Escapes belong to the harness.
-        a.focus = ManageFocus::Session;
-        assert_eq!(a.on_key(key(KeyCode::Esc)), None);
-        a.session_esc_at = Some(std::time::Instant::now() - std::time::Duration::from_millis(2000));
-        assert_eq!(a.on_key(key(KeyCode::Esc)), None);
-        assert_eq!(
-            a.focus,
-            ManageFocus::Session,
-            "slow escapes belong to the harness"
-        );
-
-        // Any other key in between resets the tap.
-        assert_eq!(a.on_key(key(KeyCode::Char('a'))), None);
-        assert!(a.session_esc_at.is_none(), "typing broke the sequence");
     }
 
     /// A drop never steals the keyboard out from under a dialog — a y/n
@@ -6632,6 +6610,18 @@ mod tests {
             Some('['),
             "the composed ⌥[ quote is the same chord"
         );
+    }
+
+    /// ⌥⇧[ and ⌥⇧] are the advertised cycle chords — `ESC {` collides with
+    /// nothing, where `ESC [` is the CSI prefix half the world has claimed.
+    /// Shift reaches us as the brace character, folded onto the same chords.
+    #[test]
+    fn alt_shift_brackets_are_the_same_chords() {
+        assert_eq!(alt_chord(&alt('{')), Some('['));
+        assert_eq!(alt_chord(&alt('}')), Some(']'));
+        // macOS composes ⌥⇧[ to the closing curly double quote; same chord.
+        assert_eq!(alt_chord(&key(KeyCode::Char('\u{201D}'))), Some('['));
+        assert_eq!(alt_chord(&key(KeyCode::Char('\u{2019}'))), Some(']'));
     }
 
     /// A screen of empty pane is not a state worth reaching by accident.

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -2451,9 +2451,10 @@ impl App {
                     self.selection = None;
                     return None;
                 }
-                // Clicking the session panel means "let me type here"; clicking
-                // the tree does not, so the tree keeps the keyboard until a
-                // double click or enter asks for it. With no session open the
+                // Clicking the session panel means "let me type here". A tree
+                // click lands on Tree first; `click_tree_row` hands the
+                // keyboard on to the session when the row clicked is one with
+                // an open pane. With no session open the
                 // right pane is the launcher (or an empty detail card):
                 // focusing it would send every key into a pane nothing is
                 // reading, so the keyboard stays where the prompt reads it —
@@ -2529,9 +2530,12 @@ impl App {
 
     /// Move the tree cursor to the row that was clicked.
     ///
-    /// A single click *views*: it shows the session in the pane and leaves the
-    /// keyboard in the tree, so clicking around does not trap you in a session.
-    /// A double click connects and hands the keyboard over, the same as enter.
+    /// Clicking a session row with an open pane shows it AND hands the keyboard
+    /// over: the click says "that one", and typing next should go into the
+    /// session — leaving the keys in the tree turned the first keystroke into
+    /// a shortcut instead. Agent and folder rows keep the keyboard in the tree
+    /// (there is nothing on the right to type into yet); a double click on a
+    /// disconnected row connects, the same as enter.
     fn click_tree_row(&mut self, row: u16, double: bool) -> Option<Effect> {
         self.click_tree_row_inner(row);
         self.sync_active_to_cursor();
@@ -2561,17 +2565,28 @@ impl App {
                 .map(|s| s.name.clone())
                 .and_then(|name| self.pane_for(&name))
             {
-                // One click selects — the pane comes up but the keyboard
-                // stays in the list, so ↑↓ and x still work on the rows. A
-                // double click is what hands the keyboard to the session.
+                // One click selects the pane and hands it the keyboard: the
+                // next thing typed is meant for the session, and routing it
+                // to the tree fired shortcuts instead. ^o (or Esc) is the way
+                // back to the rows.
                 Some(index) => {
                     self.active = Some(index);
-                    if double {
-                        self.focus = ManageFocus::Session;
-                    }
+                    self.focus = ManageFocus::Session;
                 }
                 None if double => return self.reattach_row(clicked.kind),
-                None => self.status = "Double-click (or enter) to connect".into(),
+                // No pane to focus: say how to get one, and re-ask the
+                // platform while the hint is up — a row the agent no longer
+                // reports validates away instead of inviting a reattach to
+                // nothing.
+                None => {
+                    self.status = "Double-click (or enter) to connect".into();
+                    let id = self.tree[w].projects[p].envs[e]
+                        .agents_vec()
+                        .get(a)?
+                        .id
+                        .clone();
+                    return self.refresh_agent_sessions(&id);
+                }
             }
         }
         None
@@ -5025,7 +5040,19 @@ fn merge_agents(previous: Vec<Agent>, fresh: Vec<Agent>) -> Vec<Agent> {
         .map(|mut agent| {
             if let Some((expanded, sessions)) = kept.remove(&agent.id) {
                 agent.expanded = expanded;
-                agent.sessions = sessions;
+                // Sessions live on the machine, and a machine that is not
+                // running has none — carrying the old list across a sleep
+                // kept rows for sessions that no longer exist, forever,
+                // because the refresh cadence only asks running agents.
+                // NotLoaded rather than an empty list: when the agent runs
+                // again the prefetch re-asks, and anything that survived the
+                // wake comes back on its own. A pane we are still attached
+                // to is folded back in by `adopt_pane_sessions`.
+                agent.sessions = if agent.status == "running" {
+                    sessions
+                } else {
+                    LoadSessions::NotLoaded
+                };
             }
             agent
         })
@@ -5348,9 +5375,9 @@ mod tests {
         assert!(a.maximized, "and the layout stayed put");
     }
 
-    /// Clicking the thread list while typing in a session hands the keyboard
-    /// back to the list — so ↓ and x act on rows, instead of x landing in the
-    /// connected pane.
+    /// Clicking a session's row keeps the keyboard with the session — the
+    /// click says "type here", and the way back to the rows is ^o (or Esc),
+    /// after which x acts on the highlighted row instead of typing into it.
     #[test]
     fn clicking_the_list_takes_the_keyboard_back_from_a_session() {
         let mut a = loaded_app();
@@ -5377,9 +5404,17 @@ mod tests {
             .position(|r| r.label == "[S] claude-one")
             .unwrap() as u16;
         a.on_mouse(MouseAction::Down, 5, 3 + row);
-        assert_eq!(a.focus, ManageFocus::Tree, "the click took the keyboard");
+        assert_eq!(
+            a.focus,
+            ManageFocus::Session,
+            "the click means type-into-the-session"
+        );
 
-        // And x now ends the highlighted session instead of typing into it.
+        // ^o hands the keyboard back to the list…
+        a.on_key(ctrl('o'));
+        assert_eq!(a.focus, ManageFocus::Tree, "^o returns to the rows");
+
+        // …and x now ends the highlighted session instead of typing into it.
         let effect = a.on_key(key(KeyCode::Char('x')));
         assert!(
             matches!(effect, Some(Effect::KillSession { ref session_name, .. }) if session_name == "claude-one"),
@@ -7823,7 +7858,11 @@ mod tests {
             .iter()
             .position(|r| r.label == "[S] claude-one")
             .unwrap();
-        assert_eq!(a.on_mouse(MouseAction::Down, 5, 3 + row as u16), None);
+        let effect = a.on_mouse(MouseAction::Down, 5, 3 + row as u16);
+        assert!(
+            matches!(effect, Some(Effect::LoadSessions { .. })),
+            "the first click validates the list instead of spending an ssh: {effect:?}"
+        );
         let effect = a.on_mouse(MouseAction::Down, 5, 3 + row as u16);
         assert!(
             matches!(effect, Some(Effect::Reattach { .. })),
@@ -7864,15 +7903,20 @@ mod tests {
         a.active = Some(0);
         a.panes = panes_fixture();
 
-        // A disconnected sibling: one click only selects and says how to
-        // connect; the second click (a double) reattaches.
+        // A disconnected sibling: one click selects, says how to connect, and
+        // re-asks the platform so a row that no longer exists validates away;
+        // the second click (a double) reattaches.
         let two = a
             .rows()
             .iter()
             .position(|r| r.label == "[S] claude-two")
             .unwrap();
-        assert_eq!(a.on_mouse(MouseAction::Down, 5, 3 + two as u16), None);
-        assert_eq!(a.focus, ManageFocus::Tree, "the list keeps the keyboard");
+        let effect = a.on_mouse(MouseAction::Down, 5, 3 + two as u16);
+        assert!(
+            matches!(effect, Some(Effect::LoadSessions { .. })),
+            "a click on a disconnected row validates the list: {effect:?}"
+        );
+        assert_eq!(a.focus, ManageFocus::Tree, "nothing to type into yet");
         assert!(a.status.contains("Double-click"), "{}", a.status);
         let effect = a.on_mouse(MouseAction::Down, 5, 3 + two as u16);
         assert!(
@@ -7887,9 +7931,7 @@ mod tests {
             .unwrap();
         a.on_mouse(MouseAction::Down, 5, 3 + one as u16);
         assert_eq!(a.active, Some(0), "one click shows the open pane");
-        assert_eq!(a.focus, ManageFocus::Tree, "without stealing the keys");
-        a.on_mouse(MouseAction::Down, 5, 3 + one as u16);
-        assert_eq!(a.focus, ManageFocus::Session, "a double click connects");
+        assert_eq!(a.focus, ManageFocus::Session, "and hands it the keyboard");
     }
 
     /// Enter on a project toggles it: the first press opens it straight
@@ -8319,8 +8361,9 @@ mod tests {
         assert!(a.ending.is_empty());
     }
 
-    /// A single click views, a double click connects — clicking around the
-    /// tree must not trap the keyboard in a session.
+    /// One click on a connected session row shows the pane AND hands it the
+    /// keyboard — clicking a session and typing must reach the session, not
+    /// fire tree shortcuts.
     #[test]
     fn one_click_views_and_two_clicks_connect() {
         let mut a = loaded_app();
@@ -8350,10 +8393,52 @@ mod tests {
 
         a.on_mouse(MouseAction::Down, 5, 3 + row);
         assert_eq!(a.active, Some(0), "one click shows it");
-        assert_eq!(a.focus, ManageFocus::Tree, "and leaves the keyboard alone");
+        assert_eq!(a.focus, ManageFocus::Session, "and hands it the keyboard");
 
         a.on_mouse(MouseAction::Down, 5, 3 + row);
-        assert_eq!(a.focus, ManageFocus::Session, "two clicks connect");
+        assert_eq!(a.focus, ManageFocus::Session, "a second click keeps it");
+    }
+
+    /// A refresh that finds an agent no longer running drops its session
+    /// list: those sessions lived on the machine, and the machine is gone.
+    /// Carrying them showed reattach rows for sessions that no longer exist —
+    /// forever, because the refresh cadence only re-asks running agents.
+    #[test]
+    fn sleep_drops_the_carried_session_list() {
+        let session = ConsoleSession {
+            name: "claude-one".into(),
+            kind: "SHELL".into(),
+            command: None,
+            running: true,
+            attached: false,
+            created_at: None,
+        };
+        let previous = vec![Agent {
+            id: "ca_1".into(),
+            name: "nimble-otter".into(),
+            status: "running".into(),
+            sessions: LoadSessions::Loaded(vec![session]),
+            expanded: true,
+        }];
+        let mut asleep = previous.clone();
+        asleep[0].status = "sleeping".into();
+        asleep[0].sessions = LoadSessions::NotLoaded;
+
+        let merged = merge_agents(previous.clone(), asleep);
+        assert_eq!(
+            merged[0].sessions,
+            LoadSessions::NotLoaded,
+            "a sleeping machine has no console sessions to keep"
+        );
+        assert!(merged[0].expanded, "the fold state is still ours to keep");
+
+        let mut still_running = previous.clone();
+        still_running[0].sessions = LoadSessions::NotLoaded;
+        let merged = merge_agents(previous, still_running);
+        assert!(
+            matches!(&merged[0].sessions, LoadSessions::Loaded(s) if s.len() == 1),
+            "a running agent keeps its list until the reply replaces it"
+        );
     }
 
     /// Clicking the session panel is itself a request to type in it.

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -3210,14 +3210,37 @@ impl App {
     /// only account of what happened, and the recovery keys can reconnect it.
     /// When the last pane closes under `railway code`, the TUI leaves with it
     /// — see [`Self::quit_when_done`].
+    /// A finish this soon after connecting is a harness that cannot start;
+    /// replacing it would just watch it die again, forever.
+    const RESPAWN_MIN_AGE: std::time::Duration = std::time::Duration::from_secs(10);
+
+    /// Keystrokes this close to the end mean the user ended it themselves —
+    /// ctrl-c, ctrl-d, and `/exit` all arrive as input moments before ssh
+    /// does. A respawn then would undo the gesture.
+    const DELIBERATE_EXIT_WINDOW: std::time::Duration = std::time::Duration::from_secs(5);
+
     pub fn reap_ended_sessions(&mut self) -> Option<Effect> {
         let mut closed = None;
+        let mut respawn = None;
         let mut i = 0;
         while i < self.sessions.len() {
             if self.sessions[i].finished() {
+                // Judged before the take, while the pane still knows: only
+                // the session the user was typing into earns a replacement,
+                // and only when nothing says they ended it on purpose. A
+                // background pane ending must never conjure sessions the
+                // user is not looking at.
+                let watched = self.screen == Screen::Manage
+                    && self.focus == ManageFocus::Session
+                    && self.active == Some(i);
+                let unasked = !self.sessions[i].input_within(Self::DELIBERATE_EXIT_WINDOW);
+                let settled = self.sessions[i].age() >= Self::RESPAWN_MIN_AGE;
                 // Dropping the session detaches its local half; the agent
                 // stays running (sleeping is deliberate, never a side effect).
                 if let Some(session) = self.take_session(i) {
+                    if watched && unasked && settled {
+                        respawn = Some((session.agent_id.clone(), session.harness.clone()));
+                    }
                     closed = Some(session.agent_name.clone());
                 }
             } else {
@@ -3232,7 +3255,67 @@ impl App {
             ));
             return Some(Effect::Quit);
         }
+        // The session died out from under the user: start a fresh one on the
+        // same agent so the pane they were working in comes back, rather than
+        // leaving them at a toast. Skipped when another pane on the agent is
+        // still up (that one is the work now), and while a dialog owns the
+        // keyboard — a launch underneath a y/n would race its answer.
+        if let Some((agent_id, harness)) = respawn
+            && !self.sessions.iter().any(|s| s.agent_id == agent_id)
+            && self.confirm.is_none()
+            && self.ssh_gate.is_none()
+            && let Some(effect) = self.respawn_on(&agent_id, &harness)
+        {
+            self.toast(format!(
+                "Session on {agent_name} ended — starting a new one"
+            ));
+            return Some(effect);
+        }
         self.toast(format!("Session on {agent_name} ended"));
+        None
+    }
+
+    /// A replacement session for one that died unasked (see the respawn arm
+    /// of [`Self::reap_ended_sessions`]).
+    ///
+    /// Deliberately not [`Self::launch`]: that reads the launcher's draft, and
+    /// a respawn must not submit whatever half-sentence is sitting in the
+    /// prompt box. Same harness as the session that died, a fresh durable
+    /// session (`force_new` — the old one exited with its harness), and only
+    /// onto a machine the platform still says is running: waking an agent is
+    /// a gesture, never a reap side effect.
+    fn respawn_on(&mut self, agent_id: &str, harness: &str) -> Option<Effect> {
+        for w in 0..self.tree.len() {
+            for p in 0..self.tree[w].projects.len() {
+                for e in 0..self.tree[w].projects[p].envs.len() {
+                    let agents = self.tree[w].projects[p].envs[e].agents_vec();
+                    let Some(agent) = agents.iter().find(|agent| agent.id == agent_id) else {
+                        continue;
+                    };
+                    if agent.status != "running" {
+                        return None;
+                    }
+                    let target = self.target_at((w, p, e))?;
+                    let harness = if harness.is_empty() {
+                        self.harness_name().to_string()
+                    } else {
+                        harness.to_string()
+                    };
+                    return Some(Effect::Launch(LaunchRequest {
+                        project_id: target.project_id.clone(),
+                        environment_id: target.environment_id.clone(),
+                        agent_id: Some(agent_id.to_string()),
+                        session_name: None,
+                        force_new: true,
+                        new_session: false,
+                        harness,
+                        prompt: None,
+                        label: target.label(),
+                        base: Default::default(),
+                    }));
+                }
+            }
+        }
         None
     }
 
@@ -6147,6 +6230,62 @@ mod tests {
 
         assert_eq!(a.reap_ended_sessions(), None);
         assert_eq!(a.sessions.len(), 1, "the pane stays for recovery");
+    }
+
+    /// The session the user was typing into finishing WITHOUT them asking —
+    /// no recent input, not a boot crash — starts a replacement on the same
+    /// agent, with the same harness and no prompt draft riding along.
+    #[test]
+    fn an_unasked_finish_of_the_focused_pane_respawns() {
+        let mut a = loaded_app();
+        a.attach_session(session("ca_1", "nimble-otter"), "ca_1".into());
+        assert_eq!(a.focus, ManageFocus::Session, "attach focused the pane");
+        a.prompt = "half a sentence".into();
+        a.sessions[0].backdate_spawn_for_test(std::time::Duration::from_secs(60));
+        a.sessions[0].end_for_test();
+
+        let Some(Effect::Launch(req)) = a.reap_ended_sessions() else {
+            panic!("expected a replacement launch");
+        };
+        assert_eq!(req.agent_id.as_deref(), Some("ca_1"));
+        assert!(
+            req.force_new,
+            "the old durable session exited with its harness"
+        );
+        assert_eq!(req.prompt, None, "a respawn must not submit the draft");
+        let toast = a.toast.as_ref().expect("announced").text.clone();
+        assert!(toast.contains("starting a new one"), "{toast}");
+    }
+
+    /// Input just before the end is the user ending it — ctrl-c, `/exit` —
+    /// and a finish that soon after connecting is a harness that cannot
+    /// start. Neither earns a replacement, and nor does a pane the user
+    /// was not focused on.
+    #[test]
+    fn deliberate_fast_or_background_finishes_do_not_respawn() {
+        // Typed moments before the exit: the user asked for this.
+        let mut a = loaded_app();
+        a.attach_session(session("ca_1", "nimble-otter"), "ca_1".into());
+        a.sessions[0].backdate_spawn_for_test(std::time::Duration::from_secs(60));
+        a.sessions[0].touch_input_for_test();
+        a.sessions[0].end_for_test();
+        assert_eq!(a.reap_ended_sessions(), None, "ctrl-c must stay ended");
+
+        // Died within the settle window: respawning would loop on a harness
+        // that cannot boot.
+        let mut b = loaded_app();
+        b.attach_session(session("ca_1", "nimble-otter"), "ca_1".into());
+        b.sessions[0].end_for_test();
+        assert_eq!(b.reap_ended_sessions(), None, "a boot crash must not loop");
+
+        // The keyboard was in the tree: an unwatched pane ending must not
+        // conjure a session under the user's hands.
+        let mut c = loaded_app();
+        c.attach_session(session("ca_1", "nimble-otter"), "ca_1".into());
+        c.focus = ManageFocus::Tree;
+        c.sessions[0].backdate_spawn_for_test(std::time::Duration::from_secs(60));
+        c.sessions[0].end_for_test();
+        assert_eq!(c.reap_ended_sessions(), None, "background panes just close");
     }
 
     /// A drop of the pane ON SCREEN pulls the keyboard to it — the banner

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -2183,14 +2183,15 @@ impl App {
             }
             return None;
         }
-        // The prompt boxes are single-line: newlines become spaces rather
-        // than being taken as Enter, and other control characters have no
-        // business in a draft at all.
+        // A pasted newline stays a newline — the prompt boxes hold
+        // paragraphs, and ⇧enter types the same character — but it is never
+        // taken as Enter: pasting must not launch. Other control characters
+        // have no business in a draft at all.
         let text: String = text
-            .replace("\r\n", " ")
+            .replace("\r\n", "\n")
             .chars()
-            .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
-            .filter(|c| !c.is_control())
+            .map(|c| if c == '\r' { '\n' } else { c })
+            .filter(|c| *c == '\n' || !c.is_control())
             .collect();
         match self.screen {
             Screen::Manage if self.new_session_selected() && !self.shell_selected() => {
@@ -4077,6 +4078,23 @@ impl App {
                 self.harness = (self.harness + 1) % HARNESSES.len();
                 Ok(None)
             }
+            // ⇧enter is the newline every text field owes a paragraph-sized
+            // prompt; plain enter still launches. ALT is accepted alongside
+            // SHIFT because most terminals cannot say "shifted Enter" at all
+            // (the kitty disambiguate mode exempts Enter by design) — the
+            // ones configured to send it, Claude Code's own /terminal-setup
+            // included, bind it to `ESC CR`, which parses as alt+enter. A
+            // terminal that reports neither sends a plain Enter, so the chord
+            // degrades to launching — never to a lost draft.
+            KeyCode::Enter
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT)
+                    && !self.shell_selected() =>
+            {
+                self.prompt_insert('\n');
+                Ok(None)
+            }
             KeyCode::Enter => Ok(self.launch_from_prompt()),
             // Esc walks up, one step per press: a draft is cleared first, so
             // a stray Esc mid-typing doesn't throw the session away…
@@ -4482,6 +4500,19 @@ impl App {
             }
             KeyCode::BackTab => {
                 self.harness = (self.harness + 1) % HARNESSES.len();
+                self.manage_prompt = Some(draft);
+                None
+            }
+            // Same newline chord as the launcher's box — the two are the
+            // same control. ALT rides along for the same reason it does
+            // there: most terminals deliver ⇧enter as `ESC CR`, alt+enter.
+            KeyCode::Enter
+                if key
+                    .modifiers
+                    .intersects(KeyModifiers::SHIFT | KeyModifiers::ALT)
+                    && !self.shell_selected() =>
+            {
+                draft.push('\n');
                 self.manage_prompt = Some(draft);
                 None
             }
@@ -5864,15 +5895,50 @@ mod tests {
     }
 
     /// A paste lands in the prompt as text — dictation tools insert whole
-    /// utterances this way — with newlines flattened to spaces: the box is
-    /// one line, and a line break taken as Enter would launch mid-thought.
+    /// utterances this way. Newlines stay newlines (the box holds paragraphs,
+    /// same as ⇧enter types), but a line break is never taken as Enter: a
+    /// paste must not launch mid-thought.
     #[test]
-    fn a_paste_lands_in_the_prompt_as_one_line() {
+    fn a_paste_lands_in_the_prompt_with_its_newlines() {
         let mut a = app();
         a.on_key(key(KeyCode::Char('f')));
-        assert_eq!(a.on_paste("ix the login bug\nthen deploy".into()), None);
-        assert_eq!(a.prompt, "fix the login bug then deploy");
+        assert_eq!(a.on_paste("ix the login bug\r\nthen deploy".into()), None);
+        assert_eq!(a.prompt, "fix the login bug\nthen deploy");
         assert_eq!(a.screen, Screen::Manage, "a pasted newline is not Enter");
+    }
+
+    /// ⇧enter puts a newline in the draft; plain enter still launches. The
+    /// same chord works in the ⌥p composer — the two boxes are one control.
+    #[test]
+    fn shift_enter_breaks_the_line_in_the_prompt_boxes() {
+        let shift_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT);
+
+        let mut a = app();
+        a.on_key(key(KeyCode::Char('f')));
+        a.on_key(key(KeyCode::Char('i')));
+        a.on_key(key(KeyCode::Char('x')));
+        assert_eq!(a.on_key(shift_enter), None);
+        a.on_key(key(KeyCode::Char('g')));
+        a.on_key(key(KeyCode::Char('o')));
+        assert_eq!(a.prompt, "fix\ngo");
+        assert_eq!(a.screen, Screen::Manage, "⇧enter is not a launch");
+
+        let mut b = loaded_app();
+        b.screen = Screen::ManagePrompt;
+        b.manage_prompt = Some("fix".into());
+        assert_eq!(b.on_key(shift_enter), None);
+        assert_eq!(b.manage_prompt.as_deref(), Some("fix\n"));
+        assert_eq!(b.screen, Screen::ManagePrompt, "the composer stays up");
+
+        // Most terminals can't say "shifted Enter" — the configured ones
+        // (Claude Code's /terminal-setup included) send `ESC CR`, which
+        // parses as alt+enter. Same newline.
+        let alt_enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT);
+        let mut c = app();
+        c.on_key(key(KeyCode::Char('f')));
+        assert_eq!(c.on_key(alt_enter), None);
+        assert_eq!(c.prompt, "f\n");
+        assert_eq!(c.screen, Screen::Manage, "⌥enter in the box is a newline");
     }
 
     /// Where typing is refused, pasting is too; and off the prompt a paste

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -305,6 +305,15 @@ enum Message {
         session_name: String,
         error: String,
     },
+    /// A reconnect found its target session no longer exists on the agent —
+    /// it closed, or the machine went away and came back without it.
+    /// Connecting was the ask, so the answer is a fresh session, not an
+    /// error.
+    ReattachTargetGone {
+        agent_id: String,
+        agent_name: String,
+        session_name: String,
+    },
     /// A background auto-connect resolved its ssh info; the pane opens
     /// quietly — no focus steal, no screen change.
     AutoReattachReady {
@@ -883,8 +892,36 @@ pub async fn run(
                 // row that does nothing for it reads as a dead key.
                 app.connecting.insert(session_name.clone());
                 let tx = tx.clone();
+                let client = client.clone();
+                let backboard = backboard.clone();
                 tokio::spawn(async move {
-                    let message = match code::connect_info(&environment_id, &agent_id).await {
+                    // The row the reconnect came from can be stale: the
+                    // session may have closed, or the machine died and came
+                    // back without it. Asking the platform rides alongside
+                    // connect_info, so a live session pays no extra latency —
+                    // and a dead one gets a replacement instead of a blank
+                    // pane. Only a definitive answer diverts; a listing error
+                    // attaches anyway, the benefit of the doubt.
+                    let (info, listed) = tokio::join!(
+                        code::connect_info(&environment_id, &agent_id),
+                        fetch_sessions(&client, &backboard, &agent_id),
+                    );
+                    let gone = matches!(
+                        &listed,
+                        Ok(sessions) if !sessions
+                            .iter()
+                            .any(|s| s.name == session_name && s.running)
+                    );
+                    let message = match info {
+                        Ok(_) if gone => {
+                            super::telemetry::track_session_event("reattach_target_gone", None)
+                                .await;
+                            Message::ReattachTargetGone {
+                                agent_id,
+                                agent_name,
+                                session_name,
+                            }
+                        }
                         Ok(info) => Message::ReattachReady {
                             agent_id,
                             agent_name,
@@ -1347,6 +1384,11 @@ fn handle_message(
             app.launch_failed(error);
             None
         }
+        Message::ReattachTargetGone {
+            agent_id,
+            agent_name,
+            session_name,
+        } => app.reattach_target_gone(&agent_id, &agent_name, &session_name),
         Message::AutoReattachReady {
             agent_id,
             agent_name,

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -162,8 +162,8 @@ fn kitty_scan(chunk: &[u8], kitty: &AtomicBool) -> Option<Vec<u8>> {
 pub struct Session {
     pub agent_id: String,
     pub agent_name: String,
-    /// The harness this session was started with, when we started it.
-    #[allow(dead_code)]
+    /// The harness this session was started with, when we started it — what a
+    /// respawn after an unasked-for exit launches again.
     pub harness: String,
     /// The durable session this pane is attached to.
     pub durable_name: String,
@@ -199,6 +199,10 @@ pub struct Session {
     /// The remote program pushed the kitty keyboard protocol (see
     /// [`kitty_scan`]), so modified Enter goes out CSI-u encoded.
     kitty_keys: Arc<AtomicBool>,
+    /// When local input last reached the pane. A deliberate exit — ctrl-c,
+    /// ctrl-d, `/exit` — arrives as keystrokes moments before ssh ends, and
+    /// this is what lets the reap tell "the user ended it" from "it died".
+    last_input: Option<std::time::Instant>,
     /// Last size pushed to the pty, so a redraw at the same size is free.
     size: (u16, u16),
     /// Rows scrolled back from the live view. Typing snaps back to 0 — nobody
@@ -376,6 +380,7 @@ impl Session {
             spawned_at: std::time::Instant::now(),
             got_output,
             kitty_keys,
+            last_input: None,
             size: (rows, cols),
             scroll: 0,
         })
@@ -702,7 +707,21 @@ impl Session {
     pub fn send(&mut self, bytes: &[u8]) {
         // Typing is a statement of intent to be at the bottom.
         self.scroll_to_live();
+        self.last_input = Some(std::time::Instant::now());
         self.write_raw(bytes);
+    }
+
+    /// Local input reached the pane within `window`. Every deliberate way out
+    /// of a harness — ctrl-c, ctrl-d, typing `/exit` — is keystrokes moments
+    /// before ssh ends, so a finish with no recent input is one the user did
+    /// not ask for.
+    pub fn input_within(&self, window: std::time::Duration) -> bool {
+        self.last_input.is_some_and(|at| at.elapsed() < window)
+    }
+
+    /// How long this pane has been connected.
+    pub fn age(&self) -> std::time::Duration {
+        self.spawned_at.elapsed()
     }
 
     pub fn send_key(&mut self, key: KeyEvent) {
@@ -791,6 +810,16 @@ impl Session {
         self.ended.store(true, Ordering::Relaxed);
     }
 
+    /// Pretend the user just typed into the pane.
+    pub fn touch_input_for_test(&mut self) {
+        self.last_input = Some(std::time::Instant::now());
+    }
+
+    /// Pretend the pane connected `by` ago, for the fast-crash guard.
+    pub fn backdate_spawn_for_test(&mut self, by: std::time::Duration) {
+        self.spawned_at = std::time::Instant::now() - by;
+    }
+
     /// A session backed by a local `cat` instead of ssh, so the state machine
     /// around sessions can be tested without a relay or a network.
     pub fn for_test(agent_id: &str, agent_name: &str) -> Result<Self> {
@@ -842,6 +871,7 @@ impl Session {
             spawned_at: std::time::Instant::now(),
             got_output: Arc::new(AtomicBool::new(true)),
             kitty_keys: Arc::new(AtomicBool::new(false)),
+            last_input: None,
             size: (24, 80),
             scroll: 0,
         })

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -822,7 +822,7 @@ fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
     )];
     if full && !app.sessions.is_empty() {
         // Maximized, the tree is folded away, so the open sessions become
-        // tabs on the header: click one (or ⌥[ ⌥]) to switch panes. The
+        // tabs on the header: click one (or ⌥⇧[ ⌥⇧]) to switch panes. The
         // clickable boxes are recorded as they are laid out.
         let mut x = chunks[0].x + " RAILWAY CLOUD-AGENTS ".chars().count() as u16;
         for i in 0..app.sessions.len() {
@@ -1047,7 +1047,7 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
         .selected_agent_status()
         .is_some_and(|status| status != "running");
     let hint: Vec<(&str, &str)> = if app.pane_is_full() {
-        vec![("⌥f", "restore the tree"), ("⌥/⇧esc / ^]", "stop typing")]
+        vec![("⌥f", "restore the tree"), ("⌥⇧esc / ^]", "stop typing")]
     } else if app.focus == ManageFocus::Session {
         // A dead pane's keys are recovery, not typing — the hint has to say
         // so, or "stop typing" advertises an input nothing is reading.
@@ -1061,7 +1061,7 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
                 ("esc", "back to the tree"),
             ]
         } else {
-            let mut keys = vec![("⌥/⇧esc / ^]", "stop typing"), ("⌥f", "maximize")];
+            let mut keys = vec![("⌥⇧esc / ^]", "stop typing"), ("⌥f", "maximize")];
             // The agent is taking the clicks, so say how to take one back — this is
             // the terminal's own convention, but nobody guesses it.
             if app.active_session().is_some_and(|s| s.wants_mouse()) {
@@ -1123,7 +1123,7 @@ fn render_manage_footer(app: &App, f: &mut Frame, area: Rect, rects: &PaneRects)
     // pane the chord is a no-op and the hint would just be a lie.
     let mut hint = hint;
     if app.sessions.len() > 1 {
-        hint.push(("⌥[ ⌥]", "switch session"));
+        hint.push(("⌥⇧[ ⌥⇧]", "switch session"));
     }
     let spans = chord_spans(theme, &hint);
     f.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -3355,7 +3355,7 @@ mod tests {
         let out = draw(&app, 100, 34);
         assert!(out.contains("keys"));
         assert!(out.contains("refresh"), "{out}");
-        assert!(out.contains("⌥/⇧esc / ^]"), "{out}");
+        assert!(out.contains("⌥⇧esc / ^]"), "{out}");
         assert!(out.contains("any key closes"));
     }
 

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -753,27 +753,31 @@ fn render_prompt(app: &App, f: &mut Frame, area: Rect, focused: bool) {
 }
 
 /// How many rows `text` occupies once wrapped at `width`, breaking on spaces
-/// the way ratatui does and hard-wrapping a word that cannot fit.
+/// the way ratatui does, hard-wrapping a word that cannot fit, and starting a
+/// fresh row at every `\n` — the character ⇧enter puts in a draft.
 fn wrapped_lines(text: &str, width: usize) -> usize {
     if width == 0 {
         return 1;
     }
-    let mut rows = 1usize;
-    let mut column = 0usize;
-    for word in text.split_inclusive(' ') {
-        let len = word.chars().count();
-        if column + len > width && column > 0 {
-            rows += 1;
-            column = 0;
-        }
-        if len > width {
-            rows += (len - 1) / width;
-            column = len % width;
-        } else {
-            column += len;
+    let mut rows = 0usize;
+    for line in text.split('\n') {
+        rows += 1;
+        let mut column = 0usize;
+        for word in line.split_inclusive(' ') {
+            let len = word.chars().count();
+            if column + len > width && column > 0 {
+                rows += 1;
+                column = 0;
+            }
+            if len > width {
+                rows += (len - 1) / width;
+                column = len % width;
+            } else {
+                column += len;
+            }
         }
     }
-    rows
+    rows.max(1)
 }
 
 /// The size the session pane will have, given the whole terminal — the same
@@ -1504,7 +1508,7 @@ fn render_manage_prompt(app: &App, f: &mut Frame) {
                 if app.shell_selected() {
                     " enter launch · esc close "
                 } else {
-                    " enter send · esc close "
+                    " enter send · ⇧enter newline · esc close "
                 },
                 Style::default().fg(theme.dim),
             ))


### PR DESCRIPTION
Four `railway ca` TUI fixes.

## Click a session → type into it

A single click on a session row in the tree now hands the keyboard to the session pane. Before, one click only *selected* the pane and left focus in the tree, so the next thing typed fired tree shortcuts (`x`, `r`, …) instead of reaching the session.

- `^o` / `Esc` still return the keyboard to the tree.
- Agent and folder rows keep the keyboard in the tree; double-click on a disconnected row still connects, same as enter.

## Session rows no longer outlive the machine

`merge_agents` carried an agent's old session list across every refresh, and `sessions_to_refresh` deliberately only re-asks **running** agents — so the moment an agent slept, its session rows froze in the UI showing sessions that no longer exist, forever.

- The merge now drops the carried list to `NotLoaded` when the fresh status isn't `running`. When the agent runs again the prefetch re-asks; panes we're attached to are still folded back in by `adopt_pane_sessions`.
- Clicking a session row with no open pane also refetches that agent's list alongside the "Double-click to connect" hint, so a row the platform no longer reports validates away.

## A reconnect to a gone session starts a new one

The row a reconnect comes from can be stale: the session closed, or the box died and came back without it. Redialing the dead name gave a blank pane and a stall notice.

Reattach now verifies the target against the platform's session list, fetched **alongside** `connect_info` so a live session pays no extra latency. When the list definitively lacks the session: stale row dropped, fresh session launched on the same agent with the harness the row named. A listing failure attaches anyway (benefit of the doubt); an agent that stopped running gets a failure toast plus a list refetch instead of a launch — waking stays a deliberate gesture.

## A session that dies unasked respawns

When the session the user is typing into finishes without them asking, the TUI starts a replacement on the same agent instead of leaving them at a toast. Guards:

- **Only the focused pane** — background sessions ending never conjure new ones.
- **Not after recent input** — ctrl-c, ctrl-d, and `/exit` arrive as keystrokes moments before ssh ends; input in the last 5s means the exit was the user's own gesture.
- **Not within 10s of connecting** — a harness that crashes at boot must not respawn-loop.

The replacement runs the same harness, forces a new durable session, never carries the launcher's prompt draft, and only targets an agent the platform reports running.

## Tests

Updated the three tests that encoded the old click contract; added `sleep_drops_the_carried_session_list`, `an_unasked_finish_of_the_focused_pane_respawns`, `deliberate_fast_or_background_finishes_do_not_respawn`, and `a_reconnect_to_a_gone_session_starts_a_new_one`. `cargo test -p railwayapp`: 1246 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Keyboard: ⌥⇧ chords, double-esc removed

- **Cycle sessions: ⌥⇧[ / ⌥⇧]** (unshifted ⌥[/⌥] kept as silent aliases). Under Meta, ⌥[ transmits `ESC [` — the CSI prefix every arrow key starts with — so terminals and WMs routinely eat or misparse it; `ESC {` collides with nothing. Composed-mode macOS already sent the same curly quote for both shift states.
- **Double-escape no longer releases a focused session.** The first tap always passed through, and in Claude Code a single Esc cancels the running turn — the release gesture cost you your work on the way out. **⌥⇧esc** (plus ⇧esc, `^]`, `^o`, all already accepted) releases without sending anything, and Claude's own esc-esc rewind gesture now reaches it.
- Footer hints and the `?` overlay advertise the new chords (the overlay also gains the previously-undocumented cycle chord).

## Shift+enter breaks the line in the prompt boxes

The launcher's task prompt and the ⌥p composer were single-line: shift+enter did nothing (or launched), and pasted newlines flattened to spaces. Now:

- **Shift+enter inserts a newline; plain enter still launches.** ALT is accepted alongside SHIFT because most terminals can't report a shifted Enter at all (kitty's disambiguate mode exempts Enter by design) — the ones configured to send it, Claude Code's own `/terminal-setup` included, bind the keystroke to `ESC CR`, which parses as alt+enter. A terminal that reports neither sends plain Enter, so the chord degrades to launching, never a lost draft.
- Pasted newlines stay newlines (still never taken as Enter).
- `wrapped_lines` counts explicit breaks so the caret-line scrolling stays honest; multi-line prompts ride to the VM inside the existing single-quote shell escaping unchanged.
- The composer footer advertises `⇧enter newline`.