### PR TITLE
fix: honor update opt-out and unify CLI/skill upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ railway setup agent -y --local
 railway mcp install --local --agent cursor
 ```
 
+## Update progress and status
+
+`railway upgrade` presents CLI installation and managed skill synchronization as
+one flow. Stages advance as work completes, and the final summary says whether
+the new version is active or will be used on the next command. This explicit
+command also synchronizes managed skills when automatic updates are disabled.
+
+Automatic discovery and downloads run quietly. After the new CLI is active and
+its skill sync has finished, an interactive command shows one completion receipt
+per CLI version. Preserved local edits are reported neutrally; a skill-sync
+failure is reported separately from a successful CLI install. Commands using
+JSON, piped output, help, and version output do not show or consume receipts.
+Install methods that require manual upgrades get one availability notice per
+release instead.
+
+Run `railway autoupdate status` to inspect the running and recorded installed
+versions, staged/in-progress CLI updates, skill-sync results, and unmanaged
+skills. Use `railway skills update` for detailed skill results or to retry a sync.
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/railwayapp/cli/blob/master/CONTRIBUTING.md) for information on setting up this repository locally.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ railway mcp install --agent cursor
 railway skills --agent claude-code
 ```
 
+With automatic updates enabled, CLI-managed skills update silently in the background,
+including on the first normal command after a CLI version change (whether upgraded
+with `railway upgrade` or a package manager). Locally modified or deleted skills are
+skipped, and user-added files are preserved. Restart your coding tool to load updated
+skills. Use `railway skills update` to review skipped updates, or add `--force` to
+overwrite local changes explicitly.
+
+`railway autoupdate disable` (or `RAILWAY_NO_AUTO_UPDATE=1`) disables automatic CLI
+and skill updates and their update notices. Explicit `railway upgrade`,
+`railway check-updates`, and `railway skills update` commands remain available.
+
 Opt into the local GraphQL-backed MCP server instead:
 
 ```bash

--- a/src/commands/autoupdate.rs
+++ b/src/commands/autoupdate.rs
@@ -219,6 +219,8 @@ pub async fn command(args: Args) -> Result<()> {
 
             println!("Install method: {}", method.name().bold());
             println!("Update strategy: {}", method.update_strategy());
+            crate::util::update_status::print_status();
+            crate::commands::skills::print_update_details();
 
             let update = UpdateCheck::read_normalized();
 
@@ -229,7 +231,7 @@ pub async fn command(args: Args) -> Result<()> {
             if let Some(ref staged) = crate::util::self_update::validated_staged_version() {
                 if auto_update_enabled {
                     println!(
-                        "Staged update: {} (will apply on next run)",
+                        "Staged update: {} (ready to install on the next interactive command)",
                         format!("v{staged}").green()
                     );
                 } else {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -418,17 +418,25 @@ pub(crate) fn print_agent_health_check() {
     eprintln!("\n{}", "Agent tooling:".dimmed());
 
     if skills_ok {
+        let auto_update_enabled = !crate::telemetry::is_auto_update_disabled();
         let revision = match skills::installed_skills_revision(&home) {
-            Some((installed, skills::SkillsStaleness::UpdateAvailable(newer))) => {
+            Some((installed, skills::SkillsStaleness::UpdatePending(newer)))
+                if auto_update_enabled =>
+            {
+                format!(" (rev {installed} \u{2192} {newer}, automatic update pending)")
+            }
+            Some((installed, skills::SkillsStaleness::UpdateAvailable(newer)))
+                if auto_update_enabled =>
+            {
                 format!(
-                    " (rev {installed} \u{2192} {newer} available, run `railway skills update`)"
+                    " (rev {installed} \u{2192} {newer}, local changes skipped; run `railway skills update` to review)"
                 )
             }
             Some((installed, skills::SkillsStaleness::UpToDate)) => {
                 format!(" (rev {installed}, up to date)")
             }
             // No staleness evidence yet — show the revision, claim nothing.
-            Some((installed, skills::SkillsStaleness::Unknown)) => format!(" (rev {installed})"),
+            Some((installed, _)) => format!(" (rev {installed})"),
             None => String::new(),
         };
         eprintln!(

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -60,6 +60,12 @@ struct InstallTarget {
     skills_dir: PathBuf,
 }
 
+#[derive(Clone, Copy)]
+enum InstallMode {
+    Explicit { force: bool, quiet: bool },
+    Background,
+}
+
 type SkillFiles = HashMap<String, Vec<(PathBuf, Vec<u8>)>>;
 
 // ---------------------------------------------------------------------------
@@ -97,6 +103,10 @@ struct SkillsManifest {
     /// user-modified skill the background apply can't touch.
     #[serde(default)]
     auto_applied_sha: Option<String>,
+    /// CLI version that last synced installed skills. A new binary gets one
+    /// immediate sync, regardless of the hourly upstream-check gate.
+    #[serde(default)]
+    cli_version: Option<String>,
     /// The upstream SHA we last nagged about unmanaged (pre-manifest /
     /// externally-synced) skill installs, so the banner fires once per
     /// upstream commit rather than on every command.
@@ -149,13 +159,31 @@ impl SkillsManifest {
         }
     }
 
-    /// True when a background auto-apply is worth spawning: there's a pending
-    /// update we haven't already attempted for this exact upstream SHA. Once an
-    /// attempt runs (even one that only skips modified skills), we don't retry
-    /// the same SHA — that case falls back to the user-facing nag.
+    /// Sync once per CLI version (including legacy manifests), and whenever
+    /// upstream changes. An attempt that skips modified skills is still recorded
+    /// so we don't download the same revision on every command.
     fn should_auto_apply(&self) -> bool {
-        self.update_pending() && self.latest_sha != self.auto_applied_sha
+        self.has_installed_skills()
+            && (self.cli_version.as_deref() != Some(env!("CARGO_PKG_VERSION"))
+                || (self.update_pending() && self.latest_sha != self.auto_applied_sha))
     }
+
+    fn update_requires_attention(&self) -> bool {
+        self.has_installed_skills() && self.update_pending() && !self.should_auto_apply()
+    }
+}
+
+/// Serialize manifest reads/writes and skill installs across CLI processes.
+/// Background callers quietly retry on their next invocation if the lock is busy.
+fn lock_manifest(home: &Path) -> Result<std::fs::File> {
+    use fs2::FileExt;
+
+    let dir = home.join(".railway");
+    std::fs::create_dir_all(&dir)?;
+    let file = std::fs::File::create(dir.join("skills.lock"))?;
+    file.try_lock_exclusive()
+        .context("Another skills update is in progress. Please try again shortly.")?;
+    Ok(file)
 }
 
 /// How an on-disk skill compares to the baseline we recorded and the new
@@ -168,7 +196,8 @@ enum SkillState {
     UpToDate,
     /// Unmodified since our last install and upstream changed — safe to upgrade.
     CleanUpgrade,
-    /// The user edited (or deleted) files we own — skip unless forced.
+    /// The user edited/deleted files we own, or added a file upstream now wants
+    /// to write — skip unless forced.
     Modified,
     /// Present but we have no baseline and it differs from upstream — we can't
     /// prove it's untouched, so treat it like a modification.
@@ -255,6 +284,12 @@ fn classify_skill(
         Some(r) => {
             let modified = r.files.iter().any(|(rel, recorded)| {
                 disk.get(rel).and_then(Option::clone).as_ref() != Some(recorded)
+            }) || new_hashes.iter().any(|(rel, new_hash)| {
+                !r.files.contains_key(rel)
+                    && disk
+                        .get(rel)
+                        .and_then(Option::as_ref)
+                        .is_some_and(|hash| hash != new_hash)
             });
             if modified {
                 SkillState::Modified
@@ -322,6 +357,7 @@ async fn fetch_latest_sha() -> Option<String> {
         .get(SKILLS_SHA_URL)
         .header("User-Agent", get_user_agent())
         .header("Accept", "application/vnd.github.sha")
+        .timeout(std::time::Duration::from_secs(30))
         .send()
         .await
         .ok()?;
@@ -332,24 +368,23 @@ async fn fetch_latest_sha() -> Option<String> {
     (sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit())).then_some(sha)
 }
 
-/// No-network read of cached state, for the startup banner: true when we have
-/// skills installed and a previous background check found a newer commit.
-pub(crate) fn cached_skill_update_available() -> bool {
+/// Only prompt after an automatic attempt was unable to update all skills.
+pub(crate) fn cached_skill_update_requires_attention() -> bool {
     let Some(home) = dirs::home_dir() else {
         return false;
     };
     let manifest = SkillsManifest::read(&home);
-    manifest.has_installed_skills() && manifest.update_pending()
+    manifest.update_requires_attention()
 }
 
 /// No-network read: true when a background auto-apply should be spawned (a
-/// pending update we haven't already attempted for this upstream SHA).
+/// pending upstream update or the first sync with a new CLI version).
 pub(crate) fn cached_skill_auto_apply_due() -> bool {
     let Some(home) = dirs::home_dir() else {
         return false;
     };
     let manifest = SkillsManifest::read(&home);
-    manifest.has_installed_skills() && manifest.should_auto_apply()
+    manifest.should_auto_apply()
 }
 
 /// Background staleness check, run from the same task as the CLI version check.
@@ -357,6 +392,9 @@ pub(crate) fn cached_skill_auto_apply_due() -> bool {
 /// invocation's banner is accurate. Skips entirely when no skills are installed.
 pub(crate) async fn refresh_skill_update_state() {
     let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    let Ok(_lock) = lock_manifest(&home) else {
         return;
     };
     let mut manifest = SkillsManifest::read(&home);
@@ -509,6 +547,7 @@ fn unmanaged_skill_tools(home: &Path, manifest: &SkillsManifest) -> Vec<&'static
 /// upstream SHA (re-arming when upstream moves), not on every command.
 /// No network; a couple of stat calls per known tool.
 fn orphan_skills_nag(home: &Path) -> Option<Vec<String>> {
+    let _lock = lock_manifest(home).ok()?;
     let mut manifest = SkillsManifest::read(home);
     let orphans = unmanaged_skill_tools(home, &manifest);
     if orphans.is_empty() {
@@ -545,6 +584,8 @@ pub(super) enum SkillsStaleness {
     UpToDate,
     /// Upstream has moved past the install (short SHA of the newer commit).
     UpdateAvailable(String),
+    /// A newer revision will be applied automatically on a normal invocation.
+    UpdatePending(String),
     /// No upstream check result yet — staleness unknown.
     Unknown,
 }
@@ -563,6 +604,9 @@ pub(super) fn installed_skills_revision(home: &Path) -> Option<(String, SkillsSt
     let short = |sha: &str| sha.chars().take(7).collect::<String>();
     let staleness = match manifest.latest_sha.as_deref() {
         Some(latest) if latest == installed => SkillsStaleness::UpToDate,
+        Some(latest) if manifest.should_auto_apply() => {
+            SkillsStaleness::UpdatePending(short(latest))
+        }
         Some(latest) => SkillsStaleness::UpdateAvailable(short(latest)),
         None => SkillsStaleness::Unknown,
     };
@@ -617,11 +661,16 @@ fn print_target_summary(action: &str, targets: &[InstallTarget]) {
     println!("{} {}\n", action.bold(), target_names);
 }
 
-async fn download_tarball() -> Result<Vec<u8>> {
+async fn download_tarball(source_sha: Option<&str>) -> Result<Vec<u8>> {
+    // Pin to the SHA we record: main can move between the API and tarball requests.
+    let url = source_sha
+        .map(|sha| format!("https://github.com/railwayapp/railway-skills/archive/{sha}.tar.gz"))
+        .unwrap_or_else(|| TARBALL_URL.to_string());
     let client = reqwest::Client::new();
     let response = client
-        .get(TARBALL_URL)
+        .get(url)
         .header("User-Agent", get_user_agent())
+        .timeout(std::time::Duration::from_secs(120))
         .send()
         .await
         .context("Failed to download Railway skills")?;
@@ -697,31 +746,54 @@ pub(super) async fn install_skills(
     force: bool,
     quiet: bool,
 ) -> Result<()> {
-    run_install(agent_filter, force, quiet).await
+    run_install(agent_filter, InstallMode::Explicit { force, quiet }).await
 }
 
 /// Headless skills refresh, spawned as a detached process (mirrors the binary's
-/// background self-update). Auto-detects targets, never forces — so user-edited
-/// skills are skipped and left to the nag — and prints nothing.
+/// background self-update). Only updates manifest-managed skills, never forces,
+/// and prints nothing. Re-check preferences in the child, before any writes.
 pub(crate) async fn apply_update_in_background() -> Result<()> {
-    run_install(&[], false, true).await
+    run_install(&[], InstallMode::Background).await
 }
 
-async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Result<()> {
+async fn run_install(agent_filter: &[String], mode: InstallMode) -> Result<()> {
     let home = dirs::home_dir().context("could not determine home directory")?;
-    let tools = resolve_tools(&home, agent_filter)?;
-    let targets = build_targets(&tools);
+    let _lock = lock_manifest(&home)?;
+    let manifest = SkillsManifest::read(&home);
+    let (targets, quiet) = match mode {
+        InstallMode::Explicit { quiet, .. } => {
+            (build_targets(&resolve_tools(&home, agent_filter)?), quiet)
+        }
+        InstallMode::Background => {
+            if crate::telemetry::is_auto_update_disabled() || !manifest.should_auto_apply() {
+                return Ok(());
+            }
+            let targets = manifest
+                .targets
+                .keys()
+                .map(|path| InstallTarget {
+                    tool_name: path.clone(),
+                    skills_dir: PathBuf::from(path),
+                })
+                .collect();
+            (targets, true)
+        }
+    };
 
     if !quiet {
         println!("\n{}\n", "Railway Skills".bold());
         print_target_summary("Installing to:", &targets);
     }
 
+    let source_sha = fetch_latest_sha().await;
+    if matches!(mode, InstallMode::Background) && source_sha.is_none() {
+        bail!("Failed to determine the latest Railway skills revision");
+    }
     let tarball_bytes = if quiet {
-        download_tarball().await?
+        download_tarball(source_sha.as_deref()).await?
     } else {
         let mut spinner = create_spinner("Downloading skills...".to_string());
-        match download_tarball().await {
+        match download_tarball(source_sha.as_deref()).await {
             Ok(bytes) => {
                 success_spinner(&mut spinner, "Downloaded skills".to_string());
                 bytes
@@ -734,28 +806,37 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
     };
 
     let skills = extract_skill_files(&tarball_bytes)?;
+
+    // The user may have disabled updates while the download was in flight.
+    if matches!(mode, InstallMode::Background) && crate::telemetry::is_auto_update_disabled() {
+        return Ok(());
+    }
+    install_downloaded_skills(&home, &targets, &skills, source_sha, manifest, mode)
+}
+
+fn install_downloaded_skills(
+    home: &Path,
+    targets: &[InstallTarget],
+    skills: &SkillFiles,
+    source_sha: Option<String>,
+    mut manifest: SkillsManifest,
+    mode: InstallMode,
+) -> Result<()> {
+    let (force, quiet) = match mode {
+        InstallMode::Explicit { force, quiet } => (force, quiet),
+        InstallMode::Background => (false, true),
+    };
     let mut skill_names: Vec<&String> = skills.keys().collect();
     skill_names.sort();
-
-    // Best-effort: the commit we're installing. Lets the background staleness
-    // check tell when this install has fallen behind upstream.
-    let source_sha = fetch_latest_sha().await;
 
     if !quiet {
         println!();
     }
 
-    let mut manifest = SkillsManifest::read(&home);
     let mut blocked = 0u32;
     let mut installed = 0u32;
 
-    for target in &targets {
-        std::fs::create_dir_all(&target.skills_dir).with_context(|| {
-            format!(
-                "Failed to create skills directory {}",
-                target.skills_dir.display()
-            )
-        })?;
+    for target in targets {
         let target_key = rel_key(&target.skills_dir);
 
         for skill_name in &skill_names {
@@ -763,24 +844,32 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
             let new_hashes = new_file_hashes(files);
             let skill_dir = target.skills_dir.join(skill_name);
             let record = manifest.record(&target_key, skill_name).cloned();
-            let state = classify_skill(&skill_dir, &new_hashes, record.as_ref());
+            if matches!(mode, InstallMode::Background) && record.is_none() {
+                continue;
+            }
+            let state = match classify_skill(&skill_dir, &new_hashes, record.as_ref()) {
+                // A removed managed skill is a local deletion. Only an explicit
+                // install may recreate it; automatic sync must leave it alone.
+                SkillState::NotInstalled if matches!(mode, InstallMode::Background) => {
+                    SkillState::Modified
+                }
+                state => state,
+            };
 
             let (label, action) = match state {
                 SkillState::NotInstalled => ("installed", true),
                 SkillState::CleanUpgrade => ("updated", true),
                 SkillState::UpToDate => {
-                    // Adopt an untracked-but-current skill so future upgrades
-                    // have a baseline; otherwise nothing to write.
-                    if record.is_none() {
-                        manifest.set_record(
-                            &target_key,
-                            skill_name,
-                            SkillRecord {
-                                installed_at: Utc::now().to_rfc3339(),
-                                files: new_hashes,
-                            },
-                        );
-                    }
+                    // Adopt current content as the baseline, including when a
+                    // user independently applied the same upstream changes.
+                    manifest.set_record(
+                        &target_key,
+                        skill_name,
+                        SkillRecord {
+                            installed_at: Utc::now().to_rfc3339(),
+                            files: new_hashes,
+                        },
+                    );
                     if !quiet {
                         println!(
                             "{} {}: {} already up to date",
@@ -796,7 +885,11 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
                         let detail = match (&state, &record) {
                             (SkillState::Modified, Some(r)) => {
                                 let files = modified_files(&skill_dir, r);
-                                format!("you've modified {}", files.join(", "))
+                                if files.is_empty() {
+                                    "an incoming file conflicts with a local addition".to_string()
+                                } else {
+                                    format!("you've modified {}", files.join(", "))
+                                }
                             }
                             _ => "can't verify it's unmodified".to_string(),
                         };
@@ -847,9 +940,10 @@ async fn run_install(agent_filter: &[String], force: bool, quiet: bool) -> Resul
         manifest.latest_sha = Some(sha.clone());
         manifest.last_checked = Some(Utc::now().to_rfc3339());
         manifest.auto_applied_sha = Some(sha);
+        manifest.cli_version = Some(env!("CARGO_PKG_VERSION").to_string());
     }
 
-    manifest.save(&home)?;
+    manifest.save(home)?;
 
     if !quiet {
         if blocked > 0 {
@@ -919,6 +1013,7 @@ pub(crate) fn spawn_background_skill_update() {
 // skills are renamed upstream.
 async fn remove_skills(agent_filter: &[String]) -> Result<()> {
     let home = dirs::home_dir().context("could not determine home directory")?;
+    let _lock = lock_manifest(&home)?;
     let tools = resolve_tools(&home, agent_filter)?;
     let targets = build_targets(&tools);
 
@@ -926,7 +1021,7 @@ async fn remove_skills(agent_filter: &[String]) -> Result<()> {
     print_target_summary("Removing from:", &targets);
 
     let mut spinner = create_spinner("Fetching skill list...".to_string());
-    let tarball_bytes = match download_tarball().await {
+    let tarball_bytes = match download_tarball(None).await {
         Ok(bytes) => {
             success_spinner(&mut spinner, "Fetched skill list".to_string());
             bytes
@@ -1231,21 +1326,192 @@ mod tests {
     fn should_auto_apply_skips_already_attempted_sha() {
         let mut m = SkillsManifest::default();
         m.set_record("/skills", "use-railway", SkillRecord::default());
+        m.cli_version = Some(env!("CARGO_PKG_VERSION").to_string());
         m.source_sha = Some("old".to_string());
         m.latest_sha = Some("new".to_string());
 
         // Pending and never attempted → auto-apply is due.
         assert!(m.should_auto_apply());
+        assert!(!m.update_requires_attention());
 
         // We attempted "new" but it only skipped a modified skill (source_sha
         // stayed "old"). Still pending for the banner, but don't re-download.
         m.auto_applied_sha = Some("new".to_string());
         assert!(m.update_pending());
         assert!(!m.should_auto_apply());
+        assert!(m.update_requires_attention());
 
         // Upstream moves again → due once more.
         m.latest_sha = Some("newer".to_string());
         assert!(m.should_auto_apply());
+        assert!(!m.update_requires_attention());
+    }
+
+    #[test]
+    fn cli_version_change_syncs_skills_even_with_a_fresh_upstream_cache() {
+        let mut manifest = SkillsManifest {
+            source_sha: Some("current".to_string()),
+            latest_sha: Some("current".to_string()),
+            auto_applied_sha: Some("current".to_string()),
+            last_checked: Some(Utc::now().to_rfc3339()),
+            cli_version: Some("0.0.1".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            !manifest.should_auto_apply(),
+            "never install skills for new users"
+        );
+        manifest.set_record("/skills", "use-railway", SkillRecord::default());
+        assert!(manifest.should_auto_apply());
+        manifest.cli_version = Some(env!("CARGO_PKG_VERSION").to_string());
+        assert!(!manifest.should_auto_apply());
+
+        // Pre-version-tracking manifests get the same one-time migration.
+        manifest.cli_version = None;
+        assert!(manifest.should_auto_apply());
+    }
+
+    #[test]
+    fn background_sync_updates_clean_skills_and_preserves_local_changes() {
+        let home = tempfile::tempdir().unwrap();
+        let mut manifest = SkillsManifest {
+            source_sha: Some("old".to_string()),
+            ..Default::default()
+        };
+        let cases = [
+            "clean",
+            "edited",
+            "deleted-file",
+            "deleted-skill",
+            "collision",
+            "unmanaged",
+        ];
+        let targets: Vec<_> = cases
+            .iter()
+            .map(|name| InstallTarget {
+                tool_name: name.to_string(),
+                skills_dir: home.path().join(name),
+            })
+            .collect();
+        for target in &targets {
+            let dir = target.skills_dir.join("use-railway");
+            write(&dir, "SKILL.md", "v1");
+            write(&dir, "old.md", "old");
+            write(&dir, "notes.md", "my notes");
+            if target.tool_name != "unmanaged" {
+                manifest.set_record(
+                    &rel_key(&target.skills_dir),
+                    "use-railway",
+                    record_of(&[("SKILL.md", "v1"), ("old.md", "old")]),
+                );
+            }
+        }
+        write(
+            &home.path().join("edited/use-railway"),
+            "SKILL.md",
+            "my edit",
+        );
+        std::fs::remove_file(home.path().join("deleted-file/use-railway/old.md")).unwrap();
+        std::fs::remove_dir_all(home.path().join("deleted-skill/use-railway")).unwrap();
+        write(
+            &home.path().join("collision/use-railway"),
+            "new.md",
+            "my addition",
+        );
+        let skills = HashMap::from([
+            (
+                "use-railway".to_string(),
+                new_files(&[("SKILL.md", "v2"), ("new.md", "upstream")]),
+            ),
+            (
+                "new-skill".to_string(),
+                new_files(&[("SKILL.md", "new skill")]),
+            ),
+        ]);
+
+        install_downloaded_skills(
+            home.path(),
+            &targets,
+            &skills,
+            Some("new".to_string()),
+            manifest,
+            InstallMode::Background,
+        )
+        .unwrap();
+
+        let read = |path: &str| std::fs::read_to_string(home.path().join(path)).unwrap();
+        assert_eq!(read("clean/use-railway/SKILL.md"), "v2");
+        assert_eq!(read("clean/use-railway/new.md"), "upstream");
+        assert_eq!(read("clean/use-railway/notes.md"), "my notes");
+        assert!(!home.path().join("clean/use-railway/old.md").exists());
+        assert_eq!(read("edited/use-railway/SKILL.md"), "my edit");
+        assert_eq!(read("deleted-file/use-railway/SKILL.md"), "v1");
+        assert!(!home.path().join("deleted-file/use-railway/old.md").exists());
+        assert!(!home.path().join("deleted-skill/use-railway").exists());
+        assert_eq!(read("collision/use-railway/SKILL.md"), "v1");
+        assert_eq!(read("collision/use-railway/new.md"), "my addition");
+        assert_eq!(read("unmanaged/use-railway/SKILL.md"), "v1");
+        assert!(
+            targets
+                .iter()
+                .all(|target| !target.skills_dir.join("new-skill").exists())
+        );
+
+        let manifest = SkillsManifest::read(home.path());
+        assert_eq!(manifest.source_sha.as_deref(), Some("old"));
+        assert_eq!(manifest.latest_sha.as_deref(), Some("new"));
+        assert!(
+            !manifest.should_auto_apply(),
+            "do not repeatedly retry modified skills"
+        );
+        assert!(manifest.update_requires_attention());
+    }
+
+    #[test]
+    fn successful_background_sync_records_revision_and_cli_version() {
+        let home = tempfile::tempdir().unwrap();
+        let target = InstallTarget {
+            tool_name: "test".to_string(),
+            skills_dir: home.path().join("skills"),
+        };
+        let dir = target.skills_dir.join("use-railway");
+        // The user independently applied exactly the upstream change. Adopt
+        // that content as the baseline so the next release can update it too.
+        write(&dir, "SKILL.md", "v2");
+        let mut manifest = SkillsManifest::default();
+        manifest.set_record(
+            &rel_key(&target.skills_dir),
+            "use-railway",
+            record_of(&[("SKILL.md", "v1")]),
+        );
+        let skills = HashMap::from([("use-railway".to_string(), new_files(&[("SKILL.md", "v2")]))]);
+        install_downloaded_skills(
+            home.path(),
+            &[target],
+            &skills,
+            Some("new".to_string()),
+            manifest,
+            InstallMode::Background,
+        )
+        .unwrap();
+
+        assert_eq!(std::fs::read_to_string(dir.join("SKILL.md")).unwrap(), "v2");
+        let manifest = SkillsManifest::read(home.path());
+        assert_eq!(manifest.source_sha.as_deref(), Some("new"));
+        assert_eq!(
+            manifest.cli_version.as_deref(),
+            Some(env!("CARGO_PKG_VERSION"))
+        );
+        assert!(!manifest.should_auto_apply());
+        assert!(!manifest.update_requires_attention());
+        assert_eq!(
+            classify_skill(
+                &dir,
+                &new_file_hashes(&new_files(&[("SKILL.md", "v3")])),
+                manifest.record(&rel_key(&home.path().join("skills")), "use-railway"),
+            ),
+            SkillState::CleanUpgrade
+        );
     }
 
     #[test]

--- a/src/commands/skills.rs
+++ b/src/commands/skills.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::consts::get_user_agent;
 use crate::util::progress::{create_spinner, fail_spinner, success_spinner};
+use crate::util::update_status::{self, SkillsOutcome};
 use crate::util::write_atomic;
 use chrono::Utc;
 use flate2::read::GzDecoder;
@@ -61,9 +62,23 @@ struct InstallTarget {
 }
 
 #[derive(Clone, Copy)]
-enum InstallMode {
+enum InstallMode<'a> {
     Explicit { force: bool, quiet: bool },
     Background,
+    Upgrade { cli_version: &'a str },
+}
+
+impl<'a> InstallMode<'a> {
+    fn managed_only(self) -> bool {
+        !matches!(self, Self::Explicit { .. })
+    }
+
+    fn cli_version(self) -> &'a str {
+        match self {
+            Self::Upgrade { cli_version } => cli_version,
+            _ => env!("CARGO_PKG_VERSION"),
+        }
+    }
 }
 
 type SkillFiles = HashMap<String, Vec<(PathBuf, Vec<u8>)>>;
@@ -107,11 +122,6 @@ struct SkillsManifest {
     /// immediate sync, regardless of the hourly upstream-check gate.
     #[serde(default)]
     cli_version: Option<String>,
-    /// The upstream SHA we last nagged about unmanaged (pre-manifest /
-    /// externally-synced) skill installs, so the banner fires once per
-    /// upstream commit rather than on every command.
-    #[serde(default)]
-    orphan_nag_sha: Option<String>,
     #[serde(default)]
     targets: BTreeMap<String, BTreeMap<String, SkillRecord>>,
 }
@@ -368,13 +378,24 @@ async fn fetch_latest_sha() -> Option<String> {
     (sha.len() == 40 && sha.chars().all(|c| c.is_ascii_hexdigit())).then_some(sha)
 }
 
-/// Only prompt after an automatic attempt was unable to update all skills.
-pub(crate) fn cached_skill_update_requires_attention() -> bool {
+/// Explicit status reports local edits without interrupting normal commands.
+pub(crate) fn print_update_details() {
     let Some(home) = dirs::home_dir() else {
-        return false;
+        return;
     };
     let manifest = SkillsManifest::read(&home);
-    manifest.update_requires_attention()
+    if manifest.update_requires_attention() {
+        println!(
+            "Agent skills preserved: local changes detected. Run `railway skills update` for details."
+        );
+    }
+    let unmanaged = unmanaged_skill_tools(&home, &manifest);
+    if !unmanaged.is_empty() {
+        println!(
+            "Unmanaged Railway skills: {}. Run `railway skills update` to adopt unmodified copies.",
+            unmanaged.join(", ")
+        );
+    }
 }
 
 /// No-network read: true when a background auto-apply should be spawned (a
@@ -387,9 +408,17 @@ pub(crate) fn cached_skill_auto_apply_due() -> bool {
     manifest.should_auto_apply()
 }
 
+pub(crate) fn managed_install_info() -> (bool, Option<String>) {
+    let Some(home) = dirs::home_dir() else {
+        return (false, None);
+    };
+    let manifest = SkillsManifest::read(&home);
+    (manifest.has_installed_skills(), manifest.cli_version)
+}
+
 /// Background staleness check, run from the same task as the CLI version check.
-/// Hourly-gated and best-effort: refreshes the cached upstream SHA so the next
-/// invocation's banner is accurate. Skips entirely when no skills are installed.
+/// Hourly-gated and best-effort: refreshes the cached upstream SHA for automatic
+/// synchronization and explicit status. Skips when no managed skills are installed.
 pub(crate) async fn refresh_skill_update_state() {
     let Some(home) = dirs::home_dir() else {
         return;
@@ -398,11 +427,8 @@ pub(crate) async fn refresh_skill_update_state() {
         return;
     };
     let mut manifest = SkillsManifest::read(&home);
-    // Run the check for managed installs AND for unmanaged-but-present
-    // railway skills (pre-manifest installs), so the orphan nag can key
-    // off a real upstream SHA and re-arm when upstream moves. Machines
-    // with no railway skills anywhere still never hit the network.
-    if !manifest.has_installed_skills() && unmanaged_skill_tools(&home, &manifest).is_empty() {
+    // Only managed installs participate in automatic updates.
+    if !manifest.has_installed_skills() {
         return;
     }
 
@@ -420,7 +446,7 @@ pub(crate) async fn refresh_skill_update_state() {
     // Stamp `last_checked` regardless of the fetch outcome: a failing
     // GitHub API (rate limit, network) would otherwise re-fire the
     // request on every CLI invocation until one succeeded. Worst case
-    // a transient failure just delays the banner by one interval.
+    // a transient failure just delays discovery by one interval.
     manifest.last_checked = Some(Utc::now().to_rfc3339());
     if let Some(sha) = fetch_latest_sha().await {
         manifest.latest_sha = Some(sha);
@@ -518,10 +544,8 @@ const RAILWAY_SKILL_NAMES: &[&str] = &["use-railway"];
 
 /// Coding tools that have a railway skill on disk with no manifest record
 /// for that target — installs made before the CLI tracked skills, or
-/// external syncs. We never write to these without the user asking;
-/// `orphan_skills_nag_due` surfaces a banner pointing at
-/// `railway skills update` instead (which adopts up-to-date copies and
-/// safely skips modified ones).
+/// external syncs. Explicit update status points at `railway skills update`,
+/// which adopts up-to-date copies and safely skips modified ones.
 fn unmanaged_skill_tools(home: &Path, manifest: &SkillsManifest) -> Vec<&'static str> {
     coding_tools(home)
         .into_iter()
@@ -540,40 +564,6 @@ fn unmanaged_skill_tools(home: &Path, manifest: &SkillsManifest) -> Vec<&'static
         })
         .map(|tool| tool.name)
         .collect()
-}
-
-/// Banner check for unmanaged railway skills: returns the affected tool
-/// names when a nag is due and stamps the dedupe key so it fires once per
-/// upstream SHA (re-arming when upstream moves), not on every command.
-/// No network; a couple of stat calls per known tool.
-fn orphan_skills_nag(home: &Path) -> Option<Vec<String>> {
-    let _lock = lock_manifest(home).ok()?;
-    let mut manifest = SkillsManifest::read(home);
-    let orphans = unmanaged_skill_tools(home, &manifest);
-    if orphans.is_empty() {
-        return None;
-    }
-    // Key the nag to the last-seen upstream SHA; before the first
-    // background check lands there's no SHA yet, so a sentinel gives us
-    // exactly one pre-check nag.
-    let key = manifest
-        .latest_sha
-        .clone()
-        .unwrap_or_else(|| "unknown".to_string());
-    if manifest.orphan_nag_sha.as_deref() == Some(key.as_str()) {
-        return None;
-    }
-    manifest.orphan_nag_sha = Some(key);
-    let _ = manifest.save(home);
-    Some(orphans.into_iter().map(str::to_string).collect())
-}
-
-/// No-network banner entry point for `main`: unmanaged railway skills
-/// found on disk (see `unmanaged_skill_tools`), at most once per upstream
-/// SHA.
-pub(crate) fn orphan_skills_nag_due() -> Option<Vec<String>> {
-    let home = dirs::home_dir()?;
-    orphan_skills_nag(&home)
 }
 
 /// What the background staleness check knows about an install, distinguishing
@@ -746,17 +736,30 @@ pub(super) async fn install_skills(
     force: bool,
     quiet: bool,
 ) -> Result<()> {
-    run_install(agent_filter, InstallMode::Explicit { force, quiet }).await
+    run_install(agent_filter, InstallMode::Explicit { force, quiet })
+        .await
+        .map(|_| ())
 }
 
 /// Headless skills refresh, spawned as a detached process (mirrors the binary's
 /// background self-update). Only updates manifest-managed skills, never forces,
 /// and prints nothing. Re-check preferences in the child, before any writes.
 pub(crate) async fn apply_update_in_background() -> Result<()> {
-    run_install(&[], InstallMode::Background).await
+    run_install(&[], InstallMode::Background).await.map(|_| ())
 }
 
-async fn run_install(agent_filter: &[String], mode: InstallMode) -> Result<()> {
+/// Explicit CLI upgrades include managed skills, even when automatic checks are
+/// disabled. This never forces local edits or installs skills for new users.
+pub(crate) async fn sync_for_upgrade(cli_version: &str) -> Result<SkillsOutcome> {
+    run_install(&[], InstallMode::Upgrade { cli_version })
+        .await?
+        .context("Skills synchronization did not complete")
+}
+
+async fn run_install(
+    agent_filter: &[String],
+    mode: InstallMode<'_>,
+) -> Result<Option<SkillsOutcome>> {
     let home = dirs::home_dir().context("could not determine home directory")?;
     let _lock = lock_manifest(&home)?;
     let manifest = SkillsManifest::read(&home);
@@ -764,9 +767,15 @@ async fn run_install(agent_filter: &[String], mode: InstallMode) -> Result<()> {
         InstallMode::Explicit { quiet, .. } => {
             (build_targets(&resolve_tools(&home, agent_filter)?), quiet)
         }
-        InstallMode::Background => {
-            if crate::telemetry::is_auto_update_disabled() || !manifest.should_auto_apply() {
-                return Ok(());
+        InstallMode::Background | InstallMode::Upgrade { .. } => {
+            if matches!(mode, InstallMode::Background)
+                && (crate::telemetry::is_auto_update_disabled() || !manifest.should_auto_apply())
+            {
+                return Ok(None);
+            }
+            if !manifest.has_installed_skills() {
+                update_status::record_skills(mode.cli_version(), SkillsOutcome::NotInstalled);
+                return Ok(Some(SkillsOutcome::NotInstalled));
             }
             let targets = manifest
                 .targets
@@ -785,33 +794,53 @@ async fn run_install(agent_filter: &[String], mode: InstallMode) -> Result<()> {
         print_target_summary("Installing to:", &targets);
     }
 
-    let source_sha = fetch_latest_sha().await;
-    if matches!(mode, InstallMode::Background) && source_sha.is_none() {
-        bail!("Failed to determine the latest Railway skills revision");
+    let report_outcome = mode.managed_only() || agent_filter.is_empty();
+    if report_outcome {
+        update_status::record_skills(mode.cli_version(), SkillsOutcome::Pending);
     }
-    let tarball_bytes = if quiet {
-        download_tarball(source_sha.as_deref()).await?
-    } else {
-        let mut spinner = create_spinner("Downloading skills...".to_string());
-        match download_tarball(source_sha.as_deref()).await {
-            Ok(bytes) => {
-                success_spinner(&mut spinner, "Downloaded skills".to_string());
-                bytes
-            }
-            Err(e) => {
-                fail_spinner(&mut spinner, "Failed to download skills".to_string());
-                return Err(e);
-            }
+    let result = async {
+        let source_sha = fetch_latest_sha().await;
+        if mode.managed_only() && source_sha.is_none() {
+            bail!("Failed to determine the latest Railway skills revision");
         }
-    };
+        let tarball_bytes = if quiet {
+            download_tarball(source_sha.as_deref()).await?
+        } else {
+            let mut spinner = create_spinner("Downloading skills...".to_string());
+            match download_tarball(source_sha.as_deref()).await {
+                Ok(bytes) => {
+                    success_spinner(&mut spinner, "Downloaded skills".to_string());
+                    bytes
+                }
+                Err(e) => {
+                    fail_spinner(&mut spinner, "Failed to download skills".to_string());
+                    return Err(e);
+                }
+            }
+        };
 
-    let skills = extract_skill_files(&tarball_bytes)?;
+        let skills = extract_skill_files(&tarball_bytes)?;
 
-    // The user may have disabled updates while the download was in flight.
-    if matches!(mode, InstallMode::Background) && crate::telemetry::is_auto_update_disabled() {
-        return Ok(());
+        // The user may have disabled updates while the download was in flight.
+        if matches!(mode, InstallMode::Background) && crate::telemetry::is_auto_update_disabled() {
+            return Ok(None);
+        }
+        install_downloaded_skills(&home, &targets, &skills, source_sha, manifest, mode).map(Some)
     }
-    install_downloaded_skills(&home, &targets, &skills, source_sha, manifest, mode)
+    .await;
+    if report_outcome {
+        match &result {
+            Ok(Some(outcome)) => update_status::record_skills(mode.cli_version(), outcome.clone()),
+            Err(error) => update_status::record_skills(
+                mode.cli_version(),
+                SkillsOutcome::Failed {
+                    message: error.to_string(),
+                },
+            ),
+            Ok(None) => {}
+        }
+    }
+    result
 }
 
 fn install_downloaded_skills(
@@ -820,11 +849,11 @@ fn install_downloaded_skills(
     skills: &SkillFiles,
     source_sha: Option<String>,
     mut manifest: SkillsManifest,
-    mode: InstallMode,
-) -> Result<()> {
+    mode: InstallMode<'_>,
+) -> Result<SkillsOutcome> {
     let (force, quiet) = match mode {
         InstallMode::Explicit { force, quiet } => (force, quiet),
-        InstallMode::Background => (false, true),
+        InstallMode::Background | InstallMode::Upgrade { .. } => (false, true),
     };
     let mut skill_names: Vec<&String> = skills.keys().collect();
     skill_names.sort();
@@ -844,15 +873,13 @@ fn install_downloaded_skills(
             let new_hashes = new_file_hashes(files);
             let skill_dir = target.skills_dir.join(skill_name);
             let record = manifest.record(&target_key, skill_name).cloned();
-            if matches!(mode, InstallMode::Background) && record.is_none() {
+            if mode.managed_only() && record.is_none() {
                 continue;
             }
             let state = match classify_skill(&skill_dir, &new_hashes, record.as_ref()) {
                 // A removed managed skill is a local deletion. Only an explicit
                 // install may recreate it; automatic sync must leave it alone.
-                SkillState::NotInstalled if matches!(mode, InstallMode::Background) => {
-                    SkillState::Modified
-                }
+                SkillState::NotInstalled if mode.managed_only() => SkillState::Modified,
                 state => state,
             };
 
@@ -927,20 +954,18 @@ fn install_downloaded_skills(
         }
     }
 
-    // Record the installed commit and reset the staleness cache so the "update
-    // available" banner clears immediately. We only advance source_sha when we
-    // applied the new content everywhere; if some skills were skipped as
-    // modified, leaving the old (or absent) SHA keeps the banner honest.
+    // Only advance source_sha when we applied the new content everywhere. If
+    // some skills were preserved, retain the prior revision for explicit status.
     // `auto_applied_sha` is stamped regardless so a background apply that only
     // skips modified skills doesn't re-download the same commit every run.
-    if let Some(sha) = source_sha {
+    if let Some(sha) = source_sha.as_ref() {
         if blocked == 0 {
             manifest.source_sha = Some(sha.clone());
         }
         manifest.latest_sha = Some(sha.clone());
         manifest.last_checked = Some(Utc::now().to_rfc3339());
-        manifest.auto_applied_sha = Some(sha);
-        manifest.cli_version = Some(env!("CARGO_PKG_VERSION").to_string());
+        manifest.auto_applied_sha = Some(sha.clone());
+        manifest.cli_version = Some(mode.cli_version().to_string());
     }
 
     manifest.save(home)?;
@@ -985,7 +1010,16 @@ fn install_downloaded_skills(
         }
     }
 
-    Ok(())
+    Ok(match source_sha {
+        Some(revision) if blocked > 0 => SkillsOutcome::Preserved {
+            revision,
+            count: blocked,
+        },
+        Some(revision) => SkillsOutcome::Synced { revision },
+        None => SkillsOutcome::Failed {
+            message: "Installed skills, but their upstream revision could not be verified".into(),
+        },
+    })
 }
 
 /// Re-execs this binary detached with `_RAILWAY_UPDATE_SKILLS` set so it
@@ -1139,32 +1173,6 @@ mod tests {
             .join("use-railway");
         std::fs::create_dir_all(&bare).unwrap();
         assert!(unmanaged_skill_tools(home2.path(), &SkillsManifest::default()).is_empty());
-    }
-
-    #[test]
-    fn orphan_nag_fires_once_per_upstream_sha() {
-        let home = tempfile::tempdir().unwrap();
-        plant_orphan_skill(home.path());
-
-        // First sighting nags (pre-check sentinel key) and stamps the manifest.
-        assert!(orphan_skills_nag(home.path()).is_some());
-        // Same key again: deduped.
-        assert!(orphan_skills_nag(home.path()).is_none());
-
-        // Upstream moved (background check recorded a new SHA): re-arms once.
-        let mut manifest = SkillsManifest::read(home.path());
-        manifest.latest_sha = Some("a".repeat(40));
-        manifest.save(home.path()).unwrap();
-        assert!(orphan_skills_nag(home.path()).is_some());
-        assert!(orphan_skills_nag(home.path()).is_none());
-    }
-
-    #[test]
-    fn orphan_nag_silent_when_no_skills_anywhere() {
-        let home = tempfile::tempdir().unwrap();
-        assert!(orphan_skills_nag(home.path()).is_none());
-        // And it must not create a manifest as a side effect.
-        assert!(!SkillsManifest::path(home.path()).exists());
     }
 
     // --- modification detection -------------------------------------------
@@ -1373,6 +1381,17 @@ mod tests {
 
     #[test]
     fn background_sync_updates_clean_skills_and_preserves_local_changes() {
+        assert_managed_sync_preserves_local_changes(InstallMode::Background);
+    }
+
+    #[test]
+    fn explicit_upgrade_sync_preserves_local_changes_and_records_the_installed_version() {
+        assert_managed_sync_preserves_local_changes(InstallMode::Upgrade {
+            cli_version: "255.255.254",
+        });
+    }
+
+    fn assert_managed_sync_preserves_local_changes(mode: InstallMode<'_>) {
         let home = tempfile::tempdir().unwrap();
         let mut manifest = SkillsManifest {
             source_sha: Some("old".to_string()),
@@ -1429,15 +1448,22 @@ mod tests {
             ),
         ]);
 
-        install_downloaded_skills(
+        let outcome = install_downloaded_skills(
             home.path(),
             &targets,
             &skills,
             Some("new".to_string()),
             manifest,
-            InstallMode::Background,
+            mode,
         )
         .unwrap();
+        assert_eq!(
+            outcome,
+            SkillsOutcome::Preserved {
+                revision: "new".into(),
+                count: 4
+            }
+        );
 
         let read = |path: &str| std::fs::read_to_string(home.path().join(path)).unwrap();
         assert_eq!(read("clean/use-railway/SKILL.md"), "v2");
@@ -1460,11 +1486,14 @@ mod tests {
         let manifest = SkillsManifest::read(home.path());
         assert_eq!(manifest.source_sha.as_deref(), Some("old"));
         assert_eq!(manifest.latest_sha.as_deref(), Some("new"));
-        assert!(
-            !manifest.should_auto_apply(),
-            "do not repeatedly retry modified skills"
-        );
-        assert!(manifest.update_requires_attention());
+        assert_eq!(manifest.cli_version.as_deref(), Some(mode.cli_version()));
+        if matches!(mode, InstallMode::Background) {
+            assert!(
+                !manifest.should_auto_apply(),
+                "do not repeatedly retry modified skills"
+            );
+            assert!(manifest.update_requires_attention());
+        }
     }
 
     #[test]

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -3,6 +3,8 @@ use std::process::Command;
 use is_terminal::IsTerminal;
 
 use crate::util::install_method::InstallMethod;
+use crate::util::progress::UpdateStep;
+use crate::util::update_status::{self, SkillsOutcome};
 
 use super::*;
 
@@ -62,7 +64,11 @@ fn retry_command(rollback: bool, yes: bool, elevated: bool) -> String {
     parts.join(" ")
 }
 
-fn run_upgrade_command(method: InstallMethod) -> Result<()> {
+fn run_upgrade_command(method: InstallMethod) -> Result<String> {
+    // Capture before replacement; current_exe() can point at a deleted inode
+    // after a package manager swaps the running executable on Linux.
+    let executable = std::env::current_exe().context("Failed to locate the CLI binary")?;
+    let executable = verification_path(method, &executable);
     let (program, args) = method
         .package_manager_command()
         .context("Cannot auto-upgrade for this install method")?;
@@ -90,28 +96,150 @@ fn run_upgrade_command(method: InstallMethod) -> Result<()> {
         );
     }
 
-    println!("{} {} {}", "Running:".bold(), program, args.join(" "));
-    println!();
-
-    let status = Command::new(program)
-        .args(&args)
-        .status()
-        .context(format!("Failed to execute {}", program))?;
+    let installing = UpdateStep::start(&format!("Installing CLI with {}", method.name()));
+    let output = match Command::new(program).args(&args).output() {
+        Ok(output) => output,
+        Err(error) => {
+            installing.finish("✗", "CLI installation failed");
+            return Err(error).with_context(|| format!("Failed to execute {program}"));
+        }
+    };
 
     // Clean up stale PID file from a previous background updater.
     let _ = std::fs::remove_file(&pid_path);
 
-    if !status.success() {
+    if !output.status.success() {
+        installing.finish("✗", "CLI installation failed");
         bail!(
-            "Upgrade command failed with exit code: {}",
-            status.code().unwrap_or(-1)
+            "{} {} failed (exit {}):\n{}\n{}",
+            program,
+            args.join(" "),
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stdout).trim(),
+            String::from_utf8_lossy(&output.stderr).trim(),
         );
     }
 
-    println!();
-    println!("{}", "Upgrade complete!".green().bold());
+    // Package managers resolve their own target. Check the binary they actually
+    // installed instead of claiming whatever GitHub happened to report earlier.
+    let verified = Command::new(executable)
+        .arg("--version")
+        .env("RAILWAY_NO_AUTO_UPDATE", "1")
+        .env("DO_NOT_TRACK", "1")
+        .output();
+    let version = match verified
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| installed_version(&String::from_utf8_lossy(&output.stdout)))
+    {
+        Some(version) => version,
+        None => {
+            installing.finish(
+                "·",
+                "CLI install finished; installed version could not be verified",
+            );
+            bail!(
+                "Run `railway --version` to verify the installation, then `railway skills update` to synchronize skills."
+            );
+        }
+    };
+    update_status::record_installed(&version);
+    crate::util::check_update::UpdateCheck::clear_after_update();
+    let summary = if version == env!("CARGO_PKG_VERSION") {
+        format!("CLI already up to date · v{version}")
+    } else {
+        format!(
+            "CLI installed · v{} → v{}",
+            env!("CARGO_PKG_VERSION"),
+            version
+        )
+    };
+    installing.finish("✓", &summary);
 
-    Ok(())
+    Ok(version)
+}
+
+/// Versioned package-manager directories can disappear during an upgrade.
+/// Resolve their stable entry point before checking the installed executable.
+fn verification_path(method: InstallMethod, executable: &std::path::Path) -> std::path::PathBuf {
+    if method == InstallMethod::Homebrew {
+        if let Some(cellar) = executable
+            .ancestors()
+            .find(|path| path.file_name().is_some_and(|name| name == "Cellar"))
+        {
+            if let (Some(prefix), Ok(relative)) = (cellar.parent(), executable.strip_prefix(cellar))
+            {
+                let mut parts = relative.components();
+                if let (Some(formula), Some(_version)) = (parts.next(), parts.next()) {
+                    return prefix.join("opt").join(formula).join(parts.as_path());
+                }
+            }
+        }
+    } else if method == InstallMethod::Scoop {
+        if let Some(app) = executable.ancestors().find(|path| {
+            path.file_name().is_some_and(|name| name == "railway")
+                && path
+                    .parent()
+                    .and_then(|parent| parent.file_name())
+                    .is_some_and(|name| name == "apps")
+        }) {
+            if let Ok(relative) = executable.strip_prefix(app) {
+                let mut parts = relative.components();
+                if parts.next().is_some() {
+                    return app.join("current").join(parts.as_path());
+                }
+            }
+        }
+    }
+    executable.to_path_buf()
+}
+
+fn installed_version(output: &str) -> Option<String> {
+    let version = output.trim().strip_prefix("railway ")?;
+    let core = version.split(['-', '+']).next()?;
+    let parts: Vec<_> = core.split('.').collect();
+    (parts.len() == 3
+        && parts.iter().all(|part| part.parse::<u64>().is_ok())
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+')))
+    .then(|| version.to_string())
+}
+
+async fn finish_upgrade(version: &str) {
+    let step = UpdateStep::start("Synchronizing agent skills");
+    let outcome = match skills::sync_for_upgrade(version).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let outcome = SkillsOutcome::Failed {
+                message: error.to_string(),
+            };
+            update_status::record_skills(version, outcome.clone());
+            outcome
+        }
+    };
+    let symbol = if matches!(outcome, SkillsOutcome::Synced { .. }) {
+        "✓"
+    } else {
+        "·"
+    };
+    step.finish(symbol, &outcome.summary());
+    if matches!(outcome, SkillsOutcome::Failed { .. }) {
+        eprintln!("  Details: railway autoupdate status");
+    }
+    let ready = if matches!(outcome, SkillsOutcome::Failed { .. }) {
+        "CLI ready"
+    } else {
+        "Ready"
+    };
+    if version == env!("CARGO_PKG_VERSION") {
+        eprintln!("\n{ready}. v{version} is active.");
+    } else {
+        eprintln!("\n{ready}. v{version} will be used on your next command.");
+    }
+    // This explicit flow already presented the result. Don't repeat it as an
+    // automatic receipt on the next invocation.
+    update_status::mark_presented(version);
 }
 
 pub async fn command(args: Args) -> Result<()> {
@@ -163,9 +291,9 @@ pub async fn command(args: Args) -> Result<()> {
 
     validate_interaction(args.yes, std::io::stdout().is_terminal())?;
 
-    println!(
-        "{} {} ({})",
-        "Current version:".bold(),
+    eprintln!(
+        "\n{} · v{} · {}\n",
+        "Updating Railway".bold(),
         env!("CARGO_PKG_VERSION"),
         method.name()
     );
@@ -173,8 +301,8 @@ pub async fn command(args: Args) -> Result<()> {
     // Order matters: check self-update first, then unknown, then package manager.
     match method {
         method if method.can_self_update() && method.can_write_binary() => {
-            println!();
-            crate::util::self_update::self_update_interactive().await?;
+            let version = crate::util::self_update::self_update_interactive().await?;
+            finish_upgrade(&version).await;
         }
         method if method.can_self_update() => {
             // Shell install but binary location not writable by current user
@@ -234,8 +362,8 @@ pub async fn command(args: Args) -> Result<()> {
             )?;
         }
         method if method.can_auto_upgrade() => {
-            println!();
-            run_upgrade_command(method)?;
+            let version = run_upgrade_command(method)?;
+            finish_upgrade(&version).await;
         }
         InstallMethod::Shell => {
             // Shell install on a platform where self-update is unsupported
@@ -274,7 +402,7 @@ pub async fn command(args: Args) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Args, validate_interaction};
+    use super::{Args, installed_version, validate_interaction};
     use clap::Parser;
 
     #[test]
@@ -300,5 +428,20 @@ mod tests {
     fn non_interactive_upgrade_requires_yes() {
         assert!(validate_interaction(false, false).is_err());
         assert!(validate_interaction(true, false).is_ok());
+    }
+
+    #[test]
+    fn package_manager_version_is_verified_from_cli_output() {
+        assert_eq!(
+            installed_version("railway 5.50.0\n").as_deref(),
+            Some("5.50.0")
+        );
+        assert_eq!(
+            installed_version("railway 5.50.0-beta.1\n").as_deref(),
+            Some("5.50.0-beta.1")
+        );
+        assert!(installed_version("npm 10.0.0").is_none());
+        assert!(installed_version("railway something-went-wrong").is_none());
+        assert!(installed_version("railway 5.50.0\nextra output").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,6 +274,29 @@ async fn main() -> Result<()> {
         || raw_subcommand.is_none()
         || matches!(raw_subcommand.as_deref(), Some("help"));
     let auto_update_enabled = !telemetry::is_auto_update_disabled();
+    let machine_output = raw_args.iter().any(|arg| arg == "--json");
+    let embedded_setup = std::env::var("RAILWAY_SETUP_EMBEDDED").is_ok();
+    let normal_invocation = !is_update_management_cmd
+        && !is_read_only_invocation
+        && !matches!(
+            raw_subcommand.as_deref(),
+            Some("skills" | "setup" | "completion")
+        );
+    let show_update_receipt = auto_update_enabled
+        && normal_invocation
+        && is_tty
+        && std::io::stderr().is_terminal()
+        && !machine_output
+        && !embedded_setup;
+
+    if auto_update_enabled && normal_invocation && !embedded_setup {
+        let (managed, previous) = commands::skills::managed_install_info();
+        util::update_status::observe_running(
+            env!("CARGO_PKG_VERSION"),
+            previous.as_deref(),
+            managed,
+        );
+    }
 
     // Non-TTY invocations are a supported path for coding agents and other
     // automated CLI users. They are allowed to refresh the update cache and
@@ -281,6 +304,7 @@ async fn main() -> Result<()> {
     // so the running binary never changes under a scripted invocation.
     let auto_update_applied = auto_update_enabled
         && is_tty
+        && !machine_output
         && !is_update_management_cmd
         && !is_read_only_invocation
         && util::self_update::try_apply_staged().is_some();
@@ -301,25 +325,26 @@ async fn main() -> Result<()> {
     // through to a fresh check_update() and can discover newer releases.
     let known_pending = update.latest_version;
 
-    // Show the "new version available" banner only for TTY users. Coding
-    // agents and other non-interactive callers should still refresh update
-    // state in the background, but they should not receive human-facing
-    // upgrade prompts in command output.
-    //
-    // The persisted preference, environment override, and CI all suppress
-    // unsolicited update notices as well as automatic installs.
-    // The installer's embedded agent setup renders one cohesive flow; the
-    // version/skills update banners are noise mid-install (the user just
-    // configured skills), so suppress them in that context.
-    let embedded_setup = std::env::var("RAILWAY_SETUP_EMBEDDED").is_ok();
-    if is_tty && auto_update_enabled && !embedded_setup {
+    // Automatic discovery/downloads are quiet. Installs requiring manual action
+    // get one notice per release; completed automatic updates get one receipt.
+    if show_update_receipt {
+        // Present a completed prior attempt before a retry can mark skills
+        // pending again. Fast background completions also get a chance at exit.
+        if let Some(receipt) = util::update_status::take_receipt() {
+            eprintln!("{receipt}");
+        }
         if let Some(ref latest_version) = known_pending {
+            let method = util::install_method::InstallMethod::detect();
+            let can_install = (method.can_self_update() && method.can_write_binary())
+                || method.can_auto_run_package_manager();
             let is_skipped = skipped_version.as_deref() == Some(latest_version.as_str());
-            if !is_skipped
+            if !can_install
+                && !is_skipped
                 && matches!(
                     compare_semver(env!("CARGO_PKG_VERSION"), latest_version),
                     Ordering::Less
                 )
+                && util::update_status::available_notice_due(latest_version)
             {
                 eprintln!(
                     "{} v{} run {} to update ({} for more info)",
@@ -330,48 +355,6 @@ async fn main() -> Result<()> {
                 );
             }
         }
-
-        // Clean skills update silently. Only ask for intervention after an
-        // automatic attempt left locally modified skills behind.
-        if commands::skills::cached_skill_update_requires_attention() {
-            eprintln!(
-                "{} run {} to review ({} overwrites local changes)",
-                "Railway skills update skipped due to local changes:"
-                    .yellow()
-                    .bold(),
-                "railway skills update".cyan(),
-                "--force".cyan(),
-            );
-        }
-
-        // Railway skills on disk that this CLI isn't managing yet —
-        // installed before the manifest existed or synced externally.
-        // Nag (once per upstream SHA) toward the managed path; we never
-        // write to them without the user asking.
-        if let Some(tools) = commands::skills::orphan_skills_nag_due() {
-            eprintln!(
-                "{} ({}) — run {} to keep them current ({} overwrites local changes)",
-                "Unmanaged Railway skills found".yellow().bold(),
-                tools.join(", "),
-                "railway skills update".cyan(),
-                "--force".cyan(),
-            );
-        }
-    } else if auto_update_enabled && !is_help_or_error && !embedded_setup {
-        // Non-TTY counterpart of the banner above, for agent callers only.
-        // Staged-binary apply is TTY-gated (see auto_update_applied), so a
-        // machine whose railway usage is entirely agent-driven would
-        // otherwise never apply a downloaded update nor see a reason to —
-        // tell the driving agent once per pending version instead. Skipped
-        // on parse-error paths: a typo'd command should print only the
-        // clap error.
-        util::agent_advisory::maybe_show_upgrade_nudge(
-            &raw_args,
-            raw_subcommand.as_deref(),
-            known_pending.as_deref(),
-            skipped_version.as_deref(),
-        )
-        .await;
     }
 
     // Automatic checks and installs share the same opt-out, including non-TTY
@@ -482,6 +465,12 @@ async fn main() -> Result<()> {
     util::cac_deprecation::maybe_warn(&raw_args, subcommand_name.as_deref());
 
     handle_update_task(check_updates_handle).await;
+
+    if show_update_receipt {
+        if let Some(receipt) = util::update_status::take_receipt() {
+            eprintln!("{receipt}");
+        }
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,6 @@ commands!(
 /// a background update.
 struct UpdateContext {
     known_version: Option<String>,
-    auto_update_enabled: bool,
     skipped_version: Option<String>,
     check_gate_armed: bool,
     check_skills: bool,
@@ -136,7 +135,7 @@ fn spawn_update_task(
 
         // Safe to eagerly dispatch from cache: the gate means no API call
         // will race with a newer version during this invocation.
-        if ctx.auto_update_enabled && ctx.check_gate_armed {
+        if ctx.check_gate_armed {
             if let Some(ref version) = ctx.known_version {
                 try_dispatch_update(version, ctx.skipped_version.as_deref(), &method);
             }
@@ -146,38 +145,28 @@ fn spawn_update_task(
         // — run them concurrently so a slow API call on one doesn't starve the
         // other within the short window handle_update_task() waits.
         let cli_check = async {
-            // Skip the network check entirely when auto-update is disabled
-            // and there is no TTY to show a banner on (e.g. CI / scripts).
-            let (from_cache, latest_version) = if !ctx.auto_update_enabled
-                && !std::io::stdout().is_terminal()
-            {
-                (ctx.known_version.is_some(), ctx.known_version.clone())
-            } else {
-                match util::check_update::check_update(false).await {
-                    Ok(Some(v)) => (false, Some(v)),
-                    Ok(None) | Err(_) => (ctx.known_version.is_some(), ctx.known_version.clone()),
-                }
+            let (from_cache, latest_version) = match util::check_update::check_update(false).await {
+                Ok(Some(v)) => (false, Some(v)),
+                Ok(None) | Err(_) => (ctx.known_version.is_some(), ctx.known_version.clone()),
             };
 
             if let Some(ref version) = latest_version {
-                if ctx.auto_update_enabled && !from_cache {
+                if !from_cache {
                     try_dispatch_update(version, ctx.skipped_version.as_deref(), &method);
                 }
             }
             latest_version
         };
 
-        // Skills auto-update mirrors the binary self-updater: refresh the cached
-        // upstream SHA (skipping the network only when auto-update is off and
-        // there's no TTY to ever banner on), then — when auto-update is enabled —
-        // spawn a detached process to apply it. Unmodified skills update
-        // silently; user-modified ones are skipped and left to the TTY banner.
+        // Dispatch cached updates and post-CLI-upgrade syncs before any network
+        // work so short-lived commands can't starve them. Otherwise check for
+        // skill releases independently of CLI releases, on the hourly gate.
         let skills_check = async {
             if ctx.check_skills {
-                if ctx.auto_update_enabled || std::io::stdout().is_terminal() {
+                if !commands::skills::cached_skill_auto_apply_due() {
                     commands::skills::refresh_skill_update_state().await;
                 }
-                if ctx.auto_update_enabled && commands::skills::cached_skill_auto_apply_due() {
+                if commands::skills::cached_skill_auto_apply_due() {
                     commands::skills::spawn_background_skill_update();
                 }
             }
@@ -317,15 +306,13 @@ async fn main() -> Result<()> {
     // state in the background, but they should not receive human-facing
     // upgrade prompts in command output.
     //
-    // When auto-update is disabled via preference, we still show the banner
-    // to cautious interactive users who want release visibility. Suppress it
-    // when disabled via env var or CI, where extra output is noise.
-    let env_or_ci_suppressed = telemetry::is_auto_update_disabled_by_env() || Configs::env_is_ci();
+    // The persisted preference, environment override, and CI all suppress
+    // unsolicited update notices as well as automatic installs.
     // The installer's embedded agent setup renders one cohesive flow; the
     // version/skills update banners are noise mid-install (the user just
     // configured skills), so suppress them in that context.
     let embedded_setup = std::env::var("RAILWAY_SETUP_EMBEDDED").is_ok();
-    if is_tty && !env_or_ci_suppressed && !embedded_setup {
+    if is_tty && auto_update_enabled && !embedded_setup {
         if let Some(ref latest_version) = known_pending {
             let is_skipped = skipped_version.as_deref() == Some(latest_version.as_str());
             if !is_skipped
@@ -344,13 +331,16 @@ async fn main() -> Result<()> {
             }
         }
 
-        // Mirror the CLI banner for skills: a prior background check found a
-        // newer railway-skills commit than what we last installed.
-        if commands::skills::cached_skill_update_available() {
+        // Clean skills update silently. Only ask for intervention after an
+        // automatic attempt left locally modified skills behind.
+        if commands::skills::cached_skill_update_requires_attention() {
             eprintln!(
-                "{} run {} to update",
-                "Railway skills update available:".green().bold(),
+                "{} run {} to review ({} overwrites local changes)",
+                "Railway skills update skipped due to local changes:"
+                    .yellow()
+                    .bold(),
                 "railway skills update".cyan(),
+                "--force".cyan(),
             );
         }
 
@@ -367,7 +357,7 @@ async fn main() -> Result<()> {
                 "--force".cyan(),
             );
         }
-    } else if !env_or_ci_suppressed && !is_help_or_error && !embedded_setup {
+    } else if auto_update_enabled && !is_help_or_error && !embedded_setup {
         // Non-TTY counterpart of the banner above, for agent callers only.
         // Staged-binary apply is TTY-gated (see auto_update_applied), so a
         // machine whose railway usage is entirely agent-driven would
@@ -384,24 +374,21 @@ async fn main() -> Result<()> {
         .await;
     }
 
-    // Spawn the background version check for all invocations (including
-    // non-TTY) so the version cache stays fresh for both humans and coding
-    // agents. Non-TTY callers are a first-class auto-update path: they may
-    // trigger background downloads/package-manager installs, but staged-binary
-    // apply and user-facing banners remain TTY-only.
-    let check_updates_handle = if is_update_management_cmd || is_read_only_invocation {
-        None
-    } else {
-        Some(spawn_update_task(UpdateContext {
-            known_version: known_pending,
-            auto_update_enabled,
-            skipped_version,
-            check_gate_armed,
-            // `skills`/`setup` write the manifest themselves; don't have the
-            // background check race their write.
-            check_skills: !matches!(raw_subcommand.as_deref(), Some("skills" | "setup")),
-        }))
-    };
+    // Automatic checks and installs share the same opt-out, including non-TTY
+    // callers. Explicit update-management commands handle their own checks.
+    let check_updates_handle =
+        if !auto_update_enabled || is_update_management_cmd || is_read_only_invocation {
+            None
+        } else {
+            Some(spawn_update_task(UpdateContext {
+                known_version: known_pending,
+                skipped_version,
+                check_gate_armed,
+                // `skills`/`setup` write the manifest themselves; don't have the
+                // background check race their write.
+                check_skills: !matches!(raw_subcommand.as_deref(), Some("skills" | "setup")),
+            }))
+        };
 
     // https://github.com/clap-rs/clap/blob/cb2352f84a7663f32a89e70f01ad24446d5fa1e2/clap_builder/src/error/mod.rs#L210-L215
     let cli = match args {

--- a/src/util/agent_advisory.rs
+++ b/src/util/agent_advisory.rs
@@ -1,11 +1,10 @@
-use std::{cmp::Ordering, fs::File, io::Read, path::PathBuf};
+use std::{fs::File, io::Read, path::PathBuf};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 
-use super::compare_semver::compare_semver;
 use crate::{telemetry, util};
 
 const STATE_VERSION: u32 = 1;
@@ -25,8 +24,6 @@ struct AgentState {
     setup: SetupState,
     #[serde(default)]
     advisory: AdvisoryState,
-    #[serde(default)]
-    upgrade_nudge: UpgradeNudgeState,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -42,13 +39,6 @@ struct AdvisoryState {
     last_shown_cli_version: Option<String>,
     last_shown_at: Option<DateTime<Utc>>,
     last_shown_agent_session_id: Option<String>,
-}
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct UpgradeNudgeState {
-    last_nudged_version: Option<String>,
-    last_nudged_at: Option<DateTime<Utc>>,
 }
 
 fn state_path() -> Result<PathBuf> {
@@ -232,86 +222,6 @@ pub async fn maybe_show(raw_args: &[String], command: Option<&str>) {
 
     telemetry::send(telemetry::CliTrackEvent {
         command: "agent_advisory".to_string(),
-        sub_command: Some(command.to_string()),
-        success: true,
-        error_message: None,
-        duration_ms: 0,
-        cli_version: env!("CARGO_PKG_VERSION"),
-        os: std::env::consts::OS,
-        arch: std::env::consts::ARCH,
-        is_ci: crate::config::Configs::env_is_ci(),
-    })
-    .await;
-}
-
-/// Agent-facing counterpart of the TTY-only "new version available" banner.
-///
-/// Agent-driven machines are structurally unable to upgrade through the
-/// normal flow: staged-binary apply is TTY-gated (main.rs) so a host whose
-/// railway usage is 100% agent-driven downloads updates forever without
-/// applying them, and the banner that would tell a human to act never
-/// prints. Warehouse audit 2026-06-09: the largest plain agent_unknown
-/// population was pre-5.5.0 versions that newer detection had already
-/// fixed. This nudge tells the agent itself — once per pending version, on
-/// stderr — which agents reliably surface to the user or act on directly.
-pub async fn maybe_show_upgrade_nudge(
-    raw_args: &[String],
-    command: Option<&str>,
-    latest_version: Option<&str>,
-    skipped_version: Option<&str>,
-) {
-    let Some(latest) = latest_version else {
-        return;
-    };
-    if disabled_by_env() || should_skip_for_args(raw_args) {
-        return;
-    }
-    let Some(command) = command else {
-        return;
-    };
-    if command_is_exempt(command) {
-        return;
-    }
-    // Respect a rollback: don't nudge agents toward the version the user
-    // explicitly backed out of (mirrors the TTY banner's skip logic).
-    if skipped_version == Some(latest) {
-        return;
-    }
-    if !matches!(
-        compare_semver(env!("CARGO_PKG_VERSION"), latest),
-        Ordering::Less
-    ) {
-        return;
-    }
-    // Last (most expensive) gate: process-tree-aware agent detection.
-    if !telemetry::is_agent() {
-        return;
-    }
-
-    let mut state = read_state();
-    if state.upgrade_nudge.last_nudged_version.as_deref() == Some(latest) {
-        return;
-    }
-
-    eprintln!(
-        "\n{}\n{}",
-        format!(
-            "A newer Railway CLI is available: v{} (current: v{}).",
-            latest,
-            env!("CARGO_PKG_VERSION"),
-        )
-        .yellow(),
-        "Run `railway upgrade --yes` to update.".dimmed(),
-    );
-
-    state.upgrade_nudge = UpgradeNudgeState {
-        last_nudged_version: Some(latest.to_string()),
-        last_nudged_at: Some(Utc::now()),
-    };
-    let _ = write_state(&state);
-
-    telemetry::send(telemetry::CliTrackEvent {
-        command: "upgrade_nudge".to_string(),
         sub_command: Some(command.to_string()),
         success: true,
         error_message: None,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -17,6 +17,7 @@ pub mod self_update;
 pub mod shell;
 pub mod time;
 pub mod two_factor;
+pub mod update_status;
 pub mod watcher;
 
 /// Spawns a command in a fully detached process group so it survives after the

--- a/src/util/progress.rs
+++ b/src/util/progress.rs
@@ -98,3 +98,34 @@ pub fn success_spinner(spinner: &mut ProgressBar, message: String) {
     );
     spinner.finish_with_message(format!("✓ {message}"));
 }
+
+/// A real upgrade stage, rendered on stderr. Piped invocations receive plain
+/// lines; terminal invocations get a spinner without any artificial delay.
+pub struct UpdateStep(Option<ProgressBar>);
+
+impl UpdateStep {
+    pub fn start(message: &str) -> Self {
+        use is_terminal::IsTerminal;
+        if std::io::stderr().is_terminal() && std::io::stdout().is_terminal() {
+            Self(Some(create_spinner(format!("  {message}"))))
+        } else {
+            eprintln!("  … {message}");
+            Self(None)
+        }
+    }
+
+    pub fn finish(self, symbol: &str, message: &str) {
+        if let Some(spinner) = &self.0 {
+            spinner.finish_and_clear();
+        }
+        eprintln!("  {symbol} {message}");
+    }
+}
+
+impl Drop for UpdateStep {
+    fn drop(&mut self) {
+        if let Some(spinner) = &self.0 {
+            spinner.finish_and_clear();
+        }
+    }
+}

--- a/src/util/self_update.rs
+++ b/src/util/self_update.rs
@@ -560,6 +560,7 @@ fn apply_staged_update() -> Result<String> {
 
     let current_exe = std::env::current_exe().context("Failed to get current exe path")?;
     replace_binary(&staged_binary, &current_exe)?;
+    super::update_status::record_installed(&staged.version);
 
     let version = staged.version.clone();
     StagedUpdate::clean()?;
@@ -646,11 +647,6 @@ pub fn try_apply_staged() -> Option<String> {
             #[cfg(windows)]
             clean_old_binary();
 
-            eprintln!(
-                "{} v{} (active on next run)",
-                "Auto-updated Railway CLI to".green().bold(),
-                version,
-            );
             Some(version)
         }
         Err(e) => {
@@ -666,7 +662,9 @@ pub fn try_apply_staged() -> Option<String> {
     result
 }
 
-pub async fn self_update_interactive() -> Result<()> {
+pub async fn self_update_interactive() -> Result<String> {
+    use super::progress::UpdateStep;
+    let checking = UpdateStep::start("Checking for updates");
     // Try the network check first.  If it fails and an update is already
     // staged on disk, apply that instead of surfacing a network error.
     let (latest_version, update_check_failed) =
@@ -678,35 +676,56 @@ pub async fn self_update_interactive() -> Result<()> {
                 (None, true)
             }
         };
+    if update_check_failed {
+        checking.finish("·", "Release check unavailable; checking staged update");
+    } else {
+        checking.finish("✓", "Update check complete");
+    }
 
     let lock_path = update_lock_path()?;
     let busy_message = shell_update_busy_message();
     let lock_file = acquire_update_lock(&lock_path, false, &busy_message)?;
 
     if let Some(ref version) = latest_version {
-        println!("{} v{}...", "Downloading".green().bold(), version);
-        download_and_stage_inner(version, 120).await?;
+        eprintln!("  v{} → v{}\n", env!("CARGO_PKG_VERSION"), version);
+        let downloading = UpdateStep::start("Downloading CLI");
+        if let Err(error) = download_and_stage_inner(version, 120).await {
+            downloading.finish("✗", "CLI download failed");
+            return Err(error);
+        }
+        downloading.finish("✓", "CLI downloaded");
     } else {
         match finalize_explicit_upgrade_fallback(validate_staged(), update_check_failed)? {
             Some(staged) => {
-                println!("Applying previously downloaded v{}...", staged.version);
+                eprintln!(
+                    "  v{} → v{} (previously downloaded)\n",
+                    env!("CARGO_PKG_VERSION"),
+                    staged.version
+                );
             }
             None => {
-                println!("{}", "Railway CLI is already up to date.".green());
-                return Ok(());
+                eprintln!("  ✓ CLI already up to date");
+                return Ok(env!("CARGO_PKG_VERSION").to_string());
             }
         }
     }
 
-    let version = apply_staged_update()?;
+    let installing = UpdateStep::start("Installing CLI");
+    let version = match apply_staged_update() {
+        Ok(version) => version,
+        Err(error) => {
+            installing.finish("✗", "CLI installation failed");
+            return Err(error);
+        }
+    };
 
     crate::util::check_update::UpdateCheck::clear_after_update();
 
     drop(lock_file);
 
-    println!("{} v{}", "Successfully updated to".green().bold(), version);
+    installing.finish("✓", "CLI installed");
 
-    Ok(())
+    Ok(version)
 }
 
 fn finalize_explicit_upgrade_fallback(
@@ -817,6 +836,8 @@ pub fn rollback(non_interactive: bool) -> Result<()> {
     drop(lock_file);
 
     println!("{} v{}", "Rolled back to".green().bold(), version);
+    super::update_status::record_installed(&version);
+    super::update_status::mark_presented(&version);
     println!(
         "Auto-updates will skip v{}. Run {} to disable all auto-updates.",
         current_version,

--- a/src/util/update_status.rs
+++ b/src/util/update_status.rs
@@ -1,0 +1,348 @@
+//! Shared, best-effort update outcomes. Keep this separate from the release
+//! cache: a newer available release must not erase an installed update receipt.
+use std::path::Path;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SkillsOutcome {
+    Pending,
+    NotInstalled,
+    Synced { revision: String },
+    Preserved { revision: String, count: u32 },
+    Failed { message: String },
+}
+
+impl SkillsOutcome {
+    pub fn summary(&self) -> String {
+        match self {
+            Self::Pending => "Agent skills synchronization pending".into(),
+            Self::NotInstalled => "No CLI-managed agent skills installed".into(),
+            Self::Synced { .. } => "Agent skills synchronized".into(),
+            Self::Preserved { count, .. } => {
+                let plural = if *count == 1 { "" } else { "s" };
+                format!("{count} agent skill{plural} preserved — local edits detected")
+            }
+            Self::Failed { .. } => "Agent skills could not be synchronized".into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillsSync {
+    pub cli_version: String,
+    pub outcome: SkillsOutcome,
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UpdateStatus {
+    pub last_seen_version: Option<String>,
+    pub installed_version: Option<String>,
+    pub skills: Option<SkillsSync>,
+    last_notified_version: Option<String>,
+    last_available_notice: Option<String>,
+}
+
+impl UpdateStatus {
+    pub fn read(home: &Path) -> Self {
+        std::fs::read(home.join(".railway/update-status.json"))
+            .ok()
+            .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+            .unwrap_or_default()
+    }
+
+    fn observe(&mut self, version: &str, previous: Option<&str>) {
+        let previous = self.last_seen_version.as_deref().or(previous);
+        if previous.is_some_and(|previous| previous != version)
+            && self.installed_version.as_deref().is_none_or(|installed| {
+                super::compare_semver::compare_semver(installed, version)
+                    != std::cmp::Ordering::Greater
+            })
+        {
+            self.installed_version = Some(version.to_string());
+        }
+        self.last_seen_version = Some(version.to_string());
+    }
+
+    fn set_skills(&mut self, version: &str, outcome: SkillsOutcome) {
+        // A detached process from an older binary can finish after the new one.
+        if self.installed_version.as_deref().is_some_and(|installed| {
+            super::compare_semver::compare_semver(installed, version) == std::cmp::Ordering::Greater
+        }) || self.skills.as_ref().is_some_and(|sync| {
+            super::compare_semver::compare_semver(&sync.cli_version, version)
+                == std::cmp::Ordering::Greater
+        }) {
+            return;
+        }
+        self.skills = Some(SkillsSync {
+            cli_version: version.into(),
+            outcome,
+        });
+    }
+
+    fn receipt(&mut self, running: &str) -> Option<String> {
+        if self.installed_version.as_deref() != Some(running)
+            || self.last_notified_version.as_deref() == Some(running)
+        {
+            return None;
+        }
+        let sync = self
+            .skills
+            .as_ref()
+            .filter(|sync| sync.cli_version == running)?;
+        let suffix = match &sync.outcome {
+            SkillsOutcome::Pending => return None,
+            SkillsOutcome::NotInstalled => String::new(),
+            SkillsOutcome::Synced { .. } => " · agent skills synchronized".into(),
+            SkillsOutcome::Preserved { count, .. } => {
+                let plural = if *count == 1 { "" } else { "s" };
+                format!(" · {count} agent skill{plural} preserved (local edits)")
+            }
+            SkillsOutcome::Failed { .. } => {
+                " · agent skills sync incomplete (see `railway autoupdate status`)".into()
+            }
+        };
+        self.last_notified_version = Some(running.into());
+        Some(format!("✓ Railway updated to v{running}{suffix}"))
+    }
+}
+
+/// Serialize short read-modify-write operations, never holding this lock over
+/// network access or while acquiring a skills/binary install lock.
+fn mutate<T>(home: &Path, change: impl FnOnce(&mut UpdateStatus) -> T) -> Result<T> {
+    use fs2::FileExt;
+
+    let dir = home.join(".railway");
+    std::fs::create_dir_all(&dir)?;
+    let lock = std::fs::File::create(dir.join("update-status.lock"))?;
+    lock.lock_exclusive()?;
+    let mut status = UpdateStatus::read(home);
+    let before = serde_json::to_string(&status)?;
+    let result = change(&mut status);
+    let after = serde_json::to_string(&status)?;
+    if before != after {
+        super::write_atomic(&dir.join("update-status.json"), &after)?;
+    }
+    Ok(result)
+}
+
+pub fn observe_running(version: &str, previous: Option<&str>, managed_skills: bool) {
+    if let Some(home) = dirs::home_dir() {
+        let _ = mutate(&home, |status| {
+            status.observe(version, previous);
+            if !managed_skills {
+                status.set_skills(version, SkillsOutcome::NotInstalled);
+            }
+        });
+    }
+}
+
+pub fn record_installed(version: &str) {
+    if let Some(home) = dirs::home_dir() {
+        let _ = mutate(&home, |status| {
+            status
+                .last_seen_version
+                .get_or_insert_with(|| env!("CARGO_PKG_VERSION").into());
+            status.installed_version = Some(version.into());
+            if status
+                .skills
+                .as_ref()
+                .is_some_and(|sync| sync.cli_version != version)
+            {
+                status.skills = None;
+            }
+        });
+    }
+}
+
+pub fn record_skills(version: &str, outcome: SkillsOutcome) {
+    if let Some(home) = dirs::home_dir() {
+        let _ = mutate(&home, |status| status.set_skills(version, outcome));
+    }
+}
+
+pub fn mark_presented(version: &str) {
+    if let Some(home) = dirs::home_dir() {
+        let _ = mutate(&home, |status| {
+            status.last_notified_version = Some(version.into())
+        });
+    }
+}
+
+/// Claim the notice under the same lock used to persist it: simultaneous CLI
+/// invocations cannot both print it. Read-only/machine callers never claim it.
+pub fn take_receipt() -> Option<String> {
+    let home = dirs::home_dir()?;
+    mutate(&home, |status| status.receipt(env!("CARGO_PKG_VERSION")))
+        .ok()
+        .flatten()
+}
+
+pub fn available_notice_due(version: &str) -> bool {
+    let Some(home) = dirs::home_dir() else {
+        return false;
+    };
+    mutate(&home, |status| {
+        if status.last_available_notice.as_deref() == Some(version) {
+            return false;
+        }
+        status.last_available_notice = Some(version.into());
+        true
+    })
+    .unwrap_or(false)
+}
+
+pub fn print_status() {
+    println!("Running version: v{}", env!("CARGO_PKG_VERSION"));
+    let Some(home) = dirs::home_dir() else { return };
+    let status = UpdateStatus::read(&home);
+    if let Some(version) = &status.installed_version {
+        let activation =
+            match super::compare_semver::compare_semver(version, env!("CARGO_PKG_VERSION")) {
+                std::cmp::Ordering::Equal => "active",
+                std::cmp::Ordering::Greater => "active on next command",
+                std::cmp::Ordering::Less => "previously recorded; running version is newer",
+            };
+        println!("Installed version: v{version} ({activation})");
+    }
+    if let Some(sync) = status.skills {
+        println!(
+            "Skills for CLI v{}: {}",
+            sync.cli_version,
+            sync.outcome.summary()
+        );
+        let needs_details = matches!(
+            sync.outcome,
+            SkillsOutcome::Preserved { .. } | SkillsOutcome::Failed { .. }
+        );
+        match sync.outcome {
+            SkillsOutcome::Synced { revision } | SkillsOutcome::Preserved { revision, .. } => {
+                println!("Skills revision: {revision}");
+            }
+            SkillsOutcome::Failed { message } => println!("Skills sync error: {message}"),
+            _ => {}
+        }
+        if needs_details {
+            println!(
+                "Skill details: `railway skills update` (use `--force` to overwrite local edits)."
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_waits_for_activation_and_skills_and_is_consumed_once() {
+        let home = tempfile::tempdir().unwrap();
+        mutate(home.path(), |state| {
+            state.observe("1.0.0", None);
+            state.installed_version = Some("1.1.0".into());
+            state.set_skills("1.1.0", SkillsOutcome::Pending);
+        })
+        .unwrap();
+        assert!(
+            mutate(home.path(), |state| state.receipt("1.0.0"))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            mutate(home.path(), |state| state.receipt("1.1.0"))
+                .unwrap()
+                .is_none()
+        );
+        mutate(home.path(), |state| {
+            state.set_skills(
+                "1.1.0",
+                SkillsOutcome::Synced {
+                    revision: "sha".into(),
+                },
+            )
+        })
+        .unwrap();
+        let receipt = mutate(home.path(), |state| state.receipt("1.1.0"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            receipt,
+            "✓ Railway updated to v1.1.0 · agent skills synchronized"
+        );
+        assert!(
+            mutate(home.path(), |state| state.receipt("1.1.0"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn external_updates_are_detected_without_announcing_fresh_installs() {
+        let mut state = UpdateStatus::default();
+        state.observe("1.0.0", None);
+        state.set_skills("1.0.0", SkillsOutcome::NotInstalled);
+        assert!(state.receipt("1.0.0").is_none());
+        state.observe("1.1.0", None);
+        state.set_skills("1.1.0", SkillsOutcome::NotInstalled);
+        assert_eq!(
+            state.receipt("1.1.0").as_deref(),
+            Some("✓ Railway updated to v1.1.0")
+        );
+    }
+
+    #[test]
+    fn stale_skill_workers_cannot_replace_newer_results() {
+        let mut state = UpdateStatus {
+            installed_version: Some("1.1.0".into()),
+            ..Default::default()
+        };
+        state.set_skills(
+            "1.1.0",
+            SkillsOutcome::Preserved {
+                revision: "new".into(),
+                count: 2,
+            },
+        );
+        state.set_skills(
+            "1.0.0",
+            SkillsOutcome::Synced {
+                revision: "old".into(),
+            },
+        );
+        assert!(
+            state
+                .receipt("1.1.0")
+                .unwrap()
+                .contains("2 agent skills preserved")
+        );
+    }
+
+    #[test]
+    fn concurrent_commands_claim_a_single_completion_receipt() {
+        let home = tempfile::tempdir().unwrap();
+        mutate(home.path(), |state| {
+            state.installed_version = Some("1.1.0".into());
+            state.set_skills("1.1.0", SkillsOutcome::NotInstalled);
+        })
+        .unwrap();
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let tasks: Vec<_> = (0..8)
+            .map(|_| {
+                let home = home.path().to_path_buf();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    mutate(&home, |state| state.receipt("1.1.0")).unwrap()
+                })
+            })
+            .collect();
+        let receipts = tasks
+            .into_iter()
+            .filter_map(|task| task.join().unwrap())
+            .count();
+        assert_eq!(receipts, 1);
+    }
+}

--- a/tests/update_notices.rs
+++ b/tests/update_notices.rs
@@ -1,0 +1,135 @@
+//! Exercise startup with a real TTY: piped output would hide the banner even
+//! without honoring the persisted auto-update preference.
+#![cfg(unix)]
+
+use std::io::Read;
+use std::path::Path;
+
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use serde_json::json;
+
+fn run_cli(home: &Path, args: &[&str], env: &[(&str, &str)]) -> String {
+    let pty = NativePtySystem::default()
+        .openpty(PtySize::default())
+        .unwrap();
+    let mut cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_railway"));
+    cmd.env_clear();
+    cmd.env("HOME", home);
+    cmd.env("DO_NOT_TRACK", "1");
+    cmd.env("NO_COLOR", "1");
+    for (key, value) in env {
+        cmd.env(key, value);
+    }
+    cmd.cwd(home);
+    cmd.args(args);
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut child = pty.slave.spawn_command(cmd).unwrap();
+    drop(pty.slave);
+    let output = std::thread::spawn(move || {
+        let mut output = String::new();
+        reader.read_to_string(&mut output).unwrap();
+        output
+    });
+    assert!(child.wait().unwrap().success());
+    output.join().unwrap()
+}
+
+fn seed_pending_updates(home: &Path) {
+    std::fs::create_dir_all(home.join(".railway")).unwrap();
+    std::fs::write(
+        home.join(".railway/version.json"),
+        json!({"latest_version": "255.255.255"}).to_string(),
+    )
+    .unwrap();
+    // Both a managed, locally blocked update and an unmanaged installation.
+    let managed = home.join(".agents/skills");
+    let orphan = home.join(".cursor/skills/use-railway");
+    std::fs::create_dir_all(managed.join("use-railway")).unwrap();
+    std::fs::create_dir_all(&orphan).unwrap();
+    std::fs::write(orphan.join("SKILL.md"), "unmanaged").unwrap();
+    std::fs::write(
+        home.join(".railway/skills.json"),
+        json!({
+            "source_sha": "old",
+            "latest_sha": "new",
+            "auto_applied_sha": "new",
+            "cli_version": env!("CARGO_PKG_VERSION"),
+            "targets": {managed.to_str().unwrap(): {
+                "use-railway": {"installed_at": "t", "files": {}}
+            }}
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn disabled_updates_suppress_tty_notices_and_background_checks() {
+    for (preference, env) in [
+        (true, vec![]),
+        (false, vec![("RAILWAY_NO_AUTO_UPDATE", "1")]),
+        (false, vec![("CI", "true")]),
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        seed_pending_updates(home.path());
+        std::fs::write(
+            home.path().join(".railway/preferences.json"),
+            json!({"autoUpdateDisabled": preference}).to_string(),
+        )
+        .unwrap();
+        let version_before = std::fs::read(home.path().join(".railway/version.json")).unwrap();
+        let skills_before = std::fs::read(home.path().join(".railway/skills.json")).unwrap();
+
+        for args in [&["telemetry", "status"][..], &["--help"][..]] {
+            let output = run_cli(home.path(), args, &env);
+            for notice in [
+                "New version available",
+                "Railway skills update",
+                "Unmanaged Railway skills",
+                "railway skills update",
+                "automatic update pending",
+            ] {
+                assert!(!output.contains(notice), "unexpected {notice}: {output}");
+            }
+        }
+        // A detached updater launched before the opt-out must honor it too.
+        let mut child_env = env.clone();
+        child_env.push(("_RAILWAY_UPDATE_SKILLS", "1"));
+        assert!(run_cli(home.path(), &[], &child_env).is_empty());
+        assert_eq!(
+            std::fs::read(home.path().join(".railway/version.json")).unwrap(),
+            version_before
+        );
+        assert_eq!(
+            std::fs::read(home.path().join(".railway/skills.json")).unwrap(),
+            skills_before
+        );
+        assert!(!home.path().join(".railway/auto-update.log").exists());
+    }
+}
+
+#[test]
+fn enabled_updates_still_report_pending_cli_and_blocked_skills() {
+    let home = tempfile::tempdir().unwrap();
+    seed_pending_updates(home.path());
+    // --version exercises the banners without starting a network check/install.
+    let output = run_cli(home.path(), &["--version"], &[]);
+    assert!(
+        output.contains("New version available: v255.255.255"),
+        "{output}"
+    );
+    assert!(
+        output.contains("Railway skills update skipped due to local changes"),
+        "{output}"
+    );
+
+    // A clean pending update is left to auto-apply, without a manual prompt.
+    let path = home.path().join(".railway/skills.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    manifest["auto_applied_sha"] = serde_json::Value::Null;
+    std::fs::write(path, manifest.to_string()).unwrap();
+    let output = run_cli(home.path(), &["--version"], &[]);
+    assert!(output.contains("New version available"), "{output}");
+    assert!(!output.contains("Railway skills update"), "{output}");
+}

--- a/tests/update_notices.rs
+++ b/tests/update_notices.rs
@@ -9,6 +9,12 @@ use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use serde_json::json;
 
 fn run_cli(home: &Path, args: &[&str], env: &[(&str, &str)]) -> String {
+    let (output, success) = run_cli_result(home, args, env);
+    assert!(success, "{output}");
+    output
+}
+
+fn run_cli_result(home: &Path, args: &[&str], env: &[(&str, &str)]) -> (String, bool) {
     let pty = NativePtySystem::default()
         .openpty(PtySize::default())
         .unwrap();
@@ -30,15 +36,16 @@ fn run_cli(home: &Path, args: &[&str], env: &[(&str, &str)]) -> String {
         reader.read_to_string(&mut output).unwrap();
         output
     });
-    assert!(child.wait().unwrap().success());
-    output.join().unwrap()
+    let success = child.wait().unwrap().success();
+    (output.join().unwrap(), success)
 }
 
 fn seed_pending_updates(home: &Path) {
     std::fs::create_dir_all(home.join(".railway")).unwrap();
     std::fs::write(
         home.join(".railway/version.json"),
-        json!({"latest_version": "255.255.255"}).to_string(),
+        json!({"latest_version": "255.255.255", "last_update_check": chrono::Utc::now()})
+            .to_string(),
     )
     .unwrap();
     // Both a managed, locally blocked update and an unmanaged installation.
@@ -54,6 +61,7 @@ fn seed_pending_updates(home: &Path) {
             "latest_sha": "new",
             "auto_applied_sha": "new",
             "cli_version": env!("CARGO_PKG_VERSION"),
+            "last_checked": chrono::Utc::now(),
             "targets": {managed.to_str().unwrap(): {
                 "use-railway": {"installed_at": "t", "files": {}}
             }}
@@ -72,6 +80,19 @@ fn disabled_updates_suppress_tty_notices_and_background_checks() {
     ] {
         let home = tempfile::tempdir().unwrap();
         seed_pending_updates(home.path());
+        // Make checks and a detached sync genuinely due, so opt-outs cannot
+        // accidentally pass just because the cache is still fresh.
+        let skills_path = home.path().join(".railway/skills.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&skills_path).unwrap()).unwrap();
+        manifest["cli_version"] = json!("0.0.0");
+        manifest["last_checked"] = json!("2000-01-01T00:00:00Z");
+        std::fs::write(skills_path, manifest.to_string()).unwrap();
+        std::fs::write(
+            home.path().join(".railway/version.json"),
+            json!({"latest_version": "255.255.255"}).to_string(),
+        )
+        .unwrap();
         std::fs::write(
             home.path().join(".railway/preferences.json"),
             json!({"autoUpdateDisabled": preference}).to_string(),
@@ -109,27 +130,112 @@ fn disabled_updates_suppress_tty_notices_and_background_checks() {
 }
 
 #[test]
-fn enabled_updates_still_report_pending_cli_and_blocked_skills() {
+fn manual_install_notices_are_once_per_release_and_skill_details_are_explicit() {
     let home = tempfile::tempdir().unwrap();
     seed_pending_updates(home.path());
-    // --version exercises the banners without starting a network check/install.
+    // Help/version paths do not consume notices.
     let output = run_cli(home.path(), &["--version"], &[]);
+    assert!(!output.contains("New version available"), "{output}");
+    let output = run_cli(home.path(), &["telemetry", "status"], &[]);
     assert!(
         output.contains("New version available: v255.255.255"),
         "{output}"
     );
-    assert!(
-        output.contains("Railway skills update skipped due to local changes"),
-        "{output}"
-    );
+    assert!(!output.contains("Railway skills update"), "{output}");
+    let output = run_cli(home.path(), &["telemetry", "status"], &[]);
+    assert!(!output.contains("New version available"), "{output}");
+    let output = run_cli(home.path(), &["autoupdate", "status"], &[]);
+    assert!(output.contains("Agent skills preserved"), "{output}");
+    assert!(output.contains("Unmanaged Railway skills"), "{output}");
+}
 
-    // A clean pending update is left to auto-apply, without a manual prompt.
-    let path = home.path().join(".railway/skills.json");
+fn seed_completed_update(home: &Path, outcome: serde_json::Value) {
+    seed_pending_updates(home);
+    let path = home.join(".railway/skills.json");
     let mut manifest: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-    manifest["auto_applied_sha"] = serde_json::Value::Null;
+    manifest["source_sha"] = json!("new");
     std::fs::write(path, manifest.to_string()).unwrap();
-    let output = run_cli(home.path(), &["--version"], &[]);
-    assert!(output.contains("New version available"), "{output}");
-    assert!(!output.contains("Railway skills update"), "{output}");
+    std::fs::write(
+        home.join(".railway/version.json"),
+        json!({"last_update_check": chrono::Utc::now()}).to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        home.join(".railway/update-status.json"),
+        json!({
+            "last_seen_version": env!("CARGO_PKG_VERSION"),
+            "installed_version": env!("CARGO_PKG_VERSION"),
+            "skills": {"cli_version": env!("CARGO_PKG_VERSION"), "outcome": outcome}
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn completion_receipt_is_once_only_and_is_not_consumed_by_pipes_help_or_json() {
+    let home = tempfile::tempdir().unwrap();
+    seed_completed_update(home.path(), json!({"status": "synced", "revision": "new"}));
+    let piped = std::process::Command::new(env!("CARGO_BIN_EXE_railway"))
+        .env_clear()
+        .env("HOME", home.path())
+        .env("DO_NOT_TRACK", "1")
+        .args(["telemetry", "status"])
+        .output()
+        .unwrap();
+    assert!(piped.status.success());
+    assert!(!String::from_utf8_lossy(&piped.stderr).contains("Railway updated"));
+    let help = run_cli(home.path(), &["--version"], &[]);
+    assert!(!help.contains("Railway updated"));
+    // Auth failure is expected with an empty HOME, but the valid JSON invocation
+    // must still leave the receipt for an interactive, human-facing command.
+    let (json, success) = run_cli_result(home.path(), &["status", "--json"], &[]);
+    assert!(!success);
+    assert!(!json.contains("Railway updated"), "{json}");
+    let first = run_cli(home.path(), &["telemetry", "status"], &[]);
+    assert!(
+        first.contains(&format!(
+            "Railway updated to v{} · agent skills synchronized",
+            env!("CARGO_PKG_VERSION")
+        )),
+        "{first}"
+    );
+    let second = run_cli(home.path(), &["telemetry", "status"], &[]);
+    assert!(!second.contains("Railway updated"), "{second}");
+}
+
+#[test]
+fn receipts_describe_preserved_or_failed_skills_without_claiming_sync_success() {
+    for (outcome, expected) in [
+        (
+            json!({"status": "preserved", "revision": "new", "count": 1}),
+            "1 agent skill preserved (local edits)",
+        ),
+        (
+            json!({"status": "failed", "message": "offline"}),
+            "agent skills sync incomplete",
+        ),
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        seed_completed_update(home.path(), outcome);
+        let output = run_cli(home.path(), &["telemetry", "status"], &[]);
+        assert!(output.contains(expected), "{output}");
+        assert!(!output.contains("skills synchronized"), "{output}");
+        assert!(!output.contains("--force"), "{output}");
+    }
+}
+
+#[test]
+fn disabled_updates_do_not_display_or_consume_completion_receipts() {
+    let home = tempfile::tempdir().unwrap();
+    seed_completed_update(home.path(), json!({"status": "synced", "revision": "new"}));
+    let output = run_cli(
+        home.path(),
+        &["telemetry", "status"],
+        &[("RAILWAY_NO_AUTO_UPDATE", "1")],
+    );
+    assert!(!output.contains("Railway updated"), "{output}");
+    let output = run_cli(home.path(), &["telemetry", "status"], &[]);
+    assert!(output.contains("Railway updated"), "{output}");
 }

--- a/tests/upgrade_flow.rs
+++ b/tests/upgrade_flow.rs
@@ -1,0 +1,134 @@
+//! Run explicit upgrades against a throwaway installation and package manager.
+//! No published releases, user skills, or real package managers are modified.
+#![cfg(unix)]
+
+use serde_json::json;
+use std::{os::unix::fs::PermissionsExt, path::Path, process::Command};
+
+fn install_fixture(home: &Path, script: &str) -> Command {
+    install_fixture_at(home, "node_modules/railway/railway", "npm", script)
+}
+
+fn install_fixture_at(home: &Path, path: &str, manager: &str, script: &str) -> Command {
+    let executable = home.join(path);
+    std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+    std::fs::copy(env!("CARGO_BIN_EXE_railway"), &executable).unwrap();
+    let bin = home.join("mock-bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let npm = bin.join(manager);
+    std::fs::write(&npm, format!("#!/bin/sh\n{script}\n")).unwrap();
+    std::fs::set_permissions(npm, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let mut command = Command::new(&executable);
+    command
+        .env_clear()
+        .env("HOME", home)
+        .env("PATH", bin)
+        .env("TEST_RAILWAY_EXE", executable)
+        .env("DO_NOT_TRACK", "1")
+        .env("NO_COLOR", "1")
+        .env("RAILWAY_NO_AUTO_UPDATE", "1")
+        .env("HTTPS_PROXY", "http://127.0.0.1:9")
+        .args(["upgrade", "--yes"]);
+    command
+}
+
+#[test]
+fn homebrew_upgrade_verifies_the_stable_entry_point_after_the_cellar_path_moves() {
+    let home = tempfile::tempdir().unwrap();
+    let script = r#"
+/bin/mkdir -p "$HOME/homebrew/opt/railway/bin"
+printf '#!/bin/sh\necho railway 255.255.254\n' > "$HOME/homebrew/opt/railway/bin/railway"
+/bin/chmod +x "$HOME/homebrew/opt/railway/bin/railway"
+/bin/rm "$TEST_RAILWAY_EXE"
+"#;
+    let output = install_fixture_at(
+        home.path(),
+        "homebrew/Cellar/railway/old/bin/railway",
+        "brew",
+        script,
+    )
+    .output()
+    .unwrap();
+    let text = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{text}");
+    assert!(
+        text.contains("v255.255.254 will be used on your next command"),
+        "{text}"
+    );
+}
+
+const INSTALL: &str = r#"
+printf '#!/bin/sh\necho railway 255.255.254\n' > "$TEST_RAILWAY_EXE.next"
+/bin/chmod +x "$TEST_RAILWAY_EXE.next"
+/bin/mv "$TEST_RAILWAY_EXE.next" "$TEST_RAILWAY_EXE"
+echo 'package manager chatter'
+"#;
+
+#[test]
+fn explicit_upgrade_shows_verified_cli_and_skill_outcomes_even_with_auto_updates_off() {
+    let home = tempfile::tempdir().unwrap();
+    let output = install_fixture(home.path(), INSTALL).output().unwrap();
+    let text = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{text}");
+    assert!(output.stdout.is_empty());
+    assert!(text.contains("Updating Railway"), "{text}");
+    assert!(text.contains("✓ CLI installed"), "{text}");
+    assert!(
+        text.contains("No CLI-managed agent skills installed"),
+        "{text}"
+    );
+    assert!(
+        text.contains("v255.255.254 will be used on your next command"),
+        "{text}"
+    );
+    assert!(!text.contains("package manager chatter"));
+    let status: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(home.path().join(".railway/update-status.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(status["installed_version"], "255.255.254");
+    assert_eq!(status["skills"]["cli_version"], "255.255.254");
+    assert_eq!(status["skills"]["outcome"]["status"], "not_installed");
+    assert_eq!(status["last_notified_version"], "255.255.254");
+}
+
+#[test]
+fn package_manager_failure_keeps_diagnostics_and_never_claims_completion() {
+    let home = tempfile::tempdir().unwrap();
+    let output = install_fixture(home.path(), "echo 'registry unavailable' >&2\nexit 7")
+        .output()
+        .unwrap();
+    let text = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success());
+    assert!(text.contains("registry unavailable"), "{text}");
+    assert!(text.contains("CLI installation failed"), "{text}");
+    assert!(!text.contains("✓ CLI installed"));
+    assert!(!text.contains("Ready."));
+    assert!(!home.path().join(".railway/update-status.json").exists());
+}
+
+#[test]
+fn cli_success_with_skill_failure_is_recorded_as_partial_success() {
+    let home = tempfile::tempdir().unwrap();
+    let target = home.path().join(".agents/skills");
+    std::fs::create_dir_all(home.path().join(".railway")).unwrap();
+    std::fs::write(home.path().join(".railway/skills.json"), json!({
+        "targets": {target.to_str().unwrap(): {"use-railway": {"installed_at": "t", "files": {}}}}
+    }).to_string()).unwrap();
+    let output = install_fixture(home.path(), INSTALL).output().unwrap();
+    let text = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("✓ CLI installed"), "{text}");
+    assert!(
+        text.contains("Agent skills could not be synchronized"),
+        "{text}"
+    );
+    assert!(text.contains("railway autoupdate status"), "{text}");
+    assert!(!text.contains("✓ Agent skills synchronized"));
+    let status: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(home.path().join(".railway/update-status.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(status["installed_version"], "255.255.254");
+    assert_eq!(status["skills"]["outcome"]["status"], "failed");
+}


### PR DESCRIPTION
## Summary

- Honor `railway autoupdate disable`, `RAILWAY_NO_AUTO_UPDATE`, and CI for automatic CLI/skill checks, installations, and update notices. Explicit update commands still work.
- Present `railway upgrade` as one flow: real CLI check/download/install stages, managed skill synchronization, and a final summary that distinguishes the running version from the installed version. Explicit upgrades also sync managed skills when automatic updates are disabled.
- Keep automatic discovery/downloads quiet. Once the new CLI is active and skill synchronization has an outcome, show a single completion receipt on an appropriate interactive command. Help, version, completion, JSON, and piped output do not consume receipts. Explicit upgrade results are not announced again on the next invocation.
- Replace repeated availability banners with one notice per release for install methods requiring manual action. Remove the separate agent upgrade nudge and normal-command skill nags; detailed skill results and unmanaged installations are available through `railway autoupdate status`.
- Sync CLI-managed skills on the first normal command after external CLI upgrades, with a one-time sync for legacy manifests. Independent hourly skill checks continue while automatic updates are enabled. Preserve local edits as a normal outcome and distinguish skill-sync failures from successful CLI installation.

## Update experience

Example completed package-manager upgrade:

```text
Updating Railway · v5.49.6 · npm

  ✓ CLI installed · v5.49.6 → v5.50.0
  ✓ Agent skills synchronized

