### PR TITLE
feat(cloud-agent): report the pane's session to herdr

### DIFF
--- a/src/commands/cloud_agent/herdr.rs
+++ b/src/commands/cloud_agent/herdr.rs
@@ -1,0 +1,230 @@
+//! Report the pane's cloud-agent session to Herdr, when this process runs
+//! inside one of its panes.
+//!
+//! Herdr (herdr.dev) is a terminal workspace manager for coding agents: it
+//! records which agent conversation each pane holds and, after a restart,
+//! relaunches the pane back into that conversation. Its integrations for
+//! local agents report over a unix socket the pane's environment names —
+//! `HERDR_ENV=1`, `HERDR_SOCKET_PATH`, `HERDR_PANE_ID` — with one
+//! `pane.report_agent_session` request per change. A `railway code` session
+//! is invisible to that machinery today: the harness runs on the VM, where
+//! the socket does not exist, so the pane records nothing and a restore
+//! lands on a bare shell.
+//!
+//! This module is the local half of the fix: the CLI itself reports the
+//! `--resume` reference (`<agent id>:<durable session name>`) for the session
+//! its pane is showing, under the agent label `railway-code`. Everything is
+//! best-effort and silent — a report is a convenience for the workspace
+//! manager, and no session should ever fail over one. Herdr 0.8.0
+//! acknowledges these reports but does not yet persist agent kinds outside
+//! its built-in set; reporting the honest label anyway is what its side of
+//! the integration will key on.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+/// The pane contract herdr sets in every pane's environment. Present means
+/// this process is running inside a herdr pane and the server is listening
+/// on the socket.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PaneEnv {
+    socket_path: PathBuf,
+    pane_id: String,
+}
+
+/// The pane environment, read once — it cannot change within a process's
+/// lifetime, and the callers that consult it do so from a render loop.
+pub fn pane_env() -> Option<&'static PaneEnv> {
+    static ENV: OnceLock<Option<PaneEnv>> = OnceLock::new();
+    ENV.get_or_init(|| pane_env_from(|key| std::env::var(key).ok()))
+        .as_ref()
+}
+
+/// [`pane_env`] over an arbitrary variable source, so the gating is checked
+/// by tests rather than by mutating the test process's real environment.
+fn pane_env_from(var: impl Fn(&str) -> Option<String>) -> Option<PaneEnv> {
+    if var("HERDR_ENV").as_deref() != Some("1") {
+        return None;
+    }
+    let socket_path = var("HERDR_SOCKET_PATH").filter(|v| !v.is_empty())?;
+    let pane_id = var("HERDR_PANE_ID").filter(|v| !v.is_empty())?;
+    Some(PaneEnv {
+        socket_path: PathBuf::from(socket_path),
+        pane_id,
+    })
+}
+
+/// The reference `railway code --resume` takes, in the one shape both sides
+/// agree on. The agent half is the id rather than the name: the reference is
+/// stored by a machine and replayed cold, where a name's ambiguity has no one
+/// to ask.
+pub fn session_reference(agent_id: &str, session_name: &str) -> String {
+    format!("{agent_id}:{session_name}")
+}
+
+/// Report the pane's current session, fire-and-forget.
+///
+/// Detached because every caller is on a path a user is watching — the render
+/// loop, the moment before an ssh attach — and a local socket that has gone
+/// away must cost nothing. Failures are silent for the same reason the hook
+/// integrations' are: there is nothing actionable to say.
+pub fn report_session_detached(env: &PaneEnv, reference: String) {
+    let env = env.clone();
+    tokio::task::spawn_blocking(move || {
+        let _ = send_report(&env, &reference);
+    });
+}
+
+/// One `pane.report_agent_session` request over the pane's socket: a single
+/// JSON line out, one reply line read and discarded. The `seq` orders
+/// reports on herdr's side, so a stale one can never overwrite a newer one.
+#[cfg(unix)]
+fn send_report(env: &PaneEnv, reference: &str) -> std::io::Result<()> {
+    use std::io::{Read, Write};
+    use std::os::unix::net::UnixStream;
+    use std::time::Duration;
+
+    let seq = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or_default();
+    let request = report_request(&env.pane_id, reference, seq);
+
+    let mut stream = UnixStream::connect(&env.socket_path)?;
+    stream.set_write_timeout(Some(Duration::from_millis(500)))?;
+    stream.set_read_timeout(Some(Duration::from_millis(500)))?;
+    stream.write_all(request.as_bytes())?;
+    // The reply is not checked, only drained: herdr acks unconditionally, and
+    // there is no retry that would make sense on a nack.
+    let mut reply = [0u8; 1024];
+    let _ = stream.read(&mut reply);
+    Ok(())
+}
+
+/// Windows herdr speaks a different transport; until this module learns it,
+/// the report is skipped rather than guessed at.
+#[cfg(not(unix))]
+fn send_report(_env: &PaneEnv, _reference: &str) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// The request line, newline-terminated the way the socket protocol frames
+/// requests. Split from the send so the shape is pinned by a test.
+fn report_request(pane_id: &str, reference: &str, seq: u64) -> String {
+    let request = serde_json::json!({
+        "id": format!("railway:cli:{seq}"),
+        "method": "pane.report_agent_session",
+        "params": {
+            "pane_id": pane_id,
+            "source": "railway:cli",
+            "agent": "railway-code",
+            "seq": seq,
+            "agent_session_id": reference,
+        },
+    });
+    format!("{request}\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_of<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(k, _)| *k == key)
+                .map(|(_, v)| v.to_string())
+        }
+    }
+
+    #[test]
+    fn the_pane_contract_needs_all_three_variables() {
+        let full = &[
+            ("HERDR_ENV", "1"),
+            ("HERDR_SOCKET_PATH", "/tmp/herdr.sock"),
+            ("HERDR_PANE_ID", "w1:p2"),
+        ];
+        let env = pane_env_from(env_of(full)).unwrap();
+        assert_eq!(env.pane_id, "w1:p2");
+        assert_eq!(env.socket_path, PathBuf::from("/tmp/herdr.sock"));
+
+        // Anything less than the full contract means "not a herdr pane" —
+        // reporting into a socket that was inherited from somewhere else
+        // would label a pane herdr never asked about.
+        for missing in ["HERDR_ENV", "HERDR_SOCKET_PATH", "HERDR_PANE_ID"] {
+            let partial: Vec<_> = full
+                .iter()
+                .filter(|(k, _)| *k != missing)
+                .copied()
+                .collect();
+            assert!(
+                pane_env_from(env_of(&partial)).is_none(),
+                "{missing} absent should gate the report off"
+            );
+        }
+        let off = &[
+            ("HERDR_ENV", "0"),
+            ("HERDR_SOCKET_PATH", "/tmp/herdr.sock"),
+            ("HERDR_PANE_ID", "w1:p2"),
+        ];
+        assert!(pane_env_from(env_of(off)).is_none());
+    }
+
+    #[test]
+    fn the_request_is_one_framed_line_herdr_understands() {
+        let line = report_request("w3:p7", "agent-id:claude-x3k9f2", 42);
+        assert!(line.ends_with('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(parsed["method"], "pane.report_agent_session");
+        let params = &parsed["params"];
+        assert_eq!(params["pane_id"], "w3:p7");
+        assert_eq!(params["agent"], "railway-code");
+        assert_eq!(params["source"], "railway:cli");
+        assert_eq!(params["seq"], 42);
+        assert_eq!(params["agent_session_id"], "agent-id:claude-x3k9f2");
+    }
+
+    /// End to end over a real socket: what a herdr server would read is the
+    /// framed request, and a slow or dead server never propagates an error.
+    #[cfg(unix)]
+    #[test]
+    fn a_report_reaches_a_listening_socket_and_a_dead_one_is_silent() {
+        use std::io::{BufRead, BufReader, Write};
+        use std::os::unix::net::UnixListener;
+
+        let dir = std::env::temp_dir().join(format!("railway-herdr-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let socket_path = dir.join("herdr.sock");
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let server = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(&stream);
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let mut stream = &stream;
+            stream
+                .write_all(b"{\"id\":\"x\",\"result\":{\"type\":\"ok\"}}\n")
+                .unwrap();
+            line
+        });
+
+        let env = PaneEnv {
+            socket_path: socket_path.clone(),
+            pane_id: "w3:p7".into(),
+        };
+        send_report(&env, "agent-id:claude-x3k9f2").unwrap();
+        let received = server.join().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(received.trim()).unwrap();
+        assert_eq!(
+            parsed["params"]["agent_session_id"],
+            "agent-id:claude-x3k9f2"
+        );
+
+        // Socket gone: the error stays inside `send_report`'s Result, and the
+        // detached caller drops it — nothing to assert beyond "is an Err".
+        std::fs::remove_file(&socket_path).unwrap();
+        assert!(send_report(&env, "agent-id:claude-x3k9f2").is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -15,6 +15,7 @@ use colored::Colorize;
 use is_terminal::IsTerminal;
 
 use crate::client::GQLClient;
+use crate::commands::cloud_agent::herdr;
 use crate::commands::cloud_agent::telemetry;
 use crate::commands::cloud_agent::tui::session;
 use crate::commands::code::{self, LaunchArgs, Progress};
@@ -698,6 +699,11 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
     {
         println!("Back into this exact conversation:");
         println!("  railway code --resume {}:{name}", agent.name);
+        // The verified name is also the best thing a herdr pane can hold —
+        // it corrects a minted name the mid-run report couldn't resolve.
+        if let Some(env) = herdr::pane_env() {
+            herdr::report_session_detached(env, herdr::session_reference(&agent.id, &name));
+        }
     }
 
     Ok(exit_code)
@@ -789,7 +795,7 @@ async fn attach(
         None => match running.len() {
             0 => {
                 telemetry::track_lifecycle_detached("ssh_new_session");
-                return start_session(agent).await;
+                return start_session(client, backboard, agent).await;
             }
             1 => running[0].name.clone(),
             _ => bail!(
@@ -802,6 +808,11 @@ async fn attach(
     };
 
     telemetry::track_lifecycle_detached("ssh_attach");
+    // A listed name is already the durable identity, so the herdr pane (when
+    // this is one) can hear about it before the session even opens.
+    if let Some(env) = herdr::pane_env() {
+        herdr::report_session_detached(env, herdr::session_reference(&agent.id, &session_name));
+    }
     println!(
         "{}",
         format!("Attaching to {} · {}", agent.name, session_name).dimmed()
@@ -829,7 +840,11 @@ async fn attach(
 /// it under a *named* durable session so the platform tracks it, it survives
 /// this ssh dying, and the next `railway ca ssh` reattaches instead of starting
 /// a second copy. Hands the name back with the exit code, like [`attach`].
-async fn start_session(agent: &ca::Agent) -> Result<(i32, String)> {
+async fn start_session(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent: &ca::Agent,
+) -> Result<(i32, String)> {
     let harness = code::default_harness()?;
     let launch = LaunchArgs::for_target(
         agent.project_id.clone(),
@@ -849,6 +864,30 @@ async fn start_session(agent: &ca::Agent) -> Result<(i32, String)> {
     progress.finish();
 
     let session_name = session::durable_name(prepared.harness);
+    // Resolve the name the platform will actually list — the relay names
+    // sessions itself, and the minted one rides only as an env stamp — and
+    // report it to the herdr pane while the session is still running: a
+    // restore prompted by a crash has only what was reported before it.
+    if let Some(env) = herdr::pane_env() {
+        let client = client.clone();
+        let backboard = backboard.to_string();
+        let agent_id = agent.id.clone();
+        let minted = session_name.clone();
+        tokio::spawn(async move {
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                if let Some(listed) =
+                    attached_session_name(&client, &backboard, &agent_id, &minted).await
+                {
+                    herdr::report_session_detached(
+                        env,
+                        herdr::session_reference(&agent_id, &listed),
+                    );
+                    return;
+                }
+            }
+        });
+    }
     let remote = vec![prepared.remote_cmd.clone()];
     let target = prepared.ssh_target.clone();
     let identity = prepared.identity.clone();
@@ -869,6 +908,32 @@ async fn start_session(agent: &ca::Agent) -> Result<(i32, String)> {
     .await??;
     native::clear_mouse_tracking();
     Ok((code, session_name))
+}
+
+/// The listed name of the session this process is attached to right now —
+/// the mid-run counterpart of [`listed_session_name`], for reporting a
+/// reference while the session is still going.
+///
+/// Prefers the minted name when the platform lists it; otherwise the sole
+/// running-and-attached session, because this process is demonstrably
+/// attached to one. Two candidates mean another terminal is attached too,
+/// and `None` beats labelling the wrong one — the same conservatism as the
+/// manage TUI's `adopt_pane_sessions`.
+pub(crate) async fn attached_session_name(
+    client: &reqwest::Client,
+    backboard: &str,
+    agent_id: &str,
+    minted: &str,
+) -> Option<String> {
+    let sessions = ca::list_sessions(client, backboard, agent_id).await.ok()?;
+    if sessions.iter().any(|s| s.name == minted) {
+        return Some(minted.to_string());
+    }
+    let mut attached = sessions.into_iter().filter(|s| s.running && s.attached);
+    match (attached.next(), attached.next()) {
+        (Some(only), None) => Some(only.name),
+        _ => None,
+    }
 }
 
 /// The platform's name for a session this process just ran, for a printed

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod access;
 pub mod desktop;
+pub mod herdr;
 pub mod lifecycle;
 pub mod mcp_sync;
 pub mod prefs;

--- a/src/commands/cloud_agent/resume.rs
+++ b/src/commands/cloud_agent/resume.rs
@@ -22,7 +22,10 @@ use anyhow::{Result, bail};
 use colored::Colorize;
 
 use crate::client::GQLClient;
-use crate::commands::cloud_agent::lifecycle::{describe_sessions, listed_session_name, scope};
+use crate::commands::cloud_agent::herdr;
+use crate::commands::cloud_agent::lifecycle::{
+    attached_session_name, describe_sessions, listed_session_name, scope,
+};
 use crate::commands::cloud_agent::telemetry;
 use crate::commands::cloud_agent::tui::session;
 use crate::commands::code::{self, LaunchArgs};
@@ -191,6 +194,14 @@ async fn connect(reference: &str, launch: &LaunchArgs) -> Result<i32> {
     let (session_name, remote) = match &revival {
         None => {
             telemetry::track_lifecycle_detached("resume_attach");
+            // The requested name is listed — the herdr pane (when this is
+            // one) can hold it straight away.
+            if let Some(env) = herdr::pane_env() {
+                herdr::report_session_detached(
+                    env,
+                    herdr::session_reference(&agent.id, &target.session),
+                );
+            }
             (target.session.clone(), None)
         }
         Some((harness, remote_cmd, session_name)) => {
@@ -203,6 +214,30 @@ async fn connect(reference: &str, launch: &LaunchArgs) -> Result<i32> {
                 )
                 .dimmed()
             );
+            // The revive mints a new durable name, so the reference the herdr
+            // pane holds is now stale. Resolve the listed name in the
+            // background — the relay names sessions itself — and replace it
+            // while the session is still running (see `start_session`).
+            if let Some(env) = herdr::pane_env() {
+                let client = client.clone();
+                let backboard = backboard.clone();
+                let agent_id = agent.id.clone();
+                let minted = session_name.clone();
+                tokio::spawn(async move {
+                    for _ in 0..6 {
+                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        if let Some(listed) =
+                            attached_session_name(&client, &backboard, &agent_id, &minted).await
+                        {
+                            herdr::report_session_detached(
+                                env,
+                                herdr::session_reference(&agent_id, &listed),
+                            );
+                            return;
+                        }
+                    }
+                });
+            }
             (session_name.clone(), Some(vec![remote_cmd.clone()]))
         }
     };
@@ -258,6 +293,10 @@ async fn connect(reference: &str, launch: &LaunchArgs) -> Result<i32> {
     if let Some(name) = listed_session_name(client, &backboard, &agent.id, &session_name).await {
         println!("Back into this exact conversation:");
         println!("  railway code --resume {}:{name}", agent.name);
+        // Same correction the printed hint just made, for the herdr pane.
+        if let Some(env) = herdr::pane_env() {
+            herdr::report_session_detached(env, herdr::session_reference(&agent.id, &name));
+        }
     }
 
     Ok(exit_code)

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -970,6 +970,9 @@ pub struct App {
     pub sessions: Vec<super::session::Session>,
     /// Index into `sessions` of the one being rendered.
     pub active: Option<usize>,
+    /// The `--resume` reference last reported to a herdr pane, so the render
+    /// loop's check is a string compare and a change reports exactly once.
+    pub herdr_reported: Option<String>,
     pub focus: ManageFocus,
     /// The task being prepared, and the steps reported so far.
     pub loading: Loading,
@@ -1114,6 +1117,7 @@ impl App {
             screen: Screen::Manage,
             sessions: Vec::new(),
             active: None,
+            herdr_reported: None,
             focus: ManageFocus::Tree,
             loading: Loading::default(),
             pending_select: None,
@@ -2805,6 +2809,34 @@ impl App {
 
     pub fn active_session(&self) -> Option<&super::session::Session> {
         self.active.and_then(|i| self.sessions.get(i))
+    }
+
+    /// Tell the herdr pane this TUI runs in which session it is showing, when
+    /// that changed. Called every loop iteration; a no-op outside a herdr
+    /// pane, and a string compare inside one.
+    ///
+    /// The reference tracks the *active* pane because that is what a restore
+    /// should come back to — the others are one ⌥f away once it has. A rename
+    /// by [`Self::adopt_pane_sessions`] re-reports through the same compare,
+    /// which is what replaces the short-lived minted name with the listed one
+    /// a resume can actually find.
+    pub fn report_pane_session(&mut self) {
+        let Some(env) = super::super::herdr::pane_env() else {
+            return;
+        };
+        let Some(session) = self.active_session() else {
+            return;
+        };
+        if session.ended() {
+            return;
+        }
+        let reference =
+            super::super::herdr::session_reference(&session.agent_id, &session.durable_name);
+        if self.herdr_reported.as_deref() == Some(reference.as_str()) {
+            return;
+        }
+        self.herdr_reported = Some(reference.clone());
+        super::super::herdr::report_session_detached(env, reference);
     }
 
     /// Show the pane belonging to the session row under the cursor, if it has

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -740,6 +740,12 @@ pub async fn run(
     let mut last_frame = std::time::Instant::now() - FLOOD_FRAME;
 
     loop {
+        // Whatever this iteration changed — a launch landing, an adopt
+        // renaming a session, the cursor moving panes — the herdr pane this
+        // TUI may run in hears about the active session here, once per
+        // change. A no-op outside a herdr pane.
+        app.report_pane_session();
+
         // Coalesce frames under load: with more messages already waiting,
         // painting now just repeats a screen that is about to change again.
         // See [`FLOOD_FRAME`]. Everything the skipped frame would have shown


### PR DESCRIPTION
Stacked on #1150.

# What

The local half of exact-session restore for terminal workspace managers: when `railway code` / `railway ca ssh` runs inside a [herdr](https://herdr.dev) pane, the CLI reports the active session's `railway code --resume <agent>:<session>` reference over the pane's socket, the same protocol herdr's own agent integrations use. A workspace manager that stores the reference can put the pane back into the exact cloud-agent conversation after a restart — the way it already does for local agents.

Reporting is gated on herdr's pane contract (`HERDR_ENV=1` + `HERDR_SOCKET_PATH` + `HERDR_PANE_ID`), entirely best-effort, and silent: outside a herdr pane it is a no-op, and a dead or slow socket can never fail a session.

# Changes

- New `cloud_agent::herdr` module: pane-contract detection (read once), the framed `pane.report_agent_session` request (agent `railway-code`, source `railway:cli`), and a fire-and-forget unix-socket send with 500ms timeouts. Unix-only transport; other platforms no-op.
- The manage TUI reports the active pane's session whenever it changes — a launch landing, `adopt_pane_sessions` renaming a minted name to the relay-listed one, the cursor moving between sessions. One string compare per loop iteration.
- Direct paths report too: `ca ssh` attach and `--resume` attach report the listed name up front; a fresh or revived session resolves its relay-listed name in the background (the minted name rides only as an env stamp) and reports it while the session is still running, so a restore prompted by a crash has a working reference. Disconnect re-reports the listing-verified name alongside the printed hint.

Herdr 0.8.0 acknowledges these reports but only persists agent kinds from its built-in integrations — verified against a live server. Reporting the honest label anyway is deliberate: it is the shape herdr's side of the integration can key on, and the reports are inert until then.

# Testing

- `cargo test` (1281 passing; new tests: pane-contract gating via injected env, request framing/shape, and an end-to-end send against a real `UnixListener` including the dead-socket silence).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (no new warnings).
- Live against a running herdr 0.8.0 server: the exact request shape is acknowledged over the real socket; storage behavior per agent kind/source verified with a scratch pane (known kinds persist, unknown kinds are acked and dropped — the herdr-side feature this pairs with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEpBNh4vTGb12m1ZV2XLDy
