### PR TITLE
fix(config): fail apply when the change-set workflow fails

### DIFF
--- a/src/commands/config/runner.rs
+++ b/src/commands/config/runner.rs
@@ -282,6 +282,7 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
         if !output.ok {
             bail!(runner_diagnostics_message(&output));
         }
+        reject_failed_apply_result(output.apply_result.as_ref())?;
         maybe_detailed_exit(&args, command, &output);
         return Ok(());
     }
@@ -290,6 +291,7 @@ pub(super) async fn run_command(args: Args) -> Result<()> {
     if !output.ok {
         bail!(runner_diagnostics_message(&output));
     }
+    reject_failed_apply_result(output.apply_result.as_ref())?;
 
     maybe_detailed_exit(&args, command, &output);
 
@@ -745,6 +747,26 @@ fn runner_diagnostics_message(response: &RunnerResponse) -> String {
     )
 }
 
+fn reject_failed_apply_result(apply_result: Option<&ChangeSetApplyResult>) -> Result<()> {
+    let Some(apply_result) = apply_result else {
+        return Ok(());
+    };
+    if !crate::iac::apply_status_is_failure(&apply_result.status) {
+        return Ok(());
+    }
+    let messages = crate::iac::apply_diagnostic_messages(&apply_result.diagnostics);
+    if messages.is_empty() {
+        bail!(
+            "Railway configuration apply failed (status: {}).",
+            apply_result.status
+        );
+    }
+    bail!(
+        "Railway configuration apply failed:\n{}",
+        messages.join("\n")
+    )
+}
+
 pub(super) fn print_response_with_options(response: &RunnerResponse, verbose: bool) {
     print_response_with_options_and_next(response, verbose, true);
 }
