### PR TITLE
fix(variables): list sealed variables by name instead of hiding them

### DIFF
--- a/src/commands/mcp/handler.rs
+++ b/src/commands/mcp/handler.rs
@@ -19,7 +19,7 @@ use crate::{
         project::{get_environment_instances, get_project, get_service_ids_in_env},
         upload::{create_deploy_tarball, upload_deploy_tarball},
         user::get_user,
-        variables::get_service_variables,
+        variables::get_service_variables_including_sealed,
     },
     gql::{mutations, queries},
     telemetry,
@@ -859,7 +859,7 @@ impl RailwayMcp {
     }
 
     #[tool(
-        description = "List all environment variables for a service. Returns KEY=VALUE pairs. If no IDs are provided, uses the currently linked project/service/environment."
+        description = "List all environment variables for a service. Returns KEY=VALUE pairs. Sealed variables are listed by name only, in a trailing 'Sealed' section: they are already set on the service and their value cannot be read back by anyone, so treat them as present and never recreate them. If no IDs are provided, uses the currently linked project/service/environment."
     )]
     async fn list_variables(
         &self,
@@ -869,7 +869,7 @@ impl RailwayMcp {
             .resolve_service_context(params.project_id, params.service_id, params.environment_id)
             .await?;
 
-        let variables = get_service_variables(
+        let variables = get_service_variables_including_sealed(
             &self.client(),
             &self.configs,
             ctx.project_id,
@@ -885,11 +885,28 @@ impl RailwayMcp {
             )]));
         }
 
-        let output: String = variables
-            .iter()
-            .map(|(k, v)| format!("{k}={v}"))
-            .collect::<Vec<_>>()
-            .join("\n");
+        // Sealed variables have no readable value, but the agent still needs to
+        // know they exist — dropping them made it recreate variables that were
+        // already set, or wait for ones that were never missing.
+        let mut readable: Vec<String> = Vec::new();
+        let mut sealed: Vec<String> = Vec::new();
+        for (key, value) in &variables {
+            match value {
+                Some(value) => readable.push(format!("{key}={value}")),
+                None => sealed.push(format!("- {key}")),
+            }
+        }
+
+        let mut output = readable.join("\n");
+        if !sealed.is_empty() {
+            if !output.is_empty() {
+                output.push_str("\n\n");
+            }
+            output.push_str(
+                "Sealed (set on this service, but the value cannot be read back by anyone - treat these as present and do not recreate them):\n",
+            );
+            output.push_str(&sealed.join("\n"));
+        }
 
         Ok(CallToolResult::success(vec![Content::text(output)]))
     }

