### PR TITLE
fix(postgres): ha revert never sweeps the PgBouncer pooler

### DIFF
--- a/src/commands/postgres/ha.rs
+++ b/src/commands/postgres/ha.rs
@@ -139,6 +139,73 @@ pub async fn command(
     }
 }
 
+/// The members `ha revert` must still sweep after `templateRevert`, and the
+/// one attached service it must never touch.
+///
+/// templateRevert tears down the members the template itself tracks; a node
+/// added later by LIVE scaling only belongs to the cluster through the
+/// environment config -- the dashboard's revert finds those via canvas-group
+/// membership, which the public API can't stamp. Reverting IS the
+/// instruction to remove every member, so sweep any pre-revert member still
+/// alive afterwards (volume first, then the service, same as scale-down),
+/// matched against the pre-revert snapshot by id: the revert patch clears
+/// parentServiceId on stragglers, so they can't be re-derived from the fresh
+/// config. The public patch path also DROPS parentServiceId (confirmed live:
+/// staging round-trips clusterRole but not the parent link), so a node added
+/// by live scaling is invisible to the membership snapshot too -- a
+/// role-stamped service with NO parent is not a legitimate end state of any
+/// flow, so those are swept as cluster debris as well.
+///
+/// The exception on BOTH paths is the PgBouncer pooler. It hangs off the
+/// root exactly like a member (parent = root, role "edge"), so the
+/// membership walk picks it up and the parent-dropping patch path strands it
+/// looking like debris -- but it belongs to the postgres-with-pgbouncer
+/// feature, not to the HA conversion: it may well predate the convert, and
+/// reverting the cluster to standalone is not an instruction to remove
+/// pooling. `pgbouncer remove` is. Deleting it here silently destroyed a
+/// customer-configured pooler on every revert of a pooled cluster.
+fn revert_sweep_targets(
+    pre_revert_members: &[(String, String)],
+    config: &EnvironmentConfig,
+    root_id: &str,
+    names: &std::collections::BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    let is_pooler = |id: &str| {
+        config
+            .services
+            .get(id)
+            .is_some_and(postgres_plugins::is_pgbouncer_service)
+    };
+    let mut leftovers: Vec<(String, String)> = pre_revert_members
+        .iter()
+        .filter(|(member_id, _)| {
+            config
+                .services
+                .get(member_id)
+                .is_some_and(|service| !service.is_deleted.unwrap_or(false))
+                && !is_pooler(member_id)
+        })
+        .cloned()
+        .collect();
+    for (id, service) in &config.services {
+        let orphaned_member = matches!(
+            service.cluster_role.as_deref(),
+            Some("replica") | Some("internal") | Some("edge")
+        ) && service.parent_service_id.is_none()
+            && !service.is_deleted.unwrap_or(false)
+            && id.as_str() != root_id
+            && !is_pooler(id)
+            && !leftovers.iter().any(|(seen, _)| seen == id);
+        if orphaned_member {
+            leftovers.push((
+                id.clone(),
+                names.get(id).cloned().unwrap_or_else(|| id.clone()),
+            ));
+        }
+    }
+    leftovers
+}
+
 /// Members whose live Patroni role/state actually matters for `status` and
 /// `switchover`/`revert`'s precheck -- the data nodes (root + replicas).
 /// Coordinator/edge members don't run Patroni themselves. Each entry is
