### PR TITLE
feat(variable): bulk-edit variables in $EDITOR with a reviewed diff

### DIFF
--- a/src/commands/variable.rs
+++ b/src/commands/variable.rs
@@ -2,21 +2,28 @@ use super::*;
 use crate::{
     controllers::{
         project::resolve_service_context,
-        variables::{Variable, get_service_variables, get_service_variables_including_sealed},
+        variable_edit::{
+            VarChange, applyable_changes, demo_snapshot, diff_edit_snapshot, open_in_editor,
+            parse_edit_document, print_variable_plan, temp_edit_path, write_edit_document,
+        },
+        variables::{
+            EditSnapshot, SEALED_TOKEN, Variable, get_service_variables,
+            get_service_variables_for_edit, get_service_variables_including_sealed,
+            reject_reserved_keys,
+        },
     },
     table::Table,
-    util::progress::create_spinner_if,
+    util::{progress::create_spinner_if, prompt::prompt_confirm_with_default},
 };
-use anyhow::bail;
+use anyhow::{Context, bail};
+use std::collections::BTreeMap;
+use std::fs;
 use std::io::{IsTerminal, Read};
-
-/// Stand-in shown in the variables table for a sealed variable's value.
-const SEALED_PLACEHOLDER: &str = "<sealed>";
 
 /// Manage environment variables for a service
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway variable list --service api --json\n  railway variable list --service api --kv\n  railway variable set API_URL=https://example.com --skip-deploys --json\n  echo \"secret\" | railway variable set API_KEY --stdin --skip-deploys --json\n  railway variable delete API_KEY --service api --json\n\nAutomation notes:\n  JSON and KV output include raw variable values. Avoid sharing command output from secret-bearing variable commands.\n  For idempotent deletes, list variables first, check whether the key exists, then delete it.\n  Sealed variables are listed by name with no value (null in JSON, <sealed> in the table). They are already set and nobody can read them back - do not recreate them."
+    after_help = "Examples:\n\n  railway variable list --service api --json\n  railway variable list --service api --kv\n  railway variable set API_URL=https://example.com --skip-deploys --json\n  echo \"secret\" | railway variable set API_KEY --stdin --skip-deploys --json\n  railway variable delete API_KEY --service api --json\n  railway variable edit\n  railway variable edit --demo\n\nAutomation notes:\n  JSON and KV output include raw variable values. Avoid sharing command output from secret-bearing variable commands.\n  For idempotent deletes, list variables first, check whether the key exists, then delete it.\n  Sealed variables are listed by name with no value (null in JSON, <sealed> in the table). They are already set and nobody can read them back - do not recreate them.\n  `variable edit` opens $EDITOR, then shows an IaC-style diff and asks for confirmation before applying."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -68,6 +75,9 @@ enum Commands {
     /// Delete a variable
     #[clap(visible_alias = "rm", visible_alias = "remove")]
     Delete(DeleteArgs),
+
+    /// Bulk-edit variables in $EDITOR, then confirm an IaC-style diff
+    Edit(EditArgs),
 }
 
 #[derive(Parser)]
@@ -146,12 +156,48 @@ struct DeleteArgs {
     json: bool,
 }
 
