### PR TITLE
fix(ca): preserve agent identity across uncertain VM observations

### DIFF
--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -351,27 +351,18 @@ pub async fn create(args: CreateArgs) -> Result<()> {
 pub async fn wake(args: WakeArgs) -> Result<()> {
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
-    let (configs, client) = (&mut configs, &client);
+    wake_with(&mut configs, &client, args).await
+}
+
+async fn wake_with(configs: &mut Configs, client: &reqwest::Client, args: WakeArgs) -> Result<()> {
     let (project, environment) = (args.target.project.clone(), args.target.environment.clone());
     let scoped = scope(configs, client, project, environment).await?;
     let (agent, _) = ca::resolve(configs, client, args.agent.as_deref(), scoped.as_deref()).await?;
     let backboard = configs.get_backboard();
 
-    match agent.status {
-        ca::Status::Running => {
-            println!("Agent {} is already awake.", agent.name.cyan());
-            ca::remember(configs, &agent)?;
-            return Ok(());
-        }
-        ca::Status::Sleeping => ca::wake(client, &backboard, &agent.id).await?,
-        // Something else is already booting it; a second wake would be noise.
-        ca::Status::Starting => {}
-        _ => bail!(
-            "Agent {} is {} and cannot be woken.",
-            agent.name,
-            agent.status.label()
-        ),
-    }
+    // The inventory is an observation. Let the mutation's live state check
+    // decide whether waking is necessary, including when we last saw RUNNING.
+    ca::wake(client, &backboard, &agent.id).await?;
     ca::remember(configs, &agent)?;
 
     if args.no_wait {
@@ -405,20 +396,18 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
             }
             None => ca::list_mine(client, &backboard).await?,
         };
-        let awake: Vec<_> = agents
-            .into_iter()
-            .filter(|a| matches!(a.status, ca::Status::Running | ca::Status::Starting))
-            .collect();
-        if awake.is_empty() {
-            println!("No running agents to sleep.");
+        // A sleeping observation may predate a wake elsewhere. Send the intent
+        // for every agent; the server handles already-asleep agents as no-ops.
+        if agents.is_empty() {
+            println!("No cloud agents to sleep.");
             return Ok(());
         }
         telemetry::track_lifecycle("sleep_all", Duration::ZERO, None).await;
-        let spinner = create_spinner(format!("Sleeping {} agents", awake.len()));
+        let spinner = create_spinner(format!("Requesting sleep for {} agents", agents.len()));
         // Concurrently: each sleep now flushes the agent's disk over ssh first,
         // and run in sequence that would make the cost-control command take a
         // second per agent — slow enough that people stop reaching for it.
-        let failed: Vec<String> = futures::future::join_all(awake.iter().map(|agent| {
+        let failed: Vec<String> = futures::future::join_all(agents.iter().map(|agent| {
             let backboard = backboard.clone();
             async move {
                 ca::sleep(client, &backboard, &agent.environment_id, &agent.id)
@@ -432,27 +421,17 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
         .flatten()
         .collect();
         spinner.finish_and_clear();
-        println!("✓ Slept {} agents.", awake.len() - failed.len());
+        println!(
+            "✓ Sleep requested for {} agents.",
+            agents.len() - failed.len()
+        );
         if !failed.is_empty() {
-            bail!("Some agents are still running:\n{}", failed.join("\n"));
+            bail!("Some sleep requests failed:\n{}", failed.join("\n"));
         }
         return Ok(());
     }
 
     let (agent, _) = ca::resolve(configs, client, args.agent.as_deref(), scoped.as_deref()).await?;
-    match agent.status {
-        ca::Status::Sleeping => {
-            println!("Agent {} is already asleep.", agent.name.cyan());
-            return Ok(());
-        }
-        ca::Status::Running | ca::Status::Starting => {}
-        _ => bail!(
-            "Agent {} is {} — there is nothing running to sleep.",
-            agent.name,
-            agent.status.label()
-        ),
-    }
-
     let spinner = create_spinner(format!("Sleeping agent {}", agent.name));
     let result = ca::sleep(client, &backboard, &agent.environment_id, &agent.id).await;
     spinner.finish_and_clear();
@@ -462,7 +441,7 @@ pub async fn sleep(args: SleepArgs) -> Result<()> {
     // still reports it running. Claiming a state the next command contradicts is
     // worse than describing the action taken.
     println!(
-        "✓ Sleeping agent {} — its disk is kept, compute stops billing.",
+        "✓ Sleep requested for agent {} — its disk is kept; compute stops billing once it is asleep.",
         agent.name.cyan()
     );
     Ok(())
@@ -630,10 +609,9 @@ async fn ssh_connect(args: SshArgs) -> Result<i32> {
             Err(e) => Err(e),
         },
         _ => Err(anyhow::anyhow!(
-            "Agent {} is {} — it cannot be connected to. `railway ca delete {}` and create a new one.",
+            "Agent {} is reported as {} and cannot be connected to. Check `railway ca list` and retry, or use `railway ca create` to create a separate agent.",
             agent.name,
-            agent.status.label(),
-            agent.name
+            agent.status.label()
         )),
     };
     if let Some(spinner) = spinner {
@@ -899,6 +877,58 @@ fn truncate(value: &str, width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::MockBackboard;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn wake_sends_intent_even_when_the_inventory_reports_running() {
+        for status in ["RUNNING", "STARTING", "SLEEPING", "FAILED", "FUTURE_STATE"] {
+            let server = MockBackboard::spawn();
+            let dir = tempfile::tempdir().unwrap();
+            let mut configs = server.configs(&dir);
+            server.stub(
+                "MyCloudAgents",
+                json!({"myCloudAgents": [{
+                    "id": "existing", "name": "my-agent", "status": status,
+                    "projectId": "project", "environmentId": "env",
+                    "createdAt": "2026-09-10T00:00:00Z"
+                }]}),
+            );
+            server.stub(
+                "CloudAgentWake",
+                json!({"cloudAgentWake": {
+                    "id": "existing", "status": "STARTING"
+                }}),
+            );
+            server.stub_graphql_error("CloudAgentWake", "cannot wake now");
+            wake_with(
+                &mut configs,
+                &reqwest::Client::new(),
+                WakeArgs::parse_from(["wake", "my-agent", "--no-wait"]),
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                server.variables_for("CloudAgentWake"),
+                vec![json!({"id": "existing"})]
+            );
+            assert!(
+                server.variables_for("CloudAgent").is_empty(),
+                "--no-wait must not poll"
+            );
+            assert_eq!(configs.get_code_agent("env").as_deref(), Some("existing"));
+
+            // A newer server-side refusal must not be hidden by the old status.
+            let error = wake_with(
+                &mut configs,
+                &reqwest::Client::new(),
+                WakeArgs::parse_from(["wake", "my-agent", "--no-wait"]),
+            )
+            .await
+            .unwrap_err();
+            assert!(error.to_string().contains("cannot wake now"), "{error}");
+        }
+    }
 
     #[test]
     fn truncate_leaves_short_values_alone() {

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -1838,14 +1838,17 @@ impl App {
         // When this environment last heard from the platform, so an
         // account-wide snapshot taken before it cannot overwrite it. See
         // [`Self::my_agents_loaded`].
-        if let Some(id) = answered {
-            self.answered_at.insert(id, std::time::Instant::now());
+        if let Some(id) = &answered {
+            self.answered_at
+                .insert(id.clone(), std::time::Instant::now());
         }
         if let Some(err) = refresh_failed {
             self.toast_error(format!("Couldn't refresh: {err}"));
         }
         self.collapse_if_empty(w, p);
-        self.settle_watched_agents();
+        if let Some(id) = answered {
+            self.settle_watched_agents(&[id]);
+        }
         self.restore_cursor(anchor);
         self.select_pending();
         // A just-launched agent arrives here before its sessions can be
@@ -1904,10 +1907,10 @@ impl App {
             }
         }
         let now = std::time::Instant::now();
-        for id in answered {
-            self.answered_at.insert(id, now);
+        for id in &answered {
+            self.answered_at.insert(id.clone(), now);
         }
-        self.settle_watched_agents();
+        self.settle_watched_agents(&answered);
         self.restore_cursor(anchor);
         self.select_pending();
         self.adopt_pane_sessions();
@@ -4698,9 +4701,9 @@ impl App {
 
     /// Start a lifecycle action on the agent under the cursor.
     ///
-    /// Refuses the no-ops rather than sending them: waking a running agent or
-    /// sleeping a sleeping one would spend a round-trip to change nothing, and
-    /// the status line explains why the key did nothing.
+    /// Let the server decide no-ops from live VM state: this tree's observation
+    /// can predate a sleep or wake elsewhere. Only duplicate in-flight requests
+    /// are suppressed locally.
     fn agent_op(&mut self, op: AgentOp) -> Option<Effect> {
         let row = self.selected_row()?;
         // A session belongs to an agent, so acting on it from a session row is
@@ -4717,18 +4720,6 @@ impl App {
         if self.ops.contains_key(&agent.id) {
             return None;
         }
-        match (op, agent.status.as_str()) {
-            (AgentOp::Sleep, "sleeping") => {
-                self.status = format!("{} is already asleep", agent.name);
-                return None;
-            }
-            (AgentOp::Wake, "running") => {
-                self.status = format!("{} is already running", agent.name);
-                return None;
-            }
-            _ => {}
-        }
-
         let pending = PendingConfirm {
             op,
             agent_id: agent.id.clone(),
@@ -5089,19 +5080,41 @@ impl App {
         }
     }
 
-    /// Clear the watch for any agent that has arrived, or that has gone.
-    fn settle_watched_agents(&mut self) {
+    /// Clear a watch on arrival, disappearance, or an observation that cannot
+    /// reach the target. A terminal state should not hide under "waking…" until
+    /// the patience expires.
+    fn settle_watched_agents(&mut self, answered: &[String]) {
         if self.watching.is_empty() {
             return;
         }
         let mut arrived: Vec<String> = Vec::new();
+        let mut failures = Vec::new();
         for (id, watch) in &self.watching {
-            let status = self.status_of_agent(id);
-            match status {
+            // A failed refresh or another environment's response supplies no
+            // new evidence about this operation. Retain its pending label.
+            if !answered.contains(&watch.environment_id) {
+                continue;
+            }
+            match self.agent_by_id(id) {
                 // Gone from the list entirely: deleted elsewhere, or never
                 // there. Either way nothing is coming.
                 None => arrived.push(id.clone()),
-                Some(status) if status == watch.want => arrived.push(id.clone()),
+                Some(agent) if agent.status == watch.want => arrived.push(id.clone()),
+                Some(agent)
+                    if !crate::controllers::cloud_agent::Status::from_label(&agent.status)
+                        .is_live() =>
+                {
+                    arrived.push(id.clone());
+                    let action = if watch.want == "running" {
+                        "wake"
+                    } else {
+                        "sleep"
+                    };
+                    failures.push(format!(
+                        "Couldn't {action} agent {}: reported as {}",
+                        agent.name, agent.status
+                    ));
+                }
                 Some(_) => {}
             }
         }
@@ -5109,18 +5122,20 @@ impl App {
             self.watching.remove(&id);
             self.ops.remove(&id);
         }
+        if !failures.is_empty() {
+            failures.sort();
+            self.status = failures.join("; ");
+        }
     }
 
-    /// An agent's status as the tree currently has it, wherever it lives.
-    fn status_of_agent(&self, agent_id: &str) -> Option<String> {
+    /// An agent as the tree currently has it, wherever it lives.
+    fn agent_by_id(&self, agent_id: &str) -> Option<&Agent> {
         self.tree.iter().find_map(|ws| {
             ws.projects.iter().find_map(|project| {
-                project.envs.iter().find_map(|env| {
-                    env.agents_vec()
-                        .iter()
-                        .find(|agent| agent.id == agent_id)
-                        .map(|agent| agent.status.clone())
-                })
+                project
+                    .envs
+                    .iter()
+                    .find_map(|env| env.agents_vec().iter().find(|agent| agent.id == agent_id))
             })
         })
     }
@@ -7764,10 +7779,10 @@ mod tests {
         assert_eq!(a.ops.get("ca_1").copied(), Some("deleting…"));
     }
 
-    /// Sleep and wake are reversible, so they run without a prompt — but not
-    /// when they would do nothing.
+    /// Sleep and wake send intent even when the last observation suggests a
+    /// no-op. The server can see a newer state than this tree.
     #[test]
-    fn sleep_and_wake_skip_the_no_ops() {
+    fn sleep_and_wake_let_the_server_decide_no_ops() {
         let mut a = loaded_app();
         a.cursor = a
             .rows()
@@ -7775,10 +7790,24 @@ mod tests {
             .position(|r| r.label == "nimble-otter")
             .unwrap();
 
-        // The agent is running: waking is a no-op and says so.
-        assert_eq!(a.on_key(key(KeyCode::Char('w'))), None);
-        assert!(a.status.contains("already running"));
-        assert!(a.ops.is_empty());
+        // Last observed running, but it may have slept elsewhere since then.
+        assert!(matches!(
+            a.on_key(key(KeyCode::Char('w'))),
+            Some(Effect::Agent {
+                op: AgentOp::Wake,
+                ..
+            })
+        ));
+        assert_eq!(
+            a.on_key(key(KeyCode::Char('w'))),
+            None,
+            "no duplicate requests"
+        );
+        a.agent_op_finished("ca_1", "env_prod", AgentOp::Wake, None);
+        a.agents_loaded(
+            (0, 0, 0),
+            Ok(vec![agent("ca_1", "nimble-otter", "running")]),
+        );
 
         let effect = a.on_key(key(KeyCode::Char('s'))).unwrap();
         assert_eq!(
@@ -7820,6 +7849,61 @@ mod tests {
             a.selected_row().unwrap().status.as_deref(),
             Some("sleeping")
         );
+
+        // Last observed sleeping, but it may have woken elsewhere since then.
+        assert!(matches!(
+            a.on_key(key(KeyCode::Char('s'))),
+            Some(Effect::Agent {
+                op: AgentOp::Sleep,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn terminal_observations_end_operation_watches_immediately() {
+        for op in [AgentOp::Wake, AgentOp::Sleep] {
+            for status in ["crashed", "failed", "deleting", "future_state"] {
+                let mut a = loaded_app();
+                a.ops.insert("ca_1".into(), op.pending_label());
+                a.agent_op_finished("ca_1", "env_prod", op, None);
+                a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "nimble-otter", status)]));
+                assert!(!a.watching_agents(), "{op:?}: {status}");
+                assert!(a.ops.is_empty(), "{op:?}: {status}");
+                assert!(a.status.contains("nimble-otter"), "{}", a.status);
+                assert!(a.status.contains(status), "{}", a.status);
+                assert!(a.watch_tick().is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn operation_watches_require_a_successful_refresh_of_their_environment() {
+        for old_status in ["running", "failed"] {
+            let mut a = loaded_app();
+            a.agents_loaded(
+                (0, 0, 0),
+                Ok(vec![agent("ca_1", "nimble-otter", old_status)]),
+            );
+            a.ops.insert("ca_1".into(), AgentOp::Wake.pending_label());
+            a.agent_op_finished("ca_1", "env_prod", AgentOp::Wake, None);
+            a.agents_loaded((0, 0, 0), Err("temporarily unavailable".into()));
+            assert!(
+                a.watching_agents(),
+                "old {old_status} is not a new observation"
+            );
+            a.agents_loaded((0, 0, 1), Ok(vec![]));
+            assert!(
+                a.watching_agents(),
+                "an unrelated environment cannot settle this watch"
+            );
+            a.agents_loaded(
+                (0, 0, 0),
+                Ok(vec![agent("ca_1", "nimble-otter", "running")]),
+            );
+            assert!(!a.watching_agents());
+            assert!(a.ops.is_empty());
+        }
     }
 
     /// The bug this exists for: a wake is accepted long before the VM is up,

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -1071,6 +1071,8 @@ pub struct App {
     pub ops: std::collections::HashMap<String, &'static str>,
     /// Agents whose state is still on its way. See [`AgentWatch`].
     pub watching: std::collections::HashMap<String, AgentWatch>,
+    /// Round-robin cursor so a slow operation cannot monopolize watch polling.
+    last_watched_environment: Option<String>,
     /// A refresh is in flight. Coalescing: a held ⌥r, or several actions
     /// finishing at once, must not stack account-wide queries.
     pub refreshing: bool,
@@ -1092,10 +1094,10 @@ pub struct App {
     /// Someone pressed a key for the refresh in flight, so its result is worth
     /// a line when it lands. See [`App::refreshed`].
     pub refresh_announce: bool,
-    /// Environment id → when its agent list last came back from the platform.
-    /// Keeps a slower account-wide reply from overwriting fresher per-environment
-    /// news; see [`App::my_agents_loaded`].
-    pub answered_at: std::collections::HashMap<String, std::time::Instant>,
+    /// Environment id → minimum request-start time of an acceptable snapshot.
+    /// Advanced by applied snapshots and successful mutations. This orders local
+    /// requests, not FactoryVM generations or the backend's projection freshness.
+    pub agent_snapshot_floor: std::collections::HashMap<String, std::time::Instant>,
     /// `myCloudAgents` is not available to this caller, so a refresh has to ask
     /// per environment. True for a workspace-scoped `RAILWAY_TOKEN` — the field
     /// requires an authenticated user — and for a backboard old enough not to
@@ -1177,13 +1179,14 @@ impl App {
             ssh_gate: None,
             ops: std::collections::HashMap::new(),
             watching: std::collections::HashMap::new(),
+            last_watched_environment: None,
             refreshing: false,
             last_refresh: None,
             refresh_paused_until: None,
             last_thread_refresh: None,
             thread_polls: std::collections::HashSet::new(),
             refresh_announce: false,
-            answered_at: std::collections::HashMap::new(),
+            agent_snapshot_floor: std::collections::HashMap::new(),
             account_query_unavailable: false,
             prompt_focused: true,
             prompt: String::new(),
@@ -1793,14 +1796,29 @@ impl App {
         }
     }
 
-    /// Record a finished agent fetch. Ignores paths that no longer exist, so a
-    /// response arriving after the tree changed can't panic or mis-file.
-    pub fn agents_loaded(
+    /// Apply a scoped response only to its original environment, and only if
+    /// the request follows the latest applied snapshot or mutation acceptance.
+    pub fn agents_loaded_at(
         &mut self,
         path: (usize, usize, usize),
+        environment_id: &str,
         result: Result<Vec<Agent>, String>,
+        asked_at: std::time::Instant,
     ) {
         let (w, p, e) = path;
+        if self
+            .tree
+            .get(w)
+            .and_then(|ws| ws.projects.get(p))
+            .and_then(|project| project.envs.get(e))
+            .is_none_or(|env| env.id != environment_id)
+            || self
+                .agent_snapshot_floor
+                .get(environment_id)
+                .is_some_and(|at| *at > asked_at)
+        {
+            return;
+        }
         // A load can change the order — a project that gains its first agent
         // moves up — so the cursor is put back by row identity rather than
         // left on whatever index it was.
@@ -1835,12 +1853,10 @@ impl App {
                 (Err(err), _) => Load::Failed(err),
             };
         }
-        // When this environment last heard from the platform, so an
-        // account-wide snapshot taken before it cannot overwrite it. See
-        // [`Self::my_agents_loaded`].
+        // Request time, not response time: a newer overlapping request can
+        // still deliver a newer observation after this reply arrives.
         if let Some(id) = &answered {
-            self.answered_at
-                .insert(id.clone(), std::time::Instant::now());
+            self.agent_snapshot_floor.insert(id.clone(), asked_at);
         }
         if let Some(err) = refresh_failed {
             self.toast_error(format!("Couldn't refresh: {err}"));
@@ -1856,6 +1872,22 @@ impl App {
         self.adopt_pane_sessions();
     }
 
+    /// Synchronous fixture loads represent a fresh request for the current tree.
+    #[cfg(test)]
+    fn agents_loaded(&mut self, path: (usize, usize, usize), result: Result<Vec<Agent>, String>) {
+        let (w, p, e) = path;
+        let Some(environment_id) = self
+            .tree
+            .get(w)
+            .and_then(|ws| ws.projects.get(p))
+            .and_then(|project| project.envs.get(e))
+            .map(|env| env.id.clone())
+        else {
+            return;
+        };
+        self.agents_loaded_at(path, &environment_id, result, std::time::Instant::now());
+    }
+
     /// The whole account's agents arrived in one `myCloudAgents` request.
     ///
     /// Every unanswered environment becomes loaded: one absent from the
@@ -1867,15 +1899,10 @@ impl App {
     /// else. (Skipping environments that already had a list is why `shift+r`
     /// used to report "already loaded" and change nothing.)
     ///
-    /// One rule keeps that from undoing fresher news: a snapshot may not
-    /// overwrite an answer that arrived *after* it was asked for. `asked_at` is
-    /// when this request went out, and [`Self::answered_at`] is when each
-    /// environment last heard from the platform. Without the comparison, a
-    /// refresh already in flight when you delete an agent would put the row
-    /// back — the snapshot was taken while the agent still existed — and it
-    /// would stay back until the next refresh. Environments still `Loading` are
-    /// skipped for the same reason, one step earlier: their reply has not landed
-    /// to be compared, and it is newer than this.
+    /// A snapshot may not overwrite a newer request's answer or settle a
+    /// mutation accepted after the request began. Both fetch paths compare
+    /// request-start times with [`Self::agent_snapshot_floor`]. Environments
+    /// still `Loading` await their dedicated reply.
     pub fn my_agents_loaded(&mut self, agents: Vec<(String, Agent)>, asked_at: std::time::Instant) {
         let anchor = self.selected_row().map(|row| row.kind);
         let mut by_env: HashMap<String, Vec<Agent>> = HashMap::new();
@@ -1887,7 +1914,7 @@ impl App {
             for project in &mut ws.projects {
                 for env in &mut project.envs {
                     if self
-                        .answered_at
+                        .agent_snapshot_floor
                         .get(&env.id)
                         .is_some_and(|at| *at > asked_at)
                     {
@@ -1906,9 +1933,8 @@ impl App {
                 }
             }
         }
-        let now = std::time::Instant::now();
         for id in &answered {
-            self.answered_at.insert(id.clone(), now);
+            self.agent_snapshot_floor.insert(id.clone(), asked_at);
         }
         self.settle_watched_agents(&answered);
         self.restore_cursor(anchor);
@@ -4874,6 +4900,10 @@ impl App {
             self.status = err;
             return;
         }
+        // An already-in-flight refresh describes the world before this
+        // acknowledgement. It cannot complete this watch or resurrect a delete.
+        self.agent_snapshot_floor
+            .insert(environment_id.to_string(), std::time::Instant::now());
         let (want, patience) = match op {
             AgentOp::Wake => ("running", WAKE_PATIENCE),
             AgentOp::Sleep => ("sleeping", SLEEP_PATIENCE),
@@ -4921,11 +4951,30 @@ impl App {
         open
     }
 
-    /// Ask again. One environment per tick — in practice there is one agent
-    /// waking at a time, and the loop comes back here in a moment anyway.
+    /// Ask one environment per tick, rotating fairly through concurrent watches.
     pub fn watch_tick(&mut self) -> Option<Effect> {
         self.give_up_on_stale_watches();
-        let environment_id = self.watching.values().next()?.environment_id.clone();
+        if self
+            .refresh_paused_until
+            .is_some_and(|until| until > std::time::Instant::now())
+        {
+            return None;
+        }
+        let environments: std::collections::BTreeSet<_> = self
+            .watching
+            .values()
+            .map(|watch| watch.environment_id.clone())
+            .collect();
+        let environment_id = environments
+            .iter()
+            .find(|env| {
+                self.last_watched_environment
+                    .as_ref()
+                    .is_none_or(|last| *env > last)
+            })
+            .or_else(|| environments.first())?
+            .clone();
+        self.last_watched_environment = Some(environment_id.clone());
         self.reveal_environment(&environment_id)
     }
 
@@ -5124,6 +5173,9 @@ impl App {
         }
         if !failures.is_empty() {
             failures.sort();
+            // The account-wide refresh handler's generic completion message
+            // must not erase the operation failure this snapshot just revealed.
+            self.refresh_announce = false;
             self.status = failures.join("; ");
         }
     }
@@ -5598,6 +5650,160 @@ mod tests {
             Ok(vec![agent("ca_1", "nimble-otter", "running")]),
         );
         a
+    }
+
+    #[test]
+    fn pre_mutation_snapshot_cannot_settle_a_new_operation() {
+        for scoped in [false, true] {
+            for op in [AgentOp::Wake, AgentOp::Sleep] {
+                for status in [
+                    "running",
+                    "sleeping",
+                    "failed",
+                    "crashed",
+                    "future_state",
+                    "missing",
+                ] {
+                    let mut a = loaded_app();
+                    let asked_at = std::time::Instant::now();
+                    a.ops.insert("ca_1".into(), op.pending_label());
+                    a.agent_op_finished("ca_1", "env_prod", op, None);
+                    let agents = if status == "missing" {
+                        vec![]
+                    } else {
+                        vec![agent("ca_1", "nimble-otter", status)]
+                    };
+                    if scoped {
+                        a.agents_loaded_at((0, 0, 0), "env_prod", Ok(agents), asked_at);
+                    } else {
+                        a.my_agents_loaded(
+                            agents
+                                .into_iter()
+                                .map(|agent| ("env_prod".into(), agent))
+                                .collect(),
+                            asked_at,
+                        );
+                    }
+                    assert!(
+                        a.watching_agents(),
+                        "{op:?}/{status}: response predates acceptance"
+                    );
+                    assert_eq!(a.agent_by_id("ca_1").unwrap().status, "running");
+                    let target = if op == AgentOp::Wake {
+                        "running"
+                    } else {
+                        "sleeping"
+                    };
+                    a.agents_loaded((0, 0, 0), Ok(vec![agent("ca_1", "nimble-otter", target)]));
+                    assert!(
+                        !a.watching_agents(),
+                        "a post-acceptance snapshot can settle it"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn overlapping_snapshots_keep_the_newest_request_in_every_arrival_order() {
+        // All 6 arrival orders x all 8 mixtures of account/scoped responses.
+        for order in [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ] {
+            for sources in 0..8 {
+                let mut a = loaded_app();
+                let start = std::time::Instant::now();
+                let states = ["sleeping", "starting", "failed"];
+                let mut newest = 0;
+                for index in order {
+                    let asked_at = start + std::time::Duration::from_millis(index as u64);
+                    let node = agent("ca_1", "nimble-otter", states[index]);
+                    if sources & (1 << index) == 0 {
+                        a.agents_loaded_at((0, 0, 0), "env_prod", Ok(vec![node]), asked_at);
+                    } else {
+                        a.my_agents_loaded(vec![("env_prod".into(), node)], asked_at);
+                    }
+                    newest = newest.max(index);
+                    assert_eq!(
+                        a.agent_by_id("ca_1").unwrap().status,
+                        states[newest],
+                        "{order:?}, sources {sources}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn scoped_responses_cannot_be_misfiled_after_tree_reordering() {
+        let mut a = loaded_app();
+        a.tree[0].projects[0].envs.swap(0, 1);
+        a.agents_loaded_at(
+            (0, 0, 0),
+            "env_prod",
+            Ok(vec![agent("ca_1", "nimble-otter", "failed")]),
+            std::time::Instant::now(),
+        );
+        assert_eq!(a.agent_by_id("ca_1").unwrap().status, "running");
+        assert!(a.tree[0].projects[0].envs[0].agents_vec().is_empty());
+    }
+
+    #[test]
+    fn announced_account_refresh_keeps_the_operation_failure_visible() {
+        let mut a = loaded_app();
+        a.ops.insert("ca_1".into(), AgentOp::Wake.pending_label());
+        a.agent_op_finished("ca_1", "env_prod", AgentOp::Wake, None);
+        a.refresh_announce = true;
+        a.my_agents_loaded(
+            vec![("env_prod".into(), agent("ca_1", "nimble-otter", "crashed"))],
+            std::time::Instant::now(),
+        );
+        a.refreshed(1);
+        assert!(a.status.contains("crashed"), "{}", a.status);
+        assert!(!a.watching_agents());
+    }
+
+    #[test]
+    fn concurrent_operation_watches_poll_every_environment() {
+        let mut a = loaded_app();
+        a.agents_loaded((0, 0, 1), Ok(vec![agent("ca_2", "other", "sleeping")]));
+        let other_env = a.tree[0].projects[0].envs[1].id.clone();
+        a.agent_op_finished("ca_1", "env_prod", AgentOp::Sleep, None);
+        a.agent_op_finished("ca_2", &other_env, AgentOp::Wake, None);
+        let mut polled = std::collections::HashSet::new();
+        for _ in 0..4 {
+            let Some(Effect::LoadAgents { environment_id, .. }) = a.watch_tick() else {
+                panic!("a watch should poll");
+            };
+            polled.insert(environment_id);
+        }
+        assert_eq!(
+            polled.len(),
+            2,
+            "one pending VM must not starve another environment"
+        );
+    }
+
+    #[test]
+    fn operation_polling_honors_retry_after_and_still_expires() {
+        let mut a = loaded_app();
+        a.ops.insert("ca_1".into(), AgentOp::Wake.pending_label());
+        a.agent_op_finished("ca_1", "env_prod", AgentOp::Wake, None);
+        a.rate_limited(Some(30));
+        assert!(
+            a.watch_tick().is_none(),
+            "Retry-After also applies to operation polls"
+        );
+        assert!(a.watching_agents());
+        a.watching.get_mut("ca_1").unwrap().until = std::time::Instant::now();
+        assert!(a.watch_tick().is_none());
+        assert!(!a.watching_agents());
+        assert!(a.ops.is_empty());
     }
 
     #[test]

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -499,7 +499,7 @@ async fn fetch_agents(
         .map(|a| Agent {
             id: a.id,
             name: a.name,
-            status: format!("{:?}", a.status).to_lowercase(),
+            status: crate::controllers::cloud_agent::Status::from(a.status).label(),
             sessions: LoadSessions::NotLoaded,
             expanded: false,
         })
@@ -531,7 +531,7 @@ async fn fetch_my_agents(
                 Agent {
                     id: a.id,
                     name: a.name,
-                    status: format!("{:?}", a.status).to_lowercase(),
+                    status: crate::controllers::cloud_agent::Status::from(a.status).label(),
                     sessions: LoadSessions::NotLoaded,
                     expanded: false,
                 },

--- a/src/commands/cloud_agent/tui/mod.rs
+++ b/src/commands/cloud_agent/tui/mod.rs
@@ -260,7 +260,9 @@ pub struct FullScreenRequest {
 enum Message {
     AgentsLoaded {
         path: (usize, usize, usize),
+        environment_id: String,
         result: Result<Vec<Agent>, String>,
+        asked_at: std::time::Instant,
     },
     /// The whole account's agents in one request, keyed by environment — or
     /// why that wasn't possible, in which case startup degrades to the
@@ -1425,11 +1427,14 @@ fn spawn_env_agents_fetch(
     tokio::spawn(async move {
         // A closed receiver just means the TUI already handed back;
         // the next entry re-requests, so the drop is harmless.
+        let asked_at = std::time::Instant::now();
         match fetch_agents(&client, &backboard, &environment_id).await {
             Ok(agents) => {
                 let _ = tx.send(Message::AgentsLoaded {
                     path,
+                    environment_id,
                     result: Ok(agents),
+                    asked_at,
                 });
             }
             // The same classification the background fetches do:
@@ -1443,7 +1448,9 @@ fn spawn_env_agents_fetch(
                 None => {
                     let _ = tx.send(Message::AgentsLoaded {
                         path,
+                        environment_id,
                         result: Err(err.to_string()),
+                        asked_at,
                     });
                 }
             },
@@ -1464,8 +1471,13 @@ fn handle_message(
             app.rate_limited(retry_after_secs);
             None
         }
-        Message::AgentsLoaded { path, result } => {
-            app.agents_loaded(path, result);
+        Message::AgentsLoaded {
+            path,
+            environment_id,
+            result,
+            asked_at,
+        } => {
+            app.agents_loaded_at(path, &environment_id, result, asked_at);
             // Fill in each running agent's session count without waiting for
             // someone to expand it. Bounded: one environment usually holds a
             // handful of agents, but nothing guarantees it.
@@ -1888,11 +1900,14 @@ fn spawn_sweep(
             let backboard = backboard.clone();
             let stop = stop.clone();
             tokio::spawn(async move {
+                let asked_at = std::time::Instant::now();
                 match fetch_agents(&client, &backboard, &environment_id).await {
                     Ok(agents) => {
                         let _ = tx.send(Message::AgentsLoaded {
                             path,
+                            environment_id,
                             result: Ok(agents),
+                            asked_at,
                         });
                     }
                     Err(err) => match rate_limit_from(&err) {
@@ -1903,7 +1918,9 @@ fn spawn_sweep(
                         None => {
                             let _ = tx.send(Message::AgentsLoaded {
                                 path,
+                                environment_id,
                                 result: Err(err.to_string()),
+                                asked_at,
                             });
                         }
                     },

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -15,6 +15,7 @@ use crate::commands::ssh::{
     ensure_ssh_key_quiet, probe_native_ssh, run_native_ssh_captured, run_native_ssh_with_opts,
 };
 use crate::config::Configs;
+use crate::controllers::cloud_agent as ca;
 use crate::controllers::project::get_project;
 use crate::errors::RailwayError;
 use crate::gql::{mutations, queries};
@@ -1818,44 +1819,10 @@ fn ssh_plumbing(
     bail!("SSH to the agent failed after {attempts} attempts (exit {code}):\n{reason}")
 }
 
-/// One cloud agent, reduced to what this command steers on. `pub(crate)`
-/// because [`wait_until_connectable`] returns it to the `railway ca` verbs.
-#[derive(Clone)]
-pub(crate) struct CodeAgent {
-    id: String,
-    name: String,
-    status: queries::cloud_agent::CloudAgentStatus,
-}
-
 /// How long to wait for a created or woken agent to reach RUNNING before
 /// giving up. A cold create boots a microVM and publishes routes; a wake
 /// restores a checkpoint and is much quicker.
 const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
-
-/// Read one agent by id, scoped to the environment. `None` means it is gone
-/// (deleted, or it belongs to another environment) — the caller's cue to forget
-/// its stored pointer rather than to fail.
-async fn fetch_agent(
-    client: &reqwest::Client,
-    backboard: &str,
-    environment_id: &str,
-    id: &str,
-) -> Result<Option<CodeAgent>> {
-    let res = post_graphql::<queries::CloudAgent, _>(
-        client,
-        backboard,
-        queries::cloud_agent::Variables {
-            id: id.to_owned(),
-            environment_id: environment_id.to_owned(),
-        },
-    )
-    .await?;
-    Ok(res.cloud_agent.map(|a| CodeAgent {
-        id: a.id,
-        name: a.name,
-        status: a.status,
-    }))
-}
 
 /// Wait until the agent is *connectable*, by probing the SSH route itself
 /// rather than polling status up to RUNNING. The platform routes a shell as
@@ -1900,8 +1867,8 @@ pub(crate) async fn wait_until_connectable(
     id: &str,
     access: &RelayAccess,
     initial_delay: std::time::Duration,
-) -> Result<(CodeAgent, Option<std::path::PathBuf>)> {
-    use queries::cloud_agent::CloudAgentStatus as S;
+) -> Result<(ca::Agent, Option<std::path::PathBuf>)> {
+    use ca::Status as S;
     // Measured as one stage because this is the leg the platform owns — VM
     // boot/restore up to a routable SSH target. Per-round detail goes to stderr
     // under RAILWAY_STAGE_TIMING; the recorded stage is what telemetry sees.
@@ -1924,7 +1891,7 @@ pub(crate) async fn wait_until_connectable(
     // it ride the probe cadence would triple backboard polling per launching
     // client for nothing. Round 1 always fetches.
     let mut last_fetch: Option<std::time::Instant> = None;
-    let mut last_agent: Option<CodeAgent> = None;
+    let mut last_agent: Option<ca::Agent> = None;
     loop {
         round += 1;
         let round_started = std::time::Instant::now();
@@ -1949,28 +1916,28 @@ pub(crate) async fn wait_until_connectable(
         // on its full ConnectTimeout against a box that will never answer.
         let fetch_due = last_fetch.is_none_or(|at| at.elapsed().as_millis() >= 700);
         if fetch_due {
-            let agent = fetch_agent(client, backboard, environment_id, id)
+            let agent = ca::get(client, backboard, environment_id, id)
                 .await?
                 .ok_or_else(|| anyhow!("Agent {id} disappeared while starting."))?;
             last_fetch = Some(std::time::Instant::now());
             match agent.status {
-                S::RUNNING | S::STARTING | S::SLEEPING => {}
-                S::CRASHED => bail!(
+                S::Running | S::Starting | S::Sleeping => {}
+                S::Crashed => bail!(
                     "Agent {} crashed while starting. `railway code --new` for a fresh one.",
                     agent.name
                 ),
-                S::FAILED => bail!(
+                S::Failed => bail!(
                     "Agent {} failed to start. `railway code --new` for a fresh one.",
                     agent.name
                 ),
-                S::DELETING => bail!("Agent {} is being deleted.", agent.name),
-                S::Other(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
+                S::Deleting => bail!("Agent {} is being deleted.", agent.name),
+                S::Unknown(ref s) => bail!("Agent {} is in an unknown state ({s}).", agent.name),
             }
             // RUNNING routes by definition, so don't spend another round on a
             // probe that lost the race to the status flip — but there is no
             // verified connection to promote (the in-flight probe is abandoned;
             // its master, if any, exits on the persist backstop).
-            if agent.status == S::RUNNING {
+            if agent.status == S::Running {
                 ssh_tel::record_stage("wait_connectable", wait_started.elapsed(), true);
                 return Ok((agent, None));
             }
@@ -2038,36 +2005,35 @@ fn release_probe_master(socket: &std::path::Path, target: &str) {
         .spawn();
 }
 
-/// Bring an agent that already exists up to RUNNING: reuse it when it is
-/// already up, wake it when it is asleep or still booting. `None` means the
-/// agent is dead and the caller should create a fresh one.
+/// Connect to the selected agent, waking it when needed. An unusable observation
+/// is an error on this agent, never permission to replace it with another VM.
 async fn ready_existing_agent(
     client: &reqwest::Client,
     backboard: &str,
     environment_id: &str,
-    agent: CodeAgent,
+    agent: ca::Agent,
     progress: &dyn Progress,
     access: &RelayAccess,
-) -> Result<Option<(CodeAgent, Option<std::path::PathBuf>)>> {
-    use queries::cloud_agent::CloudAgentStatus as S;
+) -> Result<(ca::Agent, Option<std::path::PathBuf>)> {
+    use ca::Status as S;
 
     match agent.status {
-        S::RUNNING => {
+        S::Running => {
             progress.note(&format!(
                 "Using agent {} (--new for a fresh one)",
                 agent.name
             ));
-            Ok(Some((agent, None)))
+            Ok((agent, None))
         }
         // STARTING means a previous run is still booting it, so a re-run seconds
         // after a ctrl-c waits rather than minting a duplicate. SLEEPING is the
         // resting state this command leaves behind.
-        S::SLEEPING | S::STARTING => {
+        S::Sleeping | S::Starting => {
             progress.step(&format!("Waking agent {}", agent.name));
             // The delay below is the wake's physical floor; a STARTING agent
             // caught mid-boot gets none — it may be routable right now.
             let mut probe_delay = std::time::Duration::ZERO;
-            if agent.status == S::SLEEPING {
+            if agent.status == S::Sleeping {
                 let wake_started = std::time::Instant::now();
                 let wake = post_graphql::<mutations::CloudAgentWake, _>(
                     client,
@@ -2096,19 +2062,17 @@ async fn ready_existing_agent(
                 "Woke agent {} — your work is on its disk",
                 running.name
             ));
-            Ok(Some((running, probe_master)))
+            Ok((running, probe_master))
         }
-        S::CRASHED | S::FAILED | S::DELETING | S::Other(_) => {
-            progress.note(&format!(
-                "Agent {} is {:?}; creating a fresh one.",
-                agent.name, agent.status
-            ));
-            Ok(None)
-        }
+        S::Crashed | S::Failed | S::Deleting | S::Unknown(_) => bail!(
+            "Agent {} is reported as {} and cannot be connected to. Check `railway ca list` and retry, or use `railway code --new` to create a separate agent.",
+            agent.name,
+            agent.status.label()
+        ),
     }
 }
 
-/// The caller's own live agent in this environment, when there is exactly one.
+/// The caller's own agent in this environment, when there is exactly one.
 ///
 /// `mine` is load-bearing rather than tidiness: agents authorize per
 /// environment, so an unfiltered list includes teammates' — and adopting one
@@ -2118,23 +2082,11 @@ async fn sole_owned_agent_id(
     backboard: &str,
     environment_id: &str,
 ) -> Result<Option<String>> {
-    use queries::cloud_agents::CloudAgentStatus as S;
+    // A failed or unknown observation still names an existing VM. Filtering it
+    // out would turn an inconclusive lookup into a new billed agent.
+    let agents = ca::list_in_environment(client, backboard, environment_id, true).await?;
 
-    let live: Vec<_> = post_graphql::<queries::CloudAgents, _>(
-        client,
-        backboard,
-        queries::cloud_agents::Variables {
-            environment_id: environment_id.to_owned(),
-            mine: Some(true),
-        },
-    )
-    .await?
-    .cloud_agents
-    .into_iter()
-    .filter(|a| matches!(a.status, S::RUNNING | S::SLEEPING | S::STARTING))
-    .collect();
-
-    match live.as_slice() {
+    match agents.as_slice() {
         [] => Ok(None),
         [only] => Ok(Some(only.id.clone())),
         many => bail!(
@@ -2403,7 +2355,7 @@ async fn resolve_agent(
     harness: Agent,
     progress: &dyn Progress,
     access: &RelayAccess,
-) -> Result<(CodeAgent, bool, Option<std::path::PathBuf>)> {
+) -> Result<(ca::Agent, bool, Option<std::path::PathBuf>)> {
     let environment_id = target.environment_id.as_str();
     let backboard = configs.get_backboard();
 
@@ -2418,23 +2370,21 @@ async fn resolve_agent(
             None => sole_owned_agent_id(client, &backboard, environment_id).await?,
         },
     };
-    // Re-read by id either way, so both paths carry the same shape and the
-    // stale-pointer case (agent deleted elsewhere) collapses into `None`.
-    let existing = match candidate {
-        Some(id) => fetch_agent(client, &backboard, environment_id, &id).await?,
-        None => None,
-    };
-    if let Some(agent) = existing {
-        if let Some((ready, probe_master)) =
+    // Once a target is selected, keep it even when its observation is missing
+    // or unusable. Creating is reserved for an empty inventory or explicit --new.
+    if let Some(id) = candidate {
+        let agent = ca::get(client, &backboard, environment_id, &id)
+            .await?
+            .ok_or_else(|| anyhow!(
+                "Agent {id} is unavailable in this environment. Check `railway ca list`, or use `railway code --new` to create a separate agent."
+            ))?;
+        let (ready, probe_master) =
             ready_existing_agent(client, &backboard, environment_id, agent, progress, access)
-                .await?
-        {
-            warn_ignored_variables(args, progress);
-            configs.set_code_agent(environment_id, &ready.id);
-            configs.write()?;
-            return Ok((ready, false, probe_master));
-        }
-        configs.remove_code_agent(environment_id);
+                .await?;
+        warn_ignored_variables(args, progress);
+        configs.set_code_agent(environment_id, &ready.id);
+        configs.write()?;
+        return Ok((ready, false, probe_master));
     }
 
     let mut variables = variables_to_input(&args.env_files, &args.variables)?
@@ -2532,7 +2482,7 @@ async fn destroy_agent(
         println!("No agent recorded for this environment.");
         return Ok(());
     };
-    let name = fetch_agent(client, &backboard, environment_id, &id)
+    let name = ca::get(client, &backboard, environment_id, &id)
         .await?
         .map(|a| a.name);
     // Forget the pointer either way: a delete that reports failure on an
@@ -3553,7 +3503,122 @@ pub fn ensure_claude_credential_cached(harness: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::MockBackboard;
     use clap::Parser;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn an_unusable_selected_vm_is_never_replaced() {
+        for selection in ["explicit", "remembered", "sole"] {
+            for status in [
+                "FAILED",
+                "CRASHED",
+                "DELETING",
+                "FUTURE_STATE",
+                "missing",
+                "lookup_error",
+            ] {
+                let server = MockBackboard::spawn();
+                let dir = tempfile::tempdir().unwrap();
+                let mut configs = server.configs(&dir);
+                let mut args = LaunchArgs::default();
+                if selection == "explicit" {
+                    args.agent_id = Some("existing".into());
+                } else if selection == "remembered" {
+                    configs.set_code_agent("env", "existing");
+                }
+                configs.write().unwrap();
+                let saved = std::fs::read(dir.path().join("config.json")).unwrap();
+                let node = json!({
+                    "id": "existing", "name": "my-agent", "status": status,
+                    "projectId": "project", "environmentId": "env",
+                    "createdAt": "2026-09-10T00:00:00Z"
+                });
+                server.stub("CloudAgents", json!({"cloudAgents": [node.clone()]}));
+                match status {
+                    "missing" => server.stub("CloudAgent", json!({"cloudAgent": null})),
+                    "lookup_error" => {
+                        server.stub_graphql_error("CloudAgent", "temporarily unavailable")
+                    }
+                    _ => server.stub("CloudAgent", json!({"cloudAgent": node})),
+                }
+                let error = resolve_agent(
+                    &mut configs,
+                    &reqwest::Client::new(),
+                    &args,
+                    &names::Target::new(("project".into(), "env".into()), false),
+                    Agent::Claude,
+                    &CliProgress::default(),
+                    &RelayAccess {
+                        identity: None,
+                        relay_opts: vec![],
+                    },
+                )
+                .await
+                .unwrap_err();
+                assert!(
+                    !error.to_string().contains("no scripted response"),
+                    "{selection}/{status}: {error}"
+                );
+                let operations: Vec<_> = server
+                    .requests()
+                    .iter()
+                    .map(|r| r["operationName"].as_str().unwrap().to_owned())
+                    .collect();
+                let expected = if selection == "sole" {
+                    vec!["CloudAgents", "CloudAgent"]
+                } else {
+                    vec!["CloudAgent"]
+                };
+                assert_eq!(operations, expected, "{selection}/{status}");
+                assert_eq!(
+                    std::fs::read(dir.path().join("config.json")).unwrap(),
+                    saved
+                );
+                if selection == "remembered" {
+                    assert_eq!(configs.get_code_agent("env").as_deref(), Some("existing"));
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn creation_is_reached_only_for_new_or_an_empty_inventory() {
+        for new in [false, true] {
+            let server = MockBackboard::spawn();
+            let dir = tempfile::tempdir().unwrap();
+            let mut configs = server.configs(&dir);
+            if new {
+                configs.set_code_agent("env", "existing");
+            }
+            server.stub("CloudAgents", json!({"cloudAgents": []}));
+            // Stop at creation so the test never opens SSH or provisions a VM.
+            server.stub_graphql_error("CloudAgentCreate", "creation reached");
+            let args = LaunchArgs {
+                new,
+                name: Some("fresh-agent".into()),
+                ..Default::default()
+            };
+            let error = resolve_agent(
+                &mut configs,
+                &reqwest::Client::new(),
+                &args,
+                &names::Target::new(("project".into(), "env".into()), false),
+                Agent::Claude,
+                &CliProgress::default(),
+                &RelayAccess {
+                    identity: None,
+                    relay_opts: vec![],
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(error.to_string().contains("creation reached"), "{error}");
+            assert_eq!(server.variables_for("CloudAgentCreate").len(), 1);
+            assert!(server.variables_for("CloudAgent").is_empty());
+            assert_eq!(server.variables_for("CloudAgents").len(), usize::from(!new));
+        }
+    }
 
     /// The shapes someone types at a prompt open in the pane. Nothing about a
     /// target, a harness or a variable changes that — they all describe a

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -433,7 +433,7 @@ pub async fn resolve(
 
 /// [`resolve`], with the empty account handed back instead of an error.
 ///
-/// `None` means exactly "no agents in scope, and no name was given" —
+/// `None` means exactly "no agents or remembered targets in scope, and no name was given" —
 /// the one case where a caller can reasonably do something other than fail,
 /// e.g. a connect command creating the first agent. Every other outcome
 /// (a named agent missing, more than one candidate) is still an error here,
@@ -452,6 +452,24 @@ pub async fn resolve_or_none(
 
     if let Some(selector) = selector {
         return match_selector(candidates, selector).map(|agent| Some((agent, Resolution::Named)));
+    }
+
+    // Missing from inventory is not permission to forget a selected VM or
+    // redirect a bare command to somebody else. Naming a target above is an
+    // explicit override; scoping to another environment also excludes this pointer.
+    for env in configs.code_agent_environments() {
+        if environment_id.is_some_and(|scope| scope != env) {
+            continue;
+        }
+        if let Some(id) = configs.get_code_agent(&env)
+            && !candidates
+                .iter()
+                .any(|a| a.environment_id == env && a.id == id)
+        {
+            bail!(
+                "Remembered agent {id} is unavailable in this scope. Check `railway ca list` and name an agent explicitly, or use `railway ca create` to create a separate agent."
+            );
+        }
     }
 
     // The pointer is what makes bare `railway ca ssh` mean "the agent I was
@@ -549,6 +567,67 @@ mod tests {
     use super::*;
     use crate::testkit::MockBackboard;
     use serde_json::json;
+
+    #[tokio::test]
+    async fn a_missing_remembered_target_never_redirects_or_permits_creation() {
+        for scoped in [None, Some("env")] {
+            for has_other in [false, true] {
+                let server = MockBackboard::spawn();
+                let dir = tempfile::tempdir().unwrap();
+                let mut configs = server.configs(&dir);
+                configs.set_code_agent("env", "remembered");
+                let nodes = if has_other {
+                    json!([{
+                        "id": "other", "name": "other-agent", "status": "RUNNING",
+                        "projectId": "project", "environmentId": "env",
+                        "createdAt": "2026-09-10T00:00:00Z"
+                    }])
+                } else {
+                    json!([])
+                };
+                server.stub("MyCloudAgents", json!({"myCloudAgents": nodes}));
+                server.stub("CloudAgents", json!({"cloudAgents": nodes}));
+                let result = resolve_or_none(&configs, &reqwest::Client::new(), None, scoped).await;
+                assert!(
+                    result.is_err(),
+                    "missing identity must not select another VM or allow creation"
+                );
+                assert_eq!(configs.get_code_agent("env").as_deref(), Some("remembered"));
+                if has_other {
+                    let (agent, _) =
+                        resolve_or_none(&configs, &reqwest::Client::new(), Some("other"), scoped)
+                            .await
+                            .unwrap()
+                            .unwrap();
+                    assert_eq!(
+                        agent.id, "other",
+                        "an explicit target can override a missing pointer"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn remembered_targets_outside_the_requested_scope_do_not_block_selection() {
+        let server = MockBackboard::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let mut configs = server.configs(&dir);
+        configs.set_code_agent("other-env", "old-target");
+        server.stub(
+            "CloudAgents",
+            json!({"cloudAgents": [{
+                "id": "in-scope", "name": "my-agent", "status": "RUNNING",
+                "projectId": "project", "environmentId": "env",
+                "createdAt": "2026-09-10T00:00:00Z"
+            }]}),
+        );
+        let (agent, _) = resolve_or_none(&configs, &reqwest::Client::new(), None, Some("env"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(agent.id, "in-scope");
+    }
 
     #[tokio::test]
     async fn failed_observations_remain_candidates_and_keep_the_remembered_target() {

--- a/src/controllers/cloud_agent.rs
+++ b/src/controllers/cloud_agent.rs
@@ -60,10 +60,24 @@ impl Status {
         }
     }
 
-    /// The agent exists and can be brought back: it is worth listing, waking,
-    /// sleeping or connecting to.
+    /// The observed state permits connecting or waiting for a boot. A false
+    /// result says nothing about whether the agent exists or should be replaced.
     pub fn is_live(&self) -> bool {
         matches!(self, Status::Running | Status::Sleeping | Status::Starting)
+    }
+
+    /// Read a status label retained by the TUI through the same vocabulary as
+    /// the lifecycle commands. Future states remain unknown, not a live state.
+    pub fn from_label(label: &str) -> Self {
+        match label {
+            "running" => Self::Running,
+            "sleeping" => Self::Sleeping,
+            "starting" => Self::Starting,
+            "crashed" => Self::Crashed,
+            "failed" => Self::Failed,
+            "deleting" => Self::Deleting,
+            other => Self::Unknown(other.to_owned()),
+        }
     }
 }
 
@@ -385,7 +399,7 @@ pub enum Resolution {
     Named,
     /// It is the agent this machine last used in its environment.
     Remembered,
-    /// It is the caller's only live agent in scope.
+    /// It is the caller's only agent in scope.
     Sole,
 }
 
@@ -419,7 +433,7 @@ pub async fn resolve(
 
 /// [`resolve`], with the empty account handed back instead of an error.
 ///
-/// `None` means exactly "no live agents in scope, and no name was given" —
+/// `None` means exactly "no agents in scope, and no name was given" —
 /// the one case where a caller can reasonably do something other than fail,
 /// e.g. a connect command creating the first agent. Every other outcome
 /// (a named agent missing, more than one candidate) is still an error here,
@@ -440,14 +454,10 @@ pub async fn resolve_or_none(
         return match_selector(candidates, selector).map(|agent| Some((agent, Resolution::Named)));
     }
 
-    let live: Vec<Agent> = candidates
-        .into_iter()
-        .filter(|a| a.status.is_live())
-        .collect();
-
     // The pointer is what makes bare `railway ca ssh` mean "the agent I was
-    // just working in" rather than "whichever one sorts first".
-    let mut remembered: Vec<Agent> = live
+    // just working in" rather than "whichever one sorts first". Observed status
+    // must not erase that identity: FAILED can also mean the VM lookup failed.
+    let mut remembered: Vec<Agent> = candidates
         .iter()
         .filter(|a| configs.get_code_agent(&a.environment_id).as_deref() == Some(a.id.as_str()))
         .cloned()
@@ -456,16 +466,16 @@ pub async fn resolve_or_none(
         return Ok(Some((remembered.remove(0), Resolution::Remembered)));
     }
 
-    match live.len() {
+    match candidates.len() {
         0 => Ok(None),
         1 => Ok(Some((
-            live.into_iter().next().expect("len checked"),
+            candidates.into_iter().next().expect("len checked"),
             Resolution::Sole,
         ))),
         _ => bail!(
             "You have {} cloud agents and none is this directory's. Name one:\n{}",
-            live.len(),
-            describe(&live)
+            candidates.len(),
+            describe(&candidates)
         ),
     }
 }
@@ -537,6 +547,76 @@ pub fn humanize_age(created_at: DateTime<Utc>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testkit::MockBackboard;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn failed_observations_remain_candidates_and_keep_the_remembered_target() {
+        for status in ["FAILED", "CRASHED", "DELETING", "FUTURE_STATE"] {
+            let server = MockBackboard::spawn();
+            let dir = tempfile::tempdir().unwrap();
+            let mut configs = server.configs(&dir);
+            let node = json!({
+                "id": "existing", "name": "my-agent", "status": status,
+                "projectId": "project", "environmentId": "env",
+                "createdAt": "2026-09-10T00:00:00Z"
+            });
+            server.stub("MyCloudAgents", json!({"myCloudAgents": [node.clone()]}));
+            let client = reqwest::Client::new();
+            let (agent, how) = resolve_or_none(&configs, &client, None, None)
+                .await
+                .unwrap()
+                .expect("an observation must not erase a VM");
+            assert_eq!(agent.id, "existing");
+            assert!(matches!(how, Resolution::Sole));
+
+            configs.set_code_agent("env", "existing");
+            let mut other = node.clone();
+            other["id"] = json!("other");
+            other["status"] = json!("RUNNING");
+            server.stub("CloudAgents", json!({"cloudAgents": [node, other]}));
+            let (agent, how) = resolve_or_none(&configs, &client, None, Some("env"))
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                agent.id, "existing",
+                "{status} must not redirect to the running VM"
+            );
+            assert!(matches!(how, Resolution::Remembered));
+            assert_eq!(
+                server.variables_for("CloudAgents"),
+                vec![json!({"environmentId": "env", "mine": true})]
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn only_an_empty_inventory_permits_automatic_creation() {
+        let server = MockBackboard::spawn();
+        let dir = tempfile::tempdir().unwrap();
+        let configs = server.configs(&dir);
+        let client = reqwest::Client::new();
+        server.stub("MyCloudAgents", json!({"myCloudAgents": []}));
+        assert!(
+            resolve_or_none(&configs, &client, None, None)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        server.stub_graphql_error("CloudAgents", "temporarily unavailable");
+        assert!(
+            resolve_or_none(&configs, &client, None, Some("env"))
+                .await
+                .is_err()
+        );
+        assert!(
+            resolve_or_none(&configs, &client, Some("missing"), None)
+                .await
+                .is_err()
+        );
+    }
 
     fn agent(id: &str, name: &str, status: Status) -> Agent {
         Agent {

--- a/tests/cloud_agent_lifecycle.rs
+++ b/tests/cloud_agent_lifecycle.rs
@@ -1,0 +1,215 @@
+//! Exercise the actual CLI, output and exit codes against a local GraphQL server.
+#![cfg(all(unix, debug_assertions))]
+
+use std::{
+    io::{BufRead, BufReader, Read, Write},
+    net::TcpListener,
+    process::{Command, Output},
+    sync::{Arc, Mutex},
+};
+
+use serde_json::{Value, json};
+
+struct Backboard {
+    url: String,
+    requests: Arc<Mutex<Vec<Value>>>,
+}
+
+impl Backboard {
+    fn new(inventory: Vec<Value>, refused: Option<&str>, wake_status: &str) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/graphql/v2", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&requests);
+        let refused = refused.map(str::to_owned);
+        let wake_status = wake_status.to_owned();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let mut stream = stream.unwrap();
+                stream
+                    .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = BufReader::new(&mut stream);
+                let mut length = 0;
+                loop {
+                    let mut line = String::new();
+                    if reader.read_line(&mut line).unwrap() == 0 || line == "\r\n" {
+                        break;
+                    }
+                    if let Some((name, value)) = line.split_once(':')
+                        && name.eq_ignore_ascii_case("content-length")
+                    {
+                        length = value.trim().parse().unwrap();
+                    }
+                }
+                let mut body = vec![0; length];
+                reader.read_exact(&mut body).unwrap();
+                let request: Value = serde_json::from_slice(&body).unwrap();
+                seen.lock().unwrap().push(request.clone());
+                let operation = request["operationName"].as_str().unwrap();
+                let id = request["variables"]["id"].as_str().unwrap_or_default();
+                let response = match operation {
+                    "MyCloudAgents" => json!({"data": {"myCloudAgents": inventory}}),
+                    "CloudAgentSleep" | "CloudAgentWake" if refused.as_deref() == Some(id) => {
+                        json!({"errors": [{"message": "mutation refused"}]})
+                    }
+                    "CloudAgentSleep" => json!({"data": {"cloudAgentSleep": {"id": id, "status": "RUNNING"}}}),
+                    "CloudAgentWake" => json!({"data": {"cloudAgentWake": {"id": id, "status": "STARTING"}}}),
+                    "CloudAgent" => json!({"data": {"cloudAgent": agent(id, &wake_status)}}),
+                    _ => json!({"errors": [{"message": format!("unexpected operation: {operation}") }]}),
+                }.to_string();
+                write!(stream, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response}", response.len()).unwrap();
+            }
+        });
+        Self { url, requests }
+    }
+
+    fn run(&self, home: &std::path::Path, args: &[&str]) -> Output {
+        // No real credentials, keys or network routes are inherited. The absent
+        // SSH key also exercises sleep's best-effort flush failure path.
+        Command::new(env!("CARGO_BIN_EXE_railway"))
+            .env_clear()
+            .env("HOME", home)
+            .env("PATH", "/usr/bin:/bin")
+            .env("RAILWAY_API_TOKEN", "test-token")
+            .env("RAILWAY_BACKBOARD_URL", &self.url)
+            .env("RAILWAY_NO_AUTO_UPDATE", "1")
+            .env("DO_NOT_TRACK", "1")
+            .env("NO_COLOR", "1")
+            .env("HTTPS_PROXY", "http://127.0.0.1:9")
+            .current_dir(home)
+            .args(["ca"])
+            .args(args)
+            .output()
+            .unwrap()
+    }
+
+    fn ids_for(&self, operation: &str) -> Vec<String> {
+        let mut ids: Vec<_> = self
+            .requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|r| r["operationName"] == operation)
+            .map(|r| r["variables"]["id"].as_str().unwrap().to_owned())
+            .collect();
+        ids.sort();
+        ids
+    }
+}
+
+fn agent(id: &str, status: &str) -> Value {
+    json!({"id": id, "name": id, "status": status, "projectId": "project",
+        "environmentId": "env", "createdAt": "2026-09-10T00:00:00Z"})
+}
+
+#[test]
+fn sleep_sends_every_observed_state_and_reports_acceptance() {
+    for status in [
+        "RUNNING",
+        "STARTING",
+        "SLEEPING",
+        "FAILED",
+        "CRASHED",
+        "DELETING",
+        "FUTURE_STATE",
+    ] {
+        let server = Backboard::new(vec![agent("existing", status)], None, "RUNNING");
+        let home = tempfile::tempdir().unwrap();
+        let output = server.run(home.path(), &["sleep", "existing"]);
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(server.ids_for("CloudAgentSleep"), ["existing"], "{status}");
+        assert!(String::from_utf8_lossy(&output.stdout).contains("Sleep requested"));
+        assert!(
+            server.ids_for("CloudAgent").is_empty(),
+            "acceptance does not poll for completion"
+        );
+    }
+}
+
+#[test]
+fn bulk_sleep_attempts_every_agent_and_reports_partial_failure() {
+    for refused in [None, Some("sleeping")] {
+        let server = Backboard::new(
+            vec![
+                agent("running", "RUNNING"),
+                agent("sleeping", "SLEEPING"),
+                agent("unknown", "FUTURE_STATE"),
+            ],
+            refused,
+            "RUNNING",
+        );
+        let home = tempfile::tempdir().unwrap();
+        let output = server.run(home.path(), &["sleep", "--all"]);
+        assert_eq!(output.status.success(), refused.is_none());
+        assert_eq!(
+            server.ids_for("CloudAgentSleep"),
+            ["running", "sleeping", "unknown"]
+        );
+        let count = if refused.is_some() { 2 } else { 3 };
+        assert!(
+            String::from_utf8_lossy(&output.stdout)
+                .contains(&format!("Sleep requested for {count} agents"))
+        );
+        if refused.is_some() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(stderr.contains("sleeping — mutation refused"), "{stderr}");
+        }
+    }
+}
+
+#[test]
+fn single_sleep_refusal_is_not_reported_as_success() {
+    let server = Backboard::new(
+        vec![agent("existing", "SLEEPING")],
+        Some("existing"),
+        "RUNNING",
+    );
+    let home = tempfile::tempdir().unwrap();
+    let output = server.run(home.path(), &["sleep", "existing"]);
+    assert!(!output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("Sleep requested"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("mutation refused"));
+    assert_eq!(server.ids_for("CloudAgentSleep"), ["existing"]);
+}
+
+#[test]
+fn wake_wait_reports_a_terminal_observation_and_no_wait_does_not_poll() {
+    for no_wait in [false, true] {
+        let server = Backboard::new(vec![agent("existing", "RUNNING")], None, "CRASHED");
+        let home = tempfile::tempdir().unwrap();
+        let args = if no_wait {
+            vec!["wake", "existing", "--no-wait"]
+        } else {
+            vec!["wake", "existing"]
+        };
+        let output = server.run(home.path(), &args);
+        assert_eq!(output.status.success(), no_wait);
+        assert_eq!(server.ids_for("CloudAgentWake"), ["existing"]);
+        assert_eq!(server.ids_for("CloudAgent").len(), usize::from(!no_wait));
+        if !no_wait {
+            assert!(String::from_utf8_lossy(&output.stderr).contains("crashed"));
+            assert!(!String::from_utf8_lossy(&output.stdout).contains("is running"));
+        }
+    }
+}
+
+#[test]
+fn missing_remembered_agent_stops_ssh_before_replacement_creation() {
+    let server = Backboard::new(vec![], None, "RUNNING");
+    let home = tempfile::tempdir().unwrap();
+    std::fs::create_dir(home.path().join(".railway")).unwrap();
+    std::fs::write(
+        home.path().join(".railway/config.json"),
+        json!({"projects": {}, "user": {}, "codeAgents": {"env": "remembered"}}).to_string(),
+    )
+    .unwrap();
+    let output = server.run(home.path(), &["ssh"]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("remembered"));
+    assert!(server.ids_for("CloudAgentCreate").is_empty());
+}


### PR DESCRIPTION
## What this fixes

When cloud-agent status is delayed or unavailable, the CLI can create a second VM instead of reconnecting to your existing one. It can also skip a wake or sleep request because an old status says the agent is already awake or asleep.

This PR makes `railway ca` keep the agent you selected and handle wake/sleep requests more reliably. The agent-selection fixes also apply to `railway code`.

## What changes

- **Keep your existing agent.** If the selected or remembered agent is missing or reports a problem, show an error instead of silently creating a replacement or choosing another agent.
- **Always send wake/sleep requests.** Let the server decide whether anything needs to happen, rather than skipping the request based on old status.
- **Make TUI progress trustworthy.** Show reported failures promptly. Ignore late replies from older status checks so they cannot incorrectly finish a newer action.
- **Handle multiple pending actions.** Poll each affected environment fairly and respect the API's retry delay when rate-limited.
- **Say what actually happened.** Sleep commands report “Sleep requested,” because accepting the request does not mean the VM has finished sleeping.

## Testing

- **1,445 unit tests and 18 integration tests passed** on Linux.
- Added tests for out-of-order replies, concurrent wake/sleep actions, missing agents, and partial failures in `ca sleep --all`.
- Command-level tests run the compiled CLI against a local API server and check its requests, output, and exit codes.
- Formatting and Clippy passed; existing warnings remain.
