### PR TITLE
Fix duplicate results panels in railway code get-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,10 @@ railway code get-config --json
 Each successful `railway code` setup saves its connection details locally,
 including when you decline or cancel the local-client prompt. OpenCode
 reconnects refresh this record too. `get-config` works from any directory and
-prints the most recently saved connection: the OpenCode server URL, username,
-password, project directory, connection commands, and Desktop configuration
-result, plus a direct SSH command and a copyable `~/.ssh/config` block.
+prints the most recently saved connection in one results panel: the OpenCode
+server URL, username, password, project directory, connection commands, and
+Desktop configuration result, plus a direct SSH command and a copyable
+`~/.ssh/config` block.
 SSH-based harness launches save the SSH details.
 
 The record is a snapshot; viewing it does not create, wake, or connect to an

--- a/src/commands/cloud_agent/opencode.rs
+++ b/src/commands/cloud_agent/opencode.rs
@@ -43,6 +43,21 @@ pub(crate) fn show_connection(
     let divider = "─".repeat(64).cyan();
     println!("\n{divider}");
     println!("{}", format!("{edition} server on {name}").cyan().bold());
+    show_server_config(connection, beta, name);
+    println!("\n{}", "Connect from your computer:".bold());
+    println!("  {command}");
+    println!("\n{}", "Connect with the Railway CLI:".bold());
+    println!("  {}", railway_connect_command(beta, name));
+    if desktop_configured {
+        println!("\nOpenCode Desktop configuration updated (you may need to restart)");
+    }
+    println!("{divider}\n");
+    Ok(())
+}
+
+/// The server fields, without a surrounding panel or connection commands.
+pub(crate) fn show_server_config(connection: &Connection, beta: bool, name: &str) {
+    let edition = if beta { "OpenCode2 [Beta]" } else { "OpenCode" };
     println!(
         "\n{}",
         format!("Railway {edition} Server Configuration:").bold()
@@ -52,24 +67,16 @@ pub(crate) fn show_connection(
     println!("  {}  {}", "Username:".bold(), connection.username);
     println!("  {}  {}", "Password:".bold(), connection.password);
     println!("  {} {}", "Directory:".bold(), connection.directory);
-    println!("\n{}", "Connect from your computer:".bold());
-    println!("  {command}");
-    println!("\n{}", "Connect with the Railway CLI:".bold());
-    println!(
-        "  {}",
-        shell_join(&[
-            "railway".into(),
-            "code".into(),
-            if beta { "--opencode2" } else { "--opencode" }.into(),
-            "connect".into(),
-            name.into()
-        ])
-    );
-    if desktop_configured {
-        println!("\nOpenCode Desktop configuration updated (you may need to restart)");
-    }
-    println!("{divider}\n");
-    Ok(())
+}
+
+pub(crate) fn railway_connect_command(beta: bool, name: &str) -> String {
+    shell_join(&[
+        "railway".into(),
+        "code".into(),
+        if beta { "--opencode2" } else { "--opencode" }.into(),
+        "connect".into(),
+        name.into(),
+    ])
 }
 
 pub(crate) fn generate_password() -> String {

--- a/src/commands/code/saved_config.rs
+++ b/src/commands/code/saved_config.rs
@@ -176,33 +176,25 @@ impl SavedConfig {
     }
 
     fn show(&self) -> Result<()> {
+        let divider = "─".repeat(64).cyan();
+        println!("\n{divider}");
         println!(
             "Saved connection for {} ({})",
             self.agent_name,
             self.saved_at.to_rfc3339()
         );
         if let Some(opencode) = &self.opencode {
-            opencode::show_connection(
-                &opencode.connection,
-                opencode.beta,
-                &self.agent_name,
-                opencode.desktop_configured,
-            )?;
-            if let Some(error) = &opencode.desktop_error {
-                println!("Desktop configuration was not saved: {error}");
-            } else if !opencode.desktop_configured {
-                let edition = if opencode.beta {
-                    "OpenCode2 [Beta]"
-                } else {
-                    "OpenCode"
-                };
-                println!("{edition} Desktop was not detected; desktop configuration was skipped.");
-            }
+            opencode::show_server_config(&opencode.connection, opencode.beta, &self.agent_name);
+            println!("\n{}", "Connect from your computer:".bold());
+            println!(
+                "  {}",
+                opencode::attach_command(&opencode.connection, opencode.beta)?
+            );
         }
-        let divider = "─".repeat(64).cyan();
-        println!("\n{divider}");
-        println!("{}", "Railway Cloud Agent SSH Configuration:".bold());
-        println!("  Agent:       {}", self.agent_name);
+        println!("\n{}", "Railway Cloud Agent SSH Configuration:".bold());
+        if self.opencode.is_none() {
+            println!("  Agent:       {}", self.agent_name);
+        }
         println!("  Agent ID:    {}", self.agent_id);
         println!("  Environment: {}", self.environment_id);
         println!("  Harness:     {}", self.harness);
@@ -210,6 +202,12 @@ impl SavedConfig {
         println!("\n{}", "SSH config block (for ~/.ssh/config):".bold());
         print!("{}", self.ssh_config);
         println!("\n{}", "Connect with the Railway CLI:".bold());
+        if let Some(opencode) = &self.opencode {
+            println!(
+                "  {}",
+                opencode::railway_connect_command(opencode.beta, &self.agent_name)
+            );
+        }
         println!(
             "  {}",
             shell_join(&[
@@ -219,6 +217,22 @@ impl SavedConfig {
                 self.agent_id.clone()
             ])
         );
+        if let Some(opencode) = &self.opencode {
+            if opencode.desktop_configured {
+                println!("\nOpenCode Desktop configuration updated (you may need to restart)");
+            } else if let Some(error) = &opencode.desktop_error {
+                println!("\nDesktop configuration was not saved: {error}");
+            } else {
+                let edition = if opencode.beta {
+                    "OpenCode2 [Beta]"
+                } else {
+                    "OpenCode"
+                };
+                println!(
+                    "\n{edition} Desktop was not detected; desktop configuration was skipped."
+                );
+            }
+        }
         println!("{divider}\n");
         Ok(())
     }

--- a/tests/code_get_config.rs
+++ b/tests/code_get_config.rs
@@ -86,6 +86,29 @@ fn get_config_replays_both_editions_and_ssh_without_prompting() {
                 .count(),
             1
         );
+        assert_eq!(
+            text.matches(&"─".repeat(64)).count(),
+            2,
+            "one results panel"
+        );
+        assert_eq!(text.matches("Connect with the Railway CLI:").count(), 1);
+        assert_eq!(
+            text.matches("Railway Cloud Agent SSH Configuration:")
+                .count(),
+            1
+        );
+        let flag = if beta { "--opencode2" } else { "--opencode" };
+        assert_eq!(
+            text.matches(&format!("railway code {flag} connect my-box"))
+                .count(),
+            1
+        );
+        assert_eq!(text.matches("railway ca ssh agent-123").count(), 1);
+        assert_eq!(
+            text.matches("OpenCode Desktop configuration updated")
+                .count(),
+            1
+        );
         for expected in [
             "https://example.up.railway.app",
             "fixture-password",


### PR DESCRIPTION
## Summary
- Render saved OpenCode and SSH connection details in a single results panel.
- Show one `Connect with the Railway CLI:` section containing both connection commands, and keep the Desktop configuration result inside the panel.
- Share OpenCode field/command rendering between launch summaries and saved configuration output.
- Tighten existing replay tests to check one panel, one Railway CLI heading, and exactly one copy of each connection command.

## Verification
- Reproduced the two-panel output using the installed 5.51.0 CLI in both a PTY and a pipe.
- `cargo test --locked --test code_get_config` — 4 passed.
- `cargo test --locked opencode` — 45 passed, 1 existing download smoke test ignored.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --all-targets --all-features --locked` — passed with existing repository warnings.
- `cargo build --release --locked` and `git diff --check` — passed.
- Rebuilt and atomically replaced the local CLI; verified one panel/heading against the existing saved configuration in terminal and piped output, plus matching JSON output.