### PR TITLE
fix(iac): stop dropping preDeployCommand during config migrate; render it first-class in pull

### DIFF
--- a/src/commands/config/migrate.rs
+++ b/src/commands/config/migrate.rs
@@ -613,6 +613,16 @@ fn emit_service_fields(cac: &CacFile) -> Vec<String> {
     } else if let Some(region) = &cac.deploy.region {
         fields.push(format!("    replicas: {{ {}: 1 }},", js_string(region)));
     }
+    if let Some(pre) = &cac.deploy.pre_deploy_command {
+        let rendered = match pre {
+            JsonValue::Array(items) if items.len() == 1 && items[0].is_string() => {
+                js_string(items[0].as_str().unwrap_or_default())
+            }
+            JsonValue::String(cmd) => js_string(cmd),
+            other => json_to_ts(other),
+        };
+        fields.push(format!("    preDeploy: {rendered},"));
+    }
     if let Some(dockerfile) = &cac.build.dockerfile_path {
         fields.push(format!(
             "    // dockerfilePath from CaC: {}",
@@ -624,12 +634,6 @@ fn emit_service_fields(cac: &CacFile) -> Vec<String> {
     }
     if let Some(cron) = &cac.deploy.cron_schedule {
         fields.push(format!("    // cronSchedule from CaC: {}", js_string(cron)));
-    }
-    if let Some(pre) = &cac.deploy.pre_deploy_command {
-        fields.push(format!(
-            "    // preDeployCommand from CaC: {}",
-            json_to_ts(pre)
-        ));
     }
     if let Some(watch) = &cac.build.watch_patterns {
         let arr = watch
@@ -845,6 +849,22 @@ mod tests {
         assert!(go.contains("github.com/railwayapp/railway-go-sdk"));
         assert!(go.contains("railway.ServiceNamed"));
         assert!(go.contains("const Partial = \"api\""));
+    }
+
+    #[test]
+    fn emits_pre_deploy_as_a_real_field() {
+        let cac = CacFile {
+            deploy: CacDeploy {
+                start_command: Some("node index.js".into()),
+                pre_deploy_command: Some(serde_json::json!(["npx prisma migrate deploy"])),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let services = [svc("api", cac)];
+        let out = emit_railway_ts("api", &services, true);
+        assert!(out.contains("preDeploy: \"npx prisma migrate deploy\""));
+        assert!(!out.contains("// preDeployCommand from CaC"));
     }
 
     #[test]

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -1307,6 +1307,18 @@ fn render_deploy(
     if let Some(timeout) = remaining.remove("healthcheckTimeout") {
         lines.push(lang.config_field("healthcheckTimeout", &code_value(&timeout, lang)));
     }
+    if let Some(pre) = remaining.remove("preDeployCommand") {
+        if !pre.is_null() {
+            let rendered = match &pre {
+                serde_json::Value::Array(items) if items.len() == 1 && items[0].is_string() => {
+                    format!("{:?}", items[0].as_str().unwrap_or_default())
+                }
+                serde_json::Value::String(command) => format!("{:?}", command),
+                other => code_value(other, lang),
+            };
+            lines.push(lang.config_field("preDeploy", &rendered));
+        }
+    }
     if let Some(regions) = remaining.remove("multiRegionConfig") {
         lines.push(lang.config_field("replicas", &render_replicas(&regions, lang)));
     }


### PR DESCRIPTION
## What's broken

`railway config migrate` turns a working `preDeployCommand` from railway.json into a comment:

```ts
// preDeployCommand from CaC: ["npx prisma migrate deploy"]
```

So a service that runs migrations loses that config the moment it migrates to IaC — silently, since the migrate output looks complete. With Config as Code sunsetting 2026-12-01, every migrating service with a pre-deploy command hits this. The odd part is the field already works end to end: the `railway` SDK accepts `preDeploy`, and apply writes it to the service (verified today with a real `railway config apply` → `serviceInstance.preDeployCommand` populated).

`config pull` has the milder version of the same gap: it dumps the field into the raw `deploy: { preDeployCommand: [...] }` block instead of the first-class form.

## The fix

Both paths now emit a real field, unwrapping the single-command array (the manifest caps it at one) to a bare string:

```ts
const web = service("web", {
  start: "node index.js",
  preDeploy: "npx drizzle-kit migrate",
});
```

## Testing

- New unit test (`emits_pre_deploy_as_a_real_field`); full `config`, `migrate`, and `iac` test suites pass.
- Verified against production with the built binary: set a `preDeployCommand` on a real service, `config pull` rendered `preDeploy: "npx drizzle-kit migrate"` first-class, and a follow-up `config plan` on the pulled file reported no drift ("already up to date"), so the bare-string form round-trips cleanly through the SDK normalization.
- Docs PR documenting the field: railwayapp/docs#1335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