+#[derive(Parser)]
+struct EditArgs {
+    /// The service to edit variables for
+    #[clap(short, long)]
+    service: Option<String>,
+
+    /// The environment to edit variables in
+    #[clap(short, long)]
+    environment: Option<String>,
+
+    /// Project ID to use (defaults to linked project)
+    #[clap(short = 'p', long, value_name = "PROJECT_ID")]
+    project: Option<String>,
+
+    /// Skip the confirmation prompt and apply the diff
+    #[clap(short = 'y', long)]
+    yes: bool,
+
+    /// Skip triggering deploys when applying variable changes
+    #[clap(long)]
+    skip_deploys: bool,
+
+    /// Show plaintext values in the diff instead of redacting them
+    #[clap(long)]
+    reveal: bool,
+
+    /// Offline prototype: edit fixture variables and print the would-be apply (no API)
+    #[clap(long)]
+    demo: bool,
+
+    /// Allow destructive deletes in non-interactive or agent sessions
+    #[clap(long)]
+    confirm_destructive: bool,
+}
+
 pub async fn command(args: Args) -> Result<()> {
     if let Some(cmd) = args.command {
         return match cmd {
             Commands::List(list_args) => list_variables(list_args).await,
             Commands::Set(set_args) => set_variable(set_args).await,
             Commands::Delete(delete_args) => delete_variable(delete_args).await,
+            Commands::Edit(edit_args) => edit_variables(edit_args).await,
         };
     }
 
@@ -232,7 +278,7 @@ async fn list_variables(args: ListArgs) -> Result<()> {
 
     let rows = variables
         .into_iter()
-        .map(|(key, value)| (key, value.unwrap_or_else(|| SEALED_PLACEHOLDER.to_string())))
+        .map(|(key, value)| (key, value.unwrap_or_else(|| SEALED_TOKEN.to_string())))
         .collect();
 
     let table = Table::new(ctx.service_name, rows);
@@ -375,6 +421,273 @@ async fn set_variables_internal(
         }
     } else {
         println!("{}", serde_json::json!({"keys": keys, "set": true}));
+    }
+
+    Ok(())
+}
+
+async fn edit_variables(args: EditArgs) -> Result<()> {
+    if args.demo {
+        return edit_variables_demo(args).await;
+    }
+
+    let yes = args.yes;
+    let reveal = args.reveal;
+    let skip_deploys = args.skip_deploys;
+    let confirm_destructive = args.confirm_destructive;
+
+    let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
+    let before = get_service_variables_for_edit(
+        &ctx.client,
+        &ctx.configs,
+        ctx.project.id.clone(),
+        ctx.environment_id.clone(),
+        ctx.service_id.clone(),
+    )
+    .await?;
+
+    let scope = format!(
+        "project={}  environment={}  service={}",
+        ctx.project.name, ctx.environment_name, ctx.service_name
+    );
+    let after = run_editor_loop(
+        &before,
+        &ctx.service_name,
+        &[
+            "railway variable edit",
+            scope.as_str(),
+            "Save and quit to review a diff. Abort the editor (non-zero exit) to cancel.",
+            "Delete a line to remove a variable. Leave sealed variables as <sealed> unless rotating.",
+            "Railway-provided variables are listed as comments and cannot be edited.",
+        ],
+    )?;
+
+    let changes = diff_edit_snapshot(&before, &after);
+    if changes.is_empty() {
+        print_variable_plan(&ctx.service_name, &changes, reveal);
+        return Ok(());
+    }
+
+    // Reject unapplyable edits before showing a plan the user cannot act on.
+    reject_reserved_keys(&changes)?;
+    let (upserts, deletes) = applyable_changes(&before, &changes)?;
+
+    print_variable_plan(&ctx.service_name, &changes, reveal);
+    guard_destructive_apply(yes, confirm_destructive, &changes)?;
+
+    let apply_args = EditApplyArgs { yes, skip_deploys };
+    if !confirm_variable_plan(&changes, &apply_args)? {
+        bail!("No changes applied.");
+    }
+
+    apply_variable_changes(&ctx, upserts, deletes, changes.len(), skip_deploys, false).await?;
+
+    Ok(())
+}
+
+async fn edit_variables_demo(args: EditArgs) -> Result<()> {
+    let service = args.service.as_deref().unwrap_or("api");
+    let yes = args.yes;
+    let reveal = args.reveal;
+    let skip_deploys = args.skip_deploys;
+    let confirm_destructive = args.confirm_destructive;
+    let before = demo_snapshot();
+
+    eprintln!(
+        "{}",
+        "Demo mode — offline fixture, nothing will be written to Railway.".dimmed()
+    );
+
+    let after = run_editor_loop(
+        &before,
+        service,
+        &[
+            "railway variable edit --demo",
+            "project=demo  environment=production  service=api",
+            "Save and quit to review a diff. Abort the editor (non-zero exit) to cancel.",
+            "Try: change LOG_LEVEL, add FEATURE_NEW=1, delete FEATURE_OLD, rotate STRIPE_SECRET_KEY",
+        ],
+    )?;
+
+    let changes = diff_edit_snapshot(&before, &after);
+    if changes.is_empty() {
+        print_variable_plan(service, &changes, reveal);
+        return Ok(());
+    }
+
+    reject_reserved_keys(&changes)?;
+    let (upserts, deletes) = applyable_changes(&before, &changes)?;
+
+    print_variable_plan(service, &changes, reveal);
+    guard_destructive_apply(yes, confirm_destructive, &changes)?;
+
+    let apply_args = EditApplyArgs { yes, skip_deploys };
+    if !confirm_variable_plan(&changes, &apply_args)? {
+        bail!("No changes applied.");
+    }
+
+    println!();
+    println!("{}", "Would apply (demo — skipped):".bold());
+    for key in upserts.keys() {
+        println!("  • set {}", key.cyan());
+    }
+    for key in &deletes {
+        println!("  • delete {}", key.cyan());
+    }
+    if skip_deploys {
+        println!("{}", "  (deploys would be skipped)".dimmed());
+    } else {
+        println!("{}", "  (would trigger a redeploy)".dimmed());
+    }
+
+    Ok(())
+}
+
+fn run_editor_loop(
+    before: &EditSnapshot,
+    service: &str,
+    header_lines: &[&str],
+) -> Result<BTreeMap<String, crate::controllers::variables::EditVariableEntry>> {
+    if !std::io::stdin().is_terminal()
+        && std::env::var_os("EDITOR").is_none()
+        && std::env::var_os("VISUAL").is_none()
+    {
+        bail!(
+            "variable edit requires a TTY (or set $EDITOR). For an offline taste:\n  EDITOR=vim railway variable edit --demo"
+        );
+    }
+
+    let path = temp_edit_path(service);
+    write_edit_document(&path, before, header_lines)?;
+
+    eprintln!(
+        "{} {}",
+        "Editing".dimmed(),
+        path.display().to_string().cyan()
+    );
+    eprintln!(
+        "{}",
+        "Opening $EDITOR — save and quit to continue, abort to cancel.".dimmed()
+    );
+
+    let edit_result = open_in_editor(&path);
+    let contents = fs::read_to_string(&path).ok();
+    let _ = fs::remove_file(&path);
+    edit_result?;
+
+    let contents = contents.context("Failed to read edited variables file")?;
+    parse_edit_document(&contents)
+}
+
+struct EditApplyArgs {
+    yes: bool,
+    skip_deploys: bool,
+}
+
+fn guard_destructive_apply(
+    yes: bool,
+    confirm_destructive: bool,
+    changes: &[VarChange],
+) -> Result<()> {
+    let destructive = changes.iter().any(|c| c.is_destructive());
+    if !destructive || confirm_destructive {
+        return Ok(());
+    }
+
+    if yes || !std::io::stdout().is_terminal() || crate::telemetry::is_agent() {
+        bail!(
+            "Destructive variable deletes require explicit confirmation. Review the plan, then re-run with `--confirm-destructive` if the removals are expected."
+        );
+    }
+
+    Ok(())
+}
+
+fn confirm_variable_plan(changes: &[VarChange], args: &EditApplyArgs) -> Result<bool> {
+    if args.yes {
+        return Ok(true);
+    }
+
+    if !std::io::stdout().is_terminal() {
+        bail!(
+            "Cannot prompt for confirmation in non-interactive mode. Re-run with --yes after reviewing the plan."
+        );
+    }
+
+    println!();
+    let destructive = changes.iter().any(|c| c.is_destructive());
+    let prompt = if destructive {
+        if args.skip_deploys {
+            "Apply these changes? This will remove variables."
+        } else {
+            "Apply these changes? This will remove variables and may redeploy."
+        }
+    } else if args.skip_deploys {
+        "Apply these variable changes?"
+    } else {
+        "Apply these variable changes? This may redeploy the service."
+    };
+
+    // Default No — :wq alone is not enough.
+    prompt_confirm_with_default(prompt, false)
+}
+
+async fn apply_variable_changes(
+    ctx: &crate::controllers::project::ServiceContext,
+    upserts: BTreeMap<String, String>,
+    deletes: Vec<String>,
+    change_count: usize,
+    skip_deploys: bool,
+    json: bool,
+) -> Result<()> {
+    let touched_keys: Vec<String> = upserts.keys().cloned().chain(deletes.clone()).collect();
+
+    let spinner = create_spinner_if(!json, "Applying variable changes...".to_string());
+
+    if !upserts.is_empty() {
+        let vars = mutations::variable_collection_upsert::Variables {
+            project_id: ctx.project_id.clone(),
+            environment_id: ctx.environment_id.clone(),
+            service_id: ctx.service_id.clone(),
+            variables: upserts,
+            skip_deploys: skip_deploys.then_some(true),
+        };
+        post_graphql::<mutations::VariableCollectionUpsert, _>(
+            &ctx.client,
+            ctx.configs.get_backboard(),
+            vars,
+        )
+        .await?;
+    }
+
+    for key in &deletes {
+        let vars = mutations::variable_delete::Variables {
+            project_id: ctx.project_id.clone(),
+            environment_id: ctx.environment_id.clone(),
+            name: key.clone(),
+            service_id: Some(ctx.service_id.clone()),
+        };
+        post_graphql::<mutations::VariableDelete, _>(
+            &ctx.client,
+            ctx.configs.get_backboard(),
+            vars,
+        )
+        .await?;
+    }
+
+    if let Some(sp) = spinner {
+        sp.finish_with_message(format!(
+            "Applied {} variable change(s)",
+            change_count.to_string().bold()
+        ));
+    } else {
+        println!(
+            "{}",
+            serde_json::json!({
+                "applied": change_count,
+                "keys": touched_keys,
+            })
+        );
     }
 
     Ok(())

--- a/src/commands/variable.rs
+++ b/src/commands/variable.rs
@@ -3,21 +3,21 @@ use crate::{
     controllers::{
         project::resolve_service_context,
         variable_edit::{
-            VarChange, applyable_changes, demo_snapshot, diff_edit_snapshot, open_in_editor,
-            parse_edit_document, print_variable_plan, temp_edit_path, write_edit_document,
+            VarChange, applyable_changes, demo_snapshot, diff_edit_snapshot, edit_file_and_cleanup,
+            parse_edit_document, print_variable_plan, require_confirm_destructive, temp_edit_path,
+            write_edit_document,
         },
         variables::{
-            EditSnapshot, SEALED_TOKEN, Variable, get_service_variables,
-            get_service_variables_for_edit, get_service_variables_including_sealed,
-            reject_reserved_keys,
+            EditSnapshot, SEALED_TOKEN, Variable, apply_service_variable_changes,
+            get_service_variables, get_service_variables_for_edit,
+            get_service_variables_including_sealed, reject_reserved_keys,
         },
     },
     table::Table,
     util::{progress::create_spinner_if, prompt::prompt_confirm_with_default},
 };
-use anyhow::{Context, bail};
+use anyhow::bail;
 use std::collections::BTreeMap;
-use std::fs;
 use std::io::{IsTerminal, Read};
 
 /// Manage environment variables for a service
@@ -570,13 +570,7 @@ fn run_editor_loop(
         "Opening $EDITOR — save and quit to continue, abort to cancel.".dimmed()
     );
 
-    let edit_result = open_in_editor(&path);
-    let contents = fs::read_to_string(&path).ok();
-    let _ = fs::remove_file(&path);
-    edit_result?;
-
-    let contents = contents.context("Failed to read edited variables file")?;
-    parse_edit_document(&contents)
+    parse_edit_document(&edit_file_and_cleanup(&path)?)
 }
 
 struct EditApplyArgs {
@@ -589,18 +583,11 @@ fn guard_destructive_apply(
     confirm_destructive: bool,
     changes: &[VarChange],
 ) -> Result<()> {
-    let destructive = changes.iter().any(|c| c.is_destructive());
-    if !destructive || confirm_destructive {
-        return Ok(());
-    }
-
-    if yes || !std::io::stdout().is_terminal() || crate::telemetry::is_agent() {
-        bail!(
-            "Destructive variable deletes require explicit confirmation. Review the plan, then re-run with `--confirm-destructive` if the removals are expected."
-        );
-    }
-
-    Ok(())
+    require_confirm_destructive(
+        confirm_destructive,
+        yes || !std::io::stdout().is_terminal() || crate::telemetry::is_agent(),
+        changes,
+    )
 }
 
 fn confirm_variable_plan(changes: &[VarChange], args: &EditApplyArgs) -> Result<bool> {
@@ -644,36 +631,17 @@ async fn apply_variable_changes(
 
     let spinner = create_spinner_if(!json, "Applying variable changes...".to_string());
 
-    if !upserts.is_empty() {
-        let vars = mutations::variable_collection_upsert::Variables {
-            project_id: ctx.project_id.clone(),
-            environment_id: ctx.environment_id.clone(),
-            service_id: ctx.service_id.clone(),
-            variables: upserts,
-            skip_deploys: skip_deploys.then_some(true),
-        };
-        post_graphql::<mutations::VariableCollectionUpsert, _>(
-            &ctx.client,
-            ctx.configs.get_backboard(),
-            vars,
-        )
-        .await?;
-    }
-
-    for key in &deletes {
-        let vars = mutations::variable_delete::Variables {
-            project_id: ctx.project_id.clone(),
-            environment_id: ctx.environment_id.clone(),
-            name: key.clone(),
-            service_id: Some(ctx.service_id.clone()),
-        };
-        post_graphql::<mutations::VariableDelete, _>(
-            &ctx.client,
-            ctx.configs.get_backboard(),
-            vars,
-        )
-        .await?;
-    }
+    apply_service_variable_changes(
+        &ctx.client,
+        &ctx.configs,
+        ctx.project_id.clone(),
+        ctx.environment_id.clone(),
+        ctx.service_id.clone(),
+        upserts,
+        deletes,
+        skip_deploys,
+    )
+    .await?;
 
     if let Some(sp) = spinner {
         sp.finish_with_message(format!(

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -30,6 +30,7 @@ pub mod tcp_proxy;
 pub mod template_apply;
 pub mod upload;
 pub mod user;
+pub mod variable_edit;
 pub mod variables;
 pub mod volume_browser;
 pub mod workflow;

--- a/src/controllers/variable_edit.rs
+++ b/src/controllers/variable_edit.rs
@@ -1,0 +1,716 @@
+//! Bulk variable editing via `$EDITOR`, with an IaC-style diff confirm before apply.
+//!
+//! Flow: fetch unrendered user vars → write dotenv temp file → open editor → parse → diff → confirm → upsert/delete.
+
+use crate::controllers::variables::{
+    EditSnapshot, EditVariableEntry, SEALED_TOKEN, is_railway_reserved_key,
+};
+use anyhow::{Context, Result, bail};
+use colored::Colorize;
+use std::collections::BTreeMap;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const REDACTED: &str = "«hidden»";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VarChangeKind {
+    Set,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VarChange {
+    pub kind: VarChangeKind,
+    pub key: String,
+    pub before: Option<String>,
+    pub after: Option<String>,
+}
+
+impl VarChange {
+    pub fn is_destructive(&self) -> bool {
+        matches!(self.kind, VarChangeKind::Delete)
+    }
+
+    pub fn summary(&self, service: &str) -> String {
+        match self.kind {
+            VarChangeKind::Set => format!("Set variable {service}.{}", self.key),
+            VarChangeKind::Update => format!("Update variable {service}.{}", self.key),
+            VarChangeKind::Delete => format!("Delete variable {service}.{}", self.key),
+        }
+    }
+
+    pub fn detail(&self, service: &str, reveal: bool) -> String {
+        let before = format_value(self.before.as_deref(), reveal);
+        let after = format_value(self.after.as_deref(), reveal);
+        match self.kind {
+            VarChangeKind::Delete => format!("{service}.{} ({before} → ∅)", self.key),
+            _ => format!("{service}.{} ({before} → {after})", self.key),
+        }
+    }
+}
+
+fn format_value(value: Option<&str>, reveal: bool) -> String {
+    match value {
+        None => "∅".into(),
+        Some(SEALED_TOKEN) => SEALED_TOKEN.into(),
+        Some("") => "\"\"".into(),
+        Some(v) if reveal => truncate_for_display(v),
+        Some(_) => REDACTED.into(),
+    }
+}
+
+fn truncate_for_display(value: &str) -> String {
+    const MAX: usize = 64;
+    let flat = value.replace('\n', "\\n");
+    if flat.chars().count() <= MAX {
+        return flat;
+    }
+    let truncated: String = flat.chars().take(MAX).collect();
+    format!("{truncated}…")
+}
+
+/// Diff editable variables from `before` → parsed `after`.
+pub fn diff_edit_snapshot(
+    before: &EditSnapshot,
+    after: &BTreeMap<String, EditVariableEntry>,
+) -> Vec<VarChange> {
+    let before_values = editable_values(&before.editable);
+    let after_values = editable_values(after);
+    diff_variables(&before_values, &after_values)
+}
+
+/// Diff `before` → `after`. Keys only in `after` are sets; only in `before` are deletes;
+/// present in both with different values are updates. Order is stable (BTreeMap).
+pub fn diff_variables(
+    before: &BTreeMap<String, String>,
+    after: &BTreeMap<String, String>,
+) -> Vec<VarChange> {
+    let mut changes = Vec::new();
+
+    for (key, after_value) in after {
+        if is_railway_reserved_key(key) {
+            continue;
+        }
+        match before.get(key) {
+            None => changes.push(VarChange {
+                kind: VarChangeKind::Set,
+                key: key.clone(),
+                before: None,
+                after: Some(after_value.clone()),
+            }),
+            Some(before_value) if before_value != after_value => changes.push(VarChange {
+                kind: VarChangeKind::Update,
+                key: key.clone(),
+                before: Some(before_value.clone()),
+                after: Some(after_value.clone()),
+            }),
+            Some(_) => {}
+        }
+    }
+
+    for (key, before_value) in before {
+        if is_railway_reserved_key(key) {
+            continue;
+        }
+        if !after.contains_key(key) {
+            changes.push(VarChange {
+                kind: VarChangeKind::Delete,
+                key: key.clone(),
+                before: Some(before_value.clone()),
+                after: None,
+            });
+        }
+    }
+
+    changes
+}
+
+fn editable_values(editable: &BTreeMap<String, EditVariableEntry>) -> BTreeMap<String, String> {
+    editable
+        .iter()
+        .map(|(key, entry)| (key.clone(), entry.value.clone()))
+        .collect()
+}
+
+pub fn plan_summary_line(changes: &[VarChange]) -> String {
+    let mut add = 0;
+    let mut change = 0;
+    let mut destroy = 0;
+    for c in changes {
+        match c.kind {
+            VarChangeKind::Set => add += 1,
+            VarChangeKind::Update => change += 1,
+            VarChangeKind::Delete => destroy += 1,
+        }
+    }
+    format!(
+        "{} {}, {}, {}",
+        "Plan:".bold(),
+        format!("{add} to add").green(),
+        format!("{change} to change").yellow(),
+        format!("{destroy} to destroy").red(),
+    )
+}
+
+/// Render an IaC-flavoured variable plan to stdout.
+pub fn print_variable_plan(service: &str, changes: &[VarChange], reveal: bool) {
+    println!();
+    println!("{}", "Railway variables".bold());
+    println!("{} {}", "Service".dimmed(), service.cyan());
+    println!();
+
+    if changes.is_empty() {
+        println!("{}", "✓ No variable changes.".green());
+        return;
+    }
+
+    println!("{}", plan_summary_line(changes));
+    for change in changes {
+        let marker = match change.kind {
+            VarChangeKind::Set => "+".green().bold(),
+            VarChangeKind::Update => "~".yellow().bold(),
+            VarChangeKind::Delete => "-".red().bold(),
+        };
+        println!("  {} {}", marker, change.summary(service));
+        println!(
+            "    {} {}",
+            "└".dimmed(),
+            change.detail(service, reveal).dimmed()
+        );
+    }
+
+    let destructive = changes.iter().filter(|c| c.is_destructive()).count();
+    if destructive > 0 {
+        println!();
+        println!(
+            "{} {}",
+            "!".red().bold(),
+            format!("{destructive} destructive change(s) will remove variables.").red()
+        );
+    }
+}
+
+pub fn render_variable_plan_plain(service: &str, changes: &[VarChange], reveal: bool) -> String {
+    if changes.is_empty() {
+        return "No changes.".into();
+    }
+    changes
+        .iter()
+        .map(|change| {
+            let marker = match change.kind {
+                VarChangeKind::Set => "+",
+                VarChangeKind::Update => "~",
+                VarChangeKind::Delete => "-",
+            };
+            format!(
+                "{marker} {}\n    {}",
+                change.summary(service),
+                change.detail(service, reveal)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Serialize an edit snapshot as a dotenv document with a Railway header.
+pub fn write_edit_document(
+    path: &Path,
+    snapshot: &EditSnapshot,
+    header_lines: &[&str],
+) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("Failed to create temp file {}", path.display()))?;
+
+    for line in header_lines {
+        writeln!(file, "# {line}")?;
+    }
+    if !header_lines.is_empty() {
+        writeln!(file)?;
+    }
+
+    for (key, value) in &snapshot.read_only {
+        writeln!(file, "# {key}={}", escape_dotenv_value(value))?;
+    }
+    if !snapshot.read_only.is_empty() {
+        writeln!(file, "# (Railway-provided variables above are read-only)")?;
+        writeln!(file)?;
+    }
+
+    for (key, entry) in &snapshot.editable {
+        writeln!(file, "{}={}", key, escape_dotenv_value(&entry.value))?;
+    }
+
+    file.flush()?;
+    Ok(())
+}
+
+fn escape_dotenv_value(value: &str) -> String {
+    let needs_quotes = value.is_empty()
+        || value.contains([' ', '\t', '\n', '\r', '#', '"', '\'', '\\'])
+        || value.starts_with(['=', '#']);
+
+    if !needs_quotes {
+        return value.to_string();
+    }
+
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
+    format!("\"{escaped}\"")
+}
+
+/// Parse editable variables from a dotenv document produced/edited by `variable edit`.
+///
+/// Comment lines (including read-only Railway-provided variables) are ignored.
+pub fn parse_edit_document(contents: &str) -> Result<BTreeMap<String, EditVariableEntry>> {
+    let mut vars = BTreeMap::new();
+
+    for (idx, raw_line) in contents.lines().enumerate() {
+        let line_no = idx + 1;
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once('=') else {
+            bail!("Invalid dotenv on line {line_no}: expected KEY=VALUE, got {raw_line:?}");
+        };
+
+        let key = key.trim();
+        if key.is_empty() || key.chars().any(|c| c.is_whitespace()) {
+            bail!("Invalid variable name on line {line_no}: {key:?}");
+        }
+        if is_railway_reserved_key(key) {
+            bail!(
+                "Line {line_no}: `{key}` is a Railway-provided variable and cannot be edited here. Remove it from the editable section."
+            );
+        }
+
+        let value = unquote_dotenv_value(value.trim())
+            .with_context(|| format!("Invalid quoted value on line {line_no}"))?;
+
+        if vars
+            .insert(
+                key.to_string(),
+                EditVariableEntry {
+                    value,
+                    is_sealed: false,
+                },
+            )
+            .is_some()
+        {
+            bail!("Duplicate variable {key:?} on line {line_no}");
+        }
+    }
+
+    Ok(vars)
+}
+
+fn unquote_dotenv_value(value: &str) -> Result<String> {
+    if value.len() >= 2 {
+        let bytes = value.as_bytes();
+        if (bytes[0] == b'"' && bytes[value.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[value.len() - 1] == b'\'')
+        {
+            let inner = &value[1..value.len() - 1];
+            if bytes[0] == b'\'' {
+                return Ok(inner.to_string());
+            }
+            return Ok(unescape_double_quoted(inner));
+        }
+    }
+    Ok(value.to_string())
+}
+
+fn unescape_double_quoted(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('r') => out.push('\r'),
+                Some('t') => out.push('\t'),
+                Some('\\') => out.push('\\'),
+                Some('"') => out.push('"'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+pub fn resolve_editor() -> Result<String> {
+    for key in ["VISUAL", "EDITOR"] {
+        if let Ok(value) = std::env::var(key) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+    }
+
+    for fallback in ["nano", "vim", "vi"] {
+        if which_exists(fallback) {
+            return Ok(fallback.to_string());
+        }
+    }
+
+    bail!("No editor found. Set $VISUAL or $EDITOR, e.g.:\n  EDITOR=vim railway variable edit")
+}
+
+fn which_exists(bin: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|dir| {
+                let candidate = dir.join(bin);
+                candidate.is_file()
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Open `path` in `$VISUAL` / `$EDITOR`. Non-zero exit aborts the edit.
+pub fn open_in_editor(path: &Path) -> Result<()> {
+    let editor = resolve_editor()?;
+    let parts = shlex::split(&editor)
+        .with_context(|| format!("Failed to parse editor command: {editor:?}"))?;
+    if parts.is_empty() {
+        bail!("Editor command is empty");
+    }
+
+    let status = Command::new(&parts[0])
+        .args(&parts[1..])
+        .arg(path)
+        .status()
+        .with_context(|| format!("Failed to launch editor `{editor}`"))?;
+
+    if !status.success() {
+        bail!("Editor exited with {status} — no changes applied");
+    }
+    Ok(())
+}
+
+pub fn temp_edit_path(service: &str) -> PathBuf {
+    let safe: String = service
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    std::env::temp_dir().join(format!(
+        "railway-vars-{}-{}-{}.env",
+        safe,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0)
+    ))
+}
+
+/// Build apply-ready upserts/deletes from a diff.
+///
+/// A sealed variable the user left alone never reaches here: its before and after
+/// are both [`SEALED_TOKEN`], so the diff reports no change and the stored ciphertext
+/// is untouched. That makes `<sealed>` in an `after` value unambiguous — the user typed
+/// it by hand on a variable that is not sealed, which we cannot honour either way.
+pub fn applyable_changes(
+    before: &EditSnapshot,
+    changes: &[VarChange],
+) -> Result<(BTreeMap<String, String>, Vec<String>)> {
+    let mut upserts = BTreeMap::new();
+    let mut deletes = Vec::new();
+
+    for change in changes {
+        match change.kind {
+            VarChangeKind::Set | VarChangeKind::Update => {
+                let after = change.after.clone().unwrap_or_default();
+                if after == SEALED_TOKEN {
+                    let sealed_before = before
+                        .editable
+                        .get(&change.key)
+                        .is_some_and(|entry| entry.is_sealed);
+                    if sealed_before {
+                        bail!(
+                            "`{}` is sealed and its value cannot be read back. Leave the line as `{SEALED_TOKEN}` to keep it, or set a new value to rotate it.",
+                            change.key
+                        );
+                    }
+                    bail!(
+                        "`{}` is not a sealed variable, so `{SEALED_TOKEN}` is not a value it can take. Set a real value or delete the line.",
+                        change.key
+                    );
+                }
+                upserts.insert(change.key.clone(), after);
+            }
+            VarChangeKind::Delete => deletes.push(change.key.clone()),
+        }
+    }
+
+    Ok((upserts, deletes))
+}
+
+/// Fixture used by `railway variable edit --demo`.
+pub fn demo_snapshot() -> EditSnapshot {
+    EditSnapshot {
+        editable: BTreeMap::from([
+            (
+                "DATABASE_URL".into(),
+                EditVariableEntry {
+                    value: "postgresql://postgres:password@postgres.railway.internal:5432/railway"
+                        .into(),
+                    is_sealed: false,
+                },
+            ),
+            (
+                "FEATURE_OLD".into(),
+                EditVariableEntry {
+                    value: "1".into(),
+                    is_sealed: false,
+                },
+            ),
+            (
+                "LOG_LEVEL".into(),
+                EditVariableEntry {
+                    value: "info".into(),
+                    is_sealed: false,
+                },
+            ),
+            (
+                "REDIS_URL".into(),
+                EditVariableEntry {
+                    value: "redis://redis.railway.internal:6379".into(),
+                    is_sealed: false,
+                },
+            ),
+            (
+                "STRIPE_SECRET_KEY".into(),
+                EditVariableEntry {
+                    value: SEALED_TOKEN.into(),
+                    is_sealed: true,
+                },
+            ),
+        ]),
+        read_only: BTreeMap::from([
+            ("RAILWAY_ENVIRONMENT_NAME".into(), "production".into()),
+            (
+                "RAILWAY_PRIVATE_DOMAIN".into(),
+                "api.railway.internal".into(),
+            ),
+            ("RAILWAY_PROJECT_NAME".into(), "demo".into()),
+            ("RAILWAY_SERVICE_NAME".into(), "api".into()),
+        ]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diffs_set_update_delete() {
+        let before = BTreeMap::from([
+            ("A".into(), "1".into()),
+            ("B".into(), "2".into()),
+            ("C".into(), "3".into()),
+        ]);
+        let after = BTreeMap::from([
+            ("A".into(), "1".into()),
+            ("B".into(), "changed".into()),
+            ("D".into(), "new".into()),
+        ]);
+        let changes = diff_variables(&before, &after);
+        assert_eq!(
+            changes
+                .iter()
+                .map(|c| (c.kind.clone(), c.key.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (VarChangeKind::Update, "B"),
+                (VarChangeKind::Set, "D"),
+                (VarChangeKind::Delete, "C"),
+            ]
+        );
+    }
+
+    #[test]
+    fn dotenv_round_trip_quotes_specials() {
+        let snapshot = EditSnapshot {
+            editable: BTreeMap::from([
+                (
+                    "PLAIN".into(),
+                    EditVariableEntry {
+                        value: "ok".into(),
+                        is_sealed: false,
+                    },
+                ),
+                (
+                    "EMPTY".into(),
+                    EditVariableEntry {
+                        value: "".into(),
+                        is_sealed: false,
+                    },
+                ),
+                (
+                    "SPACED".into(),
+                    EditVariableEntry {
+                        value: "hello world".into(),
+                        is_sealed: false,
+                    },
+                ),
+                (
+                    "HASH".into(),
+                    EditVariableEntry {
+                        value: "a#b".into(),
+                        is_sealed: false,
+                    },
+                ),
+                (
+                    "NL".into(),
+                    EditVariableEntry {
+                        value: "line1\nline2".into(),
+                        is_sealed: false,
+                    },
+                ),
+            ]),
+            read_only: BTreeMap::new(),
+        };
+        let path = temp_edit_path("test");
+        write_edit_document(&path, &snapshot, &["header"]).unwrap();
+        let parsed = parse_edit_document(&fs::read_to_string(&path).unwrap()).unwrap();
+        let _ = fs::remove_file(&path);
+        assert_eq!(
+            parsed
+                .into_iter()
+                .map(|(k, v)| (k, v.value))
+                .collect::<BTreeMap<_, _>>(),
+            editable_values(&snapshot.editable)
+        );
+    }
+
+    #[test]
+    fn read_only_railway_vars_are_comments_only() {
+        let snapshot = demo_snapshot();
+        let path = temp_edit_path("demo");
+        write_edit_document(&path, &snapshot, &["demo"]).unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        let _ = fs::remove_file(&path);
+
+        assert!(contents.contains("# RAILWAY_SERVICE_NAME=api"));
+        let parsed = parse_edit_document(&contents).unwrap();
+        assert!(!parsed.contains_key("RAILWAY_SERVICE_NAME"));
+        assert_eq!(parsed.get("STRIPE_SECRET_KEY").unwrap().value, SEALED_TOKEN);
+    }
+
+    #[test]
+    fn rejects_railway_keys_in_editable_section() {
+        let err = parse_edit_document("RAILWAY_FOO=bar\n").unwrap_err();
+        assert!(err.to_string().contains("Railway-provided"));
+    }
+
+    #[test]
+    fn sealed_preserve_skips_upsert() {
+        let before = demo_snapshot();
+        let after = before.clone();
+        let changes = diff_edit_snapshot(&before, &after.editable);
+        assert!(changes.is_empty());
+        let (upserts, deletes) = applyable_changes(&before, &changes).unwrap();
+        assert!(upserts.is_empty());
+        assert!(deletes.is_empty());
+    }
+
+    #[test]
+    fn sealed_rotate_emits_update() {
+        let before = demo_snapshot();
+        let mut after = before.editable.clone();
+        after.insert(
+            "STRIPE_SECRET_KEY".into(),
+            EditVariableEntry {
+                value: "sk_live_new".into(),
+                is_sealed: true,
+            },
+        );
+        let changes = diff_edit_snapshot(&before, &after);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].kind, VarChangeKind::Update);
+        let (upserts, _) = applyable_changes(&before, &changes).unwrap();
+        assert_eq!(
+            upserts.get("STRIPE_SECRET_KEY").map(String::as_str),
+            Some("sk_live_new")
+        );
+    }
+
+    #[test]
+    fn hand_typed_sealed_token_on_plain_variable_is_rejected() {
+        let before = demo_snapshot();
+        let mut after = before.editable.clone();
+        after.insert(
+            "LOG_LEVEL".into(),
+            EditVariableEntry {
+                value: SEALED_TOKEN.into(),
+                is_sealed: false,
+            },
+        );
+        let changes = diff_edit_snapshot(&before, &after);
+        let err = applyable_changes(&before, &changes).unwrap_err();
+        assert!(err.to_string().contains("not a sealed variable"));
+    }
+
+    #[test]
+    fn diff_ignores_railway_reserved_keys() {
+        let before = BTreeMap::from([("RAILWAY_FOO".into(), "a".into())]);
+        let after = BTreeMap::from([("RAILWAY_FOO".into(), "b".into())]);
+        assert!(diff_variables(&before, &after).is_empty());
+    }
+
+    #[test]
+    fn redacts_by_default_in_plain_render() {
+        let changes = vec![VarChange {
+            kind: VarChangeKind::Update,
+            key: "SECRET".into(),
+            before: Some("sk-before".into()),
+            after: Some("sk-after".into()),
+        }];
+        let rendered = render_variable_plan_plain("api", &changes, false);
+        assert!(rendered.contains(REDACTED));
+        assert!(!rendered.contains("sk-before"));
+        assert!(!rendered.contains("sk-after"));
+        assert!(rendered.contains("~ Update variable api.SECRET"));
+    }
+
+    #[test]
+    fn rejects_duplicate_keys() {
+        let err = parse_edit_document("A=1\nA=2\n").unwrap_err();
+        assert!(err.to_string().contains("Duplicate"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_edit_document_is_owner_readable_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let path = temp_edit_path("perms");
+        write_edit_document(&path, &demo_snapshot(), &["header"]).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        let _ = fs::remove_file(&path);
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/src/controllers/variable_edit.rs
+++ b/src/controllers/variable_edit.rs
@@ -411,6 +411,34 @@ pub fn open_in_editor(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Open `path` in the editor, always delete it afterwards, and return the
+/// contents if the editor exited 0. A non-zero editor exit still removes the
+/// file so plaintext values do not linger in `/tmp`.
+pub fn edit_file_and_cleanup(path: &Path) -> Result<String> {
+    let edit_result = open_in_editor(path);
+    let contents = fs::read_to_string(path).ok();
+    let _ = fs::remove_file(path);
+    edit_result?;
+    contents.context("Failed to read edited variables file")
+}
+
+/// Destructive deletes in `--yes` / non-interactive / agent sessions need an
+/// extra `--confirm-destructive`, matching `config apply`.
+pub fn require_confirm_destructive(
+    confirm_destructive: bool,
+    must_be_explicit: bool,
+    changes: &[VarChange],
+) -> Result<()> {
+    let destructive = changes.iter().any(|c| c.is_destructive());
+    if !destructive || confirm_destructive || !must_be_explicit {
+        return Ok(());
+    }
+
+    bail!(
+        "Destructive variable deletes require explicit confirmation. Review the plan, then re-run with `--confirm-destructive` if the removals are expected."
+    )
+}
+
 pub fn temp_edit_path(service: &str) -> PathBuf {
     let safe: String = service
         .chars()
@@ -676,6 +704,40 @@ mod tests {
     }
 
     #[test]
+    fn deleting_a_sealed_variable_emits_delete() {
+        let before = demo_snapshot();
+        let mut after = before.editable.clone();
+        after.remove("STRIPE_SECRET_KEY");
+        let changes = diff_edit_snapshot(&before, &after);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].kind, VarChangeKind::Delete);
+        let (upserts, deletes) = applyable_changes(&before, &changes).unwrap();
+        assert!(upserts.is_empty());
+        assert_eq!(deletes, vec!["STRIPE_SECRET_KEY".to_string()]);
+    }
+
+    #[test]
+    fn confirm_destructive_is_required_when_nobody_can_answer() {
+        let changes = vec![VarChange {
+            kind: VarChangeKind::Delete,
+            key: "FEATURE_OLD".into(),
+            before: Some("1".into()),
+            after: None,
+        }];
+        let err = require_confirm_destructive(false, true, &changes).unwrap_err();
+        assert!(err.to_string().contains("--confirm-destructive"));
+        assert!(require_confirm_destructive(true, true, &changes).is_ok());
+        assert!(require_confirm_destructive(false, false, &changes).is_ok());
+        let non_destructive = vec![VarChange {
+            kind: VarChangeKind::Update,
+            key: "LOG_LEVEL".into(),
+            before: Some("info".into()),
+            after: Some("debug".into()),
+        }];
+        assert!(require_confirm_destructive(false, true, &non_destructive).is_ok());
+    }
+
+    #[test]
     fn diff_ignores_railway_reserved_keys() {
         let before = BTreeMap::from([("RAILWAY_FOO".into(), "a".into())]);
         let after = BTreeMap::from([("RAILWAY_FOO".into(), "b".into())]);
@@ -712,5 +774,54 @@ mod tests {
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         let _ = fs::remove_file(&path);
         assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    fn with_editor<R>(editor: &str, f: impl FnOnce() -> R) -> R {
+        use std::sync::Mutex;
+        static EDITOR_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = EDITOR_LOCK.lock().unwrap();
+        let previous_editor = std::env::var("EDITOR").ok();
+        let previous_visual = std::env::var("VISUAL").ok();
+        // SAFETY: serialized under EDITOR_LOCK and restored before release.
+        unsafe {
+            std::env::set_var("EDITOR", editor);
+            std::env::remove_var("VISUAL");
+        }
+        let result = f();
+        unsafe {
+            match previous_editor {
+                Some(value) => std::env::set_var("EDITOR", value),
+                None => std::env::remove_var("EDITOR"),
+            }
+            match previous_visual {
+                Some(value) => std::env::set_var("VISUAL", value),
+                None => std::env::remove_var("VISUAL"),
+            }
+        }
+        result
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn editor_abort_deletes_the_temp_file() {
+        let path = temp_edit_path("abort");
+        write_edit_document(&path, &demo_snapshot(), &["abort"]).unwrap();
+        assert!(path.exists());
+        let err = with_editor("false", || edit_file_and_cleanup(&path)).unwrap_err();
+        assert!(err.to_string().contains("no changes applied"));
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn editor_success_returns_contents_and_deletes_the_temp_file() {
+        let path = temp_edit_path("ok");
+        write_edit_document(&path, &demo_snapshot(), &["ok"]).unwrap();
+        let contents = with_editor("true", || edit_file_and_cleanup(&path)).unwrap();
+        assert!(contents.contains("LOG_LEVEL=info"));
+        assert!(contents.contains(&format!("STRIPE_SECRET_KEY={SEALED_TOKEN}")));
+        assert!(contents.contains("# RAILWAY_SERVICE_NAME=api"));
+        assert!(!path.exists());
     }
 }

--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::post_graphql,
-    commands::{Configs, queries},
+    commands::{Configs, mutations, queries},
 };
 use anyhow::{Result, bail};
 use reqwest::Client;
@@ -153,6 +153,47 @@ pub async fn get_service_variables_for_edit(
     })
 }
 
+/// Upsert and/or delete user variables. Callers must have already filtered
+/// Railway-reserved keys and skipped sealed tokens that should be preserved.
+pub async fn apply_service_variable_changes(
+    client: &Client,
+    configs: &Configs,
+    project_id: String,
+    environment_id: String,
+    service_id: String,
+    upserts: BTreeMap<String, String>,
+    deletes: Vec<String>,
+    skip_deploys: bool,
+) -> Result<()> {
+    if !upserts.is_empty() {
+        let vars = mutations::variable_collection_upsert::Variables {
+            project_id: project_id.clone(),
+            environment_id: environment_id.clone(),
+            service_id: service_id.clone(),
+            variables: upserts,
+            skip_deploys: skip_deploys.then_some(true),
+        };
+        post_graphql::<mutations::VariableCollectionUpsert, _>(
+            client,
+            configs.get_backboard(),
+            vars,
+        )
+        .await?;
+    }
+
+    for name in deletes {
+        let vars = mutations::variable_delete::Variables {
+            project_id: project_id.clone(),
+            environment_id: environment_id.clone(),
+            name,
+            service_id: Some(service_id.clone()),
+        };
+        post_graphql::<mutations::VariableDelete, _>(client, configs.get_backboard(), vars).await?;
+    }
+
+    Ok(())
+}
+
 /// Reject apply attempts that touch Railway-reserved keys.
 pub fn reject_reserved_keys(
     changes: &[crate::controllers::variable_edit::VarChange],
@@ -299,5 +340,175 @@ mod sealed_variable_tests {
                 "postgres://user:pw@host:5432/db".to_string()
             )])
         );
+    }
+}
+
+#[cfg(test)]
+mod edit_snapshot_tests {
+    use super::*;
+    use crate::controllers::variable_edit::VarChange;
+    use crate::testkit::MockBackboard;
+    use serde_json::json;
+
+    fn edit_query_payload() -> serde_json::Value {
+        json!({
+            "userVariables": {
+                "DATABASE_URL": "postgres://user:pw@host:5432/db",
+                "LOG_LEVEL": "info",
+                "STRIPE_SECRET_KEY": null,
+                "RAILWAY_SERVICE_NAME": "api",
+            },
+            "deploymentVariables": {
+                "DATABASE_URL": "postgres://user:pw@host:5432/db",
+                "LOG_LEVEL": "info",
+                "STRIPE_SECRET_KEY": null,
+                "RAILWAY_SERVICE_NAME": "api",
+                "RAILWAY_PROJECT_NAME": "demo",
+            },
+            "environment": {
+                "variables": {
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "DATABASE_URL",
+                                "serviceId": "svc-1",
+                                "isSealed": false
+                            }
+                        },
+                        {
+                            "node": {
+                                "name": "LOG_LEVEL",
+                                "serviceId": "svc-1",
+                                "isSealed": false
+                            }
+                        },
+                        {
+                            "node": {
+                                "name": "STRIPE_SECRET_KEY",
+                                "serviceId": "svc-1",
+                                "isSealed": true
+                            }
+                        },
+                        {
+                            "node": {
+                                "name": "SHARED_SECRET",
+                                "serviceId": null,
+                                "isSealed": true
+                            }
+                        },
+                        {
+                            "node": {
+                                "name": "OTHER_SERVICE",
+                                "serviceId": "svc-other",
+                                "isSealed": true
+                            }
+                        }
+                    ]
+                }
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn fetch_maps_unrendered_user_vars_and_hides_railway_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("ServiceVariablesForEdit", edit_query_payload());
+
+        let snapshot = get_service_variables_for_edit(
+            &reqwest::Client::new(),
+            &server.configs(&dir),
+            "proj-1".to_string(),
+            "env-1".to_string(),
+            "svc-1".to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            snapshot
+                .editable
+                .get("DATABASE_URL")
+                .map(|e| e.value.as_str()),
+            Some("postgres://user:pw@host:5432/db")
+        );
+        assert!(!snapshot.editable["DATABASE_URL"].is_sealed);
+        assert_eq!(
+            snapshot
+                .editable
+                .get("STRIPE_SECRET_KEY")
+                .map(|e| e.value.as_str()),
+            Some(SEALED_TOKEN)
+        );
+        assert!(snapshot.editable["STRIPE_SECRET_KEY"].is_sealed);
+        assert!(!snapshot.editable.contains_key("RAILWAY_SERVICE_NAME"));
+        assert!(!snapshot.editable.contains_key("SHARED_SECRET"));
+        assert!(!snapshot.editable.contains_key("OTHER_SERVICE"));
+
+        assert_eq!(
+            snapshot
+                .read_only
+                .get("RAILWAY_SERVICE_NAME")
+                .map(String::as_str),
+            Some("api")
+        );
+        assert_eq!(
+            snapshot
+                .read_only
+                .get("RAILWAY_PROJECT_NAME")
+                .map(String::as_str),
+            Some("demo")
+        );
+        assert!(!snapshot.read_only.contains_key("DATABASE_URL"));
+        assert!(!snapshot.read_only.contains_key("STRIPE_SECRET_KEY"));
+    }
+
+    #[tokio::test]
+    async fn apply_sends_upsert_and_delete_payloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub(
+            "VariableCollectionUpsert",
+            json!({ "variableCollectionUpsert": true }),
+        );
+        server.stub("VariableDelete", json!({ "variableDelete": true }));
+
+        apply_service_variable_changes(
+            &reqwest::Client::new(),
+            &server.configs(&dir),
+            "proj-1".to_string(),
+            "env-1".to_string(),
+            "svc-1".to_string(),
+            BTreeMap::from([("LOG_LEVEL".into(), "debug".into())]),
+            vec!["FEATURE_OLD".into()],
+            true,
+        )
+        .await
+        .unwrap();
+
+        let upserts = server.variables_for("VariableCollectionUpsert");
+        assert_eq!(upserts.len(), 1);
+        assert_eq!(upserts[0]["projectId"], "proj-1");
+        assert_eq!(upserts[0]["environmentId"], "env-1");
+        assert_eq!(upserts[0]["serviceId"], "svc-1");
+        assert_eq!(upserts[0]["variables"]["LOG_LEVEL"], "debug");
+        assert_eq!(upserts[0]["skipDeploys"], true);
+
+        let deletes = server.variables_for("VariableDelete");
+        assert_eq!(deletes.len(), 1);
+        assert_eq!(deletes[0]["name"], "FEATURE_OLD");
+        assert_eq!(deletes[0]["serviceId"], "svc-1");
+    }
+
+    #[test]
+    fn reject_reserved_keys_blocks_railway_prefix() {
+        let err = reject_reserved_keys(&[VarChange {
+            kind: crate::controllers::variable_edit::VarChangeKind::Set,
+            key: "RAILWAY_SERVICE_NAME".into(),
+            before: None,
+            after: Some("hacked".into()),
+        }])
+        .unwrap_err();
+        assert!(err.to_string().contains("RAILWAY_SERVICE_NAME"));
     }
 }

--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -2,7 +2,7 @@ use crate::{
     client::post_graphql,
     commands::{Configs, queries},
 };
-use anyhow::Result;
+use anyhow::{Result, bail};
 use reqwest::Client;
 use std::fmt::Display;
 use std::{collections::BTreeMap, str::FromStr};
@@ -58,6 +58,114 @@ pub async fn get_service_variables(
     .collect();
 
     Ok(variables)
+}
+
+/// Stands in for a sealed variable's value, which nobody can read back.
+///
+/// `variable list` prints it in place of the value; `variable edit` round-trips it,
+/// so leaving the line alone keeps the variable sealed and untouched. Both spell it
+/// the same way on purpose — the editor's placeholder is what the table showed.
+pub const SEALED_TOKEN: &str = "<sealed>";
+
+/// One user-owned variable entry for the bulk editor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditVariableEntry {
+    /// Plaintext, empty string, or [`SEALED_TOKEN`].
+    pub value: String,
+    pub is_sealed: bool,
+}
+
+/// Snapshot used by `variable edit`: editable user vars plus read-only Railway-provided vars.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditSnapshot {
+    pub editable: BTreeMap<String, EditVariableEntry>,
+    pub read_only: BTreeMap<String, String>,
+}
+
+/// Keys reserved for Railway-provided variables. User upserts/deletes are rejected client-side.
+pub fn is_railway_reserved_key(key: &str) -> bool {
+    key.starts_with("RAILWAY_")
+}
+
+pub async fn get_service_variables_for_edit(
+    client: &Client,
+    configs: &Configs,
+    project_id: String,
+    environment_id: String,
+    service_id: String,
+) -> Result<EditSnapshot> {
+    let vars = queries::service_variables_for_edit::Variables {
+        project_id: project_id.clone(),
+        environment_id: environment_id.clone(),
+        service_id: service_id.clone(),
+    };
+    let response =
+        post_graphql::<queries::ServiceVariablesForEdit, _>(client, configs.get_backboard(), vars)
+            .await?;
+
+    let sealed_by_name: BTreeMap<String, bool> = response
+        .environment
+        .variables
+        .edges
+        .into_iter()
+        .filter_map(|edge| {
+            let node = edge.node;
+            if node.service_id.as_deref() != Some(service_id.as_str()) {
+                return None;
+            }
+            Some((node.name, node.is_sealed))
+        })
+        .collect();
+
+    let mut editable = BTreeMap::new();
+    for (name, value) in response.user_variables {
+        if is_railway_reserved_key(&name) {
+            continue;
+        }
+        let is_sealed = sealed_by_name.get(&name).copied().unwrap_or(false);
+        let entry_value = match value {
+            Some(v) => v,
+            None if is_sealed => SEALED_TOKEN.to_string(),
+            None => continue,
+        };
+        editable.insert(
+            name,
+            EditVariableEntry {
+                value: entry_value,
+                is_sealed,
+            },
+        );
+    }
+
+    let mut read_only = BTreeMap::new();
+    for (name, value) in response.deployment_variables {
+        if !is_railway_reserved_key(&name) {
+            continue;
+        }
+        if let Some(value) = value {
+            read_only.insert(name, value);
+        }
+    }
+
+    Ok(EditSnapshot {
+        editable,
+        read_only,
+    })
+}
+
+/// Reject apply attempts that touch Railway-reserved keys.
+pub fn reject_reserved_keys(
+    changes: &[crate::controllers::variable_edit::VarChange],
+) -> Result<()> {
+    for change in changes {
+        if is_railway_reserved_key(&change.key) {
+            bail!(
+                "Cannot modify Railway-provided variable `{}`. Remove it from the editable section — Railway-provided variables are shown read-only.",
+                change.key
+            );
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -87,6 +87,15 @@ pub struct VariablesForServiceDeployment;
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "src/gql/schema.json",
+    query_path = "src/gql/queries/strings/ServiceVariablesForEdit.graphql",
+    response_derives = "Debug, Serialize, Clone",
+    skip_serializing_none
+)]
+pub struct ServiceVariablesForEdit;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.json",
     query_path = "src/gql/queries/strings/Deployments.graphql",
     response_derives = "Debug, Serialize, Clone, PartialEq"
 )]

--- a/src/gql/queries/strings/ServiceVariablesForEdit.graphql
+++ b/src/gql/queries/strings/ServiceVariablesForEdit.graphql
@@ -1,0 +1,28 @@
+query ServiceVariablesForEdit(
+	$projectId: String!
+	$environmentId: String!
+	$serviceId: String!
+) {
+	userVariables: variables(
+		projectId: $projectId
+		environmentId: $environmentId
+		serviceId: $serviceId
+		unrendered: true
+	)
+	deploymentVariables: variablesForServiceDeployment(
+		projectId: $projectId
+		environmentId: $environmentId
+		serviceId: $serviceId
+	)
+	environment(id: $environmentId, projectId: $projectId) {
+		variables(first: 10000) {
+			edges {
+				node {
+					name
+					serviceId
+					isSealed
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds `railway variable edit`: opens the service's variables in `$EDITOR` as a
dotenv document, diffs what you saved against what was there, prints an
IaC-style plan, and asks before writing anything. Saving and quitting is not
consent — `:wq` gets you a plan, not an apply.

```
railway variable edit
railway variable edit --demo     # offline fixture, no project or API needed
```

## What the editor shows you

The first cut read its snapshot from `variablesForServiceDeployment` — the
rendered map a deploy receives. That map merges Railway-provided variables in
with the user's own and drops sealed values, which made for two bad outcomes:
`RAILWAY_SERVICE_NAME` and friends were offered as editable text, and a sealed
variable was invisible, indistinguishable from one that had been deleted.

It now reads the stored user variables through `variables(unrendered: true)`
and takes `isSealed` from the environment's variable connection.

- **Railway-provided variables** are written as comments and excluded from the
  diff. Reserved names are rejected on parse and again before apply, so a
  pasted `RAILWAY_*` line cannot reach `variableCollectionUpsert` — which would
  otherwise persist a shadow row that the deploy-time merge silently overrides.
- **Sealed variables** round-trip as `<sealed>`. Left alone they produce no diff
  entry at all and the stored ciphertext is untouched; replaced, they rotate.
  Typing `<sealed>` by hand on a variable that is not sealed is an error rather
  than a silent no-op.
- **Values are redacted** in the plan by default. `--reveal` prints them.

## Guardrails

- The temp file is written `0600`. It holds every plaintext value, and it was
  landing in a world-readable path.
- Deletions need `--confirm-destructive` when there is no one at the terminal to
  answer the prompt — `--yes`, a pipe, or an agent session. This matches how
  `config apply` treats destructive change.
- Edits that cannot be applied are rejected before the plan is printed, so you
  are never asked to confirm something that will then fail.
- A non-zero exit from the editor aborts without touching anything.

## Flags

`--yes`, `--skip-deploys`, `--reveal`, `--confirm-destructive`, `--demo`, plus
the usual `--service` / `--environment` / `--project`.

## Testing

`cargo test` — 1324 pass, 11 of them new around reserved-name exclusion, sealed
preserve/rotate, the hand-typed `<sealed>` rejection, dotenv round-tripping, and
temp file permissions. `cargo fmt --check` and `cargo clippy --all-targets
--all-features` are clean for the touched files.

Not yet covered: variable references (`${{...}}`) round-trip as their raw
unrendered text, which is correct for storage but means the editor shows the
reference rather than its value.
