### PR TITLE
feat(cloud-agent): resume an exact session with `railway code --resume`

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -157,7 +157,7 @@ pub struct DeleteArgs {
 /// across the whole account, so resolving an environment unprompted would add a
 /// request — and, in an unlinked directory, a picker — to commands that do not
 /// need one.
-async fn scope(
+pub(crate) async fn scope(
     configs: &mut Configs,
     client: &reqwest::Client,
     project: Option<String>,
@@ -644,7 +644,10 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
 
     let connected = if !args.command.is_empty() {
         telemetry::track_lifecycle_detached("ssh_command");
-        run_command(&agent, &args.command).await
+        // A one-shot command leaves no session to point a resume at.
+        run_command(&agent, &args.command)
+            .await
+            .map(|code| (code, None))
     } else {
         attach(
             client,
@@ -654,6 +657,7 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
             was_running,
         )
         .await
+        .map(|(code, name)| (code, Some(name)))
     };
 
     // The user's work is done; let detached telemetry finish before the
@@ -665,7 +669,7 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
     // found already running was someone's deliberate state (possibly a session
     // open in another terminal), and a failed connect here is no reason to
     // suspend it.
-    let exit_code = match connected {
+    let (exit_code, session_name) = match connected {
         Ok(code) => code,
         Err(e) => {
             if !was_running {
@@ -684,6 +688,17 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
         agent.name.cyan(),
         agent.name
     );
+    // The reference `railway code --resume` takes, printed while it is known:
+    // it keeps working after the session ends — even across a sleep — where a
+    // plain reattach stops. This is how the reference is learned at all.
+    // Verified against the listing first, because a freshly started session's
+    // minted name may not be the one the platform recorded.
+    if let Some(minted) = session_name
+        && let Some(name) = listed_session_name(client, &backboard, &agent.id, &minted).await
+    {
+        println!("Back into this exact conversation:");
+        println!("  railway code --resume {}:{name}", agent.name);
+    }
 
     Ok(exit_code)
 }
@@ -708,7 +723,9 @@ async fn run_command(agent: &ca::Agent, command: &[String]) -> Result<i32> {
     Ok(code)
 }
 
-/// Attach to a durable session, or start one when the agent has none.
+/// Attach to a durable session, or start one when the agent has none. Hands
+/// back the remote exit code and the session's name, so the caller can print
+/// the reference `railway code --resume` takes.
 ///
 /// Attaching deliberately skips provisioning: the credential, the skills and
 /// the harness were settled when the session was started, and walking that
@@ -720,8 +737,12 @@ async fn attach(
     agent: &ca::Agent,
     requested: Option<&str>,
     was_running: bool,
-) -> Result<i32> {
+) -> Result<(i32, String)> {
     let sessions = ca::list_sessions(client, backboard, &agent.id).await?;
+    // Whether the asked-for name exists at all, live or not — a dead one is
+    // still resumable, and the error below should say so rather than reading
+    // as a typo.
+    let requested_listed = requested.is_some_and(|name| sessions.iter().any(|s| s.name == name));
     let mut running: Vec<_> = sessions.into_iter().filter(|s| s.running).collect();
 
     // An agent that was asleep a moment ago cannot have a live session:
@@ -747,6 +768,16 @@ async fn attach(
     let session_name = match requested {
         Some(name) => {
             if !running.iter().any(|s| s.name == name) {
+                // The name exists but its process is gone (it exited, or the
+                // agent slept). Attach can't help, but resume can — it
+                // restarts the harness into the same conversation.
+                if requested_listed {
+                    bail!(
+                        "Session {name} on {} isn't running any more. Resume its conversation:\n  railway code --resume {}:{name}",
+                        agent.name,
+                        agent.name,
+                    );
+                }
                 bail!(
                     "Agent {} has no running session named {name:?}.{}",
                     agent.name,
@@ -776,13 +807,14 @@ async fn attach(
         format!("Attaching to {} · {}", agent.name, session_name).dimmed()
     );
     let info = code::connect_info(&agent.environment_id, &agent.id).await?;
+    let attached_name = session_name.clone();
     let code = tokio::task::spawn_blocking(move || {
         native::run_native_ssh_with_opts(
             &info.ssh_target,
             None,
             info.identity.as_deref(),
             Some(native::DurableResume {
-                session_name: &session_name,
+                session_name: &attached_name,
                 resume_from_last_read: false,
             }),
             &info.relay_opts,
@@ -790,14 +822,14 @@ async fn attach(
     })
     .await??;
     native::clear_mouse_tracking();
-    Ok(code)
+    Ok((code, session_name))
 }
 
 /// Start the agent's first session: install and configure the harness, then run
 /// it under a *named* durable session so the platform tracks it, it survives
 /// this ssh dying, and the next `railway ca ssh` reattaches instead of starting
-/// a second copy.
-async fn start_session(agent: &ca::Agent) -> Result<i32> {
+/// a second copy. Hands the name back with the exit code, like [`attach`].
+async fn start_session(agent: &ca::Agent) -> Result<(i32, String)> {
     let harness = code::default_harness()?;
     let launch = LaunchArgs::for_target(
         agent.project_id.clone(),
@@ -821,13 +853,14 @@ async fn start_session(agent: &ca::Agent) -> Result<i32> {
     let target = prepared.ssh_target.clone();
     let identity = prepared.identity.clone();
     let opts = prepared.relay_opts.clone();
+    let started_name = session_name.clone();
     let code = tokio::task::spawn_blocking(move || {
         native::run_native_ssh_with_opts(
             &target,
             Some(&remote),
             identity.as_deref(),
             Some(native::DurableResume {
-                session_name: &session_name,
+                session_name: &started_name,
                 resume_from_last_read: false,
             }),
             &opts,
@@ -835,22 +868,53 @@ async fn start_session(agent: &ca::Agent) -> Result<i32> {
     })
     .await??;
     native::clear_mouse_tracking();
-    Ok(code)
+    Ok((code, session_name))
+}
+
+/// The platform's name for a session this process just ran, for a printed
+/// reference.
+///
+/// The relay lists a session under a name of its own — the name the client
+/// sent rides along only as an env stamp (see the manage TUI's
+/// `adopt_pane_sessions`, which reconciles the same gap) — so a reference is
+/// verified against the listing rather than assumed. Best-effort, and `None`
+/// over a guess: a reference that names a session the platform has no record
+/// of would fail the very command it advertises.
+pub(crate) async fn listed_session_name(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent_id: &str,
+    minted: &str,
+) -> Option<String> {
+    let sessions = ca::list_sessions(client, backboard, agent_id).await.ok()?;
+    if sessions.iter().any(|s| s.name == minted) {
+        return Some(minted.to_string());
+    }
+    // Renamed by the relay. With exactly one session on the record there is
+    // no doubt which it was; with more, any pick would be the guess above.
+    match &sessions[..] {
+        [only] => Some(only.name.clone()),
+        _ => None,
+    }
 }
 
 /// The running sessions, for an error that has to be actionable — the name is
 /// what `--session` takes, so the name is what this leads with.
-fn describe_sessions(sessions: &[ca::ConsoleSession]) -> String {
+pub(crate) fn describe_sessions(sessions: &[ca::ConsoleSession]) -> String {
     if sessions.is_empty() {
         return String::new();
     }
     let mut out = String::from("\n");
     for session in sessions {
+        // The command identifies the session; it is not the session. An exec
+        // session's record carries its whole provision script, and fifty
+        // dimmed lines of shell bury the names this listing exists to offer.
+        let command = truncate(session.command.lines().next().unwrap_or(""), 60);
         out.push_str(&format!(
             "  {}{}  {}\n",
             session.name,
             if session.attached { " (attached)" } else { "" },
-            session.command.dimmed()
+            command.dimmed()
         ));
     }
     out

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -13,6 +13,7 @@ pub mod desktop;
 pub mod lifecycle;
 pub mod mcp_sync;
 pub mod prefs;
+pub mod resume;
 pub mod setup;
 pub mod skills_sync;
 pub mod telemetry;

--- a/src/commands/cloud_agent/resume.rs
+++ b/src/commands/cloud_agent/resume.rs
@@ -1,0 +1,362 @@
+//! `railway code --resume <agent>:<session>` — back into one exact
+//! conversation.
+//!
+//! Two halves, decided by whether the durable session is still alive. While
+//! it is, this is `railway ca ssh --session` with the agent pinned: attach by
+//! name and the very terminal comes back, scrollback and all. Once it has
+//! ended — the agent slept, the VM restarted, the harness exited — there is
+//! nothing to attach to, but the conversation is still recoverable: the
+//! harness reported its own session id while it ran (see
+//! [`ca::SessionThread`]), the transcript that id names lives on the agent's
+//! disk, and the disk survives sleep. The revive starts a fresh durable
+//! session running the harness's native resume against that id.
+//!
+//! The reference is exactly what a disconnect prints, and what makes a
+//! session recoverable from outside this process — a terminal manager that
+//! stored the reference can put its pane back into the same conversation
+//! after a reboot, the way it would a local agent.
+
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+use colored::Colorize;
+
+use crate::client::GQLClient;
+use crate::commands::cloud_agent::lifecycle::{describe_sessions, listed_session_name, scope};
+use crate::commands::cloud_agent::telemetry;
+use crate::commands::cloud_agent::tui::session;
+use crate::commands::code::{self, LaunchArgs};
+use crate::commands::ssh::native;
+use crate::config::Configs;
+use crate::controllers::cloud_agent as ca;
+use crate::util::progress::create_spinner;
+
+/// A parsed `<agent>:<session>` reference. The agent half is a name or id
+/// (whatever `railway ca` accepts); the session half is the durable session's
+/// name. Split on the first colon: neither agent ids nor generated names
+/// contain one, and splitting late would let an odd session name eat the
+/// agent.
+#[derive(Debug)]
+pub struct SessionRef {
+    pub agent: String,
+    pub session: String,
+}
+
+impl SessionRef {
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw.split_once(':') {
+            Some((agent, session)) if !agent.is_empty() && !session.is_empty() => Ok(Self {
+                agent: agent.to_string(),
+                session: session.to_string(),
+            }),
+            _ => bail!(
+                "--resume takes <agent>:<session> — the reference a disconnect prints, e.g. `my-agent:claude-x3k9f2`."
+            ),
+        }
+    }
+}
+
+pub async fn command(reference: &str, launch: &LaunchArgs) -> Result<()> {
+    let started = std::time::Instant::now();
+    let result = connect(reference, launch).await;
+    let message = result.as_ref().err().map(|e| format!("{e:#}"));
+    telemetry::track_lifecycle("resume", started.elapsed(), message.as_deref()).await;
+
+    // A non-zero remote exit is the session's result, not a failure of ours —
+    // same contract as `railway ca ssh`.
+    match result? {
+        0 => Ok(()),
+        code => std::process::exit(code),
+    }
+}
+
+async fn connect(reference: &str, launch: &LaunchArgs) -> Result<i32> {
+    let target = SessionRef::parse(reference)?;
+    let mut configs = Configs::new()?;
+    let client = GQLClient::new_authorized(&configs)?;
+    let (configs, client) = (&mut configs, &client);
+    let scoped = scope(
+        configs,
+        client,
+        launch.project.clone(),
+        launch.environment.clone(),
+    )
+    .await?;
+    let backboard = configs.get_backboard();
+    let (agent, _) = ca::resolve(configs, client, Some(&target.agent), scoped.as_deref()).await?;
+
+    let was_running = matches!(agent.status, ca::Status::Running);
+    // The platform's records answer before the VM has to: which sessions the
+    // relay still holds, and what ran inside them. Both survive the agent
+    // sleeping, so the plan is settled up front — a reference that cannot be
+    // resumed must not cost a wake.
+    let (sessions, threads) =
+        ca::session_threads(client, &backboard, &agent.id, &agent.environment_id).await?;
+
+    // Same zombie rule as `railway ca ssh`: sleeping stopped every process on
+    // the VM, so a session the platform still lists as running on an agent
+    // that was not is a record that outlived its process. Attaching to it
+    // streams nothing and the screen stays blank — revive instead.
+    let attachable = was_running
+        && sessions
+            .iter()
+            .any(|s| s.name == target.session && s.running);
+
+    // `Some` carries the revive: the command to run and the durable session
+    // name to run it under. Settled before the wake for the reason above.
+    let revival = match attachable {
+        true => None,
+        false => {
+            let Some(thread) = newest_thread(&threads, &target.session) else {
+                if sessions.iter().any(|s| s.name == target.session) {
+                    bail!(
+                        "Session {} on {} isn't running, and no harness ever reported a conversation from inside it (a plain shell, or a run that predates thread reports) — there is nothing to resume.\n`railway ca ssh {}` starts a fresh session.",
+                        target.session,
+                        agent.name,
+                        agent.name,
+                    );
+                }
+                bail!(
+                    "Agent {} has no record of a session named {:?}.{}",
+                    agent.name,
+                    target.session,
+                    describe_sessions(&sessions)
+                );
+            };
+            let Some(remote_cmd) = code::resume_remote_command(
+                &thread.harness,
+                &thread.session_id,
+                code::SessionStyle::FullTerminal,
+            ) else {
+                bail!(
+                    "Session {} ran {}, which has no resume this CLI knows to be safe.\n`railway ca ssh {}` starts a fresh session.",
+                    target.session,
+                    thread.harness,
+                    agent.name,
+                );
+            };
+            let session_name = session::durable_name(durable_prefix(&thread.harness));
+            Some((thread.harness.clone(), remote_cmd, session_name))
+        }
+    };
+
+    // The wake mirror of `railway ca ssh`: probe the route rather than poll
+    // status to RUNNING, wake first when asleep, and refuse terminal states.
+    let spinner = (!was_running).then(|| create_spinner(format!("Waking agent {}", agent.name)));
+    let ready = match agent.status {
+        ca::Status::Running => Ok(()),
+        ca::Status::Starting => match code::relay_access().await {
+            Ok(access) => code::wait_until_connectable(
+                client,
+                &backboard,
+                &agent.environment_id,
+                &agent.id,
+                &access,
+                // Caught mid-boot: it may be routable right now.
+                Duration::ZERO,
+            )
+            .await
+            .map(|_| ()),
+            Err(e) => Err(e),
+        },
+        ca::Status::Sleeping => match ca::wake(client, &backboard, &agent.id).await {
+            Ok(()) => match code::relay_access().await {
+                Ok(access) => code::wait_until_connectable(
+                    client,
+                    &backboard,
+                    &agent.environment_id,
+                    &agent.id,
+                    &access,
+                    // The wake's physical floor; see the wait's doc.
+                    Duration::from_millis(350),
+                )
+                .await
+                .map(|_| ()),
+                Err(e) => Err(e),
+            },
+            Err(e) => Err(e),
+        },
+        _ => Err(anyhow::anyhow!(
+            "Agent {} is {} — it cannot be connected to, and its sessions went with it.",
+            agent.name,
+            agent.status.label(),
+        )),
+    };
+    if let Some(spinner) = spinner {
+        spinner.finish_and_clear();
+    }
+    ready?;
+    ca::remember(configs, &agent)?;
+
+    let (session_name, remote) = match &revival {
+        None => {
+            telemetry::track_lifecycle_detached("resume_attach");
+            (target.session.clone(), None)
+        }
+        Some((harness, remote_cmd, session_name)) => {
+            telemetry::track_lifecycle_detached("resume_revive");
+            println!(
+                "{}",
+                format!(
+                    "Session {} has ended — resuming its {harness} conversation in a new session.",
+                    target.session
+                )
+                .dimmed()
+            );
+            (session_name.clone(), Some(vec![remote_cmd.clone()]))
+        }
+    };
+    println!(
+        "{}",
+        format!("Attaching to {} · {}", agent.name, session_name).dimmed()
+    );
+
+    let connected = {
+        let info = code::connect_info(&agent.environment_id, &agent.id).await?;
+        let session_name = session_name.clone();
+        tokio::task::spawn_blocking(move || {
+            native::run_native_ssh_with_opts(
+                &info.ssh_target,
+                remote.as_deref(),
+                info.identity.as_deref(),
+                Some(native::DurableResume {
+                    session_name: &session_name,
+                    resume_from_last_read: false,
+                }),
+                &info.relay_opts,
+            )
+        })
+        .await
+        .map_err(anyhow::Error::from)
+        .and_then(|r| r)
+    };
+    native::clear_mouse_tracking();
+    crate::commands::ssh::tel::drain_detached(Duration::from_secs(2)).await;
+
+    // A connection that never happened still woke a machine with no idle
+    // timeout, so put back what this run changed — but only that (see
+    // `railway ca ssh`, whose rule this is).
+    let exit_code = match connected {
+        Ok(code) => code,
+        Err(e) => {
+            if !was_running {
+                let _ = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
+            }
+            return Err(e);
+        }
+    };
+
+    println!(
+        "\nDisconnected — agent {} is still running. `railway ca sleep {}` stops the compute bill.",
+        agent.name.cyan(),
+        agent.name
+    );
+    // A revive moved the conversation to a new durable session, so the old
+    // reference is spent. Verified against the listing before it is
+    // advertised: a freshly minted name may not be the one the platform
+    // recorded (see `listed_session_name`).
+    if let Some(name) = listed_session_name(client, &backboard, &agent.id, &session_name).await {
+        println!("Back into this exact conversation:");
+        println!("  railway code --resume {}:{name}", agent.name);
+    }
+
+    Ok(exit_code)
+}
+
+/// The newest report attributed to this durable session. Newest because one
+/// console session can host several runs over its life (`/clear`, a second
+/// `claude`), and the conversation someone wants back is the one they were
+/// last in. ISO-8601 timestamps, so lexicographic max is chronological max —
+/// the same comparison the manage TUI's thread join makes.
+fn newest_thread<'a>(
+    threads: &'a [ca::SessionThread],
+    session: &str,
+) -> Option<&'a ca::SessionThread> {
+    threads
+        .iter()
+        .filter(|t| t.session_name.as_deref() == Some(session))
+        .max_by(|a, b| a.updated_at.cmp(&b.updated_at))
+}
+
+/// The durable-name prefix for a revived session, from the reported harness
+/// label. Identical except for Railway's own agent, which reports as
+/// "railway-agent" but names its sessions "railway" — see
+/// [`crate::commands::code`]'s `Agent::slug`.
+fn durable_prefix(harness: &str) -> &str {
+    match harness {
+        "railway-agent" => "railway",
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn thread(session_name: Option<&str>, harness: &str, id: &str, at: &str) -> ca::SessionThread {
+        ca::SessionThread {
+            session_name: session_name.map(str::to_string),
+            harness: harness.to_string(),
+            session_id: id.to_string(),
+            updated_at: at.to_string(),
+        }
+    }
+
+    #[test]
+    fn reference_splits_on_the_first_colon() {
+        let parsed = SessionRef::parse("my-agent:claude-x3k9f2").unwrap();
+        assert_eq!(parsed.agent, "my-agent");
+        assert_eq!(parsed.session, "claude-x3k9f2");
+
+        // An id works as the agent half, and any later colon stays with the
+        // session — the agent half is the one whose grammar we control.
+        let parsed = SessionRef::parse("6cbd52a5-8f3b-4a0e-9a5e-0e8f1c2d3e4f:odd:name").unwrap();
+        assert_eq!(parsed.agent, "6cbd52a5-8f3b-4a0e-9a5e-0e8f1c2d3e4f");
+        assert_eq!(parsed.session, "odd:name");
+    }
+
+    #[test]
+    fn a_reference_missing_either_half_is_refused_with_the_shape() {
+        for raw in ["claude-x3k9f2", ":claude-x3k9f2", "my-agent:", ":"] {
+            let err = SessionRef::parse(raw).unwrap_err().to_string();
+            assert!(err.contains("<agent>:<session>"), "{raw}: {err}");
+        }
+    }
+
+    #[test]
+    fn the_newest_report_for_the_session_wins() {
+        // One console session hosted two runs; the one someone wants back is
+        // the one they were last in.
+        let threads = vec![
+            thread(
+                Some("claude-abc123"),
+                "claude",
+                "old",
+                "2026-08-27T10:00:00Z",
+            ),
+            thread(
+                Some("claude-abc123"),
+                "claude",
+                "new",
+                "2026-08-28T09:00:00Z",
+            ),
+            thread(
+                Some("claude-zzz999"),
+                "claude",
+                "other",
+                "2026-08-28T12:00:00Z",
+            ),
+            thread(None, "claude", "unattributed", "2026-08-28T13:00:00Z"),
+        ];
+        let found = newest_thread(&threads, "claude-abc123").unwrap();
+        assert_eq!(found.session_id, "new");
+        assert!(newest_thread(&threads, "codex-nope").is_none());
+    }
+
+    #[test]
+    fn railways_reports_map_back_to_its_session_prefix() {
+        assert_eq!(durable_prefix("railway-agent"), "railway");
+        assert_eq!(durable_prefix("claude"), "claude");
+        assert_eq!(durable_prefix("codex"), "codex");
+    }
+}

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -20,7 +20,7 @@ use crate::errors::RailwayError;
 use crate::gql::{mutations, queries};
 use crate::macros::is_stdout_terminal;
 use crate::util::progress::create_shimmer_spinner;
-use crate::util::shell::shell_join;
+use crate::util::shell::{shell_join, shell_quote};
 
 // ---------------------------------------------------------------------------
 // `railway code --codex` / `railway code --claude` / `railway code --grok` /
@@ -114,7 +114,7 @@ pub async fn command(args: Args) -> Result<()> {
 // they would show up in `--help`.
 #[derive(Parser, Default, Clone, Debug, PartialEq, Eq)]
 #[clap(
-    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run). With no project or environment\nflag, this directory's linked project is used, and your default project when\nthe directory has no link.\n\nOn a terminal the session opens inside `railway ca`'s manage screen with the\ntree collapsed, so it has the whole window and the other agents are one key\naway — ⌥f brings the tree back, ⌥n starts another session. `--rm`, a `--`\npassthrough, and anything piped take the terminal directly instead; so does\n`railway ca start`, which never draws the TUI.\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` clears both\ncaches and re-mints.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = "Examples:\n\n  railway ca                        # launch your configured default\n  railway ca setup                  # choose the default agent and skills\n  railway code --codex              # agent VM + your local Codex sign-in\n  railway code --claude             # agent VM + your Claude setup-token\n  railway code --grok               # agent VM + your local Grok sign-in\n  railway code --railway            # agent VM + Railway's own agent, no sign-in needed\n  railway code --codex --new        # force a fresh agent instead of reusing\n  railway code --codex --new --variable DB_URL=postgres.DATABASE_URL\n  railway code --codex --new --env-file .env\n  railway code --codex -- exec \"explain this codebase\"\n\nWith no agent flag, the default saved by `railway ca setup` is used\n(RAILWAY_CA_AGENT overrides it for one run). With no project or environment\nflag, this directory's linked project is used, and your default project when\nthe directory has no link.\n\nOn a terminal the session opens inside `railway ca`'s manage screen with the\ntree collapsed, so it has the whole window and the other agents are one key\naway — ⌥f brings the tree back, ⌥n starts another session. `--rm`, a `--`\npassthrough, and anything piped take the terminal directly instead; so does\n`railway ca start`, which never draws the TUI.\n\nAgents persist between runs and stay running when you disconnect, so your\nsessions survive to reattach to. `railway ca sleep <agent>` stops the compute\nbill; `railway code --rm` destroys it.\n\nEvery session is durable and named; disconnecting prints its\n`<agent>:<session>` reference. `railway code --resume <agent>:<session>` puts\nthe terminal back into that exact conversation — reattaching while the\nsession still runs, and once it has ended (the agent slept, or the harness\nexited) waking the agent if needed and restarting the harness into the same\nconversation.\n\nClaude auth is minted once (`claude setup-token`), cached locally, and reused —\nincluding the copy already on a reused agent. `--refresh-auth` clears both\ncaches and re-mints.\n\nCarrying a sign-in from this machine is a convenience, not a requirement: with\nnothing local to copy or mint from, the agent still starts and the harness asks\nyou to sign in there.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
 )]
 pub struct LaunchArgs {
     /// Launch OpenAI Codex, carrying your local ChatGPT sign-in
@@ -158,6 +158,22 @@ pub struct LaunchArgs {
     /// or when auth fails on an existing agent
     #[clap(long)]
     refresh_auth: bool,
+
+    /// Put this terminal back into one exact session — `<agent>:<session>`,
+    /// as printed when you disconnect. Reattaches while the session is still
+    /// running; when it has ended (the agent slept, or the harness exited),
+    /// wakes the agent if needed and restarts the harness into the same
+    /// conversation. Takes the terminal directly, like `railway ca ssh`
+    //
+    // Everything else on this struct describes a launch — which harness,
+    // where, with what variables — and a resume answers all of that from the
+    // session's own record, so the flags that would contradict it conflict
+    // outright rather than being silently ignored.
+    #[clap(long, value_name = "AGENT:SESSION", conflicts_with_all = [
+        "codex", "claude", "grok", "railway", "new", "rm", "refresh_auth",
+        "name", "variables", "env_files", "agent_args",
+    ])]
+    pub resume: Option<String>,
 
     /// Name for a newly created agent (defaults to a generated one)
     #[clap(long)]
@@ -227,6 +243,7 @@ impl LaunchArgs {
             && !self.keep_awake
             && !self.rm
             && !self.refresh_auth
+            && self.resume.is_none()
             && self.name.is_none()
             && self.environment.is_none()
             && self.project.is_none()
@@ -257,8 +274,13 @@ impl LaunchArgs {
     /// The flag half of [`Self::wants_pane`], split off the terminal check so
     /// the rule is checked by tests rather than by reading it — `cargo test`
     /// captures stdout, so the whole predicate is always false under one.
+    ///
+    /// `--resume` joins `--rm` and `-- args` on the direct path: it goes back
+    /// into one known session, so the tree is navigation nobody asked for —
+    /// and the revived half of it runs a command the TUI pipeline has no way
+    /// to build.
     fn pane_shaped(&self) -> bool {
-        !self.rm && self.agent_args.is_empty()
+        !self.rm && self.agent_args.is_empty() && self.resume.is_none()
     }
 
     /// Force one harness, overriding preferences — how the TUI passes the
@@ -776,6 +798,55 @@ fn remote_command(
             shell_join(agent_args)
         ),
     }
+}
+
+/// The environment prelude every session command runs behind: the harness
+/// PATH, the GitHub token, and the carried Claude credential. One string so
+/// launch and resume cannot drift — a resumed claude sourced without the env
+/// guard would land on the login picker instead of the conversation.
+pub(crate) fn session_env_prefix() -> String {
+    format!(
+        "{HARNESS_PATH}; [ -f ~/.gh-token ] && export GH_TOKEN=\"$(cat ~/.gh-token)\"; {CLAUDE_ENV_GUARD}; "
+    )
+}
+
+/// [`remote_command`]'s shape for reviving a conversation whose durable
+/// session has ended: the harness's native resume, pointed at the id the
+/// harness itself reported while it ran (see
+/// [`crate::controllers::cloud_agent::SessionThread`]).
+///
+/// Keyed by the *reported* harness label rather than [`Agent`], because the
+/// report is the only party that knows what actually ran in the session —
+/// and the labels differ ("railway-agent" reports, "railway" launches).
+/// `None` means this harness has no resume the CLI knows to be safe: grok has
+/// no documented one, and an unrecognised label gets a refusal rather than a
+/// guessed flag executed on someone's VM.
+///
+/// The transcript each resume points at lives on the agent's disk, which
+/// survives sleep — that is what makes a dead session recoverable at all.
+pub(crate) fn resume_remote_command(
+    harness: &str,
+    thread_id: &str,
+    style: SessionStyle,
+) -> Option<String> {
+    let resume = match harness {
+        "claude" => format!("claude --resume {}", shell_quote(thread_id)),
+        "codex" => format!("codex resume {}", shell_quote(thread_id)),
+        // The daemon's `--session <id>` rejoins that exact conversation — the
+        // same flag every launch passes, now with the recorded id instead of
+        // a fresh durable-session name. See [`remote_command`].
+        "railway-agent" => format!("railway-agent-tui --session {}", shell_quote(thread_id)),
+        _ => return None,
+    };
+    let after = match style {
+        SessionStyle::FullTerminal => "; exec bash -l",
+        SessionStyle::Pane => "",
+    };
+    Some(format!(
+        "{}export RAILWAY_CODE_AUTOSTARTED=1; {resume}; {}{after}",
+        session_env_prefix(),
+        terminal_reset_printf()
+    ))
 }
 
 /// SSH options shared by every connection this command runs, plus the info
@@ -2488,6 +2559,15 @@ pub async fn resolve_launch(
 pub async fn launch(args: LaunchArgs) -> Result<()> {
     use colored::Colorize;
 
+    // `--resume` is a reconnection, not a launch: the session's own record
+    // answers where and which harness, so none of the launch pipeline applies.
+    // Checked here rather than in `command` so `railway ca start --resume`
+    // lands on the same path — every caller of the launcher funnels through
+    // this function, while only the terminal-shaped ones pass through there.
+    if let Some(reference) = args.resume.as_deref() {
+        return crate::commands::cloud_agent::resume::command(reference, &args).await;
+    }
+
     // `--rm` is a lifecycle action, not a launch: it needs no agent choice and
     // no credential, so it resolves the environment and returns.
     if args.rm {
@@ -3065,9 +3145,7 @@ async fn prepare_inner(
     };
     ssh_tel::timed_for("cloud_agent_launch", "provision", provision).await?;
 
-    let env_prefix = format!(
-        "{HARNESS_PATH}; [ -f ~/.gh-token ] && export GH_TOKEN=\"$(cat ~/.gh-token)\"; {CLAUDE_ENV_GUARD}; "
-    );
+    let env_prefix = session_env_prefix();
     let remote_cmd = remote_command(
         agent,
         &env_prefix,
@@ -3875,6 +3953,80 @@ mod tests {
             "{railway_exec}"
         );
         assert!(!railway_exec.contains("--session"), "{railway_exec}");
+    }
+
+    /// A revive runs the harness's native resume against the id the harness
+    /// itself reported — and refuses harnesses without one, because the
+    /// alternative is a guessed flag executed on someone's VM.
+    #[test]
+    fn resume_command_shapes() {
+        use SessionStyle::FullTerminal;
+
+        let claude = resume_remote_command(
+            "claude",
+            "6cbd52a5-8f3b-4a0e-9a5e-0e8f1c2d3e4f",
+            FullTerminal,
+        )
+        .unwrap();
+        assert!(
+            claude.contains("claude --resume 6cbd52a5-8f3b-4a0e-9a5e-0e8f1c2d3e4f;"),
+            "{claude}"
+        );
+        // The same prelude as a launch: without the env guard a resumed
+        // claude lands on the login picker instead of the conversation, and
+        // without the autostart guard `exec bash -l` relaunches the agent on
+        // top of the user.
+        assert!(claude.contains("RAILWAY_CODE_AUTOSTARTED=1"), "{claude}");
+        assert!(claude.contains(".claude-code-env"), "{claude}");
+        assert!(claude.ends_with("exec bash -l"), "{claude}");
+
+        let codex = resume_remote_command("codex", "thread-1", FullTerminal).unwrap();
+        assert!(codex.contains("codex resume thread-1;"), "{codex}");
+
+        // The daemon rejoins the recorded id — the same `--session` every
+        // launch passes, without the fresh-name fallback.
+        let railway =
+            resume_remote_command("railway-agent", "railway-x1y2z3", FullTerminal).unwrap();
+        assert!(
+            railway.contains("railway-agent-tui --session railway-x1y2z3;"),
+            "{railway}"
+        );
+
+        // An id is platform data, not ours — it rides quoted whatever it is.
+        let odd = resume_remote_command("claude", "id with spaces", FullTerminal).unwrap();
+        assert!(odd.contains("claude --resume 'id with spaces';"), "{odd}");
+
+        for harness in ["grok", "shell", "something-new"] {
+            assert!(
+                resume_remote_command(harness, "id", FullTerminal).is_none(),
+                "{harness} has no known-safe resume"
+            );
+        }
+    }
+
+    /// `--resume` answers where and which harness from the session's own
+    /// record, so the flags that would contradict it must conflict out loud —
+    /// a silently ignored `--claude` reads as the CLI resuming into the wrong
+    /// harness.
+    #[test]
+    fn resume_conflicts_with_launch_flags() {
+        assert!(LaunchArgs::try_parse_from(["code", "--resume", "a:b"]).is_ok());
+        for flags in [
+            ["--resume", "a:b", "--claude"],
+            ["--resume", "a:b", "--new"],
+            ["--resume", "a:b", "--rm"],
+        ] {
+            let argv = std::iter::once("code").chain(flags);
+            assert!(
+                LaunchArgs::try_parse_from(argv).is_err(),
+                "{flags:?} should conflict"
+            );
+        }
+        // The direct path, not the TUI pane: the revived half runs a command
+        // the TUI pipeline has no way to build.
+        let args = LaunchArgs::parse_from(["code", "--resume", "a:b"]);
+        assert!(!args.pane_shaped());
+        assert!(!args.is_bare());
     }
 
     /// A pane session must end when the harness does. The shell fallback that

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -379,6 +379,72 @@ pub async fn list_sessions(
         .unwrap_or_default())
 }
 
+/// One harness run's last report, from `CloudAgent.sessions` — the platform's
+/// record of which conversation ran inside a console session, kept after the
+/// session itself has ended. `session_id` is the harness's own id for the
+/// conversation (a Claude Code session UUID, a codex thread id…), which is
+/// exactly what the harness's resume flag takes.
+pub struct SessionThread {
+    /// The durable console session the report was attributed to. `None` for
+    /// reports that predate name attribution.
+    pub session_name: Option<String>,
+    /// Which harness reported: claude, codex, grok, railway-agent…
+    pub harness: String,
+    /// The harness's own session id for the conversation.
+    pub session_id: String,
+    /// The VM's clock at the last report — orders reports within one session.
+    pub updated_at: String,
+}
+
+/// The console sessions and the harness reports on one agent, one request.
+///
+/// Both halves in one call because their join is the caller's whole question:
+/// a console session says whether there is something live to reattach to, and
+/// the thread report is what makes a dead one resumable anyway.
+pub async fn session_threads(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent_id: &str,
+    environment_id: &str,
+) -> Result<(Vec<ConsoleSession>, Vec<SessionThread>)> {
+    let res = post_graphql::<queries::CloudAgentSessionThreads, _>(
+        client,
+        backboard,
+        queries::cloud_agent_session_threads::Variables {
+            cloud_agent_id: agent_id.to_owned(),
+            environment_id: environment_id.to_owned(),
+        },
+    )
+    .await?;
+    let sessions = res
+        .cloud_agent_console_sessions
+        .map(|conn| {
+            conn.edges
+                .into_iter()
+                .map(|edge| ConsoleSession {
+                    name: edge.node.name,
+                    command: edge.node.command,
+                    running: edge.node.run_state.running,
+                    attached: edge.node.attached,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let threads = res
+        .cloud_agent
+        .map(|a| a.sessions)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|s| SessionThread {
+            session_name: s.session_name,
+            harness: s.harness,
+            session_id: s.session_id,
+            updated_at: s.updated_at,
+        })
+        .collect();
+    Ok((sessions, threads))
+}
+
 /// How an agent was picked, so callers can say so.
 pub enum Resolution {
     /// The caller named it.


### PR DESCRIPTION
# What

Cloud-agent sessions are durable and reattachable while they run — but once one ends (the agent slept, the VM restarted, the harness exited), the conversation inside it was unrecoverable: `railway ca ssh` deliberately filters to running sessions, and the fallback starts a fresh harness with no memory of the last run.

The pieces to do better already exist. The platform records each run's harness and the harness's **own** session id (`CloudAgent.sessions`), the transcript that id names lives on the agent's disk, and the disk survives sleep. This PR adds `railway code --resume <agent>:<session>`, which puts the terminal back into that exact conversation:

- while the durable session is **running**, it attaches to it — same as `railway ca ssh --session`, with the agent pinned;
- once it has **ended**, it wakes the agent if needed and starts a new durable session running the harness's native resume against the recorded id (`claude --resume <id>`, `codex resume <id>`, `railway-agent-tui --session <id>`).

The reference is printed on every disconnect, so it is learnable — and stable enough for external tools (terminal workspace managers that restore panes after a reboot) to store and replay.

# Changes

- `railway code --resume <agent>:<session>` (also reachable as `railway ca --resume` / `railway ca start --resume`). Takes the terminal directly like `railway ca ssh`; conflicts with the launch flags it would contradict (`--claude`, `--new`, `--rm`, …).
- Reattach-or-revive decision is settled from platform records **before** any wake, so an unresolvable reference never costs one. The sleep-zombie rule from `ca ssh` applies: sessions listed running on an agent that was not running are treated as ended.
- Harnesses without a known-safe resume (grok, unrecognized labels) get a clear refusal rather than a guessed flag executed on the VM.
- Disconnect messages from `railway ca ssh` and `--resume` now print the `railway code --resume <agent>:<session>` line. Since the relay lists sessions under names of its own (the client-minted name rides only as an env stamp), the printed name is verified against the listing first, and omitted when it would be a guess.
- `railway ca ssh --session <name>` pointing at a session that exists but has ended now suggests the resume spelling instead of "no running session named".
- Session listings in errors show only the first line of a session's command, truncated — an exec session's record carries its entire provision script, which buried the names the listing exists to offer.
- New `cloudAgentSessionThreads`-backed controller (`session_threads`) exposing the per-session harness reports (harness, session id, updated-at) alongside the console sessions.

# Demo

```
$ railway code --resume strong-patience:vivid-rocket-bdc
Session vivid-rocket-bdc has ended — resuming its claude conversation in a new session.
Attaching to strong-patience · claude-k2m9x1
…

Disconnected — agent strong-patience is still running. `railway ca sleep strong-patience` stops the compute bill.
Back into this exact conversation:
  railway code --resume strong-patience:eager-lantern-4fq
```

# Testing

- `cargo test` (1278 passing, including new unit tests: reference parsing, resume command shapes per harness incl. quoting and refusals, newest-report selection, clap conflicts, pane routing).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (no new warnings).
- Live against real agents (read-only paths): agent resolution, the no-such-session and no-thread-report errors with the truncated session listing, and a direct GraphQL check that ended console sessions stay listed (`runState.running: false`) with their thread snapshots joined by the listed session name — the premise the revive rests on.
- The interactive revive itself needs a real terminal; exercised via the unit-tested command shapes, which mirror the existing `start_session` ssh mechanics. Would appreciate a hands-on pass: quit a `railway code` session, then `railway code --resume` the printed reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEpBNh4vTGb12m1ZV2XLDy