Ready. v5.50.0 will be used on your next command.
```

Automatic completion receipt:

```text
✓ Railway updated to v5.50.0 · agent skills synchronized
```

Preserved skills are reported as local edits, without an overwrite prompt in ordinary command output. Failed skill synchronization points to explicit status for diagnostics and leaves the CLI installation marked successful.

Package-manager upgrades verify the actual installed executable instead of assuming the latest published release was installed. Homebrew and Scoop verification uses stable entry points across versioned directory changes. Package-manager diagnostics are retained on failure. Progress is rendered on stderr with terminal spinners or plain lines and advances only when actual work completes.

A separate atomic, file-locked outcome record tracks installed CLI versions, version-scoped skill results, and claimed receipts. Available-release cache changes cannot erase completed outcomes, concurrent commands cannot claim the same receipt, and older detached skill workers cannot replace newer outcome records. `railway autoupdate status` combines these results with staged and in-flight update status.

## Skill sync details

Reuse the existing per-file hash baseline to update only managed skills during background sync and explicit CLI upgrades. Preserve edited/deleted skills, unrelated user-added files, and local files whose names collide with new upstream files. These syncs do not install into newly detected tools or adopt unmanaged skills.

Record the CLI version alongside the attempted skills revision to avoid repeat downloads. Serialize manifest/install/remove operations with a file lock, check the opt-out again in the detached child and after download, and pin archives to the revision recorded in the manifest. Refresh baselines when local content already matches upstream so later upgrades remain automatic.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --locked --all-targets --all-features` (existing warnings only; none in changed files)
- `cargo test --locked -- --test-threads=1`: **1,368 unit tests + 9 Unix integration tests passed** (5 PTY notice tests and 4 isolated upgrade-flow tests). VM-injected Railway authentication/context variables were removed for the test process; serial execution avoids existing shared-state test races.

Regression coverage includes persisted/env/CI opt-outs in a real terminal, disabled detached skill updates, one-time availability and completion notices, JSON/pipe/help suppression without consuming receipts, concurrent receipt claims, activation gating, stale-worker outcome protection, CLI-version changes with a fresh cache, legacy manifests, local edits/deletions/collisions, unmanaged installs, and baseline adoption. Isolated package-manager tests cover verified installation, moved Homebrew paths, retained failure diagnostics, and CLI success with failed skill sync, without touching real installations.
