### PR TITLE
feat(ca): settings toggle to hide the maximized layout's header tabs

### DIFF
--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -404,6 +404,7 @@ async fn browse_with_inner(opts: BrowseOpts) -> Result<()> {
         .map(|(source, _)| source.slug.to_string());
     // Mirrored so the ⌥s settings card opens showing the saved answer.
     app.skills_enabled = saved.skills.enabled;
+    app.hide_tabs = saved.hide_tabs;
     // What the key check learned. Connects gate on this in-frame: an
     // unregistered key raises a register question instead of a hung prompt.
     app.ssh_key = ssh_key;

--- a/src/commands/cloud_agent/prefs.rs
+++ b/src/commands/cloud_agent/prefs.rs
@@ -47,6 +47,11 @@ pub struct AgentPrefs {
     /// ignored rather than treated as an error.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<String>,
+
+    /// Hide the maximized layout's header tabs — ⌥⇧[ / ⌥⇧] stay the way
+    /// between sessions. A settings-card choice; the wizard never asks.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub hide_tabs: bool,
 }
 
 impl Default for AgentPrefs {
@@ -58,6 +63,7 @@ impl Default for AgentPrefs {
             mcp: McpPrefs::default(),
             default_project: None,
             theme: None,
+            hide_tabs: false,
         }
     }
 }
@@ -184,6 +190,7 @@ mod tests {
             },
             default_project: None,
             theme: Some("ember".into()),
+            hide_tabs: true,
         };
         prefs.save_in(home.path()).unwrap();
         assert_eq!(AgentPrefs::load_in(home.path()).unwrap(), prefs);

--- a/src/commands/cloud_agent/setup.rs
+++ b/src/commands/cloud_agent/setup.rs
@@ -239,11 +239,12 @@ async fn prompt(home: &Path, existing: Option<AgentPrefs>) -> Result<AgentPrefs>
         version: super::prefs::CURRENT_VERSION,
         agent: Some(agent),
         skills,
-        // Setup doesn't ask about MCP import; whatever was configured (or the
-        // on-by-default) carries through.
+        // Setup doesn't ask about MCP import or the tabs toggle; whatever was
+        // configured (or the defaults) carries through.
         mcp: previous.mcp.clone(),
         default_project,
         theme: Some(theme),
+        hide_tabs: previous.hide_tabs,
     })
 }
 

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -939,6 +939,9 @@ pub struct App {
     /// Whether the skills preference is on, mirrored from the file so the
     /// settings card opens showing the truth.
     pub skills_enabled: bool,
+    /// Hide the maximized layout's header tabs (⌥s settings): ⌥⇧[ ⌥⇧] stay
+    /// the way between sessions, and the header keeps its status line.
+    pub hide_tabs: bool,
     /// The key overlay is open.
     pub keys_open: bool,
     /// A drag in progress or a completed selection.
@@ -1048,6 +1051,7 @@ impl App {
             settings: None,
             skills_source: None,
             skills_enabled: false,
+            hide_tabs: false,
             keys_open: false,
             selection: None,
             last_click: None,
@@ -1171,6 +1175,7 @@ impl App {
             Some(self.harness_name()),
             self.theme,
             self.skills_source.clone(),
+            self.hide_tabs,
         );
         if !ask_first {
             wizard.skip_intro();
@@ -1215,6 +1220,7 @@ impl App {
             self.skills_enabled,
             self.skills_source.clone(),
             self.theme,
+            self.hide_tabs,
         ));
         self.screen = Screen::Settings;
     }
@@ -7226,7 +7232,7 @@ mod tests {
     fn settings_can_replay_first_run_setup() {
         let mut a = app();
         a.on_key(alt('s'));
-        for _ in 0..4 {
+        for _ in 0..5 {
             a.on_key(key(KeyCode::Down)); // down to the last row
         }
         assert_eq!(a.on_key(key(KeyCode::Enter)), None);

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -114,6 +114,7 @@ fn save_setup(
             environment_name: p.environment_name.clone(),
         }),
         theme: Some(outcome.theme.clone()),
+        hide_tabs: outcome.hide_tabs,
     };
     let _ = app;
     prefs.save_in(&home)?;
@@ -143,6 +144,7 @@ fn save_settings(
         environment_name: p.environment_name.clone(),
     });
     prefs.theme = Some(outcome.theme.clone());
+    prefs.hide_tabs = outcome.hide_tabs;
     prefs.save_in(&home)?;
     Ok(prefs)
 }
@@ -161,6 +163,7 @@ fn apply_settings(app: &mut App, outcome: &wizard::Outcome) {
     app.set_harness(Some(&outcome.agent));
     app.set_theme(Some(&outcome.theme));
     app.skills_enabled = outcome.skills;
+    app.hide_tabs = outcome.hide_tabs;
     match &outcome.project {
         Some(project) => {
             app.default_project = Some(project.project_id.clone());

--- a/src/commands/cloud_agent/tui/settings.rs
+++ b/src/commands/cloud_agent/tui/settings.rs
@@ -23,6 +23,9 @@ pub enum Row {
     Project,
     Skills,
     Theme,
+    /// Whether the maximized layout draws its header tabs. Settings-only —
+    /// the wizard never asks.
+    Tabs,
     /// Replay first-run setup, for anyone who wants the guided walk.
     Setup,
 }
@@ -32,6 +35,7 @@ const ROWS: &[Row] = &[
     Row::Project,
     Row::Skills,
     Row::Theme,
+    Row::Tabs,
     Row::Setup,
 ];
 
@@ -69,6 +73,7 @@ pub struct Settings {
     pub skills: bool,
     pub skills_source: Option<String>,
     pub theme: usize,
+    pub hide_tabs: bool,
 }
 
 impl Settings {
@@ -79,6 +84,7 @@ impl Settings {
         skills: bool,
         skills_source: Option<String>,
         theme: &Theme,
+        hide_tabs: bool,
     ) -> Self {
         Self {
             cursor: 0,
@@ -96,6 +102,7 @@ impl Settings {
             skills: skills && skills_source.is_some(),
             skills_source,
             theme: theme.index(),
+            hide_tabs,
         }
     }
 
@@ -108,7 +115,7 @@ impl Settings {
     /// draw the value in cycle arrows.
     pub fn cycles(&self) -> bool {
         match self.row() {
-            Row::Agent | Row::Theme => true,
+            Row::Agent | Row::Theme | Row::Tabs => true,
             Row::Skills => self.skills_source.is_some(),
             Row::Project | Row::Setup => false,
         }
@@ -146,6 +153,15 @@ impl Settings {
                     "Theme".into(),
                     THEMES[self.theme].label.to_string(),
                     "Previews as you cycle".into(),
+                ),
+                Row::Tabs => (
+                    "Full-screen tabs".into(),
+                    if self.hide_tabs { "hidden" } else { "shown" }.into(),
+                    if self.hide_tabs {
+                        "⌥⇧[ ⌥⇧] move between sessions".into()
+                    } else {
+                        "Open sessions as header tabs when maximized".into()
+                    },
                 ),
                 Row::Setup => (
                     "Run first-time setup again".into(),
@@ -297,6 +313,10 @@ impl Settings {
                 self.theme = wrap(self.theme, THEMES.len(), forward);
                 self.save()
             }
+            Row::Tabs => {
+                self.hide_tabs = !self.hide_tabs;
+                self.save()
+            }
             // → reads as "into"; ← on a row that opens a card does nothing.
             Row::Project if forward => self.open_picker(),
             _ => Action::None,
@@ -342,6 +362,7 @@ impl Settings {
             skills: self.skills,
             skills_source: self.skills_source.clone(),
             theme: THEMES[self.theme].slug.to_string(),
+            hide_tabs: self.hide_tabs,
         }))
     }
 }
@@ -404,6 +425,7 @@ mod tests {
             true,
             Some("claude".into()),
             Theme::default_theme(),
+            false,
         )
     }
 
@@ -460,7 +482,7 @@ mod tests {
         assert!(!saved(s.right()).skills, "on toggles off");
         assert!(saved(s.right()).skills, "and back on");
 
-        let mut bare = Settings::new(&tree(), None, 0, true, None, Theme::default_theme());
+        let mut bare = Settings::new(&tree(), None, 0, true, None, Theme::default_theme(), false);
         assert!(!bare.skills, "enabled with no source is not a state");
         bare.cursor = 2;
         assert_eq!(bare.right(), Action::None);
@@ -541,11 +563,22 @@ mod tests {
         assert_eq!(s.back(), Action::Close);
     }
 
+    /// The tabs row toggles in place and rides the save like every other
+    /// value.
+    #[test]
+    fn the_tabs_row_toggles_and_saves() {
+        let mut s = settings();
+        s.cursor = 4;
+        assert!(s.cycles());
+        assert!(saved(s.right()).hide_tabs, "shown toggles to hidden");
+        assert!(!saved(s.right()).hide_tabs, "and back");
+    }
+
     /// The last row hands over to the wizard.
     #[test]
     fn the_setup_row_replays_the_flow() {
         let mut s = settings();
-        s.cursor = 4;
+        s.cursor = 5;
         assert_eq!(s.select(), Action::RunSetup);
     }
 
@@ -559,7 +592,7 @@ mod tests {
         assert_eq!(s.left(), Action::None);
         assert_eq!(s.right(), Action::Redraw, "→ opens the picker");
         s.back();
-        s.cursor = 4;
+        s.cursor = 5;
         assert_eq!(s.left(), Action::None);
         assert_eq!(s.right(), Action::None);
     }

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -824,10 +824,13 @@ fn render_manage(app: &App, f: &mut Frame, rects: &mut PaneRects) {
             .bg(theme.accent)
             .add_modifier(Modifier::BOLD),
     )];
-    if full && !app.sessions.is_empty() {
+    if full && !app.sessions.is_empty() && !app.hide_tabs {
         // Maximized, the tree is folded away, so the open sessions become
         // tabs on the header: click one (or ⌥⇧[ ⌥⇧]) to switch panes. The
-        // clickable boxes are recorded as they are laid out.
+        // clickable boxes are recorded as they are laid out. Hidden entirely
+        // by the ⌥s "Full-screen tabs" setting — the rects stay zeroed (a
+        // fresh PaneRects every draw), so there is nothing stale to click —
+        // and the header falls through to the status line instead.
         let mut x = chunks[0].x + " RAILWAY CLOUD-AGENTS ".chars().count() as u16;
         for i in 0..app.sessions.len() {
             // The tab names the session (its task, or its harness-led name),
@@ -2851,6 +2854,48 @@ mod tests {
             (rects.session.w, rects.session.h),
             "the PTY must be exactly the pane the emulator is drawn into"
         );
+    }
+
+    /// The ⌥s "Full-screen tabs" setting takes the header tabs out of the
+    /// maximized layout: ⌥⇧[ ⌥⇧] stay the way between sessions, and the
+    /// zeroed tab rects mean there is nothing stale to click.
+    #[test]
+    fn hidden_tabs_leave_the_maximized_header_bare() {
+        use crate::commands::cloud_agent::tui::session::Session;
+
+        let mut app = app_with_tree();
+        app.screen = Screen::Manage;
+        app.attach_session(
+            Session::for_test("ca_1", "nimble-otter").unwrap(),
+            "ca_1".into(),
+        );
+        app.maximized = true;
+
+        let header = |out: &str| {
+            out.lines()
+                .find(|l| l.contains("RAILWAY CLOUD-AGENTS"))
+                .unwrap_or_default()
+                .to_string()
+        };
+
+        let out = draw(&app, 100, 30);
+        assert!(header(&out).contains(" 1 "), "tabs show by default:\n{out}");
+
+        app.hide_tabs = true;
+        let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
+        let mut rects = crate::commands::cloud_agent::tui::app::PaneRects::default();
+        terminal
+            .draw(|f| {
+                let (r, _) = render_with_layout(&app, f);
+                rects = r;
+            })
+            .unwrap();
+        let out = draw(&app, 100, 30);
+        assert!(
+            !header(&out).contains(" 1 "),
+            "no tab row when hidden:\n{out}"
+        );
+        assert_eq!(rects.tabs[0].w, 0, "nothing stale to click");
     }
 
     /// An error toast sits front and center at the bottom of the session

--- a/src/commands/cloud_agent/tui/wizard.rs
+++ b/src/commands/cloud_agent/tui/wizard.rs
@@ -43,6 +43,9 @@ pub struct Outcome {
     pub skills: bool,
     pub skills_source: Option<String>,
     pub theme: String,
+    /// Carried through untouched — the wizard never asks; only the ⌥s
+    /// settings card changes it.
+    pub hide_tabs: bool,
 }
 
 /// An environment leaf under a [`TargetProject`]. Selecting one finishes the
@@ -100,6 +103,8 @@ pub struct Wizard {
     pub skills: bool,
     pub skills_source: Option<String>,
     pub theme: usize,
+    /// Not a step — carried so finishing the flow doesn't reset it.
+    pub hide_tabs: bool,
 }
 
 /// What a keypress asked the loop to do.
@@ -160,6 +165,7 @@ impl Wizard {
         harness: Option<&str>,
         theme: &Theme,
         skills_source: Option<String>,
+        hide_tabs: bool,
     ) -> Self {
         let mut workspaces: Vec<TargetWorkspace> = tree
             .iter()
@@ -202,6 +208,7 @@ impl Wizard {
             skills: skills_source.is_some(),
             skills_source,
             theme: theme.index(),
+            hide_tabs,
         }
     }
 
@@ -456,6 +463,7 @@ impl Wizard {
                     skills: self.skills,
                     skills_source: self.skills_source.clone(),
                     theme: THEMES[self.theme].slug.to_string(),
+                    hide_tabs: self.hide_tabs,
                 }))
             }
         }
@@ -544,7 +552,7 @@ mod tests {
     }
 
     fn wizard() -> Wizard {
-        Wizard::new(&tree(), Some("codex"), Theme::default_theme(), None)
+        Wizard::new(&tree(), Some("codex"), Theme::default_theme(), None, false)
     }
 
     /// More than one environment still expands: the parentheses shortcut is
@@ -558,7 +566,7 @@ mod tests {
             expanded: false,
             agents: Load::NotLoaded,
         });
