### PR TITLE
fix(postgres): keep the Patroni switchover credential out of curl's argv

### DIFF
--- a/src/controllers/patroni.rs
+++ b/src/controllers/patroni.rs
@@ -88,8 +88,10 @@ pub async fn probe_any(
 }
 
 /// Resolves the member's Patroni REST credential from its OWN environment
-/// and leaves `$@` holding curl's `-u user:pass` -- empty when the member
-/// carries no password.
+/// and stages it for curl: `$PATRONI_REST_CFG` holds a one-line curl config
+/// document (`user = "user:pass"`) and `$@` holds `-K -`, which makes curl
+/// read that document from stdin. Both are empty when the member carries
+/// no password.
 ///
 /// The `postgres-ha` image authenticates Patroni's MUTATING endpoints
 /// (`POST /switchover`, `/failover`, `/restart`, `/reinitialize`,
@@ -101,20 +103,40 @@ pub async fn probe_any(
 /// The precedence mirrors the image's own resolution (the dedicated REST
 /// secret, else the superuser's), and the credential is read INSIDE the
 /// container: nothing secret enters the exec payload, this process, or a
-/// log line. A member with no password cannot be enforcing either, so the
-/// call goes out bare and Patroni's answer is the truthful outcome -- one
-/// command spans a fleet mid-rollout.
+/// log line. It reaches curl through stdin rather than `-u user:pass`
+/// because argv is public inside the container -- `/proc/<pid>/cmdline`
+/// (`ps`) shows every process's arguments to every other process in the
+/// PID namespace for as long as the request runs. `printf` is a builtin of
+/// the shells the data images ship (dash, bash), so the pipe spawns no
+/// process carrying the secret either.
+///
+/// `curl_cfg_quote` escapes a string for a double-quoted value in curl's
+/// config syntax the way curl's parser reads it back: `\` and `"` are
+/// backslashed and a newline becomes `\n`, since a raw newline would end
+/// the value. Everything else (`$`, `'`, `#`, whitespace) is literal
+/// inside the quotes. Pure POSIX sh, so it asks nothing of the image
+/// beyond the shell itself: `s` is the unread rest of the input, `c` the
+/// character in hand, `r` the input after it, `q` the escaped output.
+///
+/// A member with no password cannot be enforcing either, so the call goes
+/// out bare and Patroni's answer is the truthful outcome -- one command
+/// spans a fleet mid-rollout.
 const RESTAPI_AUTH_PRELUDE: &str = concat!(
     r#"PATRONI_REST_PW="${PATRONI_RESTAPI_PASSWORD:-${PATRONI_SUPERUSER_PASSWORD:-${PGPASSWORD:-${POSTGRES_PASSWORD:-}}}}"; "#,
     r#"PATRONI_REST_USER="${PATRONI_RESTAPI_USERNAME:-${PATRONI_SUPERUSER_USERNAME:-${PGUSER:-${POSTGRES_USER:-postgres}}}}"; "#,
-    r#"if [ -n "$PATRONI_REST_PW" ]; then set -- -u "$PATRONI_REST_USER:$PATRONI_REST_PW"; else set --; fi; "#,
+    r#"curl_cfg_quote() { s=$1; q=; nl=$(printf '\nx'); nl=${nl%x}; "#,
+    r#"while [ -n "$s" ]; do r=${s#?}; c=${s%"$r"}; s=$r; "#,
+    r#"case $c in \\) q="$q\\\\";; \") q="$q\\\"";; "$nl") q="$q\\n";; *) q="$q$c";; esac; done; "#,
+    r#"printf '%s' "$q"; }; "#,
+    r#"if [ -n "$PATRONI_REST_PW" ]; then PATRONI_REST_CFG="user = \"$(curl_cfg_quote "$PATRONI_REST_USER:$PATRONI_REST_PW")\""; set -- -K -; else PATRONI_REST_CFG=; set --; fi; "#,
 );
 
 /// The exact shell text the switchover runs, so a test can pin both halves:
-/// the credential resolution and the request itself.
+/// the credential resolution and the request itself. The config document is
+/// piped into curl on every run; curl reads it only when `$@` says `-K -`.
 fn switchover_command(body: &str) -> String {
     format!(
-        "{prelude}curl -s --max-time 8 -w '\\nHTTP_STATUS:%{{http_code}}' \"$@\" -X POST localhost:8008/switchover -H 'Content-Type: application/json' -d '{body}'",
+        r#"{prelude}printf '%s\n' "$PATRONI_REST_CFG" | curl -s --max-time 8 -w '\nHTTP_STATUS:%{{http_code}}' "$@" -X POST localhost:8008/switchover -H 'Content-Type: application/json' -d '{body}'"#,
         prelude = RESTAPI_AUTH_PRELUDE,
     )
 }
@@ -244,9 +266,18 @@ pub async fn probe_members(
 mod tests {
     use super::*;
 
+    /// What the `curl` shim saw: its argv, one entry per element, and the
+    /// config document it was handed on stdin when that argv said `-K -`.
+    #[cfg(unix)]
+    struct CurlCall {
+        argv: Vec<String>,
+        config: Option<String>,
+    }
+
     /// Runs the emitted switchover text through a real `sh`, with a `curl`
-    /// shim on PATH that records the argv it was handed. Substring checks
-    /// cannot catch a quoting slip; executing it can.
+    /// shim on PATH that records the argv it was handed and, when told to
+    /// read a config from stdin, that config too. Substring checks cannot
+    /// catch a quoting slip; executing it can.
     ///
     /// Unix-only: it needs a POSIX shell on the HOST. The text itself only
     /// ever runs inside the member's Linux container
@@ -255,7 +286,7 @@ mod tests {
     /// `switchover_command_reads_the_credential_by_name` covers what can
     /// be asserted everywhere.
     #[cfg(unix)]
-    fn curl_argv_for(env: &[(&str, &str)]) -> Vec<String> {
+    fn curl_call_for(env: &[(&str, &str)]) -> CurlCall {
         use std::io::Write;
         let dir = std::env::temp_dir().join(format!(
             "cli-patroni-auth-{}-{:?}",
@@ -265,7 +296,19 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let shim = dir.join("curl");
-        std::fs::write(&shim, "#!/bin/sh\nprintf '%s\\n' \"$@\"\n").unwrap();
+        std::fs::write(
+            &shim,
+            concat!(
+                "#!/bin/sh\n",
+                "printf '%s\\n' \"$@\"\n",
+                "prev=\n",
+                "for a in \"$@\"; do\n",
+                "  if [ \"$prev\" = -K ] && [ \"$a\" = - ]; then printf '%s\\n' '@@CONFIG@@'; cat; fi\n",
+                "  prev=$a\n",
+                "done\n",
+            ),
+        )
+        .unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -314,50 +357,97 @@ mod tests {
             "shell rejected the switchover text: {}",
             String::from_utf8_lossy(&out.stderr)
         );
-        String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .map(str::to_string)
-            .collect()
+        let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+        let (argv, config) = match stdout.split_once("@@CONFIG@@\n") {
+            Some((argv, config)) => (argv.to_string(), Some(config.to_string())),
+            None => (stdout, None),
+        };
+        CurlCall {
+            argv: argv.lines().map(str::to_string).collect(),
+            config,
+        }
+    }
+
+    /// How curl's config parser (`unslashquote` in `src/tool_parsecfg.c`)
+    /// reads a double-quoted value: `\\`, `\"`, `\t`, `\n`, `\r` and `\v`
+    /// are escapes, a backslash before anything else is dropped, and the
+    /// value ends at the closing quote. Pins that the shell-side escaper
+    /// speaks the dialect curl actually parses.
+    #[cfg(unix)]
+    fn curl_config_value(line: &str) -> String {
+        let (_, quoted) = line.split_once('"').expect("a double-quoted value");
+        let mut out = String::new();
+        let mut chars = quoted.chars();
+        while let Some(c) = chars.next() {
+            match c {
+                '"' => break,
+                '\\' => match chars.next() {
+                    Some('t') => out.push('\t'),
+                    Some('n') => out.push('\n'),
+                    Some('r') => out.push('\r'),
+                    Some('v') => out.push('\u{0B}'),
+                    Some(other) => out.push(other),
+                    None => break,
+                },
+                c => out.push(c),
+            }
+        }
+        out
     }
 
     /// The credential is READ from the member's environment by name, never
     /// interpolated into the command -- so no secret can reach the exec
-    /// payload, this process, or a log line. Host-agnostic.
+    /// payload, this process, or a log line -- and it travels to curl as a
+    /// config document on stdin, never as an argument. Host-agnostic.
     #[test]
     fn switchover_command_reads_the_credential_by_name() {
         let cmd = switchover_command(r#"{"leader":"postgres-1","candidate":"postgres-2"}"#);
         assert!(cmd.contains("${PATRONI_RESTAPI_PASSWORD:-${PATRONI_SUPERUSER_PASSWORD:-"));
-        assert!(cmd.contains(r#"set -- -u "$PATRONI_REST_USER:$PATRONI_REST_PW""#));
-        // No password in the container => no -u at all; `-u "user:"` would
-        // turn a non-enforcing cluster into a 401.
-        assert!(cmd.contains("else set --; fi"));
-        // curl carries whatever the prelude decided, ahead of the request.
-        let at = cmd
-            .find(r#""$@""#)
-            .expect("curl carries the resolved credential");
+        assert!(cmd.contains(
+            r#"PATRONI_REST_CFG="user = \"$(curl_cfg_quote "$PATRONI_REST_USER:$PATRONI_REST_PW")\""; set -- -K -"#
+        ));
+        // No password in the container => no config document and no -K at
+        // all; a `user = ":"` line would turn a non-enforcing cluster into
+        // a 401.
+        assert!(cmd.contains("else PATRONI_REST_CFG=; set --; fi"));
+        assert!(
+            !cmd.contains(" -u "),
+            "the credential must never be a curl argument"
+        );
+        // The config document is piped into curl, ahead of the request.
+        let pipe = cmd
+            .find(r#"printf '%s\n' "$PATRONI_REST_CFG" | curl "#)
+            .expect("curl reads the config document from stdin");
         let post = cmd.find("-X POST").expect("the POST survives");
-        assert!(at < post, "the credential must precede the request");
+        assert!(pipe < post, "the credential must precede the request");
     }
 
     /// An enforcing member gets HTTP Basic auth built from its own env, with
-    /// the REST secret winning over the superuser's, and the request itself
-    /// still intact behind it.
+    /// the REST secret winning over the superuser's, handed to curl as a
+    /// config document on stdin -- argv, which every process in the
+    /// container can read, never carries it -- and the request itself still
+    /// intact.
     #[cfg(unix)]
     #[test]
     fn switchover_authenticates_from_the_members_own_env() {
-        let argv = curl_argv_for(&[
+        let call = curl_call_for(&[
             ("PATRONI_RESTAPI_PASSWORD", "rest-pw"),
             ("PATRONI_SUPERUSER_PASSWORD", "super-pw"),
             ("POSTGRES_USER", "rw"),
         ]);
-        let u = argv
-            .iter()
-            .position(|a| a == "-u")
-            .expect("credential passed to curl");
-        assert_eq!(argv[u + 1], "rw:rest-pw");
-        assert!(argv.iter().any(|a| a == "localhost:8008/switchover"));
+        assert_eq!(call.config.as_deref(), Some("user = \"rw:rest-pw\"\n"));
         assert!(
-            argv.iter()
+            call.argv
+                .iter()
+                .all(|a| !a.contains("rest-pw") && !a.contains("super-pw")),
+            "credential in curl's argv: {:?}",
+            call.argv
+        );
+        assert!(!call.argv.iter().any(|a| a == "-u"), "{:?}", call.argv);
+        assert!(call.argv.iter().any(|a| a == "localhost:8008/switchover"));
+        assert!(
+            call.argv
+                .iter()
                 .any(|a| a == r#"{"leader":"postgres-1","candidate":"postgres-2"}"#)
         );
     }
@@ -367,25 +457,58 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn switchover_falls_back_to_the_superuser_credential() {
-        let argv = curl_argv_for(&[("PATRONI_SUPERUSER_PASSWORD", "super-pw")]);
-        let u = argv
-            .iter()
-            .position(|a| a == "-u")
-            .expect("credential passed to curl");
-        assert_eq!(argv[u + 1], "postgres:super-pw");
+        let call = curl_call_for(&[("PATRONI_SUPERUSER_PASSWORD", "super-pw")]);
+        assert_eq!(
+            call.config.as_deref(),
+            Some("user = \"postgres:super-pw\"\n")
+        );
+        assert!(
+            call.argv.iter().all(|a| !a.contains("super-pw")),
+            "credential in curl's argv: {:?}",
+            call.argv
+        );
     }
 
     /// A member with no password at all cannot be enforcing, so the POST
-    /// goes out bare -- `-u ""` would turn a working cluster into a 401.
+    /// goes out bare -- no `-K`, no config document -- since a `user = ":"`
+    /// line would turn a working cluster into a 401.
     #[cfg(unix)]
     #[test]
     fn switchover_stays_bare_when_the_member_has_no_password() {
-        let argv = curl_argv_for(&[]);
+        let call = curl_call_for(&[]);
         assert!(
-            !argv.iter().any(|a| a == "-u"),
-            "bare POST expected, got {argv:?}"
+            call.config.is_none(),
+            "config document without a password: {:?}",
+            call.config
         );
-        assert!(argv.iter().any(|a| a == "localhost:8008/switchover"));
+        assert!(
+            !call.argv.iter().any(|a| a == "-K" || a == "-u"),
+            "bare POST expected, got {:?}",
+            call.argv
+        );
+        assert!(call.argv.iter().any(|a| a == "localhost:8008/switchover"));
+    }
+
+    /// A password is arbitrary text, and curl's config parser gives `\` and
+    /// `"` meaning inside a double-quoted value and ends the value at a
+    /// newline -- so the shell escapes exactly those, and what curl reads
+    /// back (`curl_config_value`, its parser's rules) is the original.
+    #[cfg(unix)]
+    #[test]
+    fn switchover_escapes_the_credential_for_curls_config_parser() {
+        let password = "p\"a\\s$s' w#rd\nnext\ttab";
+        let call = curl_call_for(&[
+            ("PATRONI_RESTAPI_PASSWORD", password),
+            ("POSTGRES_USER", "rw"),
+        ]);
+        let config = call.config.expect("config document piped to curl");
+        assert_eq!(config, "user = \"rw:p\\\"a\\\\s$s' w#rd\\nnext\ttab\"\n");
+        assert_eq!(curl_config_value(&config), format!("rw:{password}"));
+        assert!(
+            call.argv.iter().all(|a| !a.contains("w#rd")),
+            "credential in curl's argv: {:?}",
+            call.argv
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`railway postgres ha switchover` (`src/controllers/patroni.rs`) authenticates against Patroni's REST API inside the member's container. Since #1171 the credential reached curl as `-u "$PATRONI_REST_USER:$PATRONI_REST_PW"`. It now reaches curl as a one-line config document on stdin, `user = "user:pass"` piped into `curl -K -`, escaped for curl's config parser by a pure-POSIX shell function (`curl_cfg_quote`: `\` and `"` backslashed, newline to `\n`).

Unchanged: the credential is resolved inside the container from the member's own environment (`PATRONI_RESTAPI_PASSWORD` > `PATRONI_SUPERUSER_PASSWORD` > `PGPASSWORD` > `POSTGRES_PASSWORD`; username `PATRONI_RESTAPI_USERNAME` > `PATRONI_SUPERUSER_USERNAME` > `PGUSER` > `POSTGRES_USER` > `postgres`); a member with no password gets a bare POST (no `-K`, no document); Patroni's status code and response body surface as the error.

## Why

HA internal-credential audit (2026-09-08), finding LOW-7 / REPORT-mono-cli Finding 7: `src/controllers/patroni.rs:110` on master emits `set -- -u "$PATRONI_REST_USER:$PATRONI_REST_PW"`, so the password sits in curl's argv for the duration of the request. `/proc/<pid>/cmdline` is world-readable, so any process in the container's PID namespace (`ps`) can read the Patroni REST password while a switchover runs, and under the ONE PASSWORD design that is the superuser password. A pipe's stdin is private to its two ends, and `printf` is a builtin of the shells the data images ship (dash on the Debian-based postgres image, bash on Oracle Linux), so no process argv carries the secret at any point.

## How verified

- `cargo fmt --all --check`; `cargo test controllers::patroni`: 11 passed, on macOS with `/bin/sh` and again with `sh` resolving to dash (CI's ubuntu runner).
- The sh-shim tests now capture curl's argv and the stdin config document. They assert the password appears in no argv element, `-u` is gone, the document is exactly `user = "user:pass"`, the precedence chain and the bare case are unchanged. A new test feeds a password containing `"`, `\`, `$`, `'`, space, `#`, newline and tab and checks the escaped document decodes back to the original under curl's own `unslashquote` rules (replicated in the test).
- Negative control: the new tests run against the previous `-u` prelude fail four of five credential tests (document absent, password in argv); only the bare-request test passes.
- Outside the suite: the emitted shell text was run under dash, bash and zsh against a local HTTP server with real curl 8.7.1. The server received the exact `Authorization: Basic` header for the same password in all three shells; the unescaped variant did not.
- clippy: no findings in `src/controllers/patroni.rs`; the repo baseline is untouched.

## Rollout notes

CLI-only; no image, template or backboard change. Behaviour against enforcing and non-enforcing members is identical apart from where curl reads the credential. `release/patch`.
