### PR TITLE
fix(database): five HA defects an adversarial audit of #1143 confirmed live

### DIFF
--- a/src/commands/database/ha.rs
+++ b/src/commands/database/ha.rs
@@ -18,7 +18,7 @@ use colored::Colorize;
 use serde::Serialize;
 
 use crate::controllers::{
-    adoption_eligibility::{AdoptionRules, AdoptionTarget},
+    adoption_eligibility::{self, AdoptionRules, AdoptionTarget},
     cluster_probe,
     cluster_scale::{self, EdgeScaleSummary, ScaleClusterParams, ScaleDimensionSummary},
     config::{ClusterWiring, EnvironmentConfig, fetch_environment_config},
@@ -154,7 +154,7 @@ pub async fn command(
 }
 
 /// The members `ha revert` must still sweep after `templateRevert`, and the
-/// one attached service it must never touch.
+/// services it must never touch.
 ///
 /// templateRevert tears down the members the template itself tracks; a node
 /// added later by LIVE scaling only belongs to the cluster through the
@@ -164,16 +164,23 @@ pub async fn command(
 /// alive afterwards (volume first, then the service, same as scale-down),
 /// matched against the pre-revert snapshot by id: the revert patch clears
 /// parentServiceId on stragglers, so they can't be re-derived from the fresh
-/// config. The public patch path also DROPS parentServiceId (confirmed live:
-/// staging round-trips clusterRole but not the parent link), so a node added
-/// by live scaling is invisible to the membership snapshot too -- a
-/// role-stamped service with NO parent is not a legitimate end state of any
-/// flow, so those are swept as cluster debris as well.
+/// config.
 ///
-/// The exception on BOTH paths is the engine's pooler, where it declares one.
-/// It hangs off the root exactly like a member (parent = root, role "edge"),
-/// so the membership walk picks it up and the parent-dropping patch path
-/// strands it looking like debris -- but it belongs to the pooling feature,
+/// The public patch path also DROPS parentServiceId on creation, so a node
+/// added by live scaling is invisible to the membership snapshot too. Those
+/// are swept as debris, but only on evidence that they are THIS cluster's
+/// debris: a role-stamped, parentless service qualifies just when it runs an
+/// image the engine's own companion publishes (`companion_repositories`).
+/// Without that scope the scan was environment-wide -- every orphan of every
+/// engine, so reverting a Redis cluster in a mixed environment would delete
+/// the Postgres cluster's live-scaled replicas, and a role stamp was the only
+/// thing standing between an unrelated service and deletion. An empty
+/// `companion_repositories` (the record was unreachable) skips the debris
+/// scan entirely: the snapshot members are the part we can still prove.
+///
+/// The pooler is excluded from BOTH paths where the engine declares one. It
+/// hangs off the root exactly like a member (parent = root, role "edge"), so
+/// the membership walk picks it up -- but it belongs to the pooling feature,
 /// not to the HA conversion: it may well predate the convert, and reverting
 /// the cluster to standalone is not an instruction to remove pooling. `pool
 /// remove` is. Deleting it here silently destroyed a customer-configured
@@ -184,6 +191,7 @@ fn revert_sweep_targets(
     config: &EnvironmentConfig,
     root_id: &str,
     names: &BTreeMap<String, String>,
+    companion_repositories: &[String],
 ) -> Vec<(String, String)> {
     let is_pooler = |id: &str| {
         engine.pooling.is_some_and(|pooling| {
@@ -204,11 +212,21 @@ fn revert_sweep_targets(
         })
         .cloned()
         .collect();
+
+    if companion_repositories.is_empty() {
+        return leftovers;
+    }
+
     for (id, service) in &config.services {
+        let runs_a_companion_image = adoption_eligibility::image_is_from_repository(
+            service.source.as_ref().and_then(|s| s.image.as_deref()),
+            companion_repositories,
+        );
         let orphaned_member = matches!(
             service.cluster_role.as_deref(),
             Some("replica") | Some("internal") | Some("edge")
         ) && service.parent_service_id.is_none()
+            && runs_a_companion_image
             && !service.is_deleted.unwrap_or(false)
             && id.as_str() != root_id
             && !is_pooler(id)
@@ -693,6 +711,26 @@ async fn revert(
     let names = service_name_map(&ctx);
     let ha_state = database_plugins::compute_ha_state(&config, &root.root_id, &names, engine);
 
+    let template_code = engine
+        .ha
+        .map(|ha| ha.template_code.to_string())
+        .with_context(|| {
+            format!(
+                "{} has no high-availability companion template.",
+                engine.display_name
+            )
+        })?;
+
+    // What this engine's companion actually deploys, so the sweep below can
+    // recognize its own debris instead of every orphan in the environment.
+    let companion_repositories =
+        template_apply::fetch_companion_image_repositories(&ctx, &template_code).await;
+    if companion_repositories.is_empty() {
+        eprintln!(
+            "Warning: could not read the {template_code} template's images, so members left behind by an earlier scale-up cannot be told apart from unrelated services and will be left in place. Re-run once the template is reachable, or remove them from the dashboard."
+        );
+    }
+
     if !ha_state.is_cluster {
         // A revert that died mid-sweep leaves no cluster to detect --
         // templateRevert already cleared the root's HA marker and the
@@ -701,15 +739,29 @@ async fn revert(
         // no parent. Bailing here would strand them with no command able to
         // remove them (this is exactly what re-running `ha revert` after a
         // transient delete failure used to do), so finish the sweep instead.
-        let leftovers = revert_sweep_targets(engine, &[], &config, &root.root_id, &names);
+        let leftovers = revert_sweep_targets(
+            engine,
+            &[],
+            &config,
+            &root.root_id,
+            &names,
+            &companion_repositories,
+        );
         if leftovers.is_empty() {
             bail!("{} is not an HA cluster.", root.root_name);
         }
+        // Name them. This path deletes services the user never listed, on
+        // evidence they cannot see, so the prompt has to show its work.
         if !confirm_or_bail(
             &format!(
-                "{} is already standalone, but {} cluster member(s) from an earlier revert are still deployed. Remove them?",
+                "{} is already standalone, but {} cluster member(s) from an earlier revert are still deployed: {}. Remove them?",
                 root.root_name.red(),
-                leftovers.len()
+                leftovers.len(),
+                leftovers
+                    .iter()
+                    .map(|(_, name)| name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
             args.yes,
         )? {
@@ -739,16 +791,6 @@ async fn revert(
         }
         return print_status(engine, &ctx, &config, json, false).await;
     }
-
-    let template_code = engine
-        .ha
-        .map(|ha| ha.template_code.to_string())
-        .with_context(|| {
-            format!(
-                "{} has no high-availability companion template.",
-                engine.display_name
-            )
-        })?;
 
     // Live precheck: revert is only safe while the root is the current
     // primary. A stale former primary still running as a replica would
@@ -860,8 +902,14 @@ async fn revert(
     }
 
     let names = service_name_map(&ctx);
-    let leftovers =
-        revert_sweep_targets(engine, &pre_revert_members, &config, &root.root_id, &names);
+    let leftovers = revert_sweep_targets(
+        engine,
+        &pre_revert_members,
+        &config,
+        &root.root_id,
+        &names,
+        &companion_repositories,
+    );
     for (member_id, member_name) in &leftovers {
         if !json {
             println!(
@@ -1620,8 +1668,35 @@ mod tests {
         assert_eq!(format_lag(&serde_json::json!("unknown")), "unknown");
     }
 
-    #[test]
-    fn revert_sweep_never_deletes_the_engines_pooler() {
+    /// The repositories `postgres-ha` declares across its slots, as
+    /// `companion_image_repositories` reads them off the live record.
+    fn postgres_ha_repositories() -> Vec<String> {
+        [
+            "ghcr.io/railwayapp-templates/postgres-ha/etcd",
+            "ghcr.io/railwayapp-templates/postgres-ha/haproxy",
+            "ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
+
+    fn redis_ha_repositories() -> Vec<String> {
+        [
+            "ghcr.io/railwayapp-templates/redis-ha/haproxy",
+            "ghcr.io/railwayapp-templates/redis-ha/redis-sentinel",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
+
+    /// A mixed environment mid-revert: a Postgres HA cluster (whose pooler
+    /// and live-scaled replica lost their parent links to the revert patch,
+    /// and whose haproxy was orphaned earlier by the parent-dropping public
+    /// patch) sitting beside an unrelated app service that happens to carry
+    /// an edge role.
+    fn mixed_environment() -> (EnvironmentConfig, BTreeMap<String, String>) {
         use crate::controllers::config::{ServiceInstance, ServiceSource};
 
         let service =
@@ -1635,16 +1710,13 @@ mod tests {
                 ..ServiceInstance::default()
             };
 
-        // Post-revert config: the pooler and a live-scaled replica survive
-        // with their parent link cleared by the revert patch; the haproxy
-        // edge was orphaned earlier by the parent-dropping public patch.
         let mut config = EnvironmentConfig::default();
         config.services.insert(
             "root".to_string(),
             service(
                 None,
                 Some("root"),
-                Some("ghcr.io/railwayapp-templates/postgres-ssl:16"),
+                Some("ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni:16"),
             ),
         );
         config.services.insert(
@@ -1657,7 +1729,11 @@ mod tests {
         );
         config.services.insert(
             "replica-1".to_string(),
-            service(None, Some("replica"), None),
+            service(
+                None,
+                Some("replica"),
+                Some("ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni:16"),
+            ),
         );
         config.services.insert(
             "haproxy".to_string(),
@@ -1668,19 +1744,38 @@ mod tests {
             ),
         );
 
+        let names: BTreeMap<String, String> = [
+            ("haproxy", "Postgres HA"),
+            ("pooler", "PgBouncer"),
+            ("replica-1", "Postgres-2"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+        (config, names)
+    }
+
+    #[test]
+    fn revert_sweep_never_deletes_the_engines_pooler() {
+        let (config, names) = mixed_environment();
+        let repositories = postgres_ha_repositories();
+
         // The membership snapshot picked the pooler up too: it hangs off the
         // root exactly like a member does.
         let pre_revert_members = vec![
-            ("replica-1".to_string(), "postgres-replica-1".to_string()),
+            ("replica-1".to_string(), "Postgres-2".to_string()),
             ("pooler".to_string(), "PgBouncer".to_string()),
         ];
-        let names: BTreeMap<String, String> = [("haproxy", "Postgres HA"), ("pooler", "PgBouncer")]
-            .into_iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
 
-        let mut targets =
-            revert_sweep_targets(&POSTGRES, &pre_revert_members, &config, "root", &names);
+        let mut targets = revert_sweep_targets(
+            &POSTGRES,
+            &pre_revert_members,
+            &config,
+            "root",
+            &names,
+            &repositories,
+        );
         targets.sort();
 
         // The replica (snapshot path) and the orphaned haproxy (debris path)
@@ -1690,7 +1785,7 @@ mod tests {
             targets,
             vec![
                 ("haproxy".to_string(), "Postgres HA".to_string()),
-                ("replica-1".to_string(), "postgres-replica-1".to_string()),
+                ("replica-1".to_string(), "Postgres-2".to_string()),
             ]
         );
 
@@ -1699,28 +1794,62 @@ mod tests {
         // scan alone must still find what the dead sweep left behind (and
         // still never the pooler). This is the path a re-run takes after a
         // member delete failed transiently.
-        let mut resumed = revert_sweep_targets(&POSTGRES, &[], &config, "root", &names);
+        let mut resumed =
+            revert_sweep_targets(&POSTGRES, &[], &config, "root", &names, &repositories);
         resumed.sort();
         assert_eq!(
             resumed,
             vec![
                 ("haproxy".to_string(), "Postgres HA".to_string()),
-                ("replica-1".to_string(), "replica-1".to_string()),
+                ("replica-1".to_string(), "Postgres-2".to_string()),
             ]
         );
+    }
 
-        // An engine that declares no pooler has no such exception to make:
-        // the same edge child is ordinary cluster debris to Redis, whose
-        // clusters never carry one.
-        let mut without_pooler = revert_sweep_targets(&REDIS, &[], &config, "root", &names);
-        without_pooler.sort();
+    #[test]
+    fn revert_sweep_never_reaches_another_engines_cluster() {
+        // Reverting a REDIS cluster in this environment. Every orphan here
+        // belongs to the Postgres cluster, and a `clusterRole` stamp is all
+        // they have in common with Redis debris -- which is exactly why the
+        // role stamp alone cannot be the test. Scoped to what the redis-ha
+        // companion actually publishes, none of them match.
+        let (config, names) = mixed_environment();
+
+        let swept = revert_sweep_targets(
+            &REDIS,
+            &[],
+            &config,
+            "redis-root",
+            &names,
+            &redis_ha_repositories(),
+        );
+
+        assert!(
+            swept.is_empty(),
+            "a redis revert swept the postgres cluster: {swept:?}"
+        );
+    }
+
+    #[test]
+    fn revert_sweep_skips_the_debris_scan_when_the_companion_is_unreadable() {
+        // No repositories means the template record was unreachable, so
+        // there is no evidence tying any orphan to this cluster. The
+        // snapshot members are still provably members and are still swept;
+        // the debris scan is skipped rather than widened to everything.
+        let (config, names) = mixed_environment();
+
+        let swept = revert_sweep_targets(
+            &POSTGRES,
+            &[("replica-1".to_string(), "Postgres-2".to_string())],
+            &config,
+            "root",
+            &names,
+            &[],
+        );
+
         assert_eq!(
-            without_pooler,
-            vec![
-                ("haproxy".to_string(), "Postgres HA".to_string()),
-                ("pooler".to_string(), "PgBouncer".to_string()),
-                ("replica-1".to_string(), "replica-1".to_string()),
-            ]
+            swept,
+            vec![("replica-1".to_string(), "Postgres-2".to_string())]
         );
     }
 

--- a/src/commands/mcp/tools/storage.rs
+++ b/src/commands/mcp/tools/storage.rs
@@ -208,7 +208,7 @@ impl RailwayMcp {
 
         let vars = mutations::volume_create::Variables {
             project_id: ctx.project_id,
-            environment_id: ctx.environment_id,
+            environment_id: Some(ctx.environment_id),
             service_id: ctx.service_id,
             mount_path: params.mount_path,
         };

--- a/src/commands/volume.rs
+++ b/src/commands/volume.rs
@@ -863,7 +863,7 @@ async fn add(
     }
     let volume = mutations::volume_create::Variables {
         service_id: service.clone(),
-        environment_id: environment.clone(),
+        environment_id: Some(environment.clone()),
         mount_path: mount.clone(),
         project_id: project.id,
     };

--- a/src/controllers/adoption_eligibility.rs
+++ b/src/controllers/adoption_eligibility.rs
@@ -118,6 +118,55 @@ pub fn rules_from_template(serialized_config: &Value) -> AdoptionRules {
     }
 }
 
+/// Every image repository the companion template's own slots run,
+/// registry-qualified and deduplicated.
+///
+/// This is what a cluster's DEBRIS looks like from the outside. A member
+/// stranded by the parent-dropping patch path carries a cluster role and no
+/// parent, which on its own says only "some cluster owned this once" -- not
+/// which one. Each HA companion publishes its nodes and sidecars under its
+/// own repository prefix (`postgres-ha/*`, `redis-ha/*`, `mysql-ha/*`), so
+/// the image is the surviving evidence of which companion built a service
+/// after the parent link is gone.
+///
+/// Read from the companion RECORD for the same reason every other gate here
+/// is: it is the authority on what that companion actually deploys, and it
+/// stays right when a template adds a sidecar the CLI has never heard of.
+pub fn companion_image_repositories(serialized_config: &Value) -> Vec<String> {
+    let Some(services) = serialized_config.get("services").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+
+    let mut repositories: Vec<String> = services
+        .values()
+        .filter_map(|service| {
+            let image = service.get("source")?.get("image")?.as_str()?;
+            let parsed = parse_image_ref(image)?;
+            Some(match &parsed.domain {
+                Some(domain) => format!("{domain}/{}", parsed.path),
+                None => parsed.path.clone(),
+            })
+        })
+        .collect();
+    repositories.sort();
+    repositories.dedup();
+    repositories
+}
+
+/// Whether `image` runs out of one of `repositories`, comparing the
+/// registry-qualified repository exactly -- never by prefix, for the reason
+/// [`AdoptionRules::image_repository_is_eligible`] spells out.
+pub fn image_is_from_repository(image: Option<&str>, repositories: &[String]) -> bool {
+    let Some(parsed) = image.and_then(parse_image_ref) else {
+        return false;
+    };
+    let qualified = match &parsed.domain {
+        Some(domain) => format!("{domain}/{}", parsed.path),
+        None => parsed.path.clone(),
+    };
+    repositories.contains(&qualified)
+}
+
 /// What the service brings to the check.
 pub struct AdoptionTarget<'a> {
     pub image: Option<&'a str>,
@@ -494,5 +543,58 @@ mod tests {
                 ))
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn companion_image_repositories_reads_every_slot_the_template_deploys() {
+        // Shaped after the live `postgres-ha` record: root and replicas share
+        // one repository, the coordinator and routing tiers have their own.
+        let repositories = companion_image_repositories(&serde_json::json!({
+            "services": {
+                "a": { "clusterRole": "root",
+                       "source": { "image": "ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni:18" } },
+                "b": { "clusterRole": "replica",
+                       "source": { "image": "ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni:18" } },
+                "c": { "clusterRole": "internal",
+                       "source": { "image": "ghcr.io/railwayapp-templates/postgres-ha/etcd:3" } },
+                "d": { "clusterRole": "edge",
+                       "source": { "image": "ghcr.io/railwayapp-templates/postgres-ha/haproxy:3" } },
+                "e": { "clusterRole": "edge" },
+            }
+        }));
+
+        // Tags dropped, duplicates collapsed, imageless slots skipped.
+        assert_eq!(
+            repositories,
+            vec![
+                "ghcr.io/railwayapp-templates/postgres-ha/etcd".to_string(),
+                "ghcr.io/railwayapp-templates/postgres-ha/haproxy".to_string(),
+                "ghcr.io/railwayapp-templates/postgres-ha/postgres-patroni".to_string(),
+            ]
+        );
+
+        assert!(companion_image_repositories(&serde_json::json!({})).is_empty());
+    }
+
+    #[test]
+    fn image_is_from_repository_matches_the_repository_exactly() {
+        let repositories = vec!["ghcr.io/railwayapp-templates/postgres-ha/haproxy".to_string()];
+
+        assert!(image_is_from_repository(
+            Some("ghcr.io/railwayapp-templates/postgres-ha/haproxy:3.2"),
+            &repositories
+        ));
+
+        // A sibling under the same prefix is a different repository, and so
+        // is a lookalike registry -- neither may pass on a prefix match.
+        assert!(!image_is_from_repository(
+            Some("ghcr.io/railwayapp-templates/postgres-ha/haproxy-sidecar:1"),
+            &repositories
+        ));
+        assert!(!image_is_from_repository(
+            Some("evil.example.com/railwayapp-templates/postgres-ha/haproxy:3.2"),
+            &repositories
+        ));
+        assert!(!image_is_from_repository(None, &repositories));
     }
 }

--- a/src/controllers/cluster_scale.rs
+++ b/src/controllers/cluster_scale.rs
@@ -39,7 +39,7 @@ use crate::{
     controllers::{
         config::{
             ClusterWiring, DeployConfig, EnvironmentConfig, RegionConfig, ServiceInstance,
-            Variable, VolumeMount, fetch_environment_config,
+            Variable, VolumeInstance, VolumeMount, fetch_environment_config,
         },
         project::ServiceContext,
         template_apply::{self, format_data_node_entry, private_domain_ref},
@@ -168,7 +168,7 @@ pub async fn scale_cluster(
         validate_data_node_quorum(&wiring, target)?;
     }
 
-    let mut patch: BTreeMap<String, ServiceInstance> = BTreeMap::new();
+    let mut patch = ScalePatch::default();
     let mut replicas_summary = None;
     let mut coordinators_summary = None;
     let mut edge_summary = None;
@@ -198,10 +198,11 @@ pub async fn scale_cluster(
     }
 
     if let Some(target) = params.edge {
-        edge_summary = scale_edge(&config, root_id, target, &mut patch)?;
+        edge_summary = scale_edge(&config, root_id, target, &mut patch.services)?;
     }
 
     let created_ids: Vec<String> = patch
+        .services
         .iter()
         .filter(|(id, service)| {
             service.parent_service_id.is_some() && !config.services.contains_key(*id)
@@ -213,7 +214,8 @@ pub async fn scale_cluster(
         false
     } else {
         let env_patch = EnvironmentConfig {
-            services: patch,
+            services: patch.services,
+            volumes: patch.volumes,
             ..EnvironmentConfig::default()
         };
         stage_and_commit(ctx, env_patch, params.auto_deploy).await?
@@ -253,6 +255,26 @@ pub async fn scale_cluster(
     })
 }
 
+/// The staged patch a scale builds up: the member services it adds, removes
+/// or rewires, plus the volume INSTANCES those members mount.
+///
+/// Volumes ride in the SAME patch as the services on purpose -- backboard
+/// sizes a new replica volume off the `clusterRole`/`parentServiceId` of
+/// whichever service mounts it, read from the resolved config, so the volume
+/// instance has to be created by the patch that stamps them and not ahead of
+/// it. See `create_clone_volume`.
+#[derive(Default)]
+struct ScalePatch {
+    services: BTreeMap<String, ServiceInstance>,
+    volumes: BTreeMap<String, VolumeInstance>,
+}
+
+impl ScalePatch {
+    fn is_empty(&self) -> bool {
+        self.services.is_empty() && self.volumes.is_empty()
+    }
+}
+
 async fn stage_and_commit(
     ctx: &ServiceContext,
     patch: EnvironmentConfig,
@@ -285,7 +307,7 @@ async fn scale_replicas(
     root_name: &str,
     target_count: i64,
     names: &BTreeMap<String, String>,
-    patch: &mut BTreeMap<String, ServiceInstance>,
+    patch: &mut ScalePatch,
 ) -> Result<(ScaleDimensionSummary, Vec<(String, String)>)> {
     let root = config
         .services
@@ -339,7 +361,18 @@ async fn scale_replicas(
             let node = create_clone_service(ctx, &node_name, &source_image).await?;
             let volume = create_clone_volume(ctx, &node.id, &mount_path, &node.name).await?;
 
-            patch.insert(
+            // Stage the volume INSTANCE alongside the service that mounts
+            // it, so the same patch that stamps this node's role and parent
+            // is the one that creates the volume -- that pairing is what
+            // sizes a replica's volume against its primary.
+            patch.volumes.insert(
+                volume.id.clone(),
+                VolumeInstance {
+                    is_created: Some(true),
+                    ..VolumeInstance::default()
+                },
+            );
+            patch.services.insert(
                 node.id.clone(),
                 ServiceInstance {
                     parent_service_id: Some(root_id.to_string()),
@@ -406,9 +439,8 @@ async fn scale_replicas(
 
     let (summary, added_ids) = summary;
     restamp_replica_wiring(
-        patch,
+        &mut patch.services,
         &wiring,
-        root_id,
         root_name,
         routing_edge_id.as_deref(),
         &existing,
@@ -429,7 +461,7 @@ async fn scale_internal(
     target_count: i64,
     names: &BTreeMap<String, String>,
     fresh_replica_roster: Option<&[(String, String)]>,
-    patch: &mut BTreeMap<String, ServiceInstance>,
+    patch: &mut ScalePatch,
 ) -> Result<ScaleDimensionSummary> {
     let root = config
         .services
@@ -500,7 +532,18 @@ async fn scale_internal(
             let node = create_clone_service(ctx, &node_name, &source_image).await?;
             let volume = create_clone_volume(ctx, &node.id, &mount_path, &node.name).await?;
 
-            patch.insert(
+            // Stage the volume INSTANCE alongside the service that mounts
+            // it, so the same patch that stamps this node's role and parent
+            // is the one that creates the volume -- that pairing is what
+            // sizes a replica's volume against its primary.
+            patch.volumes.insert(
+                volume.id.clone(),
+                VolumeInstance {
+                    is_created: Some(true),
+                    ..VolumeInstance::default()
+                },
+            );
+            patch.services.insert(
                 node.id.clone(),
                 ServiceInstance {
                     parent_service_id: Some(root_id.to_string()),
@@ -569,7 +612,7 @@ async fn scale_internal(
         }
     };
 
-    restamp_internal_wiring(patch, &wiring, &existing, &data_node_ids);
+    restamp_internal_wiring(&mut patch.services, &wiring, &existing, &data_node_ids);
 
     Ok(summary)
 }
@@ -655,24 +698,32 @@ fn set_patch_var(
     );
 }
 
-/// Restamps the root's declared wiring after a replica scale up/down: each
-/// replica's own identity variable, the routing edge's data-node list, the
-/// peer list joining nodes boot against, and consensus quorum on root +
-/// replicas. Mirrors `useScaleHACluster.tsx`'s `scaleReplicaNodes` restamp
-/// step / `template_apply::restamp_after_replica_adjust`, against
+/// Restamps the root's declared wiring after a replica scale up/down: the
+/// joining nodes' own identity variable, the routing edge's data-node list,
+/// and the peer list and consensus quorum those joining nodes boot against.
+/// Mirrors `useScaleHACluster.tsx`'s `scaleReplicaNodes` restamp step against
 /// `EnvironmentConfig`.
+///
+/// Only the routing edge's list is rebuilt fleet-wide; everything else is
+/// stamped on JOINING nodes only, so a scale-down restamps nothing at all.
+/// See the quorum block below for what stamping a survivor actually costs.
 fn restamp_replica_wiring(
     patch: &mut BTreeMap<String, ServiceInstance>,
     wiring: &ClusterWiring,
-    root_id: &str,
     root_name: &str,
     routing_edge_id: Option<&str>,
     replicas_after: &[(String, String)],
     newly_added_ids: &[String],
 ) {
+    // A replica's identity is its own name, which a scale never changes, so
+    // survivors already carry the right value -- and the one they carry may
+    // be a template reference rather than the literal this would overwrite it
+    // with. Stamp the joining nodes, which have no value yet.
     if let Some(var_name) = &wiring.replica_node_name_variable {
         for (id, name) in replicas_after {
-            set_patch_var(patch, id, var_name, name.to_ascii_lowercase());
+            if newly_added_ids.iter().any(|added| added == id) {
+                set_patch_var(patch, id, var_name, name.to_ascii_lowercase());
+            }
         }
     }
 
@@ -716,11 +767,25 @@ fn restamp_replica_wiring(
         set_patch_var(patch, edge_id, data_var, list);
     }
 
-    if let Some(quorum_var) = &wiring.quorum_variable {
+    // Consensus quorum (e.g. SENTINEL_QUORUM), at a majority of the post-scale
+    // data-node set -- on the JOINING nodes only, for the same reason the peer
+    // list above is. An existing node reads this env exactly once, on the
+    // first boot that writes its coordinator config, and never again: stamping
+    // it changes nothing functionally, while the variable edit still marks
+    // every node stale and restarts the whole fleet at once, racing the
+    // coordinator into a spurious failover mid-scale. Survivors converge at
+    // runtime through the image's own quorum-sync watcher instead -- which is
+    // also why a scale-DOWN stamps nothing here.
+    //
+    // On a real cluster the survivors' copy is a reference to the root's
+    // (`${{Redis-1.SENTINEL_QUORUM}}`), so overwriting it with a literal was
+    // not even a no-op edit -- it detached them from the root's value.
+    if let Some(quorum_var) = &wiring.quorum_variable
+        && !newly_added_ids.is_empty()
+    {
         let data_node_count = replicas_after.len() + 1; // + root
         let quorum = (data_node_count / 2 + 1).to_string();
-        set_patch_var(patch, root_id, quorum_var, quorum.clone());
-        for (id, _) in replicas_after {
+        for id in newly_added_ids {
             set_patch_var(patch, id, quorum_var, quorum.clone());
         }
     }
@@ -967,10 +1032,22 @@ struct CreatedVolume {
     id: String,
 }
 
-/// Creates a volume for a new node at `mount_path`, best-effort naming it
-/// `<node_name>-volume` (retrying with a short unique suffix on a name
-/// clash, and simply leaving it unnamed if that also fails -- volume names
-/// are cosmetic).
+/// Creates the VOLUME RECORD for a new node at `mount_path`, best-effort
+/// naming it `<node_name>-volume` (retrying with a short unique suffix on a
+/// name clash, and simply leaving it unnamed if that also fails -- volume
+/// names are cosmetic).
+///
+/// `environmentId: null` deliberately means "no environment": the record is
+/// created bare, and the caller stages the volume INSTANCE in the same patch
+/// that stamps the node's `clusterRole`/`parentServiceId`. Passing this
+/// environment instead provisioned the instance right here, ahead of the
+/// patch and ahead of the role/parent stamps, which is the whole defect --
+/// backboard sizes a new replica volume to hold a full base backup of its
+/// primary (`resolveNewVolumeInstanceSizeMB`), keyed on exactly that
+/// role/parent pair, and an instance created before either exists reads as an
+/// ordinary volume and lands on the flat plan default. It also spent a
+/// patch-system redeploy per volume on the way. This is the same split the
+/// dashboard's `useScaleHACluster` uses.
 async fn create_clone_volume(
     ctx: &ServiceContext,
     service_id: &str,
@@ -982,7 +1059,7 @@ async fn create_clone_volume(
         ctx.configs.get_backboard(),
         mutations::volume_create::Variables {
             project_id: ctx.project_id.clone(),
-            environment_id: ctx.environment_id.clone(),
+            environment_id: None,
             service_id: service_id.to_string(),
             mount_path: mount_path.to_string(),
         },
@@ -1225,15 +1302,20 @@ mod tests {
         );
     }
 
-    #[test]
-    fn restamp_replica_wiring_stamps_identity_edge_list_and_quorum() {
-        let wiring = ClusterWiring {
+    fn replica_scale_wiring() -> ClusterWiring {
+        ClusterWiring {
             replica_node_name_variable: Some("PATRONI_NAME".to_string()),
             data_nodes_variable: Some("POSTGRES_NODES".to_string()),
             data_nodes_entry_format: Some("{host}:${{{rootName}.PGPORT}}:8008".to_string()),
             quorum_variable: Some("QUORUM".to_string()),
             ..ClusterWiring::default()
-        };
+        }
+    }
+
+    #[test]
+    fn restamp_replica_wiring_stamps_identity_and_quorum_on_joining_nodes_only() {
+        let wiring = replica_scale_wiring();
+        // 1 -> 2 replicas: r1 survives the scale, r2 is joining.
         let replicas = vec![
             ("r1".to_string(), "postgres-replica-1".to_string()),
             ("r2".to_string(), "postgres-replica-2".to_string()),
@@ -1243,21 +1325,40 @@ mod tests {
         restamp_replica_wiring(
             &mut patch,
             &wiring,
-            "root",
             "db-prod",
             Some("edge"),
             &replicas,
-            &[],
+            &["r2".to_string()],
         );
 
+        // The joining node gets its identity and the post-scale quorum.
         assert_eq!(
-            patch["r1"].variables["PATRONI_NAME"]
+            patch["r2"].variables["PATRONI_NAME"]
                 .as_ref()
                 .unwrap()
                 .value
                 .as_deref(),
-            Some("postgres-replica-1")
+            Some("postgres-replica-2")
         );
+        assert_eq!(
+            patch["r2"].variables["QUORUM"]
+                .as_ref()
+                .unwrap()
+                .value
+                .as_deref(),
+            Some("2")
+        );
+
+        // The survivor and the root are not touched at all. Editing either
+        // one's variables marks it stale and restarts it -- a whole-fleet
+        // restart mid-scale is what races the coordinator into a spurious
+        // failover, and the value it would be "corrected" to is one the
+        // running node never reads again anyway.
+        assert!(!patch.contains_key("r1"));
+        assert!(!patch.contains_key("root"));
+
+        // The routing edge's list is the one thing rebuilt fleet-wide: it is
+        // read per connection, not once at boot.
         let edge_list = patch["edge"].variables["POSTGRES_NODES"]
             .as_ref()
             .unwrap()
@@ -1266,14 +1367,24 @@ mod tests {
             .unwrap();
         assert!(edge_list.contains("db-prod"));
         assert_eq!(edge_list.split(',').count(), 3);
-        assert_eq!(
-            patch["root"].variables["QUORUM"]
-                .as_ref()
-                .unwrap()
-                .value
-                .as_deref(),
-            Some("2")
-        );
+    }
+
+    #[test]
+    fn restamp_replica_wiring_touches_no_node_on_a_scale_down() {
+        let wiring = replica_scale_wiring();
+        // 3 -> 2 replicas: nothing is joining, so nothing is stamped. The
+        // survivors' quorum converges through the image's own quorum-sync
+        // watcher as the removed nodes drop out.
+        let replicas = vec![
+            ("r1".to_string(), "postgres-replica-1".to_string()),
+            ("r2".to_string(), "postgres-replica-2".to_string()),
+        ];
+        let mut patch = BTreeMap::new();
+
+        restamp_replica_wiring(&mut patch, &wiring, "db-prod", Some("edge"), &replicas, &[]);
+
+        assert_eq!(patch.keys().collect::<Vec<_>>(), vec!["edge"]);
+        assert!(patch["edge"].variables.contains_key("POSTGRES_NODES"));
     }
 
     #[test]
@@ -1474,7 +1585,6 @@ mod tests {
         restamp_replica_wiring(
             &mut patch,
             &wiring,
-            "root",
             "db",
             Some("edge"),
             &[("r1".to_string(), "replica-1".to_string())],
@@ -1499,7 +1609,6 @@ mod tests {
         restamp_replica_wiring(
             &mut patch,
             &wiring,
-            "root",
             "Redis-1",
             None,
             &replicas,
@@ -1542,7 +1651,6 @@ mod tests {
         restamp_replica_wiring(
             &mut patch,
             &wiring,
-            "root",
             "MySQL-1",
             None,
             &[("r1".to_string(), "MySQL-2".to_string())],
@@ -1586,6 +1694,204 @@ mod tests {
         };
         for replicas in [0, 1, 2, 3] {
             assert!(validate_data_node_quorum(&external_coordinator, replicas).is_ok());
+        }
+    }
+
+    /// A `ServiceContext` pointed at a stub backboard.
+    fn mock_context(
+        server: &crate::testkit::MockBackboard,
+        dir: &tempfile::TempDir,
+    ) -> ServiceContext {
+        ServiceContext {
+            client: reqwest::Client::new(),
+            configs: server.configs(dir),
+            project: serde_json::from_value(serde_json::json!({
+                "id": "proj-1",
+                "name": "db",
+                "workspaceId": null,
+                "deletedAt": null,
+                "workspace": null,
+                "buckets": { "edges": [] },
+                "environments": { "edges": [] },
+                "services": { "edges": [] },
+            }))
+            .unwrap(),
+            project_id: "proj-1".to_string(),
+            environment_id: "env-1".to_string(),
+            environment_name: "production".to_string(),
+            service_id: "root".to_string(),
+            service_name: "Redis-1".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn scaling_up_stages_the_new_replica_volume_in_the_same_patch_as_its_role_and_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = crate::testkit::MockBackboard::spawn();
+
+        let environment_config = serde_json::json!({
+            "services": {
+                "root": {
+                    "source": { "image": "ghcr.io/railwayapp-templates/redis-ha/redis-sentinel:8.4" },
+                    "clusterRole": "root",
+                    "clusterWiring": {
+                        "quorumVariable": "SENTINEL_QUORUM",
+                        "peerHostsVariable": "SENTINEL_HOSTS",
+                        "peerHostsEntryFormat": "{host}:26379",
+                    },
+                },
+                "replica-1": {
+                    "source": { "image": "ghcr.io/railwayapp-templates/redis-ha/redis-sentinel:8.4" },
+                    "clusterRole": "replica",
+                    "parentServiceId": "root",
+                    "volumeMounts": { "vol-1": { "mountPath": "/data" } },
+                },
+                "replica-2": {
+                    "source": { "image": "ghcr.io/railwayapp-templates/redis-ha/redis-sentinel:8.4" },
+                    "clusterRole": "replica",
+                    "parentServiceId": "root",
+                    "volumeMounts": { "vol-2": { "mountPath": "/data" } },
+                },
+            }
+        });
+        let environment_payload = serde_json::json!({
+            "environment": { "id": "env-1", "name": "production", "config": environment_config }
+        });
+
+        server.stub("GetEnvironmentConfig", environment_payload.clone());
+        // 2 -> 4 replicas: the data nodes carry the failover vote here, so
+        // only an odd total (5) clears the quorum fence.
+        server.stub(
+            "ServiceCreate",
+            serde_json::json!({
+                "serviceCreate": { "id": "replica-3", "name": "Redis-4" }
+            }),
+        );
+        server.stub(
+            "ServiceCreate",
+            serde_json::json!({
+                "serviceCreate": { "id": "replica-4", "name": "Redis-5" }
+            }),
+        );
+        server.stub(
+            "VolumeCreate",
+            serde_json::json!({
+                "volumeCreate": { "id": "vol-3", "name": "Redis-4-volume" }
+            }),
+        );
+        server.stub(
+            "VolumeCreate",
+            serde_json::json!({
+                "volumeCreate": { "id": "vol-4", "name": "Redis-5-volume" }
+            }),
+        );
+        server.stub(
+            "VolumeNameUpdate",
+            serde_json::json!({ "volumeUpdate": { "name": "Redis-4-volume" } }),
+        );
+        server.stub(
+            "EnvironmentStagedChanges",
+            serde_json::json!({
+                "environmentStagedChanges": { "id": "patch-0", "status": "STAGED", "patch": null }
+            }),
+        );
+        server.stub(
+            "EnvironmentStageChanges",
+            serde_json::json!({
+                "environmentStageChanges": { "id": "patch-1", "status": "STAGED" }
+            }),
+        );
+        server.stub(
+            "EnvironmentPatchCommitStaged",
+            serde_json::json!({
+                "environmentPatchCommitStaged": "wf-1"
+            }),
+        );
+        server.stub(
+            "WorkflowStatus",
+            serde_json::json!({
+                "workflowStatus": { "status": "Complete", "error": null }
+            }),
+        );
+
+        let ctx = mock_context(&server, &dir);
+        let names = names(&[
+            ("root", "Redis-1"),
+            ("replica-1", "Redis-2"),
+            ("replica-2", "Redis-3"),
+        ]);
+
+        scale_cluster(
+            &ctx,
+            "root",
+            "Redis-1",
+            &names,
+            ScaleClusterParams {
+                replicas: Some(4),
+                coordinators: None,
+                edge: None,
+                auto_deploy: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        // The volume RECORD is created with no environment: creating the
+        // instance here would put it outside the patch, ahead of the
+        // clusterRole/parentServiceId stamps that size it against the primary.
+        let volume_create = server.variables_for("VolumeCreate");
+        assert_eq!(volume_create.len(), 2);
+        for variables in &volume_create {
+            assert_eq!(
+                variables.get("environmentId"),
+                Some(&serde_json::Value::Null),
+                "the volume instance must not be provisioned outside the patch"
+            );
+        }
+
+        // The instance is created BY the staged patch instead, in the same
+        // input that carries the node's role and parent -- which is what
+        // `resolveNewVolumeInstanceSizeMB` reads to match the primary's size.
+        let staged = server.variables_for("EnvironmentStageChanges");
+        assert_eq!(staged.len(), 1);
+        let input = staged[0].get("input").unwrap();
+        for volume_id in ["vol-3", "vol-4"] {
+            assert_eq!(
+                input.pointer(&format!("/volumes/{volume_id}/isCreated")),
+                Some(&serde_json::Value::Bool(true)),
+                "{volume_id} was not staged for creation by the patch"
+            );
+        }
+        for (service_id, volume_id) in [("replica-3", "vol-3"), ("replica-4", "vol-4")] {
+            assert_eq!(
+                input.pointer(&format!("/services/{service_id}/clusterRole")),
+                Some(&serde_json::Value::String("replica".to_string()))
+            );
+            assert_eq!(
+                input.pointer(&format!("/services/{service_id}/parentServiceId")),
+                Some(&serde_json::Value::String("root".to_string()))
+            );
+            assert_eq!(
+                input.pointer(&format!(
+                    "/services/{service_id}/volumeMounts/{volume_id}/mountPath"
+                )),
+                Some(&serde_json::Value::String("/data".to_string()))
+            );
+        }
+
+        // And the surviving nodes are still not restamped (see
+        // `restamp_replica_wiring`): only the joining node carries quorum.
+        assert_eq!(
+            input.pointer("/services/replica-3/variables/SENTINEL_QUORUM/value"),
+            Some(&serde_json::Value::String("3".to_string()))
+        );
+        for survivor in ["replica-1", "replica-2", "root"] {
+            assert!(
+                input
+                    .pointer(&format!("/services/{survivor}/variables/SENTINEL_QUORUM"))
+                    .is_none(),
+                "{survivor} was restamped and will restart with the rest of the fleet"
+            );
         }
     }
 }

--- a/src/controllers/database_engines.rs
+++ b/src/controllers/database_engines.rs
@@ -226,13 +226,30 @@ pub struct ImageTagVersion {
     pub minor: Option<i64>,
 }
 
+/// The leading run of digits of a tag component, ignoring any variant suffix
+/// attached to it. This is the half of the contract the CLI kept getting
+/// wrong: a component is versioned by what it STARTS with, not by being
+/// numeric end to end.
+fn leading_number(component: &str) -> Option<i64> {
+    let digits: String = component.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// Mirrors the server's `extractImageTagVersion`
+/// (`packages/backboard/src/controllers/templates/adoptionImageEligibility.ts`),
+/// which reads the tag's leading `major[.minor]` and ignores everything past
+/// it -- patch digits and `-variant` suffixes alike.
+///
+/// Parsing a component only when it is numeric end to end read `8.2-alpine`
+/// as having no minor and `7-bookworm` as having no version at all, so the
+/// CLI refused conversions the server would have accepted: a distro-variant
+/// tag is pinned to a real `major.minor` as far as the gate that matters is
+/// concerned.
 pub fn image_tag_version(image: Option<&str>) -> Option<ImageTagVersion> {
     let tag = parse_image_ref(image?)?.tag?;
     let mut parts = tag.split('.');
-    let major: i64 = parts.next()?.parse().ok()?;
-    // Only a purely numeric second component is a minor: `8.2` is, the `2-alpine`
-    // of `8.2-alpine` is not.
-    let minor = parts.next().and_then(|part| part.parse::<i64>().ok());
+    let major = leading_number(parts.next()?)?;
+    let minor = parts.next().and_then(leading_number);
     Some(ImageTagVersion { major, minor })
 }
 
@@ -286,11 +303,25 @@ mod tests {
         assert_eq!(v.major, 16);
         assert_eq!(v.minor, None);
 
-        // A suffixed tag carries a major but no readable minor.
+        // A variant suffix does not erase the version underneath it. The
+        // server reads both of these as pinned (`8.2` and `7`), so a CLI that
+        // read "no minor" / "no version" refused conversions the server would
+        // have accepted.
         let v = image_tag_version(Some("redis:8.2-alpine")).unwrap();
         assert_eq!(v.major, 8);
+        assert_eq!(v.minor, Some(2));
+
+        let v = image_tag_version(Some("redis:7-bookworm")).unwrap();
+        assert_eq!(v.major, 7);
         assert_eq!(v.minor, None);
 
+        // Anything past the minor is ignored, patch digits included.
+        let v = image_tag_version(Some("postgres:16.4.2")).unwrap();
+        assert_eq!(v.major, 16);
+        assert_eq!(v.minor, Some(4));
+
+        // A tag has to START with digits to carry a version.
+        assert!(image_tag_version(Some("ghcr.io/x/y:v8.2")).is_none());
         assert!(image_tag_version(Some("ghcr.io/x/y:latest")).is_none());
         assert!(image_tag_version(Some("ghcr.io/x/y")).is_none());
         // A digest is not a version: `sha256:23a8...` must never read as 23.

--- a/src/controllers/database_plugins.rs
+++ b/src/controllers/database_plugins.rs
@@ -259,16 +259,29 @@ pub fn member_identity_name(
         .unwrap_or_else(|| service_name.to_ascii_lowercase())
 }
 
-/// If `service_id` is an edge child (a pooler or router in front of the
-/// database), resolves to its parent -- the actual database root -- so a
-/// command invoked with `--service` pointed at an edge node still operates on
-/// the right root.
+/// If `service_id` is any non-root member of a cluster -- a pooler or router
+/// in front of the database, a replica, or a coordinator -- resolves to its
+/// parent, the actual database root, so a command invoked with `--service`
+/// pointed at a member still operates on the right root.
+///
+/// Every member role hops, not just `edge`. Pointing `--service` at a REPLICA
+/// used to leave the replica standing in for the root: `ha revert` then
+/// prechecked the replica's own primariness, handed `templateRevert` the
+/// replica's id (whose resolver validates no root), and took a sweep snapshot
+/// that listed the TRUE root as a deletable member.
 pub fn resolve_root_service_id(config: &EnvironmentConfig, service_id: &str) -> String {
     match config.services.get(service_id) {
-        Some(service) if service.cluster_role.as_deref() == Some("edge") => service
-            .parent_service_id
-            .clone()
-            .unwrap_or_else(|| service_id.to_string()),
+        Some(service)
+            if matches!(
+                service.cluster_role.as_deref(),
+                Some("edge") | Some("replica") | Some("internal")
+            ) =>
+        {
+            service
+                .parent_service_id
+                .clone()
+                .unwrap_or_else(|| service_id.to_string())
+        }
         _ => service_id.to_string(),
     }
 }
@@ -609,5 +622,28 @@ mod tests {
         };
         let config = config_with(vec![("edge", orphan)]);
         assert_eq!(resolve_root_service_id(&config, "edge"), "edge");
+    }
+
+    #[test]
+    fn resolve_root_service_id_follows_a_replica_or_coordinator_to_its_parent() {
+        // `--service` pointed at a REPLICA used to resolve to the replica
+        // itself. `ha revert` then prechecked the replica's own primariness,
+        // handed templateRevert the replica's id, and took a sweep snapshot
+        // in which the TRUE ROOT was just another deletable member.
+        let config = config_with(vec![
+            ("root", declared_root("PATRONI_ENABLED", true)),
+            ("replica-1", child_service("root", "replica")),
+            ("etcd-1", child_service("root", "internal")),
+            ("haproxy", child_service("root", "edge")),
+        ]);
+
+        for member in ["replica-1", "etcd-1", "haproxy"] {
+            assert_eq!(
+                resolve_root_service_id(&config, member),
+                "root",
+                "{member} did not resolve to the cluster root"
+            );
+        }
+        assert_eq!(resolve_root_service_id(&config, "root"), "root");
     }
 }

--- a/src/controllers/template_apply.rs
+++ b/src/controllers/template_apply.rs
@@ -157,6 +157,35 @@ pub async fn fetch_adoption_rules(
         .unwrap_or_default())
 }
 
+/// The image repositories the companion's own slots run -- the evidence
+/// `ha revert` uses to tell ITS cluster's debris apart from every other
+/// service in the environment. See
+/// [`adoption_eligibility::companion_image_repositories`].
+///
+/// Best-effort: a failed fetch returns an empty list rather than an error,
+/// because revert must still tear the cluster down. The caller narrows what
+/// it will delete instead of widening it.
+pub async fn fetch_companion_image_repositories(
+    ctx: &ServiceContext,
+    template_code: &str,
+) -> Vec<String> {
+    let detail = post_graphql::<queries::TemplateDetail, _>(
+        &ctx.client,
+        ctx.configs.get_backboard(),
+        queries::template_detail::Variables {
+            code: template_code.to_string(),
+        },
+    )
+    .await;
+
+    detail
+        .ok()
+        .and_then(|detail| detail.template.serialized_config)
+        .as_ref()
+        .map(adoption_eligibility::companion_image_repositories)
+        .unwrap_or_default()
+}
+
 /// Fetches a template by code, adjusts its `serializedConfig` for the
 /// requested replica/internal/edge counts and edge-variable overrides, then
 /// deploys it onto `params.service_id` as the existing cluster root.

--- a/src/gql/mutations/strings/VolumeCreate.graphql
+++ b/src/gql/mutations/strings/VolumeCreate.graphql
@@ -1,4 +1,4 @@
-mutation VolumeCreate($projectId: String!, $environmentId: String!, $serviceId: String!, $mountPath: String!) {
+mutation VolumeCreate($projectId: String!, $environmentId: String, $serviceId: String!, $mountPath: String!) {
   volumeCreate(
     input: {projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId, mountPath: $mountPath}
   ) {


### PR DESCRIPTION
Follow-up to #1143, which is merged and released as v5.46.0. An adversarial audit of that PR's content found five defects that are live in the released CLI. Each is independently reachable; they are grouped here because they were found in one pass over the same feature.

## Redis/MySQL scale restamps consensus quorum on the whole fleet

`restamp_replica_wiring` wrote `quorumVariable` to the root **and every replica**, while the peer-list block directly above it stamped joining nodes only and carried a comment explaining why.

A running node reads that env exactly once, on the first boot that writes its coordinator config, and never again — so the edit changed nothing functionally, while still marking every node stale. That is a simultaneous fleet-wide restart, racing the coordinator into a spurious failover mid-scale. And on a real cluster the survivors' copy is a *reference* to the root's (`${{Redis-1.SENTINEL_QUORUM}}`), so overwriting it with a literal was not even a no-op edit — it detached them from the root's value.

Now stamped on joining nodes only, matching `useScaleHACluster.tsx`. A scale-down stamps nothing at all: survivors converge through the image's own quorum-sync watcher as removed nodes drop out. The per-replica identity variable moves to joining-nodes-only for the same reason — a replica's identity is its own name, which a scale never changes.

The routing edge's data-node list stays fleet-wide. It is read per connection, not once at boot.

## `ha revert`'s debris sweep was environment-wide and engine-blind

The sweep deleted **any** parentless, role-stamped service in the environment. In a mixed environment, reverting a Redis cluster deleted the Postgres cluster's live-scaled replicas — a `clusterRole` stamp was the only thing standing between an unrelated service and deletion.

The orphan scan is now scoped to services running an image the engine's own companion publishes, read off the companion record. Each companion publishes under its own prefix (`postgres-ha/*`, `redis-ha/*`, `mysql-ha/*`), which is the surviving evidence of which companion built a service once the parent link is gone — read from the record, so a template that adds a sidecar the CLI has never heard of stays covered.

An unreadable record skips the debris scan and warns, rather than widening it to everything: the snapshot members are the part that is still provable. The resume path also now names the services it is about to delete instead of only counting them — it deletes services the user never listed, on evidence they cannot see.

The pooler exclusion is unchanged and still needed on the snapshot path, where the pooler is a genuine child of the root.

## CLI-scaled replica volumes bypassed primary-size matching

The volume instance was provisioned by `volumeCreate` directly, ahead of the patch that stamps the node's `clusterRole`/`parentServiceId` — the exact pair backboard's `resolveNewVolumeInstanceSizeMB` keys on to size a replica volume to hold a full base backup of its primary. Created before either existed, it read as an ordinary volume and landed on the flat plan default, reintroducing the undersized-replica-volume class for CLI scaling.

The record is now created bare (`environmentId: null`) and the instance is staged in the same patch as the role and parent — the split `useScaleHACluster` already uses. It also drops a patch-system redeploy per volume.

## Tag parsing diverged from the server, producing false refusals

The CLI required a tag component to be numeric end to end; the server's `extractImageTagVersion` reads the leading `major[.minor]` and ignores everything past it.

| tag | server | CLI (before) |
|---|---|---|
| `redis:8.2-alpine` | 8.2 | major 8, **no minor** |
| `redis:7-bookworm` | major 7 | **no version at all** |

Both were refused by a CLI pre-flight for conversions the server would have accepted. Now mirrors the server. The test that codified the old parse is corrected rather than kept.

## `--service` pointed at a replica stood in for the root

`resolve_root_service_id` hopped only `edge` to its parent, so a replica resolved to itself. `ha revert` then prechecked the *replica's* primariness, handed `templateRevert` the replica's id (whose resolver does no root validation), and took a sweep snapshot in which the true root was just another deletable member. Every member role now hops. Preexisting, and inherited by all three engines when the tree was generalized.

## Not fixed here

The mono-side root cause that feeds the orphan population above: the patch path drops `parentServiceId`. `packages/backboard/src/temporal/workflows/environments/activities/service.ts` applies `clusterRole` for an existing instance on its update branch but has no equivalent block for the parent link, and `serviceCreate(environmentId)` pre-creates the instance so the create branch (which does set it) never runs for live scale-ups. CLI and dashboard are both affected; the dashboard compensates through canvas groups, which the public API cannot stamp. Separate repo, separate PR.

## Verification

- `cargo test` — 1310 pass. New coverage: joining-nodes-only restamp on scale-up and the no-op scale-down, a Redis revert leaving a Postgres cluster untouched, the unreadable-companion degrade, every member role resolving to its root, the companion-repository reader (exact match, not prefix), and an end-to-end scale against a stub backboard asserting the volume is staged rather than pre-provisioned and that survivors go unstamped.
- Each fix was re-reverted individually to confirm its own test fails without it — none of these pass against the old behavior.
- `cargo clippy --all-targets` and `cargo fmt --check` clean; no new warnings in any touched file.
- The three companion records (`postgres-ha`, `redis-ha`, `mysql-ha`) were read from the live API to confirm the per-companion repository prefixes the sweep scope relies on, rather than assumed.
