### PR TITLE
fix(iac): converge empty tcpProxies and import database networking

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -738,6 +738,12 @@ fn render_graph_as_railway(
                         lang,
                         &mut out,
                     );
+                    render_database_networking_overrides(
+                        resource.networking.as_ref(),
+                        &var_name,
+                        lang,
+                        &mut out,
+                    );
                 }
             }
             "service" => {
@@ -1134,6 +1140,42 @@ fn render_database_deploy_overrides(
         AuthoringLang::Go => out.push_str(&format!(
             "  // deploy overrides: {}\n",
             code_value(&serde_json::Value::Object(overrides), lang)
+        )),
+    }
+}
+
+/// A database's public exposure is authored on the helper result, e.g.
+/// `db.networking = { tcpProxies: { "5432": {} } }`, so a pulled file keeps the
+/// proxy it found and a plan sees the drift when one appears or disappears.
+/// Service domains are platform-generated and stay out of the file.
+fn render_database_networking_overrides(
+    networking: Option<&serde_json::Value>,
+    var_name: &str,
+    lang: AuthoringLang,
+    out: &mut String,
+) {
+    let Some(networking) = networking.and_then(|value| value.as_object()) else {
+        return;
+    };
+    let mut overrides = networking.clone();
+    overrides.remove("serviceDomains");
+    overrides.retain(|_, value| !value.as_object().is_some_and(|map| map.is_empty()));
+    if overrides.is_empty() {
+        return;
+    }
+    let value = serde_json::Value::Object(overrides);
+    match lang {
+        AuthoringLang::TypeScript => out.push_str(&format!(
+            "  {var_name}.networking = {};\n",
+            ts_value(&value)
+        )),
+        AuthoringLang::Python => out.push_str(&format!(
+            "    # networking overrides: {}\n",
+            code_value(&value, lang)
+        )),
+        AuthoringLang::Go => out.push_str(&format!(
+            "  // networking overrides: {}\n",
+            code_value(&value, lang)
         )),
     }
 }
@@ -2042,6 +2084,64 @@ mod tests {
             config: None,
             group_id: None,
         }
+    }
+
+    fn database_resource(
+        name: &str,
+        engine: &str,
+        networking: Option<serde_json::Value>,
+    ) -> runner::DesiredResource {
+        runner::DesiredResource {
+            address: Some(format!("database.{name}")),
+            r#type: "database".to_string(),
+            name: name.to_string(),
+            engine: Some(engine.to_string()),
+            variables: None,
+            source: None,
+            build: None,
+            deploy: None,
+            networking,
+            volume_attachments: None,
+            config: None,
+            group_id: None,
+        }
+    }
+
+    fn render_database(networking: Option<serde_json::Value>) -> String {
+        let graph = runner::DesiredGraph {
+            project: Some(runner::DesiredProject { name: "app".into() }),
+            resources: vec![database_resource("postgres", "postgres", networking)],
+        };
+        render_graph_as_railway(&graph, true, AuthoringLang::TypeScript)
+    }
+
+    #[test]
+    fn pull_renderer_authors_a_database_tcp_proxy() {
+        let rendered = render_database(Some(json!({
+            "tcpProxies": { "5432": {} },
+            "serviceDomains": { "postgres.up.railway.app": { "port": 5432 } }
+        })));
+        let helper = rendered
+            .lines()
+            .position(|line| line.contains("= postgres(\"postgres\")"))
+            .expect("database helper call");
+        assert_eq!(
+            rendered.lines().nth(helper + 1).unwrap().trim(),
+            "postgresDatabase.networking = { tcpProxies: { \"5432\": {} } };"
+        );
+        assert!(!rendered.contains("serviceDomains"));
+    }
+
+    #[test]
+    fn pull_renderer_leaves_a_private_database_without_networking() {
+        assert!(!render_database(None).contains(".networking"));
+        assert!(
+            !render_database(Some(json!({
+                "serviceDomains": { "postgres.up.railway.app": { "port": 5432 } }
+            })))
+            .contains(".networking")
+        );
+        assert!(!render_database(Some(json!({ "tcpProxies": {} }))).contains(".networking"));
     }
 
     #[test]