@@ -522,45 +589,8 @@ async fn revert(
         .await?
         .config;
 
-    // templateRevert tears down the members the template itself tracks; a
-    // node added later by LIVE scaling only belongs to the cluster through
-    // the environment config -- the dashboard's revert finds those via
-    // canvas-group membership, which the public API can't stamp. Reverting
-    // IS the instruction to remove every member, so sweep any pre-revert
-    // member still alive afterwards (volume first, then the service, same
-    // as scale-down). Matched against the pre-revert snapshot by id: the
-    // revert patch clears parentServiceId on stragglers, so they can't be
-    // re-derived from the fresh config.
-    let mut leftovers: Vec<(String, String)> = pre_revert_members
-        .into_iter()
-        .filter(|(member_id, _)| {
-            config
-                .services
-                .get(member_id)
-                .is_some_and(|service| !service.is_deleted.unwrap_or(false))
-        })
-        .collect();
-    // The public patch path DROPS parentServiceId (confirmed live: staging
-    // it round-trips clusterRole but not the parent link), so a node added
-    // by live scaling is invisible to the membership snapshot too. A
-    // role-stamped service with NO parent is not a legitimate end state of
-    // any flow -- treat those as cluster debris and sweep them as well.
     let names = service_name_map(&ctx);
-    for (id, service) in &config.services {
-        let orphaned_member = matches!(
-            service.cluster_role.as_deref(),
-            Some("replica") | Some("internal") | Some("edge")
-        ) && service.parent_service_id.is_none()
-            && !service.is_deleted.unwrap_or(false)
-            && id.as_str() != root.root_id
-            && !leftovers.iter().any(|(seen, _)| seen == id);
-        if orphaned_member {
-            leftovers.push((
-                id.clone(),
-                names.get(id).cloned().unwrap_or_else(|| id.clone()),
-            ));
-        }
-    }
+    let leftovers = revert_sweep_targets(&pre_revert_members, &config, &root.root_id, &names);
     for (member_id, member_name) in &leftovers {
         if !json {
             println!(
@@ -1101,5 +1131,80 @@ mod tests {
     fn format_lag_renders_numbers_and_strings_without_quoting() {
         assert_eq!(format_lag(&serde_json::json!(0)), "0");
         assert_eq!(format_lag(&serde_json::json!("unknown")), "unknown");
+    }
+
+    #[test]
+    fn revert_sweep_never_deletes_the_pgbouncer_pooler() {
+        use crate::controllers::config::{ServiceInstance, ServiceSource};
+
+        let service =
+            |parent: Option<&str>, role: Option<&str>, image: Option<&str>| ServiceInstance {
+                parent_service_id: parent.map(str::to_string),
+                cluster_role: role.map(str::to_string),
+                source: image.map(|i| ServiceSource {
+                    image: Some(i.to_string()),
+                    ..ServiceSource::default()
+                }),
+                ..ServiceInstance::default()
+            };
+
+        // Post-revert config: the pooler and a live-scaled replica survive
+        // with their parent link cleared by the revert patch; the haproxy
+        // edge was orphaned earlier by the parent-dropping public patch.
+        let mut config = EnvironmentConfig::default();
+        config.services.insert(
+            "root".to_string(),
+            service(
+                None,
+                Some("root"),
+                Some("ghcr.io/railwayapp-templates/postgres-ssl:16"),
+            ),
+        );
+        config.services.insert(
+            "pooler".to_string(),
+            service(
+                None,
+                Some("edge"),
+                Some("ghcr.io/railwayapp-templates/pgbouncer:latest"),
+            ),
+        );
+        config.services.insert(
+            "replica-1".to_string(),
+            service(None, Some("replica"), None),
+        );
+        config.services.insert(
+            "haproxy".to_string(),
+            service(
+                None,
+                Some("edge"),
+                Some("ghcr.io/railwayapp-templates/postgres-ha/haproxy:3.2"),
+            ),
+        );
+
+        // The membership snapshot picked the pooler up too: it hangs off the
+        // root exactly like a member does.
+        let pre_revert_members = vec![
+            ("replica-1".to_string(), "postgres-replica-1".to_string()),
+            ("pooler".to_string(), "PgBouncer".to_string()),
+        ];
+        let names: std::collections::BTreeMap<String, String> =
+            [("haproxy", "Postgres HA"), ("pooler", "PgBouncer")]
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+
+        let mut targets = revert_sweep_targets(&pre_revert_members, &config, "root", &names);
+        targets.sort();
+
+        // The replica (snapshot path) and the orphaned haproxy (debris path)
+        // are swept; the pooler is excluded from BOTH paths, and the root is
+        // never a target.
+        assert_eq!(
+            targets,
+            vec![
+                ("haproxy".to_string(), "Postgres HA".to_string()),
+                ("replica-1".to_string(), "postgres-replica-1".to_string()),
+            ]
+        );
     }
 }

--- a/src/controllers/postgres_plugins.rs
+++ b/src/controllers/postgres_plugins.rs
@@ -198,6 +198,24 @@ pub fn compute_ha_state(
     }
 }
 
+/// True when this service IS the PgBouncer pooler, by image -- the same
+/// discriminator `compute_pgbouncer_state` attaches with. The pooler hangs
+/// off the root exactly like an HA member does (parent = root, role "edge"),
+/// so anything walking cluster membership to DELETE services must ask this:
+/// the pooler belongs to the postgres-with-pgbouncer feature, not to the HA
+/// conversion, and `pgbouncer remove` is its only legitimate remover.
+pub fn is_pgbouncer_service(service: &ServiceInstance) -> bool {
+    service
+        .source
+        .as_ref()
+        .and_then(|s| s.image.as_deref())
+        .is_some_and(|image| {
+            image
+                .to_ascii_lowercase()
+                .contains(PGBOUNCER_IMAGE_IDENTIFIER)
+        })
+}
+
 /// Resolves PgBouncer attachment for a cluster/standalone `root_service_id`:
 /// the non-deleted child service whose image is a PgBouncer image.
 pub fn compute_pgbouncer_state(
@@ -207,15 +225,7 @@ pub fn compute_pgbouncer_state(
     let edge = config.services.iter().find(|(_, service)| {
         !service.is_deleted.unwrap_or(false)
             && service.parent_service_id.as_deref() == Some(root_service_id)
-            && service
-                .source
-                .as_ref()
-                .and_then(|s| s.image.as_deref())
-                .is_some_and(|image| {
-                    image
-                        .to_ascii_lowercase()
-                        .contains(PGBOUNCER_IMAGE_IDENTIFIER)
-                })
+            && is_pgbouncer_service(service)
     });
 
     let Some((edge_id, edge_service)) = edge else {


### PR DESCRIPTION
`railway postgres ha revert` no longer deletes the PgBouncer pooler attached to the cluster's root.

The revert's post-`templateRevert` sweep removes the cluster members the template can't track: everything in the pre-revert membership snapshot still alive, plus role-stamped parentless debris. The pooler hangs off the root exactly like a member — parent = root, role `edge` — so **both** paths picked it up, and every revert of a pooled cluster silently destroyed the customer's pooler:

```
Removing live-scaled cluster member PgBouncer left behind by the template revert...
```

Caught by the `comboLifecycle` e2e flow (attach pgbouncer → enable pitr → convert to HA → revert), where the revert took the pre-convert pooler with it and the subsequent `pgbouncer remove` failed with `PgBouncer is not attached to Postgres.`

## Changes

- **`is_pgbouncer_service` in `postgres_plugins.rs`** — pooler detection by image, extracted from `compute_pgbouncer_state` (which now uses it), so the sweep and attachment detection share one discriminator.
- **`revert_sweep_targets` in `ha.rs`** — the sweep computation, extracted pure and excluding the pooler on both paths: the membership-snapshot walk and the orphaned-debris scan. The HA haproxy edge is still swept — it matches by role but not by image.

Reverting the cluster to standalone is not an instruction to remove pooling; `pgbouncer remove` is — and the pooler keeps working after the revert, since its references target the root service, whose id doesn't change.

Test builds the post-revert config the sweep actually sees (parent links cleared by the revert patch): the replica and the orphaned haproxy are swept, the pooler never, the root never. 1219/1219 passing, `cargo fmt` + clippy clean.

Needs a release to reach the e2e battery (it installs the latest published CLI).