--- a/src/commands/variable.rs
+++ b/src/commands/variable.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{
     controllers::{
         project::resolve_service_context,
-        variables::{Variable, get_service_variables},
+        variables::{Variable, get_service_variables, get_service_variables_including_sealed},
     },
     table::Table,
     util::progress::create_spinner_if,
@@ -10,10 +10,13 @@ use crate::{
 use anyhow::bail;
 use std::io::{IsTerminal, Read};
 
+/// Stand-in shown in the variables table for a sealed variable's value.
+const SEALED_PLACEHOLDER: &str = "<sealed>";
+
 /// Manage environment variables for a service
 #[derive(Parser)]
 #[clap(
-    after_help = "Examples:\n\n  railway variable list --service api --json\n  railway variable list --service api --kv\n  railway variable set API_URL=https://example.com --skip-deploys --json\n  echo \"secret\" | railway variable set API_KEY --stdin --skip-deploys --json\n  railway variable delete API_KEY --service api --json\n\nAutomation notes:\n  JSON and KV output include raw variable values. Avoid sharing command output from secret-bearing variable commands.\n  For idempotent deletes, list variables first, check whether the key exists, then delete it."
+    after_help = "Examples:\n\n  railway variable list --service api --json\n  railway variable list --service api --kv\n  railway variable set API_URL=https://example.com --skip-deploys --json\n  echo \"secret\" | railway variable set API_KEY --stdin --skip-deploys --json\n  railway variable delete API_KEY --service api --json\n\nAutomation notes:\n  JSON and KV output include raw variable values. Avoid sharing command output from secret-bearing variable commands.\n  For idempotent deletes, list variables first, check whether the key exists, then delete it.\n  Sealed variables are listed by name with no value (null in JSON, <sealed> in the table). They are already set and nobody can read them back - do not recreate them."
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -192,7 +195,10 @@ pub async fn command(args: Args) -> Result<()> {
 async fn list_variables(args: ListArgs) -> Result<()> {
     let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
 
-    let variables = get_service_variables(
+    // Sealed variables are listed by name with no value. Hiding them entirely
+    // made them look unset, so agents and scripts would recreate a variable
+    // that was already there, or stall waiting for one that already existed.
+    let variables = get_service_variables_including_sealed(
         &ctx.client,
         &ctx.configs,
         ctx.project.id.clone(),
@@ -202,13 +208,19 @@ async fn list_variables(args: ListArgs) -> Result<()> {
     .await?;
 
     if args.kv {
-        for (key, value) in variables {
-            println!("{key}={value}");
+        for (key, value) in &variables {
+            match value {
+                Some(value) => println!("{key}={value}"),
+                // A comment, not `KEY=`: this output is meant to be sourced,
+                // and an empty string is not what the variable is set to.
+                None => println!("# {key} is sealed; its value cannot be read"),
+            }
         }
         return Ok(());
     }
 
     if args.json {
+        // Sealed variables serialize as `null`, matching the API.
         println!("{}", serde_json::to_string_pretty(&variables)?);
         return Ok(());
     }
@@ -218,7 +230,12 @@ async fn list_variables(args: ListArgs) -> Result<()> {
         return Ok(());
     }
 
-    let table = Table::new(ctx.service_name, variables);
+    let rows = variables
+        .into_iter()
+        .map(|(key, value)| (key, value.unwrap_or_else(|| SEALED_PLACEHOLDER.to_string())))
+        .collect();
+
+    let table = Table::new(ctx.service_name, rows);
     table.print()?;
 
     Ok(())
@@ -261,7 +278,8 @@ async fn set_variable(args: SetArgs) -> Result<()> {
 async fn delete_variable(args: DeleteArgs) -> Result<()> {
     let ctx = resolve_service_context(args.project, args.service, args.environment).await?;
 
-    let variables = get_service_variables(
+    // Including sealed: a sealed variable is deletable, it just cannot be read.
+    let variables = get_service_variables_including_sealed(
         &ctx.client,
         &ctx.configs,
         ctx.project_id.clone(),

--- a/src/controllers/variables.rs
+++ b/src/controllers/variables.rs
@@ -7,13 +7,20 @@ use reqwest::Client;
 use std::fmt::Display;
 use std::{collections::BTreeMap, str::FromStr};
 
-pub async fn get_service_variables(
+/// Every variable the service sees at deploy time, sealed ones included.
+///
+/// A sealed variable comes back with a `None` value: it is set on the service,
+/// but its value cannot be read back by anyone, including the account owner.
+/// Callers that show the user (or an agent) what is configured want this, so a
+/// sealed variable is not mistaken for a missing one. Callers that need to put
+/// variables into a process environment want [`get_service_variables`].
+pub async fn get_service_variables_including_sealed(
     client: &Client,
     configs: &Configs,
     project_id: String,
     environment_id: String,
     service_id: String,
-) -> Result<BTreeMap<String, String>> {
+) -> Result<BTreeMap<String, Option<String>>> {
     let vars = queries::variables_for_service_deployment::Variables {
         project_id,
         environment_id,
@@ -26,17 +33,29 @@ pub async fn get_service_variables(
     )
     .await?;
 
-    let variables = response
-        .variables_for_service_deployment
-        .into_iter()
-        .filter_map(|var| {
-            if let Some(value) = var.1 {
-                Some((var.0, value))
-            } else {
-                None
-            }
-        })
-        .collect();
+    Ok(response.variables_for_service_deployment)
+}
+
+/// The variables that have a readable value, for injecting into a process
+/// environment. Sealed variables are dropped — there is no value to inject.
+pub async fn get_service_variables(
+    client: &Client,
+    configs: &Configs,
+    project_id: String,
+    environment_id: String,
+    service_id: String,
+) -> Result<BTreeMap<String, String>> {
+    let variables = get_service_variables_including_sealed(
+        client,
+        configs,
+        project_id,
+        environment_id,
+        service_id,
+    )
+    .await?
+    .into_iter()
+    .filter_map(|(key, value)| value.map(|value| (key, value)))
+    .collect();
 
     Ok(variables)
 }
@@ -102,5 +121,75 @@ mod variable_from_str_tests {
 impl Display for Variable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}={}", self.key, self.value)
+    }
+}
+
+#[cfg(test)]
+mod sealed_variable_tests {
+    use super::*;
+    use crate::testkit::MockBackboard;
+    use serde_json::json;
+
+    /// The API reports a sealed variable as a present key with a null value:
+    /// it is set, but nobody can read it back.
+    fn response() -> serde_json::Value {
+        json!({
+            "variablesForServiceDeployment": {
+                "DATABASE_URL": "postgres://user:pw@host:5432/db",
+                "STRIPE_SECRET_KEY": null,
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn sealed_variables_keep_their_name_and_lose_only_their_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("VariablesForServiceDeployment", response());
+
+        let variables = get_service_variables_including_sealed(
+            &reqwest::Client::new(),
+            &server.configs(&dir),
+            "proj-1".to_string(),
+            "env-1".to_string(),
+            "svc-1".to_string(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            variables.get("DATABASE_URL"),
+            Some(&Some("postgres://user:pw@host:5432/db".to_string()))
+        );
+        // The name is here, so a caller knows the variable is already set...
+        assert_eq!(variables.get("STRIPE_SECRET_KEY"), Some(&None));
+        // ...and the value is not.
+        assert_eq!(variables.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn process_environment_drops_sealed_variables() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockBackboard::spawn();
+        server.stub("VariablesForServiceDeployment", response());
+
+        let variables = get_service_variables(
+            &reqwest::Client::new(),
+            &server.configs(&dir),
+            "proj-1".to_string(),
+            "env-1".to_string(),
+            "svc-1".to_string(),
+        )
+        .await
+        .unwrap();
+
+        // There is nothing to inject into a process for a sealed variable.
+        assert_eq!(
+            variables,
+            BTreeMap::from([(
+                "DATABASE_URL".to_string(),
+                "postgres://user:pw@host:5432/db".to_string()
+            )])
+        );
     }
 }


### PR DESCRIPTION
Reported on X: an agent driving the CLI kept trying to recreate a sealed variable, or stalling on one that was already set.

`railway variable list` dropped every variable whose value the API withholds — which is exactly the sealed ones. A sealed variable was therefore indistinguishable from one that was never set.

The API has always reported a sealed variable as a **present key with a null value**. This keeps that distinction instead of collapsing it. Names were never the secret — the dashboard has always shown them. Only the values stay unreadable.

## What changed

- `get_service_variables_including_sealed` returns the map as the API sends it, sealed entries included with `None`. `get_service_variables` stays a filter over it and is still what `run`, `shell`, `dev` and `connect` use — there is no value to inject into a process for a sealed var.
- `variable list` shows sealed names in every output mode:
  - table: `<sealed>` in the value column
  - `--json`: `null`, matching the API
  - `--kv`: `# KEY is sealed; its value cannot be read` — a comment, not `KEY=`, so the output stays safe to source
- MCP `list_variables` lists them under a trailing `Sealed` section that tells the agent they are set and must not be recreated.
- **Bug fix along the way:** `variable delete` now finds sealed variables. Deleting one previously failed with `Variable 'X' not found`, because the existence check ran against the filtered map.

## Compatibility

`--json` gains keys that were previously absent, with `null` values. Existing consumers reading a known key are unaffected. Nothing that injects variables into a process changed behavior.

## Testing

Two tests in `src/controllers/variables.rs` against the scripted `MockBackboard`: sealed entries keep their name and lose only their value; the process-environment path still drops them. Full suite: 1315 passed.

Paired with a backboard change that does the same for the API's own `list-variables` MCP tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)