### PR TITLE
fix(postgres): ha revert waits for the reverted config to apply before sweeping

### DIFF
--- a/src/commands/postgres/ha.rs
+++ b/src/commands/postgres/ha.rs
@@ -628,9 +628,37 @@ async fn revert(
     .await
     .context("Failed to revert HA cluster")?;
 
-    let config = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, true)
-        .await?
-        .config;
+    // templateRevert COMMITS the reverted config, but the commit only
+    // enqueues the apply -- until it lands, a fresh config read still shows
+    // the root HA-enabled. Wait it out (bounded) before sweeping: a sweep
+    // failure past this point is then retryable, because the re-run's
+    // `is_cluster` check sees the applied (standalone) config and takes the
+    // resume path. Without the wait, a retry arriving inside the apply
+    // window took the NORMAL path instead and died in the leader precheck,
+    // probing a half-torn-down cluster and advising an impossible
+    // switchover. On timeout, proceed -- the sweep itself only needs the
+    // pre-revert snapshot, and stopping here would leave every member
+    // running.
+    let mut config;
+    let apply_deadline = std::time::Instant::now() + std::time::Duration::from_secs(180);
+    loop {
+        config = fetch_environment_config(&ctx.client, &ctx.configs, &ctx.environment_id, true)
+            .await?
+            .config;
+        let still_ha =
+            postgres_plugins::compute_ha_state(&config, &root.root_id, &service_name_map(&ctx))
+                .is_cluster;
+        if !still_ha {
+            break;
+        }
+        if std::time::Instant::now() >= apply_deadline {
+            eprintln!(
+                "Warning: the reverted configuration has not finished applying yet; sweeping remaining members anyway."
+            );
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
 
     let names = service_name_map(&ctx);
     let leftovers = revert_sweep_targets(&pre_revert_members, &config, &root.root_id, &names);


### PR DESCRIPTION
Closes the last race in the revert's retry story.

`templateRevert` commits the reverted config, but the commit only **enqueues** the apply. Until it lands, a fresh config read still shows the root HA-enabled — so a re-run of `ha revert` inside that window takes the normal path instead of #1153's resume path, and dies in the leader precheck, probing a cluster that is mid-teardown (replicas and coordinators already deleted, DCS gone, root demoted) and advising a switchover that is impossible:

```
19:29:47 attempt 1: sweep dies transiently (Failed to delete service 026caec7 / Problem processing request)
19:30:07 attempt 2: Postgres is not currently the Patroni leader. Run `railway postgres ha switchover --to Postgres` first, then revert.
```

(2026-08-29 19:07 UTC e2e run: `haLifecycle` passed through the same transient because its retry landed after the apply; `comboLifecycle`'s landed inside the window.)

## Change

After `revert_template` returns, poll the environment config (bounded: 180s, 5s interval) until it reads standalone, then sweep. A sweep failure past that point is deterministically resumable: the retry's `is_cluster` check sees the applied config and takes #1153's resume path. On timeout, warn and proceed — the sweep only needs the pre-revert snapshot, and stopping would leave every member running.

1273/1273, fmt + clippy clean.
