### PR TITLE
feat(database): add MySQL point-in-time recovery

### DIFF
--- a/src/commands/database/pitr.rs
+++ b/src/commands/database/pitr.rs
@@ -1,14 +1,18 @@
-//! The `pitr` verb -- point-in-time recovery / continuous backups, for every
-//! engine whose registry entry declares a PITR contract.
+//! `railway {postgres,mysql} pitr` -- point-in-time recovery / continuous
+//! backups, for every engine whose registry entry declares a PITR contract.
 //!
-//! The engine declaration decides which composable template the enable
-//! overlay deploys and which variables carry the archive
-//! (`PitrSpec::template_code`, `archive_var_prefix`). Which images may adopt
-//! the overlay is not decided here at all: that rule ships with the enable
-//! template (`adoptionImageEligibility`) and is read off the fetched record,
-//! so widening it is a template update rather than a CLI release. Backups,
+//! The engine declaration decides three things here: which composable
+//! template the enable overlay deploys (`PitrSpec::template_code`), whether
+//! the rolling HA enable/disable workflow exists at all (`supports_ha` --
+//! MySQL's archiver only runs standalone, so its HA path is a refusal, not a
+//! workflow), and which live coverage probe backs `status` (`probe_kind` --
+//! only pgBackRest ships one). Which images may adopt the overlay is not
+//! decided here at all: that rule ships with the enable template
+//! (`adoptionImageEligibility`) and is read off the fetched record, so
+//! widening it is a template update rather than a CLI release. Backups,
 //! schedules and restore ride the volume-instance mutations, which are
 //! engine-agnostic server-side.
