### PR TITLE
fix(mcp): derive SEP-2243 Mcp-Method/Mcp-Name headers in the proxy

### DIFF
--- a/src/commands/mcp/proxy.rs
+++ b/src/commands/mcp/proxy.rs
@@ -127,6 +127,16 @@ const MCP_CLIENT_HEADER: &str = "x-railway-mcp-client";
 /// project".
 const MCP_INJECTED_HEADER: &str = "x-railway-mcp-injected";
 
+/// SEP-2243 transport headers. The modern (2026-07-28) lifecycle restates a
+/// request's method — and, for a tool call, the target name — in headers the
+/// streamable-HTTP transport requires; the server rejects a modern body whose
+/// `Mcp-Method` header is absent. A native HTTP client sets these itself, but
+/// the harness reaches us over stdio, which carries neither, so we derive them
+/// from the body being forwarded. The server ignores them on a request it
+/// classifies as legacy.
+const MCP_METHOD_HEADER: &str = "mcp-method";
+const MCP_NAME_HEADER: &str = "mcp-name";
+
 type Out = mpsc::UnboundedSender<String>;
 
 pub async fn serve_proxy() -> Result<()> {
@@ -524,10 +534,30 @@ async fn post_message(
     if let Some(sid) = session_id {
         req = req.header("mcp-session-id", sid);
     }
+    // SEP-2243: derive the modern transport headers from the body. A value a
+    // header cannot legally carry is left off rather than sent malformed — the
+    // server then classifies the request as legacy, which is the same outcome
+    // as before this was added.
+    if let Some(method) = method_of(msg) {
+        if header_safe(method) {
+            req = req.header(MCP_METHOD_HEADER, method);
+        }
+        if let Some(name) = msg.pointer("/params/name").and_then(JsonValue::as_str)
+            && header_safe(name)
+        {
+            req = req.header(MCP_NAME_HEADER, name);
+        }
+    }
     req.json(msg)
         .send()
         .await
         .context("failed to reach the remote MCP server")
+}
+
+/// A header may only carry visible ASCII; a value that cannot restate the body
+/// in a header is left off rather than sent malformed.
+fn header_safe(value: &str) -> bool {
+    !value.is_empty() && value.chars().all(|c| c.is_ascii_graphic() || c == ' ')
 }
 
 /// Pull a telemetry-safe client identity out of an MCP `initialize` request.
@@ -814,6 +844,17 @@ mod tests {
             validate_mcp_override("http://localhost:8080", true).unwrap(),
             Some("http://localhost:8080".to_string()),
         );
+    }
+
+    #[test]
+    fn header_safe_accepts_wire_methods_and_rejects_unsendable_values() {
+        assert!(header_safe("server/discover"));
+        assert!(header_safe("tools/call"));
+        assert!(header_safe("get-service-config"));
+        // A blank value, control chars, or non-ASCII can't restate the body.
+        assert!(!header_safe(""));
+        assert!(!header_safe("tools/call\n"));
+        assert!(!header_safe("naïve"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`railway mcp proxy` forwards each JSON-RPC frame to the remote MCP endpoint verbatim but never sets the SEP-2243 `Mcp-Method` / `Mcp-Name` headers. A native streamable-HTTP client derives these from the body; the harness reaches the proxy over **stdio**, which carries neither.

Two things collided:
- **railway-agent v0.1.15** (and any harness on the 2026-07-28 lifecycle) now probes `server/discover` **first**.
- The remote MCP server has been on `@modelcontextprotocol/server` **v2 since Aug 25** (mono #36536), which **rejects a modern-lifecycle body whose `Mcp-Method` header is absent**.

So every modern `server/discover` routed through the proxy was rejected:

> `Rejected inbound request (method-header-missing): the body names method server/discover but the required Mcp-Method header is absent`

Backboard logged **~490 of these in a single day** (2026-09-07), all `surface:http` — i.e. user-credentialed proxy traffic, not agent-VM traffic. Zero before that day.

## Fix

Derive both headers from the forwarded body in `post_message`, exactly as the express-agent bridge does after mono **#38237**:
- `Mcp-Method` ← the frame's `method`
- `Mcp-Name` ← `params.name` (tool calls)

A value a header cannot legally carry (empty / control chars / non-ASCII) is left off rather than sent malformed, so the server classifies the request as legacy — the same outcome as before this change. Legacy `initialize` clients are unaffected; the server ignores the headers on a request it classifies as legacy.

## Verification (against prod `mcp.railway.com`)

- **Before:** a modern `server/discover` through the proxy → header-disagreement **400** (`method-header-missing`).
- **After:** passes the transport gate — the server answers `-32601`, which is rmcp's documented **legacy-fallback signal** — and `initialize` + `tools/list` return the modern `listChanged` capability and the full 42-tool set.
- `cargo build`, `cargo test` (72 proxy tests + new `header_safe` unit test), `fmt`, `clippy` all clean.

## Notes

- The cloud-agent path (express-agent bridge) is **not** affected — it already got this treatment in mono #38237 and degrades cleanly via legacy fallback on the current image. This PR brings the CLI proxy to parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)