### PR TITLE
fix(database): read suffixed image tags the way the server-side gate does

### DIFF
--- a/src/controllers/adoption_eligibility.rs
+++ b/src/controllers/adoption_eligibility.rs
@@ -448,6 +448,38 @@ mod tests {
     }
 
     #[test]
+    fn suffixed_tags_are_read_the_way_the_server_side_gate_reads_them() {
+        // The platform's gate parses the LEADING major.minor of a tag and
+        // ignores the variant suffix, so the pre-flight must too -- refusing
+        // `redis:8.2-alpine` for "declaring only a major" blocked a
+        // conversion the backend accepts (and pins to 8.2).
+        let rules = rules_from_template(&json!({
+            "services": {
+                "root": {
+                    "clusterRole": "root",
+                    "haConversionConfig": {
+                        "supportedImageMajorVersions": [7, 8],
+                        "pinToMinorVersion": true
+                    }
+                }
+            }
+        }));
+        assert!(
+            rules
+                .blockers(&target("redis:8.2-alpine", false))
+                .is_empty()
+        );
+
+        // A suffixed BARE major still declares no minor: refused with the
+        // retag remedy naming its actual major, not a "no version can be
+        // read" dead end.
+        let blockers = rules.blockers(&target("redis:7-bookworm", false));
+        assert_eq!(blockers.len(), 1);
+        assert!(blockers[0].contains("declares only a major"));
+        assert!(blockers[0].contains("\":7.2\""));
+    }
+
+    #[test]
     fn mysql_ha_conversion_declares_its_own_majors() {
         let rules = rules_from_template(&json!({
             "services": {

--- a/src/controllers/database_engines.rs
+++ b/src/controllers/database_engines.rs
@@ -228,11 +228,21 @@ pub struct ImageTagVersion {
 
 pub fn image_tag_version(image: Option<&str>) -> Option<ImageTagVersion> {
     let tag = parse_image_ref(image?)?.tag?;
-    let mut parts = tag.split('.');
-    let major: i64 = parts.next()?.parse().ok()?;
-    // Only a purely numeric second component is a minor: `8.2` is, the `2-alpine`
-    // of `8.2-alpine` is not.
-    let minor = parts.next().and_then(|part| part.parse::<i64>().ok());
+    // Mirror the platform's own parse (`extractImageTagVersion`, regex
+    // `^(\d+)(?:\.(\d+))?`): the LEADING `major` or `major.minor` run of the
+    // tag, ignoring whatever follows it -- `8.2-alpine` declares minor 2, and
+    // `7-bookworm` declares major 7. These checks pre-flight the server-side
+    // gate, so reading a suffixed tag more strictly than the gate does turns
+    // the pre-flight into a false blocker for images the platform accepts.
+    fn leading_number(s: &str) -> Option<(i64, &str)> {
+        let end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
+        s[..end].parse::<i64>().ok().map(|n| (n, &s[end..]))
+    }
+    let (major, rest) = leading_number(&tag)?;
+    let minor = rest
+        .strip_prefix('.')
+        .and_then(leading_number)
+        .map(|(minor, _)| minor);
     Some(ImageTagVersion { major, minor })
 }
 
@@ -286,12 +296,30 @@ mod tests {
         assert_eq!(v.major, 16);
         assert_eq!(v.minor, None);
 
-        // A suffixed tag carries a major but no readable minor.
+        // Suffixed tags declare exactly what their leading digits say, the
+        // way the platform's own gate parses them: `8.2-alpine` IS pinned to
+        // 8.2, `7-bookworm` declares major 7 and no minor, `7.2.4-debian`
+        // declares 7.2. Reading these more strictly than the server-side
+        // gate turned the pre-flight into a false blocker (a `redis:8.2-alpine`
+        // conversion was refused for "declaring only a major").
         let v = image_tag_version(Some("redis:8.2-alpine")).unwrap();
+        assert_eq!(v.major, 8);
+        assert_eq!(v.minor, Some(2));
+        let v = image_tag_version(Some("redis:7-bookworm")).unwrap();
+        assert_eq!(v.major, 7);
+        assert_eq!(v.minor, None);
+        let v = image_tag_version(Some("bitnami/redis:7.2.4-debian")).unwrap();
+        assert_eq!(v.major, 7);
+        assert_eq!(v.minor, Some(2));
+        // A trailing dot with no digits after it is a bare major, not a
+        // parse error.
+        let v = image_tag_version(Some("redis:8.")).unwrap();
         assert_eq!(v.major, 8);
         assert_eq!(v.minor, None);
 
         assert!(image_tag_version(Some("ghcr.io/x/y:latest")).is_none());
+        // A non-digit LEAD is not a version at all, mirroring the platform.
+        assert!(image_tag_version(Some("ghcr.io/x/y:v8")).is_none());
         assert!(image_tag_version(Some("ghcr.io/x/y")).is_none());
         // A digest is not a version: `sha256:23a8...` must never read as 23.
         assert!(image_tag_version(Some("ghcr.io/x/y@sha256:23a8ff")).is_none());


### PR DESCRIPTION
Follow-up to #1143 (same audit as #1160/#1161).

`image_tag_version` required purely numeric tag components; the platform's gate (`extractImageTagVersion` in backboard, regex `^(\d+)(?:\.(\d+))?`) parses the **leading** `major.minor` run and ignores the variant suffix. Since these checks pre-flight that gate, the stricter parse turned the pre-flight into a false blocker:

- `redis:8.2-alpine` read as "declares only a major" and was refused for a `pinToMinorVersion` conversion the backend accepts (and pins to 8.2).
- `redis:7-bookworm` read as carrying no version at all — refused with "no version can be read" and a spurious supported-majors complaint, instead of the accurate "declares only a major" with the retag remedy. Bookworm-suffixed tags are what the frozen pre-rebase redis sub-fleet still runs, and conversion is its patch path.

Now parsed identically to the platform: leading digits are the major, a following `.digits` run is the minor, anything after is ignored, and a non-digit lead is no version at all.

## Verification

`cargo test` — 1304 pass, with new coverage pinning `8.2-alpine` / `7-bookworm` / `7.2.4-debian` at both layers: the parser itself, and the conversion pre-flight's verdicts (accepted; refused with the retag remedy). `cargo clippy` / `cargo fmt` clean.