@@ -810,6 +832,28 @@ pub(super) fn print_response_with_options_and_next(
         .unwrap_or(&[]);
 
     if let Some(apply_result) = &response.apply_result {
+        if crate::iac::apply_status_is_failure(&apply_result.status) {
+            println!("{} {}", "Apply".red().bold(), "failed".red());
+            for message in crate::iac::apply_diagnostic_messages(&apply_result.diagnostics) {
+                println!("{} {}", "Error".red().bold(), message.red());
+            }
+            let empty_diagnostics = match &apply_result.diagnostics {
+                Value::Array(items) => items.is_empty(),
+                Value::Null => true,
+                _ => false,
+            };
+            if apply_result.changes.is_empty() && empty_diagnostics {
+                println!(
+                    "{} {}",
+                    "Error".red().bold(),
+                    format!(
+                        "Railway configuration apply failed (status: {}).",
+                        apply_result.status
+                    )
+                    .red()
+                );
+            }
+        }
         print_operation_results(apply_result, verbose);
         if verbose {
             println!();
@@ -1045,5 +1089,36 @@ mod runner_discovery_tests {
         fs::set_permissions(&shared, fs::Permissions::from_mode(0o777)).unwrap();
 
         assert_eq!(find_project_runner(&shared), None);
+    }
+
+    #[test]
+    fn reject_failed_apply_result_surfaces_server_diagnostics() {
+        let apply_result = ChangeSetApplyResult {
+            id: "iac-change-set/env/hash".into(),
+            status: "failed".into(),
+            changes: Vec::new(),
+            diagnostics: serde_json::json!([{
+                "message": "A service named \"Redis Exporter\" already exists in this project but not in this environment."
+            }]),
+            deployment_id: None,
+            staged_patch_id: None,
+        };
+        let err = reject_failed_apply_result(Some(&apply_result))
+            .expect_err("failed apply must exit non-zero");
+        let message = format!("{err:#}");
+        assert!(message.contains("Railway configuration apply failed"));
+        assert!(message.contains("Redis Exporter"));
+        assert!(reject_failed_apply_result(None).is_ok());
+        assert!(
+            reject_failed_apply_result(Some(&ChangeSetApplyResult {
+                id: "ok".into(),
+                status: "applied".into(),
+                changes: Vec::new(),
+                diagnostics: serde_json::json!([]),
+                deployment_id: None,
+                staged_patch_id: None,
+            }))
+            .is_ok()
+        );
     }
 }

--- a/src/iac/engine.rs
+++ b/src/iac/engine.rs
@@ -594,9 +594,82 @@ pub(crate) async fn apply_change_set(
         let mut value = serde_json::to_value(&applied.result.rest)?;
         value["id"] = json!(applied.result.id);
         value["status"] = json!(applied.result.status);
-        return Ok(value);
+        return ensure_apply_succeeded(value);
     }
-    wait_for_apply(client, endpoint, environment_id, &applied.result.id).await
+    ensure_apply_succeeded(
+        wait_for_apply(client, endpoint, environment_id, &applied.result.id).await?,
+    )
+}
+
+/// Reject a terminal change-set apply whose workflow ended in failure.
+///
+/// Backboard can return `status: "failed"` with an empty `changes` list and
+/// the real explanation only in `diagnostics` (for example a duplicate
+/// database name). Treating that payload as success made `railway config
+/// apply` exit 0 and print nothing while the environment was unchanged.
+pub(crate) fn ensure_apply_succeeded(result: Value) -> Result<Value> {
+    let status = result
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !apply_status_is_failure(status) {
+        return Ok(result);
+    }
+
+    let messages = apply_diagnostic_messages(result.get("diagnostics").unwrap_or(&Value::Null));
+    if messages.is_empty() {
+        bail!("Railway configuration apply failed (status: {status}).");
+    }
+    bail!(
+        "Railway configuration apply failed:\n{}",
+        messages.join("\n")
+    )
+}
+
+pub(crate) fn apply_status_is_failure(status: &str) -> bool {
+    matches!(status, "failed" | "error" | "cancelled")
+}
+
+pub(crate) fn apply_diagnostic_messages(diagnostics: &Value) -> Vec<String> {
+    match diagnostics {
+        Value::Array(items) => items.iter().filter_map(apply_diagnostic_message).collect(),
+        Value::Object(object) => {
+            if let Some(items) = object
+                .get("items")
+                .or_else(|| object.get("diagnostics"))
+                .and_then(Value::as_array)
+            {
+                items.iter().filter_map(apply_diagnostic_message).collect()
+            } else {
+                apply_diagnostic_message(diagnostics).into_iter().collect()
+            }
+        }
+        Value::String(message) if !message.is_empty() => vec![message.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn apply_diagnostic_message(value: &Value) -> Option<String> {
+    match value {
+        Value::String(message) if !message.is_empty() => Some(message.clone()),
+        Value::Object(object) => {
+            let message = object.get("message")?.as_str()?.trim();
+            if message.is_empty() {
+                return None;
+            }
+            let path = object
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim();
+            if path.is_empty() {
+                Some(message.to_string())
+            } else {
+                Some(format!("{path}: {message}"))
+            }
+        }
+        _ => None,
+    }
 }
 
 async fn wait_for_apply(
@@ -681,6 +754,51 @@ mod tests {
         let node = &buckets.project.unwrap().buckets.edges[0].node;
         assert_eq!(node.name.as_deref(), Some("uploads"));
         assert_eq!(node.group_id.as_deref(), Some("grp-1"));
+    }
+
+    #[test]
+    fn ensure_apply_succeeded_rejects_failed_workflow_with_diagnostics() {
+        let err = ensure_apply_succeeded(json!({
+            "id": "iac-change-set/env/hash",
+            "status": "failed",
+            "changes": [],
+            "diagnostics": [{
+                "message": "A service named \"Redis Exporter\" already exists in this project but not in this environment."
+            }]
+        }))
+        .expect_err("failed apply must not look like success");
+        let message = format!("{err:#}");
+        assert!(message.contains("Railway configuration apply failed"));
+        assert!(message.contains("Redis Exporter"));
+    }
+
+    #[test]
+    fn ensure_apply_succeeded_allows_successful_statuses() {
+        for status in ["applied", "completed", "success", "noop"] {
+            let result = ensure_apply_succeeded(json!({
+                "id": "iac-change-set/env/hash",
+                "status": status,
+                "changes": [],
+                "diagnostics": []
+            }))
+            .unwrap();
+            assert_eq!(result["status"], status);
+        }
+    }
+
+    #[test]
+    fn apply_diagnostic_messages_read_path_qualified_entries() {
+        let messages = apply_diagnostic_messages(&json!([
+            { "path": "service.api", "message": "invalid image" },
+            "bare diagnostic"
+        ]));
+        assert_eq!(
+            messages,
+            vec![
+                "service.api: invalid image".to_string(),
+                "bare diagnostic".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/iac/mod.rs
+++ b/src/iac/mod.rs
@@ -21,6 +21,7 @@ pub use compiler::{
     graph_to_environment_config, project_definition_to_graph,
 };
 pub use engine::{NativeRun, run as run_native};
+pub(crate) use engine::{apply_diagnostic_messages, apply_status_is_failure};
 #[allow(dead_code)]
 pub use eval::{EvalContext, EvaluatedFile, evaluate_file, evaluate_file_with_context};
 #[allow(dead_code)]


### PR DESCRIPTION
## Summary
- Fixes #1170: `railway config apply` treated a failed change-set workflow (`status: failed`, often with empty `changes` and the real explanation only in `diagnostics`) as success, exiting 0 and printing only the header.
- Reject failed apply payloads in `apply_change_set` so both live apply and `apply --plan` return a non-zero exit with the server diagnostics.
- Defense-in-depth in the config runner for legacy TS-runner responses, plus clearer apply-failure printing when changes are empty.

## Root cause
`environmentApplyChangeSet` / `environmentChangeSetApply` can finish as `failed` with `changes: []` and diagnostics such as a duplicate database name. The CLI stored that payload in `apply_result`, left `ok: true`, printed nothing when `changes` was empty, and exited 0 — so CI (including `railwayapp/config`) reported a successful apply that changed nothing.

## Test plan
- [x] `cargo test ensure_apply_succeeded`
- [x] `cargo test apply_diagnostic`
- [x] `cargo test reject_failed_apply_result_surfaces`
- [x] `cargo test iac::` (74 passed)
- [ ] Repro from #1170: apply a plan that creates a database service whose name already exists project-wide; expect non-zero exit and the diagnostic message on stderr
