### PR TITLE
Improve IaC pull, missing-SDK errors, and monorepo migrate

### DIFF
--- a/assets/iac/README.md
+++ b/assets/iac/README.md
@@ -8,6 +8,12 @@ This project defines its Railway infrastructure in code.
 
 Use this file to describe the Railway project you want: services, databases, buckets, custom domains, replicas, groups, and environment variables.
 
+The TypeScript file imports `railway/iac`. Install the SDK from the repository root:
+
+```bash
+npm install railway
+```
+
 ## Common commands
 
 Create the configuration files:
@@ -44,4 +50,5 @@ railway config apply
 - Keep one `.railway` file for the whole project. A named `export const partial` (or `PARTIAL` / `const Partial`) is a last resort for separate repos that cannot share that file. Do not add it unless omit=delete across repos is a blocker.
 - Use `replicas` for scaling; advanced placement can still specify region names.
 - Use `group("Name", [resources])` to keep large projects organized on the Railway canvas.
-- Secrets imported from Railway are rendered as `preserve()` so existing values are retained without writing secret values to source. Use `railway config pull --omit-preserved-variables` for a smaller import.
+- Secrets imported from Railway are rendered as `preserve()` so existing values are retained without writing secret values to source. Use `railway config pull --omit-preserved-variables` for a smaller import. `railway config pull --include-variables` decrypts and inlines non-sealed values (including secrets that were never sealed).
+- `railway config migrate` finds every `railway.json` / `railway.toml` in the repository and writes them into this one file.

--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -1,18 +1,23 @@
 //! Migrate Config as Code (`railway.json` / `railway.toml`) into
 //! `.railway/railway.ts`. CaC → graph/DSL translation lives in the CLI only.
 
-use std::{fs, path::Path};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
+use serde_json::{Value as JsonValue, json};
 
 use crate::{
-    client::{GQLClient, post_graphql},
+    client::{GQLClient, post_graphql, post_graphql_raw},
     config::Configs,
     gql::mutations::{self, ServiceInstanceUpdate},
-    util::cac_deprecation::find_cac_file,
+    util::cac_deprecation::{find_all_cac_files, find_cac_file},
 };
 
 use super::*;
@@ -77,6 +82,13 @@ struct CacDeploy {
     overlap_seconds: Option<i64>,
 }
 
+struct CacService {
+    name: String,
+    path: PathBuf,
+    service_id: Option<String>,
+    cac: CacFile,
+}
+
 pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
     if !matches!(args.lang.as_str(), "ts" | "py" | "go") {
         bail!("--lang must be one of: ts, py, go");
@@ -86,14 +98,9 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
     }
 
     let cwd = std::env::current_dir().context("Unable to get current directory")?;
-    let cac_path = find_cac_file(&cwd)
-        .context("No railway.json or railway.toml found in this directory or its parents.")?;
-
-    let cac = parse_cac_file(&cac_path)?;
-    let service_name = args
-        .service
-        .clone()
-        .unwrap_or_else(|| guess_service_name(&cwd, &cac_path));
+    let services = discover_cac_services(&cwd, args.service.as_deref()).await?;
+    let project_name = project_name_for_emit(&cwd, &services).await;
+    let named_partial = services.len() == 1;
 
     let railway_dir = cwd.join(".railway");
     let ext = match args.lang.as_str() {
@@ -103,25 +110,41 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
     };
     let railway_file = railway_dir.join(format!("railway.{ext}"));
     let emitted = match args.lang.as_str() {
-        "py" => emit_railway_py(&service_name, &cac),
-        "go" => emit_railway_go(&service_name, &cac),
-        _ => emit_railway_ts(&service_name, &cac),
+        "py" => emit_railway_py(&project_name, &services, named_partial),
+        "go" => emit_railway_go(&project_name, &services, named_partial),
+        _ => emit_railway_ts(&project_name, &services, named_partial),
     };
 