-        let mut w = Wizard::new(&base, None, Theme::default_theme(), None);
+        let mut w = Wizard::new(&base, None, Theme::default_theme(), None, false);
         w.skip_intro();
         let devtools = w
             .options()
@@ -721,7 +729,7 @@ mod tests {
     /// way through is the escape hatch.
     #[test]
     fn with_no_workspaces_only_decide_later_is_offered() {
-        let mut w = Wizard::new(&[], None, Theme::default_theme(), None);
+        let mut w = Wizard::new(&[], None, Theme::default_theme(), None, false);
         w.select(); // set up now
         let labels: Vec<String> = w.options().into_iter().map(|(label, _)| label).collect();
         assert_eq!(labels, vec!["Decide later"]);
@@ -752,7 +760,7 @@ mod tests {
                 }],
             }],
         });
-        let mut w = Wizard::new(&tree, Some("codex"), Theme::default_theme(), None);
+        let mut w = Wizard::new(&tree, Some("codex"), Theme::default_theme(), None, false);
         w.skip_intro();
 
         let before = w.options();


### PR DESCRIPTION
Adds a **Full-screen tabs** row to the ⌥s settings card (settings only — the first-run wizard doesn't ask). Cycling it to `hidden`:

- The maximized layout's header stops drawing session tabs and keeps its status line instead; ⌥⇧[ / ⌥⇧] remain the way between sessions.
- Tab click targets are gone with the pixels — `PaneRects` is rebuilt every draw, so the rects stay zeroed and there's nothing stale to click.

Persisted as `hideTabs` in `~/.railway/agent-prefs`, defaulting to `false` and omitted from the file until set. The wizard and `railway ca setup` carry it through untouched, the same way the MCP-import setting rides along.

## Tests

`the_tabs_row_toggles_and_saves`, `hidden_tabs_leave_the_maximized_header_bare`, plus row-index updates for the new settings row. `cargo test -p railwayapp`: 1250 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)