+
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
@@ -25,7 +29,7 @@ use crate::{
         adoption_eligibility::AdoptionTarget,
         config::{EnvironmentConfig, fetch_environment_config},
         database::DatabaseType,
-        database_engines::{DatabaseEngine, PitrSpec},
+        database_engines::{DatabaseEngine, PitrProbeKind, PitrSpec},
         database_plugins,
         db_stats::{diagnose_db_stats_failure, preflight_db_stats_ssh},
         exec::exec_probe_in_container,
@@ -44,7 +48,7 @@ use super::{
 /// Manage point-in-time recovery (continuous backups)
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway postgres pitr status --service postgres\n  railway postgres pitr enable --service postgres\n  railway postgres pitr disable --service postgres --yes\n  railway postgres pitr restore --service postgres --at 2026-07-20T12:00:00Z\n  railway postgres pitr backup create --service postgres --name pre-migration\n  railway postgres pitr schedule set --daily --weekly\n\nAutomation notes:\n  <time> for `restore` accepts RFC3339 (2026-07-20T12:00:00Z), `YYYY-MM-DD HH:MM:SS`/`YYYY-MM-DD HH:MM` (interpreted in your local timezone), or a relative offset back from now (30m, 2h, 1d, 1w).\n  `enable`/`disable` auto-detect whether the target is a standalone database or the root of an HA cluster.\n  `progress`/`cancel`/`clear` only apply to HA clusters (the rolling enable/disable workflow).\n  `status`'s coverage/archiver section is a best-effort live probe over SSH into the running container; it degrades to \"unavailable\" instead of failing the command if the service isn't reachable."
+    after_help = "Examples (any database command with PITR works the same way):\n\n  railway postgres pitr status --service postgres\n  railway mysql pitr enable --service mysql\n  railway postgres pitr disable --service postgres --yes\n  railway postgres pitr restore --service postgres --at 2026-07-20T12:00:00Z\n  railway mysql pitr backup create --service mysql --name pre-migration\n  railway postgres pitr schedule set --daily --weekly\n\nAutomation notes:\n  <time> for `restore` accepts RFC3339 (2026-07-20T12:00:00Z), `YYYY-MM-DD HH:MM:SS`/`YYYY-MM-DD HH:MM` (interpreted in your local timezone), or a relative offset back from now (30m, 2h, 1d, 1w).\n  `enable`/`disable` auto-detect whether the target is a standalone database or the root of an HA cluster.\n  `progress`/`cancel`/`clear` only apply to HA clusters (the rolling enable/disable workflow), on engines whose PITR supports HA.\n  `status`'s coverage/archiver section is a best-effort live probe over SSH into the running container, on engines that ship one; it degrades to \"unavailable\" instead of failing the command if the service isn't reachable."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -246,9 +250,11 @@ pub async fn command(
         Commands::Status => status(engine, pitr, project, service, environment, json).await,
         Commands::Enable(a) => enable(engine, pitr, project, service, environment, json, a).await,
         Commands::Disable(a) => disable(engine, pitr, project, service, environment, json, a).await,
-        Commands::Progress(a) => progress(engine, project, service, environment, json, a).await,
-        Commands::Cancel => cancel(engine, project, service, environment, json).await,
-        Commands::Clear => clear(engine, project, service, environment, json).await,
+        Commands::Progress(a) => {
+            progress(engine, pitr, project, service, environment, json, a).await
+        }
+        Commands::Cancel => cancel(engine, pitr, project, service, environment, json).await,
+        Commands::Clear => clear(engine, pitr, project, service, environment, json).await,
         Commands::Restore(a) => restore(project, service, environment, json, a).await,
         Commands::Backup(a) => match a.command {
             BackupCommands::List => backup_list(project, service, environment, json).await,
@@ -351,7 +357,7 @@ async fn print_status(
     // nothing. An engine that declares no probe implementation renders no
     // coverage section at all: there is nothing to run, which is not the same
     // as "unavailable".
-    let live = if include_live && root_pitr.enabled {
+    let live = if include_live && root_pitr.enabled && live_probe_applies(&pitr) {
         Some(probe_pitr_live(ctx, &root.root_id).await)
     } else {
         None
@@ -479,6 +485,28 @@ fn print_pitr_status(output: &PitrStatusOutput) {
     }
 }
 
+/// Why the rolling HA enable/disable workflow does not exist for this engine,
+/// or `None` for engines whose archiver runs inside a cluster. Everything that
+/// would take (or follow) the HA path checks this first, so the refusal is one
+/// clear sentence instead of a server error from a workflow that was never
+/// going to start.
+fn ha_pitr_unsupported_reason(engine: &DatabaseEngine, pitr: &PitrSpec) -> Option<String> {
+    if pitr.supports_ha {
+        return None;
+    }
+    Some(format!(
+        "{} PITR is standalone-only: its archiver does not run on HA cluster members",
+        engine.display_name
+    ))
+}
+
+/// Whether `status` has a live coverage probe implementation for this engine.
+/// Selected by the declared probe kind, never by engine name -- an engine
+/// declaring none gets no coverage section rather than a fake "unavailable".
+fn live_probe_applies(pitr: &PitrSpec) -> bool {
+    matches!(pitr.probe_kind, Some(PitrProbeKind::PgBackRest))
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn enable(
     engine: &'static DatabaseEngine,
@@ -535,6 +563,12 @@ async fn enable(
     }
 
     if ha_state.is_cluster {
+        if let Some(reason) = ha_pitr_unsupported_reason(engine, &pitr) {
+            bail!(
+                "Cannot enable PITR for {}: it is the root of an HA cluster, and {reason}.",
+                root.root_name
+            );
+        }
         if args.no_deploy {
             eprintln!(
                 "Note: --no-deploy has no effect here -- enabling PITR on an HA cluster runs a live rolling restart with no staging step."
@@ -644,6 +678,18 @@ async fn disable(
             println!("PITR is already disabled for {}.", root.root_name.bold());
         }
         return print_status(engine, pitr, &ctx, &config, json, true).await;
+    }
+
+    // The rolling HA disable drives engine-specific server-side machinery
+    // that only exists where the archiver runs inside a cluster -- refuse
+    // with the reason instead of surfacing that workflow's own error.
+    if ha_state.is_cluster
+        && let Some(reason) = ha_pitr_unsupported_reason(engine, &pitr)
+    {
+        bail!(
+            "Cannot disable PITR for {} via the rolling HA workflow: {reason}.",
+            root.root_name
+        );
     }
 
     if !confirm_or_bail(
@@ -762,11 +808,15 @@ async fn disable(
 
 async fn cancel(
     engine: &'static DatabaseEngine,
+    pitr: PitrSpec,
     project: Option<String>,
     service: Option<String>,
     environment: Option<String>,
     json: bool,
 ) -> Result<()> {
+    if let Some(reason) = ha_pitr_unsupported_reason(engine, &pitr) {
+        bail!("{reason}, so there is no rolling PITR workflow to cancel.");
+    }
     let ctx = resolve_service_context(project, service, environment).await?;
     let config = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, true)
         .await?
@@ -805,11 +855,15 @@ async fn cancel(
 
 async fn clear(
     engine: &'static DatabaseEngine,
+    pitr: PitrSpec,
     project: Option<String>,
     service: Option<String>,
     environment: Option<String>,
     json: bool,
 ) -> Result<()> {
+    if let Some(reason) = ha_pitr_unsupported_reason(engine, &pitr) {
+        bail!("{reason}, so there is no rolling PITR workflow progress to clear.");
+    }
     let ctx = resolve_service_context(project, service, environment).await?;
     let config = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, true)
         .await?
@@ -894,12 +948,16 @@ const PROGRESS_VISIBILITY_GRACE_SECS: u64 = 60;
 #[allow(clippy::too_many_arguments)]
 async fn progress(
     engine: &'static DatabaseEngine,
+    pitr: PitrSpec,
     project: Option<String>,
     service: Option<String>,
     environment: Option<String>,
     json: bool,
     args: ProgressArgs,
 ) -> Result<()> {
+    if let Some(reason) = ha_pitr_unsupported_reason(engine, &pitr) {
+        bail!("{reason}, so there is no rolling PITR workflow progress to show.");
+    }
     let ctx = resolve_service_context(project, service, environment).await?;
     let config = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, true)
         .await?
@@ -2510,16 +2568,46 @@ mod tests {
         assert_eq!(probe.backup_set_count, None);
     }
 
-    // The archive variable contract the enabled-state detection and the
-    // enable overlay ride on: the gate suffix over the engine's declared
-    // prefix. A drift here would make `status` read the wrong variable and
+    // The archive variable contract each engine's enabled-state detection and
+    // overlay ride on: the same gate suffix over an engine-specific prefix. A
+    // drift here would make `status` read the wrong engine's variables and
     // report a configured database as having no archive at all.
     #[test]
-    fn archive_variable_names_resolve_from_the_declared_prefix() {
-        use crate::controllers::database_engines::POSTGRES;
+    fn archive_variable_names_resolve_per_engine() {
+        use crate::controllers::database_engines::{MYSQL, POSTGRES};
 
         let postgres = POSTGRES.pitr.unwrap();
         assert_eq!(postgres.archive_gate_variable(), "WAL_ARCHIVE_BUCKET");
         assert_eq!(postgres.template_code, "postgres-pitr");
+
+        let mysql = MYSQL.pitr.unwrap();
+        assert_eq!(mysql.archive_gate_variable(), "BINLOG_ARCHIVE_BUCKET");
+        assert_eq!(mysql.template_code, "mysql-pitr");
+    }
+
+    // The gate in front of every HA-workflow path (enable/disable's cluster
+    // branches, progress/cancel/clear): an engine whose archiver is
+    // standalone-only must be refused with the reason, never routed into the
+    // rolling workflow's GraphQL operations.
+    #[test]
+    fn ha_workflow_gate_refuses_standalone_only_engines() {
+        use crate::controllers::database_engines::{MYSQL, POSTGRES};
+
+        assert!(ha_pitr_unsupported_reason(&POSTGRES, &POSTGRES.pitr.unwrap()).is_none());
+
+        let reason = ha_pitr_unsupported_reason(&MYSQL, &MYSQL.pitr.unwrap()).unwrap();
+        assert!(reason.contains("MySQL"));
+        assert!(reason.contains("standalone-only"));
+    }
+
+    // The coverage probe is selected by the declared probe kind: an engine
+    // that ships none renders no coverage section instead of a fake
+    // "unavailable" (or a probe run with another engine's tooling).
+    #[test]
+    fn live_probe_runs_only_for_engines_declaring_one() {
+        use crate::controllers::database_engines::{MYSQL, POSTGRES};
+
+        assert!(live_probe_applies(&POSTGRES.pitr.unwrap()));
+        assert!(!live_probe_applies(&MYSQL.pitr.unwrap()));
     }
 }

--- a/src/commands/database/pitr.rs
+++ b/src/commands/database/pitr.rs
@@ -4,9 +4,10 @@
 //! The engine declaration decides three things here: which composable
 //! template the enable overlay deploys (`PitrSpec::template_code`), whether
 //! the rolling HA enable/disable workflow exists at all (`supports_ha` --
-//! MySQL's archiver only runs standalone, so its HA path is a refusal, not a
-//! workflow), and which live coverage probe backs `status` (`probe_kind` --
-//! only pgBackRest ships one). Which images may adopt the overlay is not
+//! Postgres and MySQL both roll their clusters; an engine that declares
+//! neither gets a refusal, not a workflow), and which live coverage probe
+//! backs `status` (`probe_kind` -- only pgBackRest ships one, so MySQL's
+//! `status` has no coverage section). Which images may adopt the overlay is not
 //! decided here at all: that rule ships with the enable template
 //! (`adoptionImageEligibility`) and is read off the fetched record, so
 //! widening it is a template update rather than a CLI release. Backups,
@@ -2586,17 +2587,27 @@ mod tests {
     }
 
     // The gate in front of every HA-workflow path (enable/disable's cluster
-    // branches, progress/cancel/clear): an engine whose archiver is
-    // standalone-only must be refused with the reason, never routed into the
-    // rolling workflow's GraphQL operations.
+    // branches, progress/cancel/clear) follows the declaration: both shipped
+    // engines roll their clusters, and an engine that declares no rolling
+    // workflow is refused with the reason, never routed into the workflow's
+    // GraphQL operations.
     #[test]
-    fn ha_workflow_gate_refuses_standalone_only_engines() {
-        use crate::controllers::database_engines::{MYSQL, POSTGRES};
+    fn ha_workflow_gate_follows_the_engine_declaration() {
+        use crate::controllers::database_engines::{DatabaseEngine, MYSQL, POSTGRES, PitrSpec};
 
         assert!(ha_pitr_unsupported_reason(&POSTGRES, &POSTGRES.pitr.unwrap()).is_none());
+        assert!(ha_pitr_unsupported_reason(&MYSQL, &MYSQL.pitr.unwrap()).is_none());
 
-        let reason = ha_pitr_unsupported_reason(&MYSQL, &MYSQL.pitr.unwrap()).unwrap();
-        assert!(reason.contains("MySQL"));
+        let standalone_only = PitrSpec {
+            supports_ha: false,
+            ..MYSQL.pitr.unwrap()
+        };
+        let engine = DatabaseEngine {
+            display_name: "Widget",
+            ..MYSQL
+        };
+        let reason = ha_pitr_unsupported_reason(&engine, &standalone_only).unwrap();
+        assert!(reason.contains("Widget"));
         assert!(reason.contains("standalone-only"));
     }
 

--- a/src/commands/mysql.rs
+++ b/src/commands/mysql.rs
@@ -1,19 +1,23 @@
 //! `railway mysql` -- the managed MySQL features: high-availability
-//! clustering, Group Replication behind a routing proxy.
+//! clustering (Group Replication behind a routing proxy) and point-in-time
+//! recovery (binlog archiving).
 //!
-//! Only the capability set lives here; the subcommand bodies are the shared
+//! Only the capability set lives here; every subcommand body is the shared
 //! implementation in [`crate::commands::database`]. There is no pooling
-//! subcommand because no MySQL pooler companion ships.
+//! subcommand because no MySQL pooler companion ships, and MySQL's PITR is
+//! standalone-only -- its archiver refuses to run while the cluster's seed
+//! list is set -- which the shared PITR tree enforces from the engine's own
+//! declaration rather than from anything stated here.
 
 use crate::controllers::database_engines::MYSQL;
 
 use super::database::{self, Action, HistoryArgs, Selectors};
 use super::*;
 
-/// Manage MySQL features: high availability
+/// Manage MySQL features: high availability and point-in-time recovery
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway mysql ha status --service mysql\n  railway mysql ha convert --service mysql --replicas 2\n  railway mysql ha scale --service mysql --replicas 4\n  railway mysql ha switchover --service mysql --to MySQL-2\n\nAutomation notes:\n  --service/--environment/--project/--json apply to every subcommand below `railway mysql`.\n  Actions that change config (convert/revert/scale) commit and deploy by default; pass --no-deploy to commit the config change without triggering deploys (it then applies on each affected service's next deploy).\n  MySQL clusters carry the failover vote on the data nodes themselves, so their total must be odd and at least three -- pass an even --replicas.\n  Conversion pins every node to the source image's exact major.minor version, so the service must already run a minor-tagged image."
+    after_help = "Examples:\n\n  railway mysql ha status --service mysql\n  railway mysql ha convert --service mysql --replicas 2\n  railway mysql ha switchover --service mysql --to MySQL-2\n  railway mysql pitr enable --service mysql\n  railway mysql pitr restore --service mysql --at 2026-07-20T12:00:00Z\n\nAutomation notes:\n  --service/--environment/--project/--json apply to every subcommand below `railway mysql`.\n  Actions that change config (enable/disable/convert/revert/scale) commit and deploy by default; pass --no-deploy to commit the config change without triggering deploys (it then applies on each affected service's next deploy).\n  MySQL clusters carry the failover vote on the data nodes themselves, so their total must be odd and at least three -- pass an even --replicas.\n  Point-in-time recovery is standalone-only on MySQL: it cannot be enabled on an HA cluster."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -28,6 +32,9 @@ enum Commands {
     /// Manage high-availability clustering
     Ha(database::ha::Args),
 
+    /// Manage point-in-time recovery (continuous backups)
+    Pitr(database::pitr::Args),
+
     /// Show the local audit trail of MySQL operations
     History(HistoryArgs),
 }
@@ -35,6 +42,7 @@ enum Commands {
 pub async fn command(args: Args) -> Result<()> {
     let action = match args.command {
         Commands::Ha(sub) => Action::Ha(sub),
+        Commands::Pitr(sub) => Action::Pitr(sub),
         Commands::History(sub) => Action::History(sub),
     };
     database::dispatch(&MYSQL, args.selectors, action).await
@@ -50,6 +58,10 @@ mod tests {
         assert!(matches!(
             Args::parse_from(["mysql", "ha", "status"]).command,
             Commands::Ha(_)
+        ));
+        assert!(matches!(
+            Args::parse_from(["mysql", "pitr", "status"]).command,
+            Commands::Pitr(_)
         ));
         assert!(matches!(
             Args::parse_from(["mysql", "history"]).command,
@@ -84,7 +96,7 @@ mod tests {
         assert_eq!(args.selectors.service.as_deref(), Some("db"));
         assert!(args.selectors.json);
 
-        let args = Args::parse_from(["mysql", "ha", "status", "--service", "db", "--json"]);
+        let args = Args::parse_from(["mysql", "pitr", "status", "--service", "db", "--json"]);
         assert_eq!(args.selectors.service.as_deref(), Some("db"));
         assert!(args.selectors.json);
     }

--- a/src/commands/mysql.rs
+++ b/src/commands/mysql.rs
@@ -4,10 +4,11 @@
 //!
 //! Only the capability set lives here; every subcommand body is the shared
 //! implementation in [`crate::commands::database`]. There is no pooling
-//! subcommand because no MySQL pooler companion ships, and MySQL's PITR is
-//! standalone-only -- its archiver refuses to run while the cluster's seed
-//! list is set -- which the shared PITR tree enforces from the engine's own
-//! declaration rather than from anything stated here.
+//! subcommand because no MySQL pooler companion ships. MySQL's PITR rolls HA
+//! clusters the same way Postgres's does -- enable/disable on a cluster root,
+//! and progress/cancel/clear, drive backboard's rolling workflow -- which the
+//! shared PITR tree reads from the engine's own declaration rather than from
+//! anything stated here.
 
 use crate::controllers::database_engines::MYSQL;
 
@@ -17,7 +18,7 @@ use super::*;
 /// Manage MySQL features: high availability and point-in-time recovery
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway mysql ha status --service mysql\n  railway mysql ha convert --service mysql --replicas 2\n  railway mysql ha switchover --service mysql --to MySQL-2\n  railway mysql pitr enable --service mysql\n  railway mysql pitr restore --service mysql --at 2026-07-20T12:00:00Z\n\nAutomation notes:\n  --service/--environment/--project/--json apply to every subcommand below `railway mysql`.\n  Actions that change config (enable/disable/convert/revert/scale) commit and deploy by default; pass --no-deploy to commit the config change without triggering deploys (it then applies on each affected service's next deploy).\n  MySQL clusters carry the failover vote on the data nodes themselves, so their total must be odd and at least three -- pass an even --replicas.\n  Point-in-time recovery is standalone-only on MySQL: it cannot be enabled on an HA cluster."
+    after_help = "Examples:\n\n  railway mysql ha status --service mysql\n  railway mysql ha convert --service mysql --replicas 2\n  railway mysql ha switchover --service mysql --to MySQL-2\n  railway mysql pitr enable --service mysql\n  railway mysql pitr restore --service mysql --at 2026-07-20T12:00:00Z\n\nAutomation notes:\n  --service/--environment/--project/--json apply to every subcommand below `railway mysql`.\n  Actions that change config (enable/disable/convert/revert/scale) commit and deploy by default; pass --no-deploy to commit the config change without triggering deploys (it then applies on each affected service's next deploy).\n  MySQL clusters carry the failover vote on the data nodes themselves, so their total must be odd and at least three -- pass an even --replicas.\n  Point-in-time recovery can be enabled on an HA cluster: enable/disable roll the cluster, and progress/cancel/clear manage that rolling workflow."
 )]
 pub struct Args {
     #[clap(subcommand)]

--- a/src/controllers/database_engines.rs
+++ b/src/controllers/database_engines.rs
@@ -51,6 +51,18 @@ pub struct HaCompanion {
     pub switchover: SwitchoverMechanism,
 }
 
+/// Which live-archive probe implementation backs an engine's PITR status.
+///
+/// Declared kind -> code registry, so the probe is selected by declaration
+/// rather than by branching on the engine's name. An engine that declares
+/// none simply reports no coverage detail: the archive's own restore is the
+/// hard guard, and inventing a probe it has no tool for would be worse than
+/// saying nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PitrProbeKind {
+    PgBackRest,
+}
+
 /// The engine's PITR contract -- the mirror of one `pitrEngineSpecs` entry.
 #[derive(Debug, Clone, Copy)]
 pub struct PitrSpec {
@@ -59,6 +71,14 @@ pub struct PitrSpec {
     /// Prefix of the archive variable contract the template stamps. Every
     /// engine's contract is the same six variables, differing only in prefix.
     pub archive_var_prefix: &'static str,
+    /// Live coverage probe backing `pitr status`, when one exists for this
+    /// engine's archiver.
+    pub probe_kind: Option<PitrProbeKind>,
+    /// Whether PITR is supported on an HA cluster of this engine. MySQL's
+    /// archiver refuses to run whenever the Group Replication seed list is
+    /// set, so its PITR is standalone-only and the HA progress/cancel
+    /// subcommands have nothing to drive.
+    pub supports_ha: bool,
 }
 
 impl PitrSpec {
@@ -103,6 +123,8 @@ pub const POSTGRES: DatabaseEngine = DatabaseEngine {
     pitr: Some(PitrSpec {
         template_code: "postgres-pitr",
         archive_var_prefix: "WAL_ARCHIVE_",
+        probe_kind: Some(PitrProbeKind::PgBackRest),
+        supports_ha: true,
     }),
     pooling: Some(PoolingSpec {
         template_code: "postgres-with-pgbouncer",
@@ -119,7 +141,14 @@ pub const MYSQL: DatabaseEngine = DatabaseEngine {
         legacy_active_variable: None,
         switchover: SwitchoverMechanism::DeclaredHttp,
     }),
-    pitr: None,
+    pitr: Some(PitrSpec {
+        template_code: "mysql-pitr",
+        archive_var_prefix: "BINLOG_ARCHIVE_",
+        probe_kind: None,
+        // The image's restore-on-boot runs in standalone mode only -- it is
+        // refused outright whenever the cluster's seed list is set.
+        supports_ha: false,
+    }),
     pooling: None,
 };
 
@@ -357,6 +386,10 @@ mod tests {
             POSTGRES.pitr.unwrap().archive_gate_variable(),
             "WAL_ARCHIVE_BUCKET"
         );
+        assert_eq!(
+            MYSQL.pitr.unwrap().archive_gate_variable(),
+            "BINLOG_ARCHIVE_BUCKET"
+        );
     }
 
     #[test]
@@ -365,8 +398,9 @@ mod tests {
         // which subcommands exist at all, so they are worth pinning.
         assert!(POSTGRES.pitr.is_some());
         assert!(POSTGRES.pooling.is_some());
-        assert!(MYSQL.pitr.is_none());
+        assert!(MYSQL.pitr.is_some());
         assert!(MYSQL.pooling.is_none());
+        // No Redis image ships a continuous archiver.
         assert!(REDIS.pitr.is_none());
         assert!(REDIS.pooling.is_none());
         // Every engine here ships an HA companion; that is the feature this
@@ -374,5 +408,9 @@ mod tests {
         assert!(POSTGRES.ha.is_some());
         assert!(MYSQL.ha.is_some());
         assert!(REDIS.ha.is_some());
+        // MySQL's archiver only runs standalone, which is what removes the
+        // rolling HA workflow verbs for it.
+        assert!(POSTGRES.pitr.unwrap().supports_ha);
+        assert!(!MYSQL.pitr.unwrap().supports_ha);
     }
 }

--- a/src/controllers/database_engines.rs
+++ b/src/controllers/database_engines.rs
@@ -74,10 +74,11 @@ pub struct PitrSpec {
     /// Live coverage probe backing `pitr status`, when one exists for this
     /// engine's archiver.
     pub probe_kind: Option<PitrProbeKind>,
-    /// Whether PITR is supported on an HA cluster of this engine. MySQL's
-    /// archiver refuses to run whenever the Group Replication seed list is
-    /// set, so its PITR is standalone-only and the HA progress/cancel
-    /// subcommands have nothing to drive.
+    /// Whether the platform's rolling HA enable/disable workflow exists for
+    /// this engine's clusters (backboard's `enable-pitr-ha`, dispatched on
+    /// the registry's `haRolloutKind`). An engine without one refuses the
+    /// HA paths up front instead of surfacing a server error from a workflow
+    /// that was never going to start.
     pub supports_ha: bool,
 }
 
@@ -145,9 +146,12 @@ pub const MYSQL: DatabaseEngine = DatabaseEngine {
         template_code: "mysql-pitr",
         archive_var_prefix: "BINLOG_ARCHIVE_",
         probe_kind: None,
-        // The image's restore-on-boot runs in standalone mode only -- it is
-        // refused outright whenever the cluster's seed list is set.
-        supports_ha: false,
+        // mysql-ha archives from whichever member is the writable primary and
+        // the platform rolls Group Replication clusters the same way it rolls
+        // Patroni (replicas first, a controlled switchover, the former primary
+        // last) -- `enable`/`disable` on a cluster root, and
+        // `progress`/`cancel`/`clear`, drive that workflow.
+        supports_ha: true,
     }),
     pooling: None,
 };

--- a/src/controllers/database_engines.rs
+++ b/src/controllers/database_engines.rs
@@ -412,9 +412,10 @@ mod tests {
         assert!(POSTGRES.ha.is_some());
         assert!(MYSQL.ha.is_some());
         assert!(REDIS.ha.is_some());
-        // MySQL's archiver only runs standalone, which is what removes the
-        // rolling HA workflow verbs for it.
+        // Both shipped engines roll their clusters through the platform's
+        // rolling HA enable/disable workflow -- MySQL's archiver runs off
+        // whichever member is the writable primary, the same as Postgres.
         assert!(POSTGRES.pitr.unwrap().supports_ha);
-        assert!(!MYSQL.pitr.unwrap().supports_ha);
+        assert!(MYSQL.pitr.unwrap().supports_ha);
     }
 }

--- a/src/controllers/database_plugins.rs
+++ b/src/controllers/database_plugins.rs
@@ -290,7 +290,7 @@ pub fn resolve_root_service_id(config: &EnvironmentConfig, service_id: &str) -> 
 mod tests {
     use super::*;
     use crate::controllers::config::{DeployConfig, ServiceSource, Variable};
-    use crate::controllers::database_engines::{MYSQL, POSTGRES, PitrSpec, REDIS};
+    use crate::controllers::database_engines::{MYSQL, POSTGRES, REDIS};
 
     fn service_with_image(image: &str) -> ServiceInstance {
         ServiceInstance {
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn pitr_state_reads_the_gate_variable_the_spec_declares() {
+    fn pitr_state_reads_the_engines_own_gate_variable() {
         let postgres = with_var(
             service_with_image("ghcr.io/railwayapp-templates/postgres-ssl:16"),
             "WAL_ARCHIVE_BUCKET",
@@ -324,22 +324,18 @@ mod tests {
         assert!(state.enabled);
         assert!(state.bucket_wired);
 
-        // The detection follows the declared prefix, not a variable name
-        // baked in here: the same service reads as NOT configured under a
-        // contract whose archive lives somewhere else.
-        let other = PitrSpec {
-            template_code: "other-pitr",
-            archive_var_prefix: "OTHER_ARCHIVE_",
-        };
-        assert!(!compute_pitr_state(&postgres, &other).enabled);
+        // The very same service reads as NOT configured under MySQL's
+        // contract: each engine's archive lives under its own prefix, and
+        // detection follows the declaration rather than one baked-in name.
+        assert!(!compute_pitr_state(&postgres, &MYSQL.pitr.unwrap()).enabled);
 
-        let elsewhere = with_var(
-            service_with_image("ghcr.io/railwayapp-templates/postgres-ssl:16"),
-            "OTHER_ARCHIVE_BUCKET",
-            "somewhere",
+        let mysql = with_var(
+            service_with_image("ghcr.io/railwayapp-templates/mysql-ha/mysql:8.4"),
+            "BINLOG_ARCHIVE_BUCKET",
+            "binlogs",
         );
-        assert!(compute_pitr_state(&elsewhere, &other).enabled);
-        assert!(!compute_pitr_state(&elsewhere, &POSTGRES.pitr.unwrap()).enabled);
+        assert!(compute_pitr_state(&mysql, &MYSQL.pitr.unwrap()).enabled);
+        assert!(!compute_pitr_state(&mysql, &POSTGRES.pitr.unwrap()).enabled);
     }
 
     #[test]


### PR DESCRIPTION
Stacked: **2 of 2**, on top of #1143 — review that one first. **Base is `pcs/mysql-redis-ha-cli`**, so the diff here is only the PITR delta (4 files, ~180 lines).

## What this adds

`railway mysql pitr` — binlog archiving into a Railway bucket, enabled by the `mysql-pitr` composable overlay.

The generic `pitr` tree (from #1143) already drives everything an engine's archive needs from its declared contract, so this is mostly the declaration plus the two ways MySQL genuinely differs from Postgres. Both become declarations rather than branches on the engine name:

**`supports_ha: false`** — the image's archiver refuses to run whenever the Group Replication seed list is set, so MySQL PITR is standalone-only. Every path that would take or follow the rolling HA workflow checks this first:

- `progress` / `cancel` / `clear` refuse **before any network call**
- `enable` / `disable` refuse **before the HA mutation**

so you get one clear sentence instead of a server error from a workflow that was never going to start:

```
$ railway mysql pitr progress
MySQL PITR is standalone-only: its archiver does not run on HA cluster
members, so there is no rolling PITR workflow progress to show.
```

**`probe_kind: None`** — the live coverage probe in `pitr status` is pgBackRest shelling into the container, which MySQL has no equivalent tool for. Selecting the probe by declared kind means MySQL renders no coverage section at all, rather than a probe run with another engine's tooling or a fake "unavailable" for something it simply doesn't implement.

## What needed no code

- **The archive variable contract.** `BINLOG_ARCHIVE_` as the declared prefix is all the enabled-state detection and the enable overlay need.
- **Image eligibility.** It ships with the `mysql-pitr` template record. Worth noting that template does **not** set `requireFloatingMajorTag`, unlike `postgres-pitr` — its image matrix only publishes exact minors, so the old hardcoded "minor pins are bad" rule would have refused every MySQL image. Reading the declaration is what makes both engines correct at once.
- **Restore, backups and schedules.** These ride the volume-instance mutations, which are engine-agnostic server-side.

## Verification

- `cargo test` — 1305 pass. New coverage for the per-engine archive-variable contrast (a Postgres service reads as unconfigured under MySQL's contract and vice versa), the HA-workflow gate refusing MySQL while passing Postgres, and probe-kind selection.
- `cargo clippy` / `cargo fmt` clean.
- The `mysql-pitr` template record was read from the live API; the fixtures mirror it.
