### PR TITLE
fix(postgres): ha revert resumes a sweep an earlier run left unfinished

### DIFF
--- a/src/commands/postgres/ha.rs
+++ b/src/commands/postgres/ha.rs
@@ -504,7 +504,50 @@ async fn revert(
     let ha_state = postgres_plugins::compute_ha_state(&config, &root.root_id, &names);
 
     if !ha_state.is_cluster {
-        bail!("{} is not an HA cluster.", root.root_name);
+        // A revert that died mid-sweep leaves no cluster to detect --
+        // templateRevert already cleared the root's HA marker and the
+        // survivors' parent links -- but the members it never got to are
+        // still deployed and still billing, stamped with a cluster role and
+        // no parent. Bailing here would strand them with no command able to
+        // remove them (this is exactly what re-running `ha revert` after a
+        // transient delete failure used to do), so finish the sweep instead.
+        let leftovers = revert_sweep_targets(&[], &config, &root.root_id, &names);
+        if leftovers.is_empty() {
+            bail!("{} is not an HA cluster.", root.root_name);
+        }
+        if !confirm_or_bail(
+            &format!(
+                "{} is already standalone, but {} cluster member(s) from an earlier revert are still deployed. Remove them?",
+                root.root_name.red(),
+                leftovers.len()
+            ),
+            args.yes,
+        )? {
+            println!("Cancelled.");
+            return Ok(());
+        }
+        for (member_id, member_name) in &leftovers {
+            if !json {
+                println!(
+                    "Removing cluster member {} left behind by an earlier revert...",
+                    member_name.bold()
+                );
+            }
+            cluster_scale::delete_member(&ctx, &config, member_id)
+                .await
+                .with_context(|| format!("Failed to remove cluster member {member_name}"))?;
+        }
+        let config = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, true)
+            .await?
+            .config;
+        if !json {
+            println!(
+                "Removed {} cluster member(s) left behind by an earlier revert of {}.",
+                leftovers.len(),
+                root.root_name.bold()
+            );
+        }
+        return print_status(&ctx, &config, json, false).await;
     }
 
     // Live precheck: revert is only safe while the root is the current
@@ -1204,6 +1247,21 @@ mod tests {
             vec![
                 ("haproxy".to_string(), "Postgres HA".to_string()),
                 ("replica-1".to_string(), "postgres-replica-1".to_string()),
+            ]
+        );
+
+        // A RESUMED revert has no membership snapshot at all -- the earlier
+        // run's templateRevert already cleared the HA marker -- so the debris
+        // scan alone must still find what the dead sweep left behind (and
+        // still never the pooler). This is the path a re-run takes after a
+        // member delete failed transiently.
+        let mut resumed = revert_sweep_targets(&[], &config, "root", &names);
+        resumed.sort();
+        assert_eq!(
+            resumed,
+            vec![
+                ("haproxy".to_string(), "Postgres HA".to_string()),
+                ("replica-1".to_string(), "replica-1".to_string()),
             ]
         );
     }


### PR DESCRIPTION
Re-running `railway postgres ha revert` after a partial failure now finishes removing the members the first run left behind, instead of refusing to.

The post-`templateRevert` sweep deletes members one at a time, and a single member's `ServiceDelete` can fail transiently (its private-network endpoints still tearing down, handed to the repair workflow — the retryable case the e2e harness already waits out). By that point the first run has already cleared the root's HA marker and the members' parent links, so the retry hit the `is not an HA cluster` bail **before any sweep** — stranding whatever the dead sweep hadn't reached: deployed, billing, role-stamped, and unreachable by any command.

Reproduced on the 2026-08-29 17:45 UTC e2e run (`haLifecycle`): the sweep died deleting the haproxy edge, the retry was told `Postgres is not an HA cluster.`, and member `d890df33` sat alive for the full 900s convergence budget.

## Changes

In `revert`, the `!is_cluster` path now runs the debris scan (`revert_sweep_targets` with an empty snapshot — the same role-stamped-and-parentless match the normal sweep uses, pooler still excluded) before bailing:

- **No debris** → `is not an HA cluster.`, exactly as today.
- **Debris found** → confirm (`--yes` honored), delete each member, report `Removed N cluster member(s) left behind by an earlier revert.`, print status. Deleting can hit the same transient again — the command fails with the same signature and the next retry resumes from wherever it stopped.

Test extends the sweep fixture: a resumed run (empty snapshot) still finds the debris via the scan alone, and still never touches the pooler. 1273/1273, fmt + clippy clean.

Companion consumer: the e2e harness's revert retry (paulocsanz/test-postgres-cli#9/#10) needs no change — a resumed sweep exits 0, and the `Postgres is not an HA cluster.` acceptance stays correct for the no-debris case.