-    eprintln!(
-        "{} {}",
-        "Found".dimmed(),
-        cac_path.display().to_string().cyan()
-    );
-    eprintln!("{} service {}", "Migrating".dimmed(), service_name.cyan());
+    for service in &services {
+        eprintln!(
+            "{} {} → {}",
+            "Found".dimmed(),
+            display_rel(&cwd, &service.path).cyan(),
+            service.name.cyan()
+        );
+    }
+    if services.len() > 1 {
+        eprintln!(
+            "{} {} services into one {}",
+            "Merging".dimmed(),
+            services.len().to_string().cyan(),
+            format!(".railway/railway.{ext}").cyan()
+        );
+    } else {
+        eprintln!(
+            "{} service {}",
+            "Migrating".dimmed(),
+            services[0].name.cyan()
+        );
+    }
 
     if !args.apply {
         println!("{emitted}");
         eprintln!(
-            "\n{} Dry-run only. Re-run with {} to write {} and clear the Railway Config File setting.",
+            "\n{} Dry-run only. Re-run with {} to write {} and clear Railway Config File settings.",
             "Note:".yellow().bold(),
             "railway config migrate --apply".cyan(),
-            ".railway/railway.{ts,py,go}".cyan()
+            format!(".railway/railway.{ext}").cyan()
         );
         eprintln!(
             "  {} Review with {} then {}",
@@ -166,16 +189,18 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
         _ => {}
     }
 
-    clear_railway_config_file_on_linked_service().await?;
+    clear_railway_config_files(&services).await?;
 
     if args.delete_files {
-        fs::remove_file(&cac_path)
-            .with_context(|| format!("Failed to delete {}", cac_path.display()))?;
-        eprintln!(
-            "{} {}",
-            "Deleted".green().bold(),
-            cac_path.display().to_string().cyan()
-        );
+        for service in &services {
+            fs::remove_file(&service.path)
+                .with_context(|| format!("Failed to delete {}", service.path.display()))?;
+            eprintln!(
+                "{} {}",
+                "Deleted".green().bold(),
+                display_rel(&cwd, &service.path).cyan()
+            );
+        }
     }
 
     eprintln!(
@@ -185,6 +210,243 @@ pub async fn migrate_config(args: MigrateArgs) -> Result<()> {
         "railway config apply".cyan()
     );
     Ok(())
+}
+
+async fn discover_cac_services(
+    cwd: &Path,
+    service_filter: Option<&str>,
+) -> Result<Vec<CacService>> {
+    let root = git_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let mut files = find_all_cac_files(&root);
+    if files.is_empty() {
+        if let Some(one) = find_cac_file(cwd) {
+            files.push(one);
+        }
+    }
+    if files.is_empty() {
+        bail!("No railway.json or railway.toml found in this repository.");
+    }
+
+    let env_index = environment_cac_index(&root).await.unwrap_or_default();
+    let mut claimed = HashSet::new();
+    let mut services = Vec::new();
+
+    for (rel, meta) in &env_index {
+        let path = root.join(rel);
+        if !path.is_file() {
+            eprintln!(
+                "{} {} is set as the Railway Config File for {} but was not found on disk.",
+                "Warning:".yellow().bold(),
+                rel.cyan(),
+                meta.name.cyan()
+            );
+            continue;
+        }
+        let cac = parse_cac_file(&path)?;
+        claimed.insert(canonicalize_or_clone(&path));
+        services.push(CacService {
+            name: meta.name.clone(),
+            path,
+            service_id: Some(meta.id.clone()),
+            cac,
+        });
+    }
+
+    for path in files {
+        if claimed.contains(&canonicalize_or_clone(&path)) {
+            continue;
+        }
+        let name = guess_service_name(cwd, &path);
+        let cac = parse_cac_file(&path)?;
+        services.push(CacService {
+            name,
+            path,
+            service_id: None,
+            cac,
+        });
+    }
+
+    if let Some(filter) = service_filter {
+        services.retain(|service| service.name == filter);
+        if services.is_empty() {
+            bail!("No Config as Code file found for service {filter}.");
+        }
+    }
+
+    services.sort_by(|left, right| left.name.cmp(&right.name).then(left.path.cmp(&right.path)));
+
+    let mut seen = HashSet::new();
+    for service in &services {
+        if !seen.insert(service.name.clone()) {
+            bail!(
+                "Two Config as Code files map to the service name {}. Pass --service or rename one of them.",
+                service.name
+            );
+        }
+    }
+
+    Ok(services)
+}
+
+fn canonicalize_or_clone(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn git_root(start: &Path) -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(start)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
+fn display_rel(cwd: &Path, path: &Path) -> String {
+    path.strip_prefix(cwd)
+        .or_else(|_| path.strip_prefix(git_root(cwd).unwrap_or_else(|| cwd.to_path_buf())))
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+struct EnvCacMeta {
+    id: String,
+    name: String,
+}
+
+async fn environment_cac_index(root: &Path) -> Result<BTreeMap<String, EnvCacMeta>> {
+    let configs = Configs::new()?;
+    let linked = configs.get_linked_project().await?;
+    let environment_id = linked
+        .environment
+        .clone()
+        .context("No linked environment")?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let endpoint = configs.get_backboard();
+
+    #[derive(Deserialize)]
+    struct EnvQuery {
+        environment: EnvNode,
+    }
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct EnvNode {
+        config: JsonValue,
+    }
+    #[derive(Deserialize)]
+    struct ProjectQuery {
+        project: Option<ProjectNode>,
+    }
+    #[derive(Deserialize)]
+    struct ProjectNode {
+        services: Option<ServiceConnection>,
+    }
+    #[derive(Deserialize)]
+    struct ServiceConnection {
+        edges: Vec<ServiceEdge>,
+    }
+    #[derive(Deserialize)]
+    struct ServiceEdge {
+        node: ServiceNode,
+    }
+    #[derive(Deserialize)]
+    struct ServiceNode {
+        id: String,
+        name: Option<String>,
+    }
+
+    let env = post_graphql_raw::<EnvQuery, _>(
+        &client,
+        &endpoint,
+        "query IacMigrateEnv($id: String!) { environment(id: $id) { config } }",
+        json!({ "id": environment_id }),
+    )
+    .await?;
+    let names = post_graphql_raw::<ProjectQuery, _>(
+        &client,
+        &endpoint,
+        "query IacMigrateServices($id: String!) { project(id: $id) { services(first: 1000) { edges { node { id name } } } } }",
+        json!({ "id": linked.project }),
+    )
+    .await
+    .ok()
+    .and_then(|data| data.project)
+    .and_then(|project| project.services)
+    .map(|connection| {
+        connection
+            .edges
+            .into_iter()
+            .map(|edge| (edge.node.id, edge.node.name.unwrap_or_default()))
+            .collect::<BTreeMap<_, _>>()
+    })
+    .unwrap_or_default();
+
+    let mut index = BTreeMap::new();
+    let Some(services) = env
+        .environment
+        .config
+        .get("services")
+        .and_then(JsonValue::as_object)
+    else {
+        return Ok(index);
+    };
+    for (id, service) in services {
+        let Some(config_file) = service.get("configFile").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        if !is_cac_config_file(config_file) {
+            continue;
+        }
+        let rel = config_file.trim_start_matches("./");
+        let name = names
+            .get(id)
+            .cloned()
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| guess_service_name(root, Path::new(rel)));
+        index.insert(
+            rel.to_string(),
+            EnvCacMeta {
+                id: id.clone(),
+                name,
+            },
+        );
+    }
+    Ok(index)
+}
+
+fn is_cac_config_file(path: &str) -> bool {
+    let name = Path::new(path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(path);
+    name == "railway.json" || name == "railway.toml"
+}
+
+async fn project_name_for_emit(cwd: &Path, services: &[CacService]) -> String {
+    if let Ok(configs) = Configs::new() {
+        if let Ok(linked) = configs.get_linked_project().await {
+            if let Some(name) = linked.name.filter(|name| !name.is_empty()) {
+                return name;
+            }
+        }
+    }
+    git_root(cwd)
+        .and_then(|root| root.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .filter(|name| !name.is_empty())
+        .or_else(|| cwd.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| {
+            services
+                .first()
+                .map(|service| service.name.clone())
+                .unwrap_or_else(|| "app".to_string())
+        })
 }
 
 fn parse_cac_file(path: &Path) -> Result<CacFile> {
@@ -218,82 +480,107 @@ fn guess_service_name(cwd: &Path, cac_path: &Path) -> String {
         .unwrap_or_else(|| "web".to_string())
 }
 
-fn emit_railway_py(service_name: &str, cac: &CacFile) -> String {
-    let mut kwargs = Vec::new();
-    if let Some(cmd) = &cac.build.build_command {
-        kwargs.push(format!("        build={}", js_string(cmd)));
+fn emit_railway_py(project_name: &str, services: &[CacService], named_partial: bool) -> String {
+    let mut stmts = Vec::new();
+    let mut idents = Vec::new();
+    for service in services {
+        let ident = service_ident(&service.name, &idents);
+        let mut kwargs = Vec::new();
+        if let Some(cmd) = &service.cac.build.build_command {
+            kwargs.push(format!("        build={}", js_string(cmd)));
+        }
+        if let Some(cmd) = &service.cac.deploy.start_command {
+            kwargs.push(format!("        start={}", js_string(cmd)));
+        }
+        if let Some(path) = &service.cac.deploy.healthcheck_path {
+            kwargs.push(format!("        healthcheck={}", js_string(path)));
+        }
+        stmts.push(if kwargs.is_empty() {
+            format!("    {ident} = service({})", js_string(&service.name))
+        } else {
+            format!(
+                "    {ident} = service(\n        {},\n{},\n    )",
+                js_string(&service.name),
+                kwargs.join(",\n")
+            )
+        });
+        idents.push(ident);
     }
-    if let Some(cmd) = &cac.deploy.start_command {
-        kwargs.push(format!("        start={}", js_string(cmd)));
-    }
-    if let Some(path) = &cac.deploy.healthcheck_path {
-        kwargs.push(format!("        healthcheck={}", js_string(path)));
-    }
-    let service_call = if kwargs.is_empty() {
-        format!("    web = service({})", js_string(service_name))
-    } else {
+    let partial = if named_partial {
         format!(
-            "    web = service(\n        {},\n{},\n    )",
-            js_string(service_name),
-            kwargs.join(",\n")
+            "\n# Last resort for a per-service CaC repo. Prefer one .railway file for the\n# project and drop this if you later combine services into that file.\nPARTIAL = {}\n",
+            js_string(&services[0].name)
         )
+    } else {
+        String::new()
     };
     format!(
         r#"from railway_sdk import define_railway, project, service
-
-# Last resort for a per-service CaC repo. Prefer one .railway file for the
-# project and drop this if you later combine services into that file.
-PARTIAL = {project}
-
+{partial}
 @define_railway
 def main(ctx=None):
-{service_call}
-    return project({project}, resources=[web])
+{stmts}
+    return project({project}, resources=[{resources}])
 "#,
-        service_call = service_call,
-        project = js_string(service_name),
+        stmts = stmts.join("\n"),
+        project = js_string(project_name),
+        resources = idents.join(", "),
     )
 }
 
-fn emit_railway_go(service_name: &str, cac: &CacFile) -> String {
-    let mut fields = Vec::new();
-    if let Some(cmd) = &cac.build.build_command {
-        fields.push(format!("\t\t\"build\": {},", js_string(cmd)));
+fn emit_railway_go(project_name: &str, services: &[CacService], named_partial: bool) -> String {
+    let mut stmts = Vec::new();
+    let mut idents = Vec::new();
+    for service in services {
+        let ident = service_ident(&service.name, &idents);
+        let mut fields = Vec::new();
+        if let Some(cmd) = &service.cac.build.build_command {
+            fields.push(format!("\t\t\"build\": {},", js_string(cmd)));
+        }
+        if let Some(cmd) = &service.cac.deploy.start_command {
+            fields.push(format!("\t\t\"start\": {},", js_string(cmd)));
+        }
+        if let Some(path) = &service.cac.deploy.healthcheck_path {
+            fields.push(format!("\t\t\"healthcheck\": {},", js_string(path)));
+        }
+        let config_block = if fields.is_empty() {
+            "nil".to_string()
+        } else {
+            format!("railway.ServiceConfig{{\n{}\n\t}}", fields.join("\n"))
+        };
+        stmts.push(format!(
+            "\t{ident} := railway.ServiceNamed({}, {config_block})",
+            js_string(&service.name)
+        ));
+        idents.push(ident);
     }
-    if let Some(cmd) = &cac.deploy.start_command {
-        fields.push(format!("\t\t\"start\": {},", js_string(cmd)));
-    }
-    if let Some(path) = &cac.deploy.healthcheck_path {
-        fields.push(format!("\t\t\"healthcheck\": {},", js_string(path)));
-    }
-    let config_block = if fields.is_empty() {
-        "nil".to_string()
+    let partial = if named_partial {
+        format!(
+            "\n// Last resort for a per-service CaC repo. Prefer one .railway file for the\n// project and drop this if you later combine services into that file.\nconst Partial = {}\n",
+            js_string(&services[0].name)
+        )
     } else {
-        format!("railway.ServiceConfig{{\n{}\n\t}}", fields.join("\n"))
+        String::new()
     };
+    let resources = idents.join(", ");
     format!(
         r#"package main
 
 import "github.com/railwayapp/railway-go-sdk"
-
-// Last resort for a per-service CaC repo. Prefer one .railway file for the
-// project and drop this if you later combine services into that file.
-const Partial = {name}
-
+{partial}
 func Railway(ctx railway.Context) railway.Project {{
 	ctx = railway.NewContext(ctx)
-	web := railway.ServiceNamed({name}, {config})
-	return railway.ProjectNamed({name}, []any{{web}})
+{stmts}
+	return railway.ProjectNamed({project}, []any{{{resources}}})
 }}
 "#,
-        name = js_string(service_name),
-        config = config_block,
+        stmts = stmts.join("\n"),
+        project = js_string(project_name),
     )
 }
 
-fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
+fn emit_service_fields(cac: &CacFile) -> Vec<String> {
     let mut fields: Vec<String> = Vec::new();
-
     if let Some(cmd) = &cac.build.build_command {
         fields.push(format!("    build: {},", js_string(cmd)));
     }
@@ -312,7 +599,6 @@ fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
     if let Some(regions) = &cac.deploy.multi_region_config {
         fields.push(format!("    replicas: {},", json_to_ts(regions)));
     } else if let Some(region) = &cac.deploy.region {
-        // Single-region placement via replicas map is the IaC form.
         fields.push(format!("    replicas: {{ {}: 1 }},", js_string(region)));
     }
     if let Some(dockerfile) = &cac.build.dockerfile_path {
@@ -341,34 +627,71 @@ fn emit_railway_ts(service_name: &str, cac: &CacFile) -> String {
             .join(", ");
         fields.push(format!("    // watchPatterns from CaC: [{arr}]"));
     }
+    fields
+}
 
-    let body = if fields.is_empty() {
-        format!("  const web = service({});\n", js_string(service_name))
-    } else {
+fn emit_railway_ts(project_name: &str, services: &[CacService], named_partial: bool) -> String {
+    let mut stmts = Vec::new();
+    let mut idents = Vec::new();
+    for service in services {
+        let ident = service_ident(&service.name, &idents);
+        let fields = emit_service_fields(&service.cac);
+        stmts.push(if fields.is_empty() {
+            format!("  const {ident} = service({});", js_string(&service.name))
+        } else {
+            format!(
+                "  const {ident} = service({}, {{\n{}\n  }});",
+                js_string(&service.name),
+                fields.join("\n")
+            )
+        });
+        idents.push(ident);
+    }
+    let partial = if named_partial {
         format!(
-            "  const web = service({}, {{\n{}\n  }});\n",
-            js_string(service_name),
-            fields.join("\n")
+            "\n// Last resort for a per-service CaC repo. Prefer one .railway file for the\n// project and drop this if you later combine services into that file.\nexport const partial = {};\n",
+            js_string(&services[0].name)
         )
+    } else {
+        String::new()
     };
-
     format!(
         r#"import {{ defineRailway, project, service }} from "railway/iac";
-
-// Last resort for a per-service CaC repo. Prefer one .railway file for the
-// project and drop this if you later combine services into that file.
-export const partial = {project};
-
+{partial}
 export default defineRailway(() => {{
 {body}
   return project({project}, {{
-    resources: [web],
+    resources: [{resources}],
   }});
 }});
 "#,
-        body = body,
-        project = js_string(service_name),
+        body = stmts.join("\n"),
+        project = js_string(project_name),
+        resources = idents.join(", "),
     )
+}
+
+fn service_ident(name: &str, taken: &[String]) -> String {
+    let mut ident: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    if ident.is_empty() || ident.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+        ident = format!("service_{ident}");
+    }
+    if matches!(
+        ident.as_str(),
+        "service" | "project" | "default" | "package" | "func" | "main"
+    ) {
+        ident = format!("{ident}_service");
+    }
+    let base = ident.clone();
+    let mut n = 2;
+    while taken.contains(&ident) {
+        ident = format!("{base}_{n}");
+        n += 1;
+    }
+    ident
 }
 
 fn js_string(value: &str) -> String {
@@ -396,7 +719,7 @@ fn json_to_ts(value: &JsonValue) -> String {
     }
 }
 
-async fn clear_railway_config_file_on_linked_service() -> Result<()> {
+async fn clear_railway_config_files(services: &[CacService]) -> Result<()> {
     let configs = Configs::new()?;
     let linked = match configs.get_linked_project().await {
         Ok(linked) => linked,
@@ -408,13 +731,6 @@ async fn clear_railway_config_file_on_linked_service() -> Result<()> {
             return Ok(());
         }
     };
-    let Some(service_id) = linked.service.clone() else {
-        eprintln!(
-            "{} No linked service — skipped clearing Railway Config File.",
-            "Warning:".yellow().bold()
-        );
-        return Ok(());
-    };
 
     let Some(environment_id) = linked.environment.clone() else {
         eprintln!(
@@ -424,34 +740,71 @@ async fn clear_railway_config_file_on_linked_service() -> Result<()> {
         return Ok(());
     };
 
+    let mut ids: Vec<(String, String)> = services
+        .iter()
+        .filter_map(|service| {
+            service
+                .service_id
+                .clone()
+                .map(|id| (service.name.clone(), id))
+        })
+        .collect();
+    if ids.is_empty() {
+        if let Some(service_id) = linked.service.clone() {
+            let name = services
+                .first()
+                .map(|service| service.name.clone())
+                .unwrap_or_else(|| "linked service".to_string());
+            ids.push((name, service_id));
+        }
+    }
+    if ids.is_empty() {
+        eprintln!(
+            "{} No service IDs to clear — skipped clearing Railway Config File.",
+            "Warning:".yellow().bold()
+        );
+        return Ok(());
+    }
+
     let client = GQLClient::new_authorized(&configs)?;
-    let input = mutations::service_instance_update::ServiceInstanceUpdateInput {
-        // Empty string clears the dashboard config-file path.
-        railway_config_file: Some(String::new()),
-        ..Default::default()
-    };
-    let vars = mutations::service_instance_update::Variables {
-        service_id,
-        environment_id: Some(environment_id),
-        input,
-    };
-
-    post_graphql::<ServiceInstanceUpdate, _>(&client, configs.get_backboard(), vars)
-        .await
-        .context(
-            "Failed to clear railwayConfigFile on the linked service. Clear it in the dashboard if set.",
-        )?;
-
-    eprintln!(
-        "{} Cleared Railway Config File on the linked service",
-        "Updated".green().bold()
-    );
+    for (name, service_id) in ids {
+        let input = mutations::service_instance_update::ServiceInstanceUpdateInput {
+            railway_config_file: Some(String::new()),
+            ..Default::default()
+        };
+        let vars = mutations::service_instance_update::Variables {
+            service_id,
+            environment_id: Some(environment_id.clone()),
+            input,
+        };
+        post_graphql::<ServiceInstanceUpdate, _>(&client, configs.get_backboard(), vars)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to clear railwayConfigFile on {name}. Clear it in the dashboard if set."
+                )
+            })?;
+        eprintln!(
+            "{} Cleared Railway Config File on {}",
+            "Updated".green().bold(),
+            name.cyan()
+        );
+    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn svc(name: &str, cac: CacFile) -> CacService {
+        CacService {
+            name: name.to_string(),
+            path: PathBuf::from(name),
+            service_id: None,
+            cac,
+        }
+    }
 
     #[test]
     fn emits_build_and_start() {
@@ -466,19 +819,50 @@ mod tests {
                 ..Default::default()
             },
         };
-        let out = emit_railway_ts("api", &cac);
+        let services = [svc("api", cac)];
+        let out = emit_railway_ts("api", &services, true);
         assert!(out.contains("build: \"pnpm build\""));
         assert!(out.contains("start: \"pnpm start\""));
         assert!(out.contains("healthcheck: \"/health\""));
         assert!(out.contains("service(\"api\""));
         assert!(out.contains("export const partial = \"api\""));
-        let py = emit_railway_py("api", &cac);
+        let py = emit_railway_py("api", &services, true);
         assert!(py.contains("from railway_sdk import"));
         assert!(py.contains("PARTIAL = \"api\""));
-        let go = emit_railway_go("api", &cac);
+        let go = emit_railway_go("api", &services, true);
         assert!(go.contains("github.com/railwayapp/railway-go-sdk"));
         assert!(go.contains("railway.ServiceNamed"));
         assert!(go.contains("const Partial = \"api\""));
+    }
+
+    #[test]
+    fn merges_multiple_services_without_a_partial() {
+        let web = svc(
+            "web",
+            CacFile {
+                build: CacBuild {
+                    build_command: Some("pnpm --filter web build".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let api = svc(
+            "api",
+            CacFile {
+                deploy: CacDeploy {
+                    start_command: Some("node server.js".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+        let out = emit_railway_ts("acme", &[web, api], false);
+        assert!(out.contains("service(\"web\""));
+        assert!(out.contains("service(\"api\""));
+        assert!(out.contains("project(\"acme\""));
+        assert!(out.contains("resources: [web, api]"));
+        assert!(!out.contains("export const partial"));
     }
 
     #[test]

--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -36,7 +36,8 @@ pub struct MigrateArgs {
     #[clap(long)]
     delete_files: bool,
 
-    /// Service name to emit in the DSL (defaults to directory name).
+    /// Migrate only the service with this name. With a single Config as Code
+    /// file it instead overrides the emitted service name.
     #[clap(long)]
     service: Option<String>,
 
@@ -266,12 +267,7 @@ async fn discover_cac_services(
         });
     }
 
-    if let Some(filter) = service_filter {
-        services.retain(|service| service.name == filter);
-        if services.is_empty() {
-            bail!("No Config as Code file found for service {filter}.");
-        }
-    }
+    apply_service_filter(&mut services, service_filter)?;
 
     services.sort_by(|left, right| left.name.cmp(&right.name).then(left.path.cmp(&right.path)));
 
@@ -279,13 +275,29 @@ async fn discover_cac_services(
     for service in &services {
         if !seen.insert(service.name.clone()) {
             bail!(
-                "Two Config as Code files map to the service name {}. Pass --service or rename one of them.",
+                "Two Config as Code files map to the service name {}. Rename one of the directories or remove one of the files.",
                 service.name
             );
         }
     }
 
     Ok(services)
+}
+
+fn apply_service_filter(services: &mut Vec<CacService>, filter: Option<&str>) -> Result<()> {
+    let Some(filter) = filter else {
+        return Ok(());
+    };
+    if services.iter().any(|service| service.name == filter) {
+        services.retain(|service| service.name == filter);
+    } else if services.len() == 1 {
+        // Single-file repos historically used --service to override the
+        // guessed name; keep that working.
+        services[0].name = filter.to_string();
+    } else {
+        bail!("No Config as Code file found for service {filter}.");
+    }
+    Ok(())
 }
 
 fn canonicalize_or_clone(path: &Path) -> PathBuf {
@@ -863,6 +875,35 @@ mod tests {
         assert!(out.contains("project(\"acme\""));
         assert!(out.contains("resources: [web, api]"));
         assert!(!out.contains("export const partial"));
+    }
+
+    #[test]
+    fn service_filter_selects_matching_service() {
+        let mut services = vec![
+            svc("web", CacFile::default()),
+            svc("api", CacFile::default()),
+        ];
+        apply_service_filter(&mut services, Some("api")).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "api");
+    }
+
+    #[test]
+    fn service_filter_renames_a_single_service() {
+        let mut services = vec![svc("guessed-dir", CacFile::default())];
+        apply_service_filter(&mut services, Some("backend")).unwrap();
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "backend");
+    }
+
+    #[test]
+    fn service_filter_errors_when_nothing_matches_multiple() {
+        let mut services = vec![
+            svc("web", CacFile::default()),
+            svc("api", CacFile::default()),
+        ];
+        let err = apply_service_filter(&mut services, Some("worker")).unwrap_err();
+        assert!(err.to_string().contains("worker"));
     }
 
     #[test]

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -148,6 +148,10 @@ struct PullArgs {
     #[clap(long)]
     omit_preserved_variables: bool,
 
+    /// Decrypt and inline non-sealed variable values into the authoring file.
+    #[clap(long)]
+    include_variables: bool,
+
     /// Ask an agent to turn imported state into idiomatic authoring code.
     #[clap(long)]
     agent: bool,
@@ -322,7 +326,7 @@ async fn init_config(args: InitArgs) -> Result<()> {
             args.force,
         )?,
         InitMode::ImportFromRailway => {
-            write_pulled_config(&railway_file, args.force, None, true).await?
+            write_pulled_config(&railway_file, args.force, None, true, false).await?
         }
         InitMode::MinimalFile => write_new(
             &railway_file,
@@ -426,8 +430,15 @@ async fn pull_config(args: PullArgs) -> Result<()> {
     let relative_file = format!(".railway/{}", lang.file_name());
     let readme_file = cwd.join(".railway").join("README.md");
 
+    if args.include_variables {
+        eprintln!(
+            "{} non-sealed variables, including secrets, will be decrypted and included in the spec",
+            "Warning:".yellow().bold()
+        );
+    }
+
     if args.json {
-        let graph = load_current_graph(args.runner).await?;
+        let graph = load_current_graph(args.runner, args.include_variables).await?;
         println!("{}", serde_json::to_string_pretty(&graph)?);
         return Ok(());
     }
@@ -438,6 +449,7 @@ async fn pull_config(args: PullArgs) -> Result<()> {
         args.force,
         args.runner,
         !args.omit_preserved_variables,
+        args.include_variables,
     )
     .await?;
     let wrote_readme = write_asset_if_missing(&readme_file, &iac_readme(lang))?;
@@ -483,8 +495,9 @@ async fn write_pulled_config(
     force: bool,
     runner: Option<String>,
     preserve_variables: bool,
+    include_variables: bool,
 ) -> Result<()> {
-    let graph = load_current_graph(runner).await?;
+    let graph = load_current_graph(runner, include_variables).await?;
     let lang = AuthoringLang::from_path(path).unwrap_or(AuthoringLang::TypeScript);
     write_new(
         path,
@@ -493,37 +506,28 @@ async fn write_pulled_config(
     )
 }
 
-async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGraph> {
-    // A PID-derived name in the working directory is predictable, and
-    // `create_dir_all` + `fs::write` will happily adopt a directory someone else
-    // precreated and follow a `railway.ts` they left as a symlink. On a shared
-    // workspace that turns this placeholder write into a clobber of any file the
-    // victim can write. Let the OS pick a random owner-only directory instead,
-    // and refuse to write through anything that already exists.
-    let temp_dir = tempfile::Builder::new()
-        .prefix(".railway-config-pull-")
-        .tempdir_in(std::env::current_dir().context("Unable to get current directory")?)
-        .context("Failed to create temporary Railway config directory")?;
-    let temp_file = temp_dir.path().join("railway.ts");
-    {
-        use std::io::Write;
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp_file)
-            .context("Failed to create temporary Railway config")?;
-        file.write_all(railway_stub("import-placeholder", AuthoringLang::TypeScript).as_bytes())
-            .context("Failed to write temporary Railway config")?;
-    }
+async fn load_current_graph(
+    runner: Option<String>,
+    decrypt_variables: bool,
+) -> Result<runner::DesiredGraph> {
+    // The native engine's `current` command reads live state and does not
+    // evaluate an authoring file. The legacy TypeScript runner still requires
+    // a file on disk, so keep a throwaway stub only on that path.
+    let temp_dir = if crate::iac::use_legacy_ts_runner(runner.as_deref()) {
+        Some(write_pull_stub()?)
+    } else {
+        None
+    };
+    let file = temp_dir.as_ref().map(|dir| dir.path().join("railway.ts"));
 
     let args = runner::Args {
-        file: Some(temp_file.clone()),
+        file,
         stage: false,
         json: true,
         yes: false,
         confirm_destructive: false,
         apply: false,
-        decrypt_variables: false,
+        decrypt_variables,
         include_types: false,
         runner,
         verbose: false,
@@ -534,7 +538,6 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
         source_tree: None,
     };
     let response = runner::run(&args, "current").await?;
-    // `temp_dir` cleans itself up on drop, including on the error paths below.
     drop(temp_dir);
 
     if !response.ok {
@@ -559,6 +562,25 @@ async fn load_current_graph(runner: Option<String>) -> Result<runner::DesiredGra
     response
         .current_graph
         .context("Railway did not return current project state")
+}
+
+fn write_pull_stub() -> Result<tempfile::TempDir> {
+    let temp_dir = tempfile::Builder::new()
+        .prefix(".railway-config-pull-")
+        .tempdir_in(std::env::current_dir().context("Unable to get current directory")?)
+        .context("Failed to create temporary Railway config directory")?;
+    let temp_file = temp_dir.path().join("railway.ts");
+    {
+        use std::io::Write;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_file)
+            .context("Failed to create temporary Railway config")?;
+        file.write_all(railway_stub("import-placeholder", AuthoringLang::TypeScript).as_bytes())
+            .context("Failed to write temporary Railway config")?;
+    }
+    Ok(temp_dir)
 }
 
 fn render_graph_as_railway(

--- a/src/iac/compiler.rs
+++ b/src/iac/compiler.rs
@@ -829,10 +829,12 @@ fn variables_from_environment_config(variables: &Value) -> Value {
         if value.is_null() {
             continue;
         }
+        let sealed = value.get("isSealed").and_then(Value::as_bool) == Some(true);
         let literal = value.get("value").and_then(Value::as_str);
+        let masked = literal.is_none() || literal == Some("") || literal == Some("*****") || sealed;
         out.insert(
             key.clone(),
-            if literal.is_none() || literal == Some("") {
+            if masked {
                 json!({ "type": "preserve" })
             } else {
                 json!({ "type": "literal", "value": literal })

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -151,6 +151,10 @@ pub async fn run(
     linked_project: &LinkedProject,
     command: &str,
 ) -> Result<Value> {
+    if command == "current" {
+        return import_current_environment(args, configs, linked_project).await;
+    }
+
     let cwd = std::env::current_dir()?;
     let file = args
         .file
@@ -277,6 +281,68 @@ pub async fn run(
         preview,
     })?;
     Ok(serialized)
+}
+
+/// Import live environment state without evaluating an authoring file.
+///
+/// `railway config pull` only needs the current graph. Evaluating a stub
+/// `service("web")` file was colliding with Config as Code ownership checks
+/// and required the `railway` npm package to be installed.
+async fn import_current_environment(
+    args: &NativeRun,
+    configs: &Configs,
+    linked_project: &LinkedProject,
+) -> Result<Value> {
+    let client = GQLClient::new_authorized(configs)?;
+    let endpoint = configs.get_backboard();
+    let environment_id = linked_project.environment_id()?;
+    let current =
+        fetch_current_environment(&client, &endpoint, environment_id, args.decrypt_variables)
+            .await?;
+    let mut options = EnvironmentConfigToGraphOptions {
+        project_name: linked_project.name.clone(),
+        ..Default::default()
+    };
+    if let Some(project_id) = current
+        .project_id
+        .clone()
+        .or_else(|| Some(linked_project.project.clone()))
+    {
+        fill_name_maps(
+            &client,
+            &endpoint,
+            &project_id,
+            current.id.as_str(),
+            &current,
+            &mut options,
+        )
+        .await?;
+    }
+    let current_graph = environment_config_to_graph(&current.config, &options);
+    Ok(serde_json::to_value(RunnerWire {
+        ok: true,
+        command: "current".to_string(),
+        file: args
+            .file
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string())
+            .unwrap_or_default(),
+        current_environment: Some(json!({
+            "projectId": current.project_id,
+            "projectName": options.project_name,
+            "environmentId": current.id,
+            "environmentName": current.name,
+            "configEtag": current.config_etag,
+        })),
+        change_set: None,
+        diff: None,
+        diagnostics: Vec::new(),
+        current_graph: Some(current_graph),
+        desired_graph: None,
+        apply_result: None,
+        claim: false,
+        preview: None,
+    })?)
 }
 
 #[derive(serde::Serialize)]

--- a/src/iac/eval.rs
+++ b/src/iac/eval.rs
@@ -396,9 +396,94 @@ fn decode_eval_output(runtime: &str, output: &std::process::Output) -> Result<Va
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     if !output.status.success() {
+        if let Some(help) = missing_authoring_package_help(runtime, &stderr, &stdout) {
+            bail!("{help}");
+        }
         bail!("{runtime} failed to evaluate IaC file.\n{stderr}\n{stdout}");
     }
     serde_json::from_str(&stdout).with_context(|| {
         format!("{runtime} returned non-JSON output.\nstdout:\n{stdout}\nstderr:\n{stderr}")
     })
+}
+
+fn missing_authoring_package_help(runtime: &str, stderr: &str, stdout: &str) -> Option<String> {
+    let text = format!("{stderr}\n{stdout}");
+    match runtime {
+        "node" if is_missing_js_railway_package(&text) => Some(
+            "The Railway TypeScript SDK is not installed.\n\
+             \n\
+             `.railway/railway.ts` imports `railway/iac`. Install the package \
+             from the repository root, then re-run this command:\n\
+             \n\
+               npm install railway\n\
+             \n\
+             or `pnpm add railway` / `yarn add railway` / `bun add railway`."
+                .to_string(),
+        ),
+        "python3" if is_missing_python_railway_package(&text) => Some(
+            "The Railway Python SDK is not installed.\n\
+             \n\
+             `.railway/railway.py` imports `railway_sdk`. Install it, then re-run this command:\n\
+             \n\
+               pip install railway-sdk"
+                .to_string(),
+        ),
+        "go run" if is_missing_go_railway_package(&text) => Some(
+            "The Railway Go SDK is not installed.\n\
+             \n\
+             `.railway/railway.go` imports `github.com/railwayapp/railway-go-sdk`. \
+             From `.railway/`, run:\n\
+             \n\
+               go get github.com/railwayapp/railway-go-sdk"
+                .to_string(),
+        ),
+        _ => None,
+    }
+}
+
+fn is_missing_js_railway_package(text: &str) -> bool {
+    let missing_module = text.contains("ERR_MODULE_NOT_FOUND")
+        || text.contains("Cannot find package")
+        || text.contains("Cannot find module");
+    missing_module
+        && (text.contains("package 'railway'")
+            || text.contains("package \"railway\"")
+            || text.contains("'railway/iac'")
+            || text.contains("\"railway/iac\"")
+            || text.contains("/railway/iac")
+            || text.contains("imported from") && text.contains("'railway'"))
+}
+
+fn is_missing_python_railway_package(text: &str) -> bool {
+    text.contains("ModuleNotFoundError") && text.contains("railway_sdk")
+}
+
+fn is_missing_go_railway_package(text: &str) -> bool {
+    (text.contains("cannot find module") || text.contains("cannot find package"))
+        && text.contains("railway-go-sdk")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_node_missing_railway_package() {
+        let stderr = r#"node:internal/modules/package_json_reader:301
+  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
+        ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'railway' imported from /tmp/.railway-config-pull-ioRDH0/railway.ts
+"#;
+        let help = missing_authoring_package_help("node", stderr, "").unwrap();
+        assert!(help.contains("npm install railway"));
+        assert!(help.contains("railway/iac"));
+        assert!(!help.contains("package_json_reader"));
+    }
+
+    #[test]
+    fn ignores_unrelated_node_module_errors() {
+        let stderr = "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'left-pad'";
+        assert!(missing_authoring_package_help("node", stderr, "").is_none());
+    }
 }

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -677,6 +677,33 @@ fn variable_removal_is_destructive() {
 }
 
 #[test]
+fn imported_variables_preserve_sealed_and_inline_decrypted() {
+    let graph = env_config(json!({
+        "services": {
+            "web": {
+                "source": { "repo": "r" },
+                "variables": {
+                    "PUBLIC_URL": { "value": "https://example.com", "isSealed": false },
+                    "SECRET": { "value": "should-not-leak", "isSealed": true },
+                    "MASKED": { "value": "" }
+                }
+            }
+        }
+    }));
+    let vars = graph
+        .resources
+        .iter()
+        .find(|r| r["name"] == "web")
+        .and_then(|r| r.get("variables"))
+        .cloned()
+        .unwrap();
+    assert_eq!(vars["PUBLIC_URL"]["type"], "literal");
+    assert_eq!(vars["PUBLIC_URL"]["value"], "https://example.com");
+    assert_eq!(vars["SECRET"]["type"], "preserve");
+    assert_eq!(vars["MASKED"]["type"], "preserve");
+}
+
+#[test]
 fn preserve_variable_never_plans() {
     let current = env_config(json!({
         "services": { "web": { "source": { "repo": "r" }, "variables": { "SECRET": { "value": "existing" } } } }
@@ -879,7 +906,9 @@ fn image_to_github_clears_credentials() {
     )]);
     let changes = diff(&current, &desired).changes;
     assert!(changes.iter().any(|c| c["field"] == "source"));
-    assert!(changes.iter().any(|c| c["field"] == "deploy" && c["after"] == json!({ "registryCredentials": null })));
+    assert!(changes
+        .iter()
+        .any(|c| c["field"] == "deploy" && c["after"] == json!({ "registryCredentials": null })));
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1073,6 +1073,8 @@ mod cli_tests {
                 "--yes",
                 "--confirm-destructive",
             ]);
+            assert_parses(&["config", "pull", "--include-variables"]);
+            assert_parses(&["config", "pull", "--include-variables", "--force"]);
         }
     }
 }

--- a/src/util/cac_deprecation.rs
+++ b/src/util/cac_deprecation.rs
@@ -69,6 +69,61 @@ pub fn find_cac_file(start: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Find every `railway.toml` / `railway.json` under `start`, preferring toml
+/// when both exist in the same directory. Respects `.gitignore`.
+pub fn find_all_cac_files(start: &Path) -> Vec<PathBuf> {
+    use std::collections::BTreeMap;
+
+    let mut by_dir: BTreeMap<PathBuf, PathBuf> = BTreeMap::new();
+    let walker = ignore::WalkBuilder::new(start)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(false)
+        .git_exclude(false)
+        .build();
+    for entry in walker.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = path.file_name().and_then(|n| n.to_str());
+        let Some(name) = name else {
+            continue;
+        };
+        if name != "railway.toml" && name != "railway.json" {
+            continue;
+        }
+        if path.components().any(|c| {
+            matches!(
+                c.as_os_str().to_str(),
+                Some(
+                    ".railway"
+                        | "node_modules"
+                        | "target"
+                        | "vendor"
+                        | "dist"
+                        | ".next"
+                        | "__pycache__"
+                        | ".venv"
+                        | "venv"
+                )
+            )
+        }) {
+            continue;
+        }
+        let Some(dir) = path.parent() else {
+            continue;
+        };
+        match by_dir.get(dir) {
+            Some(existing) if existing.extension().and_then(|e| e.to_str()) == Some("toml") => {}
+            _ => {
+                by_dir.insert(dir.to_path_buf(), path.to_path_buf());
+            }
+        }
+    }
+    by_dir.into_values().collect()
+}
+
 fn display_path(path: &Path) -> String {
     std::env::current_dir()
         .ok()
@@ -160,5 +215,43 @@ mod tests {
     fn returns_none_when_absent() {
         let dir = tempfile::tempdir().unwrap();
         assert!(find_cac_file(dir.path()).is_none());
+    }
+
+    #[test]
+    fn finds_all_cac_files_in_monorepo() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("packages/web")).unwrap();
+        fs::create_dir_all(dir.path().join("packages/api")).unwrap();
+        fs::create_dir_all(dir.path().join("packages/web/node_modules/other")).unwrap();
+        fs::write(dir.path().join("packages/web/railway.json"), "{}\n").unwrap();
+        fs::write(dir.path().join("packages/api/railway.toml"), "[build]\n").unwrap();
+        fs::write(
+            dir.path()
+                .join("packages/web/node_modules/other/railway.json"),
+            "{}\n",
+        )
+        .unwrap();
+        let found = find_all_cac_files(dir.path());
+        assert_eq!(found.len(), 2);
+        assert!(
+            found
+                .iter()
+                .any(|p| p.ends_with("packages/web/railway.json"))
+        );
+        assert!(
+            found
+                .iter()
+                .any(|p| p.ends_with("packages/api/railway.toml"))
+        );
+    }
+
+    #[test]
+    fn find_all_prefers_toml_in_same_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("railway.toml"), "[build]\n").unwrap();
+        fs::write(dir.path().join("railway.json"), "{}\n").unwrap();
+        let found = find_all_cac_files(dir.path());
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("railway.toml"));
     }
 }


### PR DESCRIPTION
## Summary
- `railway config pull` reads live environment state without evaluating a stub `service("web")` file, so Config as Code services no longer block import and the `railway` npm package is not required just to pull.
- `--include-variables` decrypts and inlines non-sealed variable values. The CLI warns that non-sealed variables, including secrets, will be decrypted and included in the spec. Sealed or masked values stay `preserve()`.
- Missing authoring SDKs print an install hint (`npm install railway` / `pip install railway-sdk` / `go get …`) instead of a raw `ERR_MODULE_NOT_FOUND` stack.
- `railway config migrate` finds every `railway.json` / `railway.toml` in the repo (respecting gitignore), merges them into one `.railway/railway.ts`, and clears Config File settings on each matched service. A single-service migrate still emits a named partial.

## Test plan
- [ ] `railway config pull` on a project whose `web` service is managed by `packages/web/railway.json` writes `.railway/railway.ts`
- [ ] `railway config pull` without `npm install railway` succeeds
- [ ] `railway config plan` without the package prints the install hint
- [ ] `railway config pull --include-variables` prints the warning and inlines unsealed values; sealed vars stay `preserve()`
- [ ] `railway config migrate` in a monorepo with multiple `railway.json` files emits one file with every service and no `partial` export
- [ ] `railway config migrate --service web` still emits a named partial
- [ ] `railway config migrate --apply` clears Config File on each migrated service