--- a/src/iac/change_set.rs
+++ b/src/iac/change_set.rs
@@ -339,8 +339,7 @@ fn diff_networking(
     let after = resource.get("networking");
     // The database helpers take no networking, and pulled files only author it
     // when a proxy exists, so a database node without a networking block keeps
-    // whatever exposure it has. An authored block is compared as written: an
-    // empty `tcpProxies` means "no public proxy" and plans the removal of one.
+    // whatever exposure it has.
     if resource_type(resource) == "database" && after.is_none() {
         return;
     }
@@ -356,9 +355,18 @@ fn diff_networking(
         obj.remove("customDomains");
         obj.remove("serviceDomains");
     }
+    diagnose_unremovable_tcp_proxies(resource, diagnostics, &before_copy, &after_copy);
     let normalized_before = normalize_for_diff("networking", &before_copy);
     let normalized_after = normalize_for_diff("networking", &after_copy);
-    if stable_stringify(&normalized_before) != stable_stringify(&normalized_after) {
+    // Plan the change only when applying the authored block moves something.
+    // The block is a sparse patch, so what the plan promises is its effect,
+    // while the change set still carries the block as written: that is the
+    // payload the apply sends, and a `null` entry is how a proxy is deleted.
+    let applied = normalize_for_diff(
+        "networking",
+        &networking_after_apply(&before_copy, &after_copy),
+    );
+    if stable_stringify(&normalized_before) != stable_stringify(&applied) {
         changes.push(update(
             &resource_addr(resource),
             "networking",
@@ -369,6 +377,85 @@ fn diff_networking(
             "safe",
         ));
     }
+}
+
+/// What `networking` looks like once Railway has applied the authored block.
+///
+/// `environmentApplyChangeSet` reads the block as a sparse patch: a key the
+/// author leaves out stays as Railway has it, and inside `tcpProxies` an entry
+/// keeps or creates a proxy, a `null` entry deletes one, and an unmentioned port
+/// is left alone — so an empty map changes nothing. The plan diffs against that
+/// same effect, because a plan that plans anything else promises work the apply
+/// will not do and then plans it again after every apply.
+fn networking_after_apply(before: &Value, after: &Value) -> Value {
+    let mut effective = before.as_object().cloned().unwrap_or_default();
+    let Some(authored) = after.as_object() else {
+        return Value::Object(effective);
+    };
+    for (key, value) in authored {
+        if key != "tcpProxies" {
+            effective.insert(key.clone(), value.clone());
+            continue;
+        }
+        let mut proxies = before
+            .get("tcpProxies")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        for (port, entry) in value.as_object().into_iter().flatten() {
+            if entry.is_null() {
+                proxies.remove(port);
+            } else {
+                proxies.entry(port.clone()).or_insert_with(|| entry.clone());
+            }
+        }
+        effective.insert(key.clone(), Value::Object(proxies));
+    }
+    Value::Object(effective)
+}
+
+/// An empty `tcpProxies` map — what `tcp: []` compiles to — cannot take a proxy
+/// away, because the apply leaves every port the block does not mention alone.
+/// Say that out loud instead of leaving the author with a file that reads
+/// "private" next to a proxy that is still serving traffic.
+fn diagnose_unremovable_tcp_proxies(
+    resource: &Value,
+    diagnostics: &mut Vec<Diagnostic>,
+    before: &Value,
+    after: &Value,
+) {
+    let authored_empty = after
+        .get("tcpProxies")
+        .and_then(Value::as_object)
+        .is_some_and(Map::is_empty);
+    if !authored_empty {
+        return;
+    }
+    let live = before.get("tcpProxies").and_then(Value::as_object);
+    let Some(live) = live.filter(|proxies| !proxies.is_empty()) else {
+        return;
+    };
+    let ports = live
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let removals = live
+        .keys()
+        .map(|port| format!("\"{port}\": null"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    diagnostics.push(Diagnostic {
+        severity: "warning".into(),
+        path: format!(
+            "resources.{}.networking.tcpProxies",
+            resource_addr(resource)
+        ),
+        message: format!(
+            "{} has a public TCP proxy on port {ports}, and an empty tcpProxies map does not remove it. Author networking.tcpProxies = {{ {removals} }} to remove the proxy, or remove it from the dashboard.",
+            resource_name(resource)
+        ),
+    });
 }
 
 fn diagnose_unsupported_custom_domains(

--- a/src/iac/change_set.rs
+++ b/src/iac/change_set.rs
@@ -337,6 +337,13 @@ fn diff_networking(
 ) {
     let before = previous.get("networking");
     let after = resource.get("networking");
+    // The database helpers take no networking, and pulled files only author it
+    // when a proxy exists, so a database node without a networking block keeps
+    // whatever exposure it has. An authored block is compared as written: an
+    // empty `tcpProxies` means "no public proxy" and plans the removal of one.
+    if resource_type(resource) == "database" && after.is_none() {
+        return;
+    }
     let before_domains = before.and_then(|n| n.get("customDomains"));
     diagnose_unsupported_custom_domains(resource, diagnostics, before_domains);
     let mut before_copy = before.cloned().unwrap_or(json!({}));
@@ -1099,6 +1106,11 @@ fn normalize_for_diff(field_name: &str, value: &Value) -> Value {
         if copy.get("dockerfilePath") == Some(&json!("Dockerfile")) {
             copy.remove("dockerfilePath");
         }
+    }
+    if field_name == "networking" {
+        // `tcp: []` compiles to `tcpProxies: {}`; Railway serializes a service
+        // with no proxy as no `tcpProxies` at all. Both mean the same thing.
+        copy.retain(|_, child| !child.is_null() && !child.as_object().is_some_and(Map::is_empty));
     }
     if field_name == "deploy" {
         if copy.get("useLegacyStacker") == Some(&json!(false)) {

--- a/src/iac/compiler.rs
+++ b/src/iac/compiler.rs
@@ -656,6 +656,11 @@ pub fn environment_config_to_graph(
                     "deploy": service.get("deploy").cloned().unwrap_or(Value::Null),
                     "volumeMounts": service.get("volumeMounts").cloned().unwrap_or(Value::Null),
                 }));
+                if let Some(networking) =
+                    networking_from_environment_config(service, service_id, options)
+                {
+                    node["networking"] = networking;
+                }
                 if let Some(group_id) = field_str(service, "groupId") {
                     node["groupId"] = json!(
                         group_names_by_id
@@ -710,20 +715,8 @@ pub fn environment_config_to_graph(
             if let Some(variables) = service.get("variables") {
                 node["variables"] = variables_from_environment_config(variables);
             }
-            let mut networking = service.get("networking").cloned().unwrap_or(json!({}));
-            if let Some(domains) = options.custom_domains_by_service_id.get(service_id) {
-                networking["customDomains"] = domains.clone();
-            } else if let Some(existing) = service
-                .get("networking")
-                .and_then(|n| n.get("customDomains"))
-            {
-                networking["customDomains"] = existing.clone();
-            }
-            let networking = prune_empty(networking);
-            if networking.as_object().is_some_and(|obj| !obj.is_empty())
-                || options
-                    .custom_domains_by_service_id
-                    .contains_key(service_id)
+            if let Some(networking) =
+                networking_from_environment_config(service, service_id, options)
             {
                 node["networking"] = networking;
             }
@@ -818,6 +811,32 @@ pub fn environment_config_to_graph(
         "name": options.project_name.clone().unwrap_or_else(|| "imported-project".to_string()),
         "resources": resources,
     }))
+}
+
+/// Import a service's live networking (TCP proxies, domains) as graph state.
+///
+/// Databases go through this too: a public TCP proxy on a database is exposure
+/// the plan has to be able to see, and the imported graph is what
+/// `railway config pull` renders.
+fn networking_from_environment_config(
+    service: &Value,
+    service_id: &str,
+    options: &EnvironmentConfigToGraphOptions,
+) -> Option<Value> {
+    let mut networking = service.get("networking").cloned().unwrap_or(json!({}));
+    if let Some(domains) = options.custom_domains_by_service_id.get(service_id) {
+        networking["customDomains"] = domains.clone();
+    }
+    let networking = prune_empty(networking);
+    if networking.as_object().is_some_and(|obj| !obj.is_empty())
+        || options
+            .custom_domains_by_service_id
+            .contains_key(service_id)
+    {
+        Some(networking)
+    } else {
+        None
+    }
 }
 
 fn variables_from_environment_config(variables: &Value) -> Value {

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -318,6 +318,130 @@ fn existing_custom_domains_are_plan_clean() {
     assert!(result.diagnostics.is_empty());
 }
 
+fn imported_postgres(networking: Option<Value>) -> super::graph::RailwayGraph {
+    let mut service = json!({
+        "source": { "image": "ghcr.io/railwayapp-templates/postgres-ssl:18" },
+        "deploy": {
+            "multiRegionConfig": { "us-east4-eqdc4a": { "numReplicas": 1 } },
+            "requiredMountPath": "/var/lib/postgresql/data"
+        },
+        "volumeMounts": { "vol-id": { "mountPath": "/var/lib/postgresql/data" } }
+    });
+    if let Some(networking) = networking {
+        service["networking"] = networking;
+    }
+    environment_config_to_graph(
+        &json!({ "services": { "db-id": service } }),
+        &EnvironmentConfigToGraphOptions {
+            project_name: Some("app".into()),
+            service_names_by_id: super::compiler::map_from_str(&[("db-id", "postgres")]),
+            ..Default::default()
+        },
+    )
+}
+
+fn with_networking(mut node: Value, networking: Value) -> Value {
+    node["networking"] = networking;
+    node
+}
+
+#[test]
+fn empty_database_tcp_proxies_converge_when_no_proxy_exists() {
+    let current = imported_postgres(None);
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "tcpProxies": {} }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+
+    let current = env_config(json!({
+        "services": {
+            "cache": {
+                "source": { "image": "railwayapp/redis:8.2" },
+                "deploy": { "requiredMountPath": "/bitnami" }
+            }
+        }
+    }));
+    let desired = graph_from(vec![with_networking(
+        redis("cache"),
+        json!({ "tcpProxies": {} }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn imported_database_keeps_its_tcp_proxy() {
+    let current = imported_postgres(Some(json!({ "tcpProxies": { "5432": {} } })));
+    let database = current
+        .resources
+        .iter()
+        .find(|resource| resource["address"] == "database.postgres")
+        .unwrap();
+    assert_eq!(
+        database["networking"],
+        json!({ "tcpProxies": { "5432": {} } })
+    );
+
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "tcpProxies": { "5432": {} } }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn unauthored_database_networking_is_not_drift() {
+    let current = imported_postgres(Some(json!({ "tcpProxies": { "5432": {} } })));
+    let desired = graph_from(vec![postgres("postgres", None)]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn private_database_declaration_plans_removing_a_public_proxy() {
+    let current = imported_postgres(Some(json!({ "tcpProxies": { "5432": {} } })));
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "tcpProxies": {} }),
+    )]);
+    let change_set = diff(&current, &desired);
+    assert_eq!(kinds(&change_set), vec!["resource.update"]);
+    let change = &change_set.changes[0];
+    assert_eq!(change["field"], "networking");
+    assert_eq!(change["summary"], "Update postgres networking");
+    assert_eq!(change["before"], json!({ "tcpProxies": { "5432": {} } }));
+    assert!(change["after"].is_null());
+}
+
+#[test]
+fn public_database_declaration_plans_the_proxy() {
+    let current = imported_postgres(None);
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "tcpProxies": { "5432": {} } }),
+    )]);
+    let change_set = diff(&current, &desired);
+    assert_eq!(kinds(&change_set), vec!["resource.update"]);
+    assert_eq!(
+        change_set.changes[0]["after"],
+        json!({ "tcpProxies": { "5432": {} } })
+    );
+}
+
+#[test]
+fn empty_service_tcp_proxies_converge_when_no_proxy_exists() {
+    let current = env_config(json!({
+        "services": { "web": { "source": { "image": "ghcr.io/acme/web:1.2.3" } } }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/web:1.2.3"),
+            "networking": { "tcpProxies": {} }
+        }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
 #[test]
 fn round_tripped_config_plans_no_changes() {
     let desired = graph_from(vec![

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -397,11 +397,29 @@ fn unauthored_database_networking_is_not_drift() {
 }
 
 #[test]
-fn private_database_declaration_plans_removing_a_public_proxy() {
+fn empty_tcp_proxies_warn_instead_of_planning_a_removal_the_apply_skips() {
     let current = imported_postgres(Some(json!({ "tcpProxies": { "5432": {} } })));
     let desired = graph_from(vec![with_networking(
         postgres("postgres", None),
         json!({ "tcpProxies": {} }),
+    )]);
+    let change_set = diff(&current, &desired);
+    assert!(change_set.changes.is_empty());
+    let warning = &change_set.diagnostics[0];
+    assert_eq!(warning.severity, "warning");
+    assert_eq!(
+        warning.path,
+        "resources.database.postgres.networking.tcpProxies"
+    );
+    assert!(warning.message.contains(r#"{ "5432": null }"#));
+}
+
+#[test]
+fn a_null_tcp_proxy_entry_plans_the_removal_and_converges() {
+    let current = imported_postgres(Some(json!({ "tcpProxies": { "5432": {} } })));
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "tcpProxies": { "5432": null } }),
     )]);
     let change_set = diff(&current, &desired);
     assert_eq!(kinds(&change_set), vec!["resource.update"]);
@@ -409,7 +427,61 @@ fn private_database_declaration_plans_removing_a_public_proxy() {
     assert_eq!(change["field"], "networking");
     assert_eq!(change["summary"], "Update postgres networking");
     assert_eq!(change["before"], json!({ "tcpProxies": { "5432": {} } }));
-    assert!(change["after"].is_null());
+    // The apply is sent the block as written, so the `null` entry survives to
+    // the server — that entry is what deletes the proxy.
+    assert_eq!(change["after"], json!({ "tcpProxies": { "5432": null } }));
+    assert!(change_set.diagnostics.is_empty());
+
+    // The proxy is gone; the same file has nothing left to do.
+    let current = imported_postgres(None);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn omitted_networking_keys_keep_what_railway_has() {
+    let current = imported_postgres(Some(json!({
+        "privateNetworkEndpoint": "postgres",
+        "tcpProxies": { "5432": {} }
+    })));
+    // tcpProxies left out: the apply never touches the proxy.
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "privateNetworkEndpoint": "postgres" }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+    // privateNetworkEndpoint left out: the apply never touches the endpoint.
+    let desired = graph_from(vec![with_networking(
+        postgres("postgres", None),
+        json!({ "tcpProxies": { "5432": {} } }),
+    )]);
+    assert!(diff(&current, &desired).changes.is_empty());
+}
+
+#[test]
+fn service_tcp_empty_warns_about_a_proxy_it_cannot_remove() {
+    let current = env_config(json!({
+        "services": {
+            "web": {
+                "source": { "image": "ghcr.io/acme/web:1.2.3" },
+                "networking": { "tcpProxies": { "8080": {} } }
+            }
+        }
+    }));
+    let desired = graph_from(vec![service(
+        "web",
+        json!({
+            "source": image("ghcr.io/acme/web:1.2.3"),
+            "networking": { "tcpProxies": {} }
+        }),
+    )]);
+    let change_set = diff(&current, &desired);
+    assert!(change_set.changes.is_empty());
+    assert_eq!(change_set.diagnostics[0].severity, "warning");
+    assert!(
+        change_set.diagnostics[0]
+            .message
+            .contains(r#"{ "8080": null }"#)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1168.

**What.** `railway config plan` converges after a successful apply. A file that declares a database (or service) private no longer re-plans `Update <name> networking` forever, database nodes import their live networking so `railway config pull` writes a public proxy back as `db.networking = { tcpProxies: { "5432": {} } }`, and a database node without a `networking` block keeps the exposure it has. `tcpProxies: { "5432": null }` converges once the apply has removed the proxy, and `tcpProxies: {}` warns that it cannot remove one instead of planning a removal that never lands.

**Why.** Backboard merges a networking change as `servicePatch.networking = change.after`, which makes an authored block a sparse patch: a key the author leaves out stays as Railway has it, and inside `tcpProxies` an entry keeps or creates a proxy, a per-port `null` deletes one, and an unmentioned port is left alone — so an empty map changes nothing. `diff_networking` compared the block as if it were the whole desired state, so three plans promised work the apply never does and proposed it again after every apply: `tcpProxies` left out, `privateNetworkEndpoint` left out, and `tcpProxies: {}` against a live proxy. Backboard also serializes a service with no proxy as no `tcpProxies` key while the SDK compiles `tcp: []` to `tcpProxies: {}`, and the database import branch built its node without networking at all, so a public proxy on a database was invisible to both the plan and `pull`.

**How.**
- `networking_after_apply` replays an authored block over the live one the way backboard merges it, and `diff_networking` plans a change only when that effect differs from what Railway has. The change set still carries the block as written, because that is the payload the apply sends and a per-port `null` is what deletes a proxy.
- `normalize_for_diff("networking")` drops empty maps, so `{ tcpProxies: {} }` and absent networking compare equal (services included).
- An empty `tcpProxies` against a live proxy raises a warning naming the spelling that removes it, in place of a removal the apply would skip.
- `environment_config_to_graph` imports networking for databases through the same helper services use.
- `diff_networking` skips a database whose desired node has no `networking` key: the helpers cannot author it, and pulled files only carry it when a proxy exists.
- `railway config pull` renders `db.networking = { ... }` after the helper call for databases with a proxy (TypeScript; Python and Go get the same comment form as deploy overrides). Service domains stay out of the file, as for services.

**Tests.** `src/iac/tests.rs`: empty `tcpProxies` converges for postgres, redis and a service; an imported database keeps and round-trips its proxy; unauthored database networking is clean against a live proxy; an empty map warns instead of planning a removal, for a database and for a service; a per-port `null` plans the removal and plans nothing once the proxy is gone; an omitted `tcpProxies` or `privateNetworkEndpoint` keeps what Railway has; an explicit public declaration plans the proxy. `src/commands/config/mod.rs`: pull renders the override line right after the helper call, strips service domains, and writes nothing for a private database.
