### PR TITLE
fix(release): unblock i686 Windows GNU builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,30 @@ jobs:
         with:
           command: check
 
+  windows-gnu-release:
+    name: Release build (i686-pc-windows-gnu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: i686-pc-windows-gnu
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: i686-pc-windows-gnu-release
+
+      - name: Install cross
+        run: cargo install cross --version 0.2.5 --locked
+
+      # Match release.yml's cross target and release profile: cargo check and
+      # native Windows tests do not catch cross-target linker failures.
+      - name: Build release binary
+        run: cross build --release --locked --target i686-pc-windows-gnu
+
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,16 +39,15 @@ jobs:
           targets: i686-pc-windows-gnu
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: i686-pc-windows-gnu-release
-
-      - name: Install cross
-        run: cargo install cross --version 0.2.5 --locked
 
       # Match release.yml's cross target and release profile: cargo check and
       # native Windows tests do not catch cross-target linker failures.
-      - name: Build release binary
-        run: cross build --release --locked --target i686-pc-windows-gnu
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --locked --target i686-pc-windows-gnu
+          use-cross: true
 
   lints:
     name: Lints

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[target.i686-pc-windows-gnu.env]
+# Bundled SQLite links MinGW's kernel32 alongside winapi's bundled import
+# libraries, which both define _imp__InterlockedCompareExchange@12 on i686.
+# Use the toolchain's import libraries consistently inside the cross container.
+passthrough = ["WINAPI_NO_BUNDLED_LIBRARIES=1"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,9 @@
+[target.i686-pc-windows-gnu]
+# cross 0.2.5's default image ships GCC 7.5 / old MinGW without
+# libsynchronization. Pin the Ubuntu 24.04 / GCC 13 upstream image so all
+# of winapi's toolchain import libraries are available and builds are repeatable.
+image = "ghcr.io/cross-rs/i686-pc-windows-gnu@sha256:e24e854384cdad24ae7c02a4f64d9c330abb226f92eef7478b78aecab3348d46"
+
 [target.i686-pc-windows-gnu.env]
 # Bundled SQLite links MinGW's kernel32 alongside winapi's bundled import
 # libraries, which both define _imp__InterlockedCompareExchange@12 on i686.

--- a/tests/upgrade_flow.rs
+++ b/tests/upgrade_flow.rs
@@ -3,13 +3,24 @@
 #![cfg(unix)]
 
 use serde_json::json;
-use std::{os::unix::fs::PermissionsExt, path::Path, process::Command};
+use std::{
+    os::unix::fs::PermissionsExt,
+    path::Path,
+    process::{Command, Output},
+    sync::Mutex,
+};
 
-fn install_fixture(home: &Path, script: &str) -> Command {
-    install_fixture_at(home, "node_modules/railway/railway", "npm", script)
+static FIXTURE_LAUNCH: Mutex<()> = Mutex::new(());
+
+fn run_fixture(home: &Path, script: &str) -> Output {
+    run_fixture_at(home, "node_modules/railway/railway", "npm", script)
 }
 
-fn install_fixture_at(home: &Path, path: &str, manager: &str, script: &str) -> Command {
+fn run_fixture_at(home: &Path, path: &str, manager: &str, script: &str) -> Output {
+    // A concurrent child launch can inherit another test's writable copy handle
+    // until exec, causing ETXTBSY when that test starts its copied executable.
+    // Keep fixture writes and child execution together under the same lock.
+    let _launch = FIXTURE_LAUNCH.lock().unwrap();
     let executable = home.join(path);
     std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
     std::fs::copy(env!("CARGO_BIN_EXE_railway"), &executable).unwrap();
@@ -29,7 +40,7 @@ fn install_fixture_at(home: &Path, path: &str, manager: &str, script: &str) -> C
         .env("RAILWAY_NO_AUTO_UPDATE", "1")
         .env("HTTPS_PROXY", "http://127.0.0.1:9")
         .args(["upgrade", "--yes"]);
-    command
+    command.output().unwrap()
 }
 
 #[test]
@@ -41,14 +52,12 @@ printf '#!/bin/sh\necho railway 255.255.254\n' > "$HOME/homebrew/opt/railway/bin
 /bin/chmod +x "$HOME/homebrew/opt/railway/bin/railway"
 /bin/rm "$TEST_RAILWAY_EXE"
 "#;
-    let output = install_fixture_at(
+    let output = run_fixture_at(
         home.path(),
         "homebrew/Cellar/railway/old/bin/railway",
         "brew",
         script,
-    )
-    .output()
-    .unwrap();
+    );
     let text = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "{text}");
     assert!(
@@ -67,7 +76,7 @@ echo 'package manager chatter'
 #[test]
 fn explicit_upgrade_shows_verified_cli_and_skill_outcomes_even_with_auto_updates_off() {
     let home = tempfile::tempdir().unwrap();
-    let output = install_fixture(home.path(), INSTALL).output().unwrap();
+    let output = run_fixture(home.path(), INSTALL);
     let text = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "{text}");
     assert!(output.stdout.is_empty());
@@ -95,9 +104,7 @@ fn explicit_upgrade_shows_verified_cli_and_skill_outcomes_even_with_auto_updates
 #[test]
 fn package_manager_failure_keeps_diagnostics_and_never_claims_completion() {
     let home = tempfile::tempdir().unwrap();
-    let output = install_fixture(home.path(), "echo 'registry unavailable' >&2\nexit 7")
-        .output()
-        .unwrap();
+    let output = run_fixture(home.path(), "echo 'registry unavailable' >&2\nexit 7");
     let text = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success());
     assert!(text.contains("registry unavailable"), "{text}");
@@ -115,7 +122,7 @@ fn cli_success_with_skill_failure_is_recorded_as_partial_success() {
     std::fs::write(home.path().join(".railway/skills.json"), json!({
         "targets": {target.to_str().unwrap(): {"use-railway": {"installed_at": "t", "files": {}}}}
     }).to_string()).unwrap();
-    let output = install_fixture(home.path(), INSTALL).output().unwrap();
+    let output = run_fixture(home.path(), INSTALL);
     let text = String::from_utf8_lossy(&output.stderr);
     assert!(output.status.success(), "{text}");
     assert!(text.contains("✓ CLI installed"), "{text}");


### PR DESCRIPTION
## Summary

- Pin the `i686-pc-windows-gnu` cross image to an upstream Ubuntu 24.04 / GCC 13 image by digest.
- Use MinGW's import libraries consistently via `WINAPI_NO_BUNDLED_LIBRARIES=1` in `Cross.toml`.
- Add a full release-mode cross-build to CI using the same checkout, Rust toolchain, cache, and `actions-rs/cargo@v1` structure as the existing checks. The build action and arguments match `release.yml`.

- Serialize the Unix upgrade tests’ executable fixture writes and child execution to avoid intermittent Linux `ETXTBSY` failures.

## Why

The releases containing #1173 (`v5.50.0` and `v5.50.1`) are stuck as drafts because the 32-bit Windows GNU build fails with:

```text
multiple definition of `_imp__InterlockedCompareExchange@12'
```

Bundled SQLite stores the address of this function in its Windows syscall table, exposing a collision between MinGW's `libkernel32.a` and winapi's bundled `libwinapi_kernel32.a`. The successful preceding release used the same Rust version, cross version, and container digest; the release workflow was unchanged.

The first CI attempt confirmed the library setting removes that collision but exposed a second issue: cross 0.2.5's default GCC 7.5 / MinGW image lacks `libsynchronization.a`. The pinned modern upstream image provides that library and the other import libraries needed by the full CLI. Both CI and the existing release workflow read the same target-specific `Cross.toml` configuration.

Image source: cross-rs/cross revision `8c1a8aa4b661711f4b7b6ac07c2e8929ce2f7d27`, built 2026-09-04.

The other 11 release targets succeeded, but the failed matrix job prevents crates.io, GitHub Release, and npm publication. Normal native CI does not build this target.

Failed releases:
- https://github.com/railwayapp/cli/actions/runs/34293256109/job/102284295599
- https://github.com/railwayapp/cli/actions/runs/34308453562/job/102330015059

## Validation

- Reproduced the exact original duplicate-symbol error in a minimal C program using the release's old cross container; the same code links using only MinGW's libraries. [Reproduction details](https://github.com/railwayapp/cli/pull/1182#issuecomment-5603818197).
- Verified the pinned image supplies `libsynchronization.a` and links the reproduction with all ten libraries requested by winapi.
- `git diff --check` passed.
- `actionlint` passed for the changed CI workflow with existing diagnostic categories excluded (legacy cargo action and undefined `docker-prep` output).
- All eight PR checks passed on `8fe0abb`: full Windows GNU release build, Ubuntu/macOS/Windows tests, cargo check, lints, POSIX installer, and release label. [Successful CI run](https://github.com/railwayapp/cli/actions/runs/34367819127).
- `cargo fmt --all -- --check` passed after the fixture change.

## Release

The `release/patch` label will trigger a new patch release when merged, including the already-merged OpenCode features and this build fix.
