### PR TITLE
fix: harden Herdr reconciliation and bootstrap retries

### DIFF
--- a/src/commands/cloud_agent/herdr/agents.rs
+++ b/src/commands/cloud_agent/herdr/agents.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use super::herdr_cli::{Herdr, Machine};
-use super::state::State;
+use super::state::Store;
 use super::sync;
 use super::target;
 use crate::client::GQLClient;
@@ -134,7 +134,7 @@ struct Picker {
     client: reqwest::Client,
     backboard: String,
     herdr: Herdr,
-    state: State,
+    store: Store,
     remote: bool,
 }
 
@@ -148,17 +148,17 @@ pub async fn command(args: Args) -> Result<()> {
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
-    let state = State::load().unwrap_or_default();
+    let store = Store::new(&configs)?;
     let mut picker = Picker {
         configs,
         client,
         backboard,
         herdr,
-        state,
+        store,
         remote: args.remote,
     };
     let this_vm = std::env::var("RAILWAY_CLOUD_AGENT_ID").ok();
-    let mut names = picker.state.project_names.clone();
+    let mut names = picker.store.load()?.project_names;
 
     loop {
         let agents = ca::list_mine(&picker.client, &picker.backboard).await?;
@@ -168,16 +168,11 @@ pub async fn command(args: Args) -> Result<()> {
                 .into_iter()
                 .collect();
             if !names.is_empty() {
-                picker.state.project_names = names.clone();
-                let _ = picker.state.save();
+                picker
+                    .store
+                    .update(|s| s.project_names = names.clone())
+                    .await?;
             }
-        }
-        if agents.is_empty() {
-            println!(
-                "No cloud agents. {} creates one and adds it to herdr.",
-                "railway ca herdr new".cyan()
-            );
-            return Ok(());
         }
         let machines = if args.remote {
             Vec::new()
@@ -229,12 +224,14 @@ pub async fn command(args: Args) -> Result<()> {
             };
         }
 
-        let mut items = Vec::with_capacity(rows.len() + 2);
-        if !args.remote {
-            items.push(Item::New);
+        let items = picker_items(rows, args.remote);
+        if items.is_empty() {
+            println!(
+                "No cloud agents. {} creates one and adds it to herdr.",
+                "railway ca herdr new".cyan()
+            );
+            return Ok(());
         }
-        items.push(Item::Sync);
-        items.extend(rows.into_iter().map(Item::Agent));
         let Some(item) = inquire::Select::new("Agent", items)
             .with_render_config(Configs::get_render_config())
             .with_page_size(17)
@@ -296,6 +293,19 @@ pub async fn command(args: Args) -> Result<()> {
     }
 }
 
+fn picker_items(rows: Vec<Row>, remote: bool) -> Vec<Item> {
+    if remote && rows.is_empty() {
+        return Vec::new();
+    }
+    let mut items = Vec::with_capacity(rows.len() + 2);
+    if !remote {
+        items.push(Item::New);
+    }
+    items.push(Item::Sync);
+    items.extend(rows.into_iter().map(Item::Agent));
+    items
+}
+
 impl Picker {
     async fn connect(&mut self, row: &Row) -> Result<()> {
         let agent = self.ensure_awake(&row.agent).await?;
@@ -305,15 +315,18 @@ impl Picker {
         ready?;
         match &row.machine {
             Some(machine) => {
-                self.herdr.machine_disable(&machine.id)?;
-                self.herdr.machine_enable(&machine.id)?;
-                self.remember(&agent.id, Some(&machine.id))?;
+                self.reconnect(&agent, machine).await?;
+                if let Some(harness) = self.store.load()?.bootstrap_pending.get(&agent.id).cloned()
+                {
+                    super::bootstrap::run(&agent, &harness, &self.store).await?;
+                }
                 println!(
                     "✓ {} is enabled in herdr; pick it from the sidebar.",
                     machine.label.cyan()
                 );
             }
             None => {
+                let harness = super::harness::choose(&Default::default(), true)?;
                 let target = target::target(&agent);
                 let label = target::label(&row.project, &agent.name);
                 super::known_hosts::ensure_relay_known_host()?;
@@ -323,15 +336,9 @@ impl Picker {
                     .machines()?
                     .into_iter()
                     .find(|m| sync::is_machine_for(&agent, m));
-                self.remember(&agent.id, added.as_ref().map(|m| m.id.as_str()))?;
-                let harness = super::harness::choose(&Default::default(), true)?;
-                if let Err(e) = super::bootstrap::run(&agent, harness).await {
-                    eprintln!(
-                        "{} bootstrap did not finish: {e:#}\n  {} retries it.",
-                        "warning:".yellow(),
-                        format!("railway ca herdr bootstrap {}", agent.name).cyan()
-                    );
-                }
+                self.remember(&agent.id, added.as_ref().map(|m| m.id.as_str()))
+                    .await?;
+                super::bootstrap::run(&agent, harness, &self.store).await?;
                 println!(
                     "✓ Added {} to herdr; pick it from the sidebar.",
                     label.cyan()
@@ -343,42 +350,34 @@ impl Picker {
 
     async fn sleep(&mut self, row: &Row) -> Result<()> {
         let agent = &row.agent;
-        match agent.status {
-            ca::Status::Sleeping => {
-                println!("Agent {} is already asleep.", agent.name.cyan());
-            }
-            ca::Status::Running | ca::Status::Starting => {
-                self.herdr.notify(
-                    &format!("Sleeping {}", agent.name),
-                    "railway: cloudAgentSleep issued; its herdr machine is being disabled",
-                );
-                let spinner = create_spinner(format!("Sleeping agent {}", agent.name));
-                let result = ca::sleep(
-                    &self.client,
-                    &self.backboard,
-                    &agent.environment_id,
-                    &agent.id,
-                )
-                .await;
-                spinner.finish_and_clear();
-                result?;
-                println!(
-                    "✓ Sleeping agent {}; its disk is kept, compute stops billing.",
-                    agent.name.cyan()
-                );
-            }
-            _ => bail!(
-                "Agent {} is {}; there is nothing running to sleep.",
-                agent.name,
-                agent.status.label()
-            ),
-        }
+        self.herdr.notify(
+            &format!("Sleeping {}", agent.name),
+            "Requesting sleep; its disk is kept",
+        );
+        let mut locked = self.store.lock().await?;
+        let spinner = create_spinner(format!("Sleeping agent {}", agent.name));
+        let result = ca::sleep(
+            &self.client,
+            &self.backboard,
+            &agent.environment_id,
+            &agent.id,
+        )
+        .await;
+        spinner.finish_and_clear();
+        result?;
+        locked.state.sleep_until.insert(
+            agent.id.clone(),
+            chrono::Utc::now() + chrono::Duration::seconds(60),
+        );
+        // Record the acknowledgement even if disabling Herdr subsequently fails.
+        locked.save()?;
         if let Some(machine) = &row.machine {
-            if machine.enabled {
-                self.herdr.machine_disable(&machine.id)?;
-            }
-            self.remember(&agent.id, Some(&machine.id))?;
+            self.herdr.machine_disable(&machine.id)?;
         }
+        println!(
+            "✓ Sleep requested for agent {}; compute stops billing once it is asleep.",
+            agent.name.cyan()
+        );
         Ok(())
     }
 
@@ -392,9 +391,7 @@ impl Picker {
                 ready?;
                 // Off then on: a profile change makes herdr open a fresh
                 // connection, which is what clears a stuck Attention state.
-                self.herdr.machine_disable(&machine.id)?;
-                self.herdr.machine_enable(&machine.id)?;
-                self.remember(&agent.id, Some(&machine.id))?;
+                self.reconnect(&agent, machine).await?;
                 println!(
                     "✓ Agent {} is running; {} is back in the sidebar.",
                     agent.name.cyan(),
@@ -425,6 +422,7 @@ impl Picker {
             return Ok(());
         }
 
+        let mut locked = self.store.lock().await?;
         let spinner = create_spinner(format!("Deleting agent {}", agent.name));
         let result = ca::delete(&self.client, &self.backboard, &agent.id).await;
         spinner.finish_and_clear();
@@ -436,30 +434,26 @@ impl Picker {
         if let Some(machine) = &row.machine {
             self.herdr.machine_remove(&machine.id)?;
         }
-        self.remember(&agent.id, None)?;
+        locked.state.machines.remove(&agent.id);
+        locked.state.sleep_until.remove(&agent.id);
+        locked.state.bootstrap_pending.remove(&agent.id);
+        locked.save()?;
         println!("✓ Deleted agent {}", agent.name.cyan());
         Ok(())
     }
 
     async fn ensure_awake(&mut self, agent: &ca::Agent) -> Result<ca::Agent> {
-        match agent.status {
-            ca::Status::Running => {
-                ca::remember(&mut self.configs, agent)?;
-                return Ok(agent.clone());
-            }
-            ca::Status::Sleeping => {
-                self.herdr.notify(
-                    &format!("Waking {}", agent.name),
-                    "railway: cloudAgentWake issued; the machine is re-enabled once its ssh relay answers",
-                );
-                ca::wake(&self.client, &self.backboard, &agent.id).await?;
-            }
-            ca::Status::Starting => {}
-            _ => bail!(
-                "Agent {} is {} and cannot be woken.",
-                agent.name,
-                agent.status.label()
-            ),
+        // Inventory can lag a sleep/wake elsewhere. The server reads live VM
+        // state and handles no-ops; always send the user's intent to it.
+        self.herdr.notify(
+            &format!("Waking {}", agent.name),
+            "The machine is re-enabled once its SSH relay answers",
+        );
+        {
+            let mut locked = self.store.lock().await?;
+            ca::wake(&self.client, &self.backboard, &agent.id).await?;
+            locked.state.sleep_until.remove(&agent.id);
+            locked.save()?;
         }
         ca::remember(&mut self.configs, agent)?;
         let spinner = create_spinner(format!("Waking agent {}", agent.name));
@@ -478,24 +472,93 @@ impl Picker {
         if self.remote {
             return Ok(Vec::new());
         }
-        let applied = sync::resync(&self.client, &self.backboard, &self.herdr).await?;
-        self.state = State::load().unwrap_or_default();
-        Ok(applied)
+        sync::resync(&self.client, &self.backboard, &self.herdr, &self.store).await
     }
 
-    /// Reloads first: the watcher may have written state since the picker opened.
-    fn remember(&mut self, agent_id: &str, profile_id: Option<&str>) -> Result<()> {
-        self.state = State::load().unwrap_or_default();
-        match profile_id {
-            Some(profile) => {
-                self.state
-                    .machines
-                    .insert(agent_id.to_string(), profile.to_string());
-            }
-            None => {
-                self.state.machines.remove(agent_id);
-            }
+    async fn reconnect(&self, agent: &ca::Agent, machine: &Machine) -> Result<()> {
+        let mut locked = self.store.lock().await?;
+        if locked.state.sleep_pending(&agent.id, chrono::Utc::now()) {
+            bail!(
+                "A sleep was requested for {} while connecting; wake it again to reconnect.",
+                agent.name
+            );
         }
-        self.state.save()
+        self.herdr.machine_disable(&machine.id)?;
+        self.herdr.machine_enable(&machine.id)?;
+        locked
+            .state
+            .machines
+            .insert(agent.id.clone(), machine.id.clone());
+        locked.save()
+    }
+
+    async fn remember(&self, agent_id: &str, profile_id: Option<&str>) -> Result<()> {
+        self.store
+            .update(|state| match profile_id {
+                Some(profile) => {
+                    state
+                        .machines
+                        .insert(agent_id.to_string(), profile.to_string());
+                }
+                None => {
+                    state.machines.remove(agent_id);
+                }
+            })
+            .await
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::testkit::MockBackboard;
+
+    #[tokio::test]
+    async fn an_observed_running_agent_still_sends_the_wake_request() {
+        let api = MockBackboard::spawn();
+        let home = tempfile::tempdir().unwrap();
+        let fake = super::super::herdr_cli::fake::FakeHerdr::with_machines("[]");
+        let agent = ca::Agent {
+            id: "agent-1".into(),
+            name: "reviewer".into(),
+            status: ca::Status::Running,
+            project_id: "project-1".into(),
+            environment_id: "environment-1".into(),
+            created_at: chrono::Utc::now(),
+        };
+        api.stub(
+            "CloudAgentWake",
+            serde_json::json!({"cloudAgentWake": {"id": agent.id, "status": "STARTING"}}),
+        );
+        api.stub(
+            "CloudAgent",
+            serde_json::json!({"cloudAgent": {
+                "id": agent.id, "name": agent.name, "status": "RUNNING",
+                "projectId": agent.project_id, "environmentId": agent.environment_id,
+                "createdAt": agent.created_at,
+            }}),
+        );
+        let mut picker = Picker {
+            configs: api.configs(&home),
+            client: reqwest::Client::new(),
+            backboard: api.url(),
+            herdr: fake.herdr(),
+            store: Store::at(home.path().join("state.json"), &api.url(), "test"),
+            remote: false,
+        };
+        picker.ensure_awake(&agent).await.unwrap();
+        assert!(
+            api.requests()
+                .iter()
+                .any(|r| r["operationName"] == "CloudAgentWake"),
+            "an inventory observation must not veto explicit wake intent"
+        );
+    }
+
+    #[test]
+    fn empty_local_picker_offers_creation() {
+        let items = picker_items(Vec::new(), false);
+        assert!(matches!(items.first(), Some(Item::New)));
+        assert!(picker_items(Vec::new(), true).is_empty());
     }
 }

--- a/src/commands/cloud_agent/herdr/bootstrap.rs
+++ b/src/commands/cloud_agent/herdr/bootstrap.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use colored::Colorize;
 
+use super::state::Store;
 use crate::client::GQLClient;
 use crate::commands::code;
 use crate::commands::code::{HARNESS_PATH, LaunchArgs, Progress};
@@ -26,12 +27,42 @@ pub async fn command(args: Args) -> Result<()> {
     let client = GQLClient::new_authorized(&configs)?;
     let (agent, _) = ca::resolve(&configs, &client, args.agent.as_deref(), None).await?;
     let harness = super::harness::choose(&args.harness, false)?;
-    run(&agent, harness).await
+    run(&agent, harness, &Store::new(&configs)?).await
 }
 
 /// Prepare a running agent's VM for herdr. Idempotent; `new` calls this right
 /// after `herdr machine add`.
-pub async fn run(agent: &ca::Agent, harness: &str) -> Result<()> {
+pub(super) async fn run(agent: &ca::Agent, harness: &str, store: &Store) -> Result<()> {
+    track_bootstrap(store, &agent.id, harness, run_inner(agent, harness)).await.with_context(|| format!(
+        "Herdr setup is incomplete for {}. Connect again, or retry `railway ca herdr bootstrap {} --{harness}`",
+        agent.name, agent.id,
+    ))
+}
+
+async fn track_bootstrap(
+    store: &Store,
+    agent_id: &str,
+    harness: &str,
+    run: impl std::future::Future<Output = Result<()>>,
+) -> Result<()> {
+    store
+        .update(|s| {
+            s.bootstrap_pending
+                .insert(agent_id.to_owned(), harness.to_owned());
+        })
+        .await?;
+    let result = run.await;
+    if result.is_ok() {
+        store
+            .update(|s| {
+                s.bootstrap_pending.remove(agent_id);
+            })
+            .await?;
+    }
+    result
+}
+
+async fn run_inner(agent: &ca::Agent, harness: &str) -> Result<()> {
     if !matches!(agent.status, ca::Status::Running) {
         bail!(
             "Agent {} is {}. Wake it first: {}",
@@ -92,13 +123,10 @@ pub async fn run(agent: &ca::Agent, harness: &str) -> Result<()> {
             )
         }
         Outcome::HerdrMissing => {
-            println!(
-                "{} herdr is not installed on agent {}; `herdr machine add` installs it. Re-run {} afterwards.",
-                "!".yellow(),
-                agent.name.cyan(),
-                format!("railway ca herdr bootstrap {}", agent.name).cyan()
-            );
-            Ok(())
+            bail!(
+                "herdr is not installed on agent {}; connect it with `railway ca herdr agents` first",
+                agent.name
+            )
         }
         Outcome::NoMarker => bail!(
             "Bootstrap of agent {} produced no status marker (ssh exit {code}).\n{}\n{}",
@@ -224,7 +252,7 @@ if ws="$(herdr workspace list 2>/dev/null)"; then
     echo "workspace app: FAILED to create"; fail=1
   fi
 else
-  echo "workspace app: skipped (no herdr server running; connecting starts one)"
+  echo "workspace app: FAILED (no herdr server running; connecting starts one)"; fail=1
 fi
 "##;
 
@@ -370,6 +398,32 @@ fn script(remote: &Remote) -> String {
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn failed_bootstrap_preserves_the_selected_harness_for_connect_to_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("state.json"), "backboard", "account");
+        store
+            .update(|s| {
+                s.machines.insert("agent".into(), "profile".into());
+            })
+            .await
+            .unwrap();
+        let result = track_bootstrap(&store, "agent", "codex", async {
+            bail!("provisioning failed")
+        })
+        .await;
+        assert!(result.is_err());
+        let state = store.load().unwrap();
+        assert_eq!(state.machines["agent"], "profile");
+        // The same persisted value the existing-profile Connect path reads.
+        let harness = &state.bootstrap_pending["agent"];
+        assert_eq!(harness, "codex");
+        track_bootstrap(&store, "agent", harness, async { Ok(()) })
+            .await
+            .unwrap();
+        assert!(store.load().unwrap().bootstrap_pending.is_empty());
+    }
+
     #[test]
     fn outcome_reads_markers() {
         assert!(matches!(outcome("HERDR-MISSING\n"), Outcome::HerdrMissing));
@@ -425,6 +479,15 @@ mod tests {
                 vm.install_herdr(&format!(
                     "#!/bin/bash\necho \"$*\" >> \"$HOME/herdr.log\"\nif [ \"$1 $2\" = \"workspace list\" ]; then cat <<'EOF'\n{workspaces}\nEOF\nfi\nif [ \"$1 $2\" = \"workspace create\" ]; then echo '{{\"result\":{{\"root_pane\":{{\"pane_id\":\"w9:p1\"}}}}}}'; fi\n"
                 ));
+                // Never discover or upgrade the host's real Railway CLI. The
+                // script prepends this directory to PATH just as it does on a VM.
+                for tool in ["railway", "curl"] {
+                    use std::os::unix::fs::PermissionsExt;
+                    let path = vm.home.path().join(".local/bin").join(tool);
+                    std::fs::write(&path, "#!/bin/sh\nexit 127\n").unwrap();
+                    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                        .unwrap();
+                }
                 vm
             }
 
@@ -631,14 +694,14 @@ mod tests {
         }
 
         #[test]
-        fn no_server_skips_the_workspace() {
+        fn no_server_reports_incomplete_bootstrap() {
             let vm = Vm::new("");
             vm.install_herdr(
                 "#!/bin/bash\necho \"$*\" >> \"$HOME/herdr.log\"\n[ \"$1\" = workspace ] && exit 1\nexit 0\n",
             );
             let out = vm.run();
-            assert!(out.contains("workspace app: skipped"), "{out}");
-            assert!(out.trim_end().ends_with("BOOTSTRAP-OK"), "{out}");
+            assert!(out.contains("workspace app: FAILED"), "{out}");
+            assert!(out.trim_end().ends_with("BOOTSTRAP-FAILED"), "{out}");
         }
 
         #[test]

--- a/src/commands/cloud_agent/herdr/new.rs
+++ b/src/commands/cloud_agent/herdr/new.rs
@@ -15,7 +15,7 @@ use crate::util::progress::create_spinner;
 use crate::workspace::{self, Workspace};
 
 use super::herdr_cli::{Herdr, Machine};
-use super::state::State;
+use super::state::Store;
 use super::target;
 
 #[derive(Parser)]
@@ -65,6 +65,7 @@ pub async fn command(args: Args) -> Result<()> {
 
     let mut configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
+    let store = Store::new(&configs)?;
     let workspaces = workspace::workspaces_with_client(&client, &configs).await?;
     let rows = rows(&workspaces);
     let row = pick_project(rows, args.project.as_deref(), args.environment.as_deref())?;
@@ -130,9 +131,11 @@ pub async fn command(args: Args) -> Result<()> {
         .map(|machines| profile_id_for(&machines, &target))
     {
         Ok(Some(profile)) => {
-            let mut state = State::load()?;
-            state.machines.insert(agent.id.clone(), profile);
-            state.save()?;
+            store
+                .update(|s| {
+                    s.machines.insert(agent.id.clone(), profile);
+                })
+                .await?;
         }
         Ok(None) => {
             warn("herdr did not list the new machine; `railway ca herdr sync` will record it")
@@ -140,18 +143,13 @@ pub async fn command(args: Args) -> Result<()> {
         Err(e) => warn(&format!("could not read herdr machines: {e:#}")),
     }
 
-    if let Err(e) = super::bootstrap::run(&agent, harness).await {
-        warn(&format!(
-            "bootstrap skipped: {e:#}\n  run `railway ca herdr bootstrap {} --{harness}` to retry",
-            agent.name
-        ));
-    }
+    super::bootstrap::run(&agent, harness, &store).await?;
 
     println!(
-        "\n{} is in the herdr sidebar as {}. Open a pane there and run {}.",
+        "\n{} is in the herdr sidebar as {}, provisioned for {}.",
         agent.name.cyan(),
         label.cyan(),
-        "claude".cyan()
+        harness.cyan()
     );
     Ok(())
 }

--- a/src/commands/cloud_agent/herdr/relay.rs
+++ b/src/commands/cloud_agent/herdr/relay.rs
@@ -4,12 +4,15 @@
 //! retries on its own. So a machine is only handed to herdr once a real
 //! command has round-tripped.
 
+use std::path::Path;
 use std::time::{Duration, Instant};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 use crate::commands::code;
+use crate::commands::ssh::config as ssh_config;
 use crate::commands::ssh::native::run_native_ssh_captured;
+use crate::config::Configs;
 use crate::controllers::cloud_agent as ca;
 
 const TIMEOUT: Duration = Duration::from_secs(150);
@@ -17,6 +20,11 @@ const PAUSE: Duration = Duration::from_secs(3);
 
 pub async fn wait_until_ready(agent: &ca::Agent) -> Result<()> {
     let info = code::connect_info(&agent.environment_id, &agent.id).await?;
+    // Herdr persists only the URI and invokes OpenSSH itself. Carry over the
+    // identity used by this probe so its later connections use the same key.
+    let config = ssh_config::expand_tilde(Path::new("~/.ssh/config"))?;
+    let (host, _) = Configs::get_ssh_relay();
+    ensure_identity(&config, host, &info.ssh_target, info.identity.as_deref()).await?;
     let nonce = format!("herdr-ready-{}", rand::random::<u32>());
     let started = Instant::now();
     loop {
@@ -42,5 +50,101 @@ pub async fn wait_until_ready(agent: &ca::Agent) -> Result<()> {
             );
         }
         tokio::time::sleep(PAUSE).await;
+    }
+}
+
+async fn ensure_identity(
+    config: &Path,
+    host: &str,
+    user: &str,
+    identity: Option<&Path>,
+) -> Result<()> {
+    let marker = format!("herdr-{host}-{user}");
+    let _lock = super::state::lock_file(&config.with_extension("herdr.lock")).await?;
+    let Some(identity) = identity else {
+        ssh_config::remove_marked_block(config, &marker)?;
+        return Ok(());
+    };
+    // Match arguments are patterns. Relay hostnames and agent usernames must
+    // remain literal rather than broadening the rule to other SSH connections.
+    for value in [host, user] {
+        if value.is_empty()
+            || value
+                .chars()
+                .any(|c| c.is_whitespace() || matches!(c, '*' | '?' | '!' | ',' | '"' | '\\'))
+        {
+            bail!("Cannot write an SSH identity rule for {value:?}");
+        }
+    }
+    let identity =
+        ssh_config::quote_ssh_config_value(&identity.to_string_lossy().replace('%', "%%"));
+    let block = format!(
+        "# BEGIN railway:{marker}\n\
+         Match host {host} user {user}\n\
+             IdentityFile {identity}\n\
+             IdentitiesOnly yes\n\
+         Host *\n\
+         # END railway:{marker}\n"
+    );
+    ssh_config::upsert_marked_block(config, &marker, &block)
+        .with_context(|| format!("Configuring Herdr's SSH identity in {}", config.display()))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn raw_herdr_uri_uses_the_selected_key_only_for_that_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = dir.path().join("config");
+        let key = dir.path().join("custom key");
+        std::fs::write(&config, "Host workbox\n    IdentityFile /work/key\n").unwrap();
+        ensure_identity(&config, "relay.example", "agent:env:a1", Some(&key))
+            .await
+            .unwrap();
+        // An update replaces the rule rather than accumulating identity keys.
+        let selected = dir.path().join("selected key");
+        ensure_identity(&config, "relay.example", "agent:env:a1", Some(&selected))
+            .await
+            .unwrap();
+        let resolved = |target| {
+            let out = std::process::Command::new("ssh")
+                .arg("-G")
+                .arg("-F")
+                .arg(&config)
+                .arg(target)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "{}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            String::from_utf8(out.stdout).unwrap()
+        };
+        let output = resolved("ssh://agent%3Aenv%3Aa1@relay.example:2222");
+        assert!(output.contains("user agent:env:a1\n"), "{output}");
+        assert!(
+            output.contains(&format!("identityfile {}\n", selected.display())),
+            "{output}"
+        );
+        assert!(output.contains("identitiesonly yes\n"), "{output}");
+        assert!(!output.contains(&key.to_string_lossy().to_string()));
+        for target in [
+            "ssh://agent%3Aenv%3Aa2@relay.example",
+            "ssh://agent%3Aenv%3Aa1@other.example",
+            "workbox",
+        ] {
+            assert!(!resolved(target).contains(&selected.to_string_lossy().to_string()));
+        }
+        assert!(resolved("workbox").contains("identityfile /work/key\n"));
+        ensure_identity(&config, "relay.example", "agent:env:a1", None)
+            .await
+            .unwrap();
+        assert!(
+            !resolved("ssh://agent%3Aenv%3Aa1@relay.example")
+                .contains(&selected.to_string_lossy().to_string())
+        );
     }
 }

--- a/src/commands/cloud_agent/herdr/state.rs
+++ b/src/commands/cloud_agent/herdr/state.rs
@@ -1,14 +1,25 @@
-//! `state.json` in the plugin dir: which herdr profile belongs to which agent.
-//! A cache only; `sync` rebuilds it from `railway ca list` and `herdr machine list`.
+//! Plugin bookkeeping: cached profile matches, acknowledged transitions and
+//! incomplete bootstrap steps. Inventory comes from Railway and Herdr on sync.
 
 use std::collections::BTreeMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::Configs;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct State {
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    revision: u64,
     /// agent id → herdr profile id
     #[serde(default)]
     pub machines: BTreeMap<String, String>,
@@ -22,18 +33,21 @@ pub struct State {
     /// noticed and its machine reconnected.
     #[serde(default)]
     pub agent_status: BTreeMap<String, String>,
+    /// An acknowledged sleep must not be undone by a lagging RUNNING read.
+    /// Cleared on a sleeping observation, an explicit wake, or the bounded
+    /// transition deadline (a wake elsewhere may have overtaken the sleep).
+    #[serde(default)]
+    pub sleep_until: BTreeMap<String, DateTime<Utc>>,
+    /// A saved machine is not proof that its Railway bootstrap completed.
+    #[serde(default)]
+    pub bootstrap_pending: BTreeMap<String, String>,
 }
 
 impl State {
-    /// One file per herdr session: machine profiles and toggles belong to the
-    /// client that owns them, and a named test session must not overwrite
-    /// the default session's memory.
+    /// One file per watcher session, so a named session's sync observations
+    /// do not overwrite the default session's memory.
     pub fn path() -> Result<PathBuf> {
         Ok(super::plugin_dir()?.join(file_name(std::env::var_os("HERDR_SOCKET_PATH").as_deref())))
-    }
-
-    pub fn load() -> Result<Self> {
-        Self::load_from(&Self::path()?)
     }
 
     pub fn load_from(path: &Path) -> Result<Self> {
@@ -45,16 +59,126 @@ impl State {
         }
     }
 
-    pub fn save(&self) -> Result<()> {
-        self.save_to(&Self::path()?)
-    }
-
     pub fn save_to(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(path, serde_json::to_string_pretty(self)?)
+        crate::util::write_atomic(path, &serde_json::to_string_pretty(self)?)
             .with_context(|| format!("Writing {}", path.display()))
+    }
+
+    fn bind_scope(&mut self, scope: &str) {
+        if self.scope.as_deref() != Some(scope) {
+            *self = Self {
+                scope: Some(scope.to_owned()),
+                revision: self.revision,
+                ..Default::default()
+            };
+        }
+    }
+
+    pub fn same_revision(&self, other: &Self) -> bool {
+        self.scope == other.scope && self.revision == other.revision
+    }
+
+    pub fn sleep_pending(&self, id: &str, now: DateTime<Utc>) -> bool {
+        self.sleep_until.get(id).is_some_and(|until| *until > now)
+    }
+}
+
+/// Capture the same account/backend as the request client, including token
+/// overrides. Raw credentials never go into the state file. A token rotation
+/// without a stable user ID conservatively discards the old pruning evidence.
+#[derive(Clone)]
+pub(super) struct Store {
+    pub path: PathBuf,
+    scope: String,
+}
+
+impl Store {
+    pub fn new(configs: &Configs) -> Result<Self> {
+        let principal = if let Some(token) = Configs::get_railway_token() {
+            format!("project:{token}")
+        } else if let Some(token) = Configs::get_railway_api_token() {
+            format!("api:{token}")
+        } else if let Some(id) = &configs.root_config.user.id {
+            format!("user:{id}")
+        } else {
+            format!(
+                "session:{}",
+                configs.get_railway_auth_token().unwrap_or_default()
+            )
+        };
+        Ok(Self::at(
+            State::path()?,
+            &configs.get_backboard(),
+            &principal,
+        ))
+    }
+
+    pub(super) fn at(path: PathBuf, backboard: &str, principal: &str) -> Self {
+        let encoded = serde_json::to_vec(&(backboard, principal)).expect("strings serialize");
+        Self {
+            path,
+            scope: format!("{:x}", Sha256::digest(encoded)),
+        }
+    }
+
+    pub fn load(&self) -> Result<State> {
+        let mut state = State::load_from(&self.path)?;
+        state.bind_scope(&self.scope);
+        Ok(state)
+    }
+
+    pub async fn lock(&self) -> Result<LockedState> {
+        let file = lock_file(&self.path.with_extension("lock")).await?;
+        Ok(LockedState {
+            state: self.load()?,
+            path: self.path.clone(),
+            _file: file,
+        })
+    }
+
+    pub async fn update(&self, change: impl FnOnce(&mut State)) -> Result<()> {
+        let mut locked = self.lock().await?;
+        change(&mut locked.state);
+        locked.save()
+    }
+}
+
+pub(super) struct LockedState {
+    pub state: State,
+    path: PathBuf,
+    _file: File,
+}
+
+impl LockedState {
+    pub fn save(&mut self) -> Result<()> {
+        self.state.revision = self.state.revision.wrapping_add(1);
+        self.state.save_to(&self.path)
+    }
+}
+
+/// A sibling lock survives atomic replacement of the state file. Waiting is
+/// asynchronous, and closing the file releases the lock on every error path.
+pub(super) async fn lock_file(path: &Path) -> Result<File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = File::options()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)?;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(file),
+            Err(e) if e.kind() == fs2::lock_contended_error().kind() => {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+            Err(e) => return Err(e).context("Locking herdr state"),
+        }
     }
 }
 
@@ -97,5 +221,54 @@ mod tests {
         s.machines.insert("agent-1".into(), "profile-1".into());
         s.save_to(&path).unwrap();
         assert_eq!(State::load_from(&path).unwrap(), s);
+    }
+
+    #[tokio::test]
+    async fn account_and_backend_changes_discard_pruning_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let a = Store::at(path.clone(), "https://production", "account-a");
+        a.update(|s| {
+            s.machines.insert("agent-a".into(), "profile-a".into());
+        })
+        .await
+        .unwrap();
+        assert_eq!(a.load().unwrap().machines.len(), 1);
+        for (host, account) in [
+            ("https://production", "account-b"),
+            ("https://staging", "account-a"),
+        ] {
+            let other = Store::at(path.clone(), host, account);
+            assert!(other.load().unwrap().machines.is_empty());
+        }
+        assert!(!std::fs::read_to_string(path).unwrap().contains("account-a"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_updates_preserve_each_registration_and_invalidate_old_plans() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Store::at(dir.path().join("state.json"), "backboard", "account");
+        let before = store.load().unwrap();
+        let start = std::sync::Arc::new(tokio::sync::Barrier::new(20));
+        let writes = (0..20).map(|n| {
+            let store = store.clone();
+            let start = start.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                store
+                    .update(|s| {
+                        s.machines
+                            .insert(format!("agent-{n}"), format!("profile-{n}"));
+                    })
+                    .await
+                    .unwrap();
+            })
+        });
+        for result in futures::future::join_all(writes).await {
+            result.unwrap();
+        }
+        let after = store.load().unwrap();
+        assert_eq!(after.machines.len(), 20);
+        assert!(!after.same_revision(&before));
     }
 }

--- a/src/commands/cloud_agent/herdr/sync.rs
+++ b/src/commands/cloud_agent/herdr/sync.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use colored::Colorize;
 
 use super::herdr_cli::{Herdr, Machine};
-use super::state::State;
+use super::state::{State, Store};
 use super::target;
 use crate::client::GQLClient;
 use crate::config::Configs;
@@ -101,7 +101,7 @@ impl Op {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(super) struct Plan {
     pub ops: Vec<Op>,
     /// agent id → herdr profile id, for every agent that has a machine
@@ -121,10 +121,8 @@ pub(super) fn machine_for<'a>(agent: &ca::Agent, machines: &'a [Machine]) -> Opt
     machines.iter().find(|m| is_machine_for(agent, m))
 }
 
-/// `known` is agent id → profile id from the last sync: only machines this
-/// plugin has seen attached to an agent are ever removed, so a login to another
-/// account, a different `RAILWAY_ENV`, or a machine pointed at a teammate's
-/// agent cannot wipe the catalog.
+/// `known` is agent id → profile id from a previous sync in the SAME account
+/// and backend. Store discards this evidence on a scope change.
 pub(super) fn reconcile(
     agents: &[ca::Agent],
     machines: &[Machine],
@@ -168,25 +166,42 @@ pub(super) fn reconcile(
     plan
 }
 
+fn plan_for(agents: &[ca::Agent], machines: &[Machine], state: &State) -> Plan {
+    let mut plan = reconcile(agents, machines, &state.agent_status, &state.machines);
+    plan.ops.retain(|op| {
+        !matches!(op, Op::Enable(_) | Op::Kick(_))
+            || !op
+                .profile_id()
+                .and_then(|id| plan.agents.get(id))
+                .is_some_and(|agent| state.sleep_pending(&agent.id, Utc::now()))
+    });
+    for agent in agents
+        .iter()
+        .filter(|a| state.sleep_pending(&a.id, Utc::now()))
+    {
+        if let Some(machine) = machine_for(agent, machines)
+            && machine.enabled
+            && !plan
+                .ops
+                .iter()
+                .any(|op| matches!(op, Op::Disable(id) if id == &machine.id))
+        {
+            plan.ops.push(Op::Disable(machine.id.clone()));
+        }
+    }
+    plan
+}
+
 #[derive(Debug, Default)]
 pub(super) struct Outcome {
     pub applied: Vec<Op>,
     pub failed: Vec<(Op, String)>,
 }
 
-/// `wait` holds Enable and Kick until the agent's ssh relay executes commands;
-/// enabling earlier is exactly what parks herdr in Attention.
-pub(super) async fn apply(herdr: &Herdr, plan: &Plan, wait: bool) -> Outcome {
+/// Apply only after relay readiness and the state revision have been checked.
+fn apply(herdr: &Herdr, ops: &[Op]) -> Outcome {
     let mut outcome = Outcome::default();
-    for op in &plan.ops {
-        if wait
-            && matches!(op, Op::Enable(_) | Op::Kick(_))
-            && let Some(agent) = op.profile_id().and_then(|id| plan.agents.get(id))
-            && let Err(e) = super::relay::wait_until_ready(agent).await
-        {
-            outcome.failed.push((op.clone(), format!("{e:#}")));
-            continue;
-        }
+    for op in ops {
         let result = match op {
             Op::Remove(id) => herdr.machine_remove(id),
             Op::Disable(id) => herdr.machine_disable(id),
@@ -208,34 +223,24 @@ pub async fn command(args: Args) -> Result<()> {
     if args.spawn_watch {
         super::watch::spawn_detached();
     }
-    if let Some(secs) = args.debounce
-        && let Ok(state) = State::load()
-        && synced_within(&state, secs, Utc::now())
-    {
-        return Ok(());
-    }
-    super::watch::nudge();
     let configs = Configs::new()?;
     let client = GQLClient::new_authorized(&configs)?;
     let backboard = configs.get_backboard();
     let herdr = Herdr::from_env();
-
-    let agents = ca::list_mine(&client, &backboard).await?;
-    let machines = herdr.machines()?;
-    let mut state = State::load().unwrap_or_default();
-    let plan = reconcile(&agents, &machines, &state.agent_status, &state.machines);
-
-    let outcome = if args.dry_run {
-        Outcome::default()
-    } else {
-        // Claim the window before the relay waits, so debounced hook runs
-        // started meanwhile back off instead of stacking up.
-        state.last_sync = Some(Utc::now().to_rfc3339());
-        state.save()?;
-        let outcome = apply(&herdr, &plan, true).await;
-        remember(&mut state, &plan, &outcome)?;
-        outcome
+    let store = Store::new(&configs)?;
+    let Some(report) = run_sync(&client, &backboard, &herdr, &store, &args, relay_ready).await?
+    else {
+        return Ok(());
     };
+    if !args.dry_run {
+        super::watch::nudge();
+    }
+    let Report {
+        agents,
+        machines,
+        plan,
+        outcome,
+    } = report;
 
     if args.json {
         println!(
@@ -364,15 +369,20 @@ pub(super) async fn resync(
     client: &reqwest::Client,
     backboard: &str,
     herdr: &Herdr,
+    store: &Store,
 ) -> Result<Vec<String>> {
-    let agents = ca::list_mine(client, backboard).await?;
-    let machines = herdr.machines()?;
-    let mut state = State::load().unwrap_or_default();
-    let plan = reconcile(&agents, &machines, &state.agent_status, &state.machines);
-    state.last_sync = Some(Utc::now().to_rfc3339());
-    state.save()?;
-    let outcome = apply(herdr, &plan, true).await;
-    remember(&mut state, &plan, &outcome)?;
+    let args = Args {
+        dry_run: false,
+        json: false,
+        debounce: None,
+        spawn_watch: false,
+    };
+    let report = run_sync(client, backboard, herdr, store, &args, relay_ready)
+        .await?
+        .expect("an undebounced sync always runs");
+    let Report {
+        machines, outcome, ..
+    } = report;
     if let Some((op, err)) = outcome.failed.first() {
         bail!("{} failed: {err}", op.describe(&machines));
     }
@@ -381,6 +391,92 @@ pub(super) async fn resync(
         .iter()
         .map(|op| op.describe(&machines))
         .collect())
+}
+
+struct Report {
+    agents: Vec<ca::Agent>,
+    machines: Vec<Machine>,
+    plan: Plan,
+    outcome: Outcome,
+}
+
+async fn relay_ready(agent: ca::Agent) -> Result<()> {
+    super::relay::wait_until_ready(&agent).await
+}
+
+/// One sync at a time, but never hold the state lock during a relay wait:
+/// sleep/wake and registration can proceed while a machine is unresponsive.
+/// Their writes advance the revision, so a waiting sync must refetch before
+/// applying its old plan. Both CLI and watcher take this same path.
+async fn run_sync<F, Fut>(
+    client: &reqwest::Client,
+    backboard: &str,
+    herdr: &Herdr,
+    store: &Store,
+    args: &Args,
+    mut ready: F,
+) -> Result<Option<Report>>
+where
+    F: FnMut(ca::Agent) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let _sync = super::state::lock_file(&store.path.with_extension("sync.lock")).await?;
+    let mut applied = Vec::new();
+    'retry: for _ in 0..3 {
+        let baseline = store.load()?;
+        if args
+            .debounce
+            .is_some_and(|secs| synced_within(&baseline, secs, Utc::now()))
+        {
+            return Ok(None);
+        }
+        let agents = ca::list_mine(client, backboard).await?;
+        let machines = herdr.machines()?;
+        let plan = plan_for(&agents, &machines, &baseline);
+        if args.dry_run {
+            return Ok(Some(Report {
+                agents,
+                machines,
+                plan,
+                outcome: Outcome::default(),
+            }));
+        }
+
+        let mut outcome = Outcome::default();
+        for op in &plan.ops {
+            if matches!(op, Op::Enable(_) | Op::Kick(_))
+                && let Some(agent) = op.profile_id().and_then(|id| plan.agents.get(id))
+                && let Err(e) = ready(agent.clone()).await
+            {
+                outcome.failed.push((op.clone(), format!("{e:#}")));
+                continue;
+            }
+            let locked = store.lock().await?;
+            if !locked.state.same_revision(&baseline) {
+                continue 'retry;
+            }
+            // Apply in plan order without delaying earlier disables behind
+            // later relay probes. Keep the lock only for the catalog edit.
+            let change = apply(herdr, std::slice::from_ref(op));
+            applied.extend(change.applied);
+            outcome.failed.extend(change.failed);
+        }
+
+        let mut locked = store.lock().await?;
+        if !locked.state.same_revision(&baseline) {
+            continue;
+        }
+        outcome.applied = applied;
+        remember(&mut locked.state, &plan, &outcome);
+        locked.save()?;
+        return Ok(Some(Report {
+            agents,
+            machines,
+            plan,
+            outcome,
+        }));
+    }
+    bail!("Agent actions changed while syncing; retry `railway ca herdr sync`.")
 }
 
 /// `Some(true)` when a toast is due, `Some(false)` for a quiet hook run,
@@ -400,7 +496,7 @@ fn plain(s: &str) -> String {
 
 /// A failed Enable or Kick keeps the agent's previous status, so the next run
 /// plans it again instead of believing the machine already followed.
-fn remember(state: &mut State, plan: &Plan, outcome: &Outcome) -> Result<()> {
+fn remember(state: &mut State, plan: &Plan, outcome: &Outcome) {
     let mut statuses = plan.statuses.clone();
     for (op, _) in &outcome.failed {
         if let Some(agent) = op.profile_id().and_then(|id| plan.agents.get(id)) {
@@ -412,8 +508,10 @@ fn remember(state: &mut State, plan: &Plan, outcome: &Outcome) -> Result<()> {
     }
     state.machines = plan.matches.clone();
     state.agent_status = statuses;
+    state.sleep_until.retain(|id, until| {
+        *until > Utc::now() && plan.statuses.get(id).is_none_or(|s| s != "sleeping")
+    });
     state.last_sync = Some(Utc::now().to_rfc3339());
-    state.save()
 }
 
 pub(super) fn synced_within(state: &State, secs: u64, now: chrono::DateTime<Utc>) -> bool {
@@ -692,7 +790,7 @@ mod tests {
         // Never recorded by a previous sync: someone else's agent, or a hand-added machine.
         let plan = reconcile(
             &[agent("a1", Status::Running)],
-            &[orphan.clone()],
+            std::slice::from_ref(&orphan),
             &BTreeMap::new(),
             &BTreeMap::new(),
         );
@@ -700,7 +798,7 @@ mod tests {
         // Recorded before, but the agent list came back empty (wrong account, API blip).
         let mut known = BTreeMap::new();
         known.insert("nobody".to_string(), "p9".to_string());
-        let plan = reconcile(&[], &[orphan.clone()], &BTreeMap::new(), &known);
+        let plan = reconcile(&[], std::slice::from_ref(&orphan), &BTreeMap::new(), &known);
         assert_eq!(removals(&plan), 0, "{:?}", plan.ops);
         // Recorded before and the account still has agents: the agent is really gone.
         let plan = reconcile(
@@ -726,22 +824,11 @@ mod tests {
         };
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("state.json");
-        let mut state = State {
-            agent_status: previous.clone(),
-            ..Default::default()
-        };
-        // remember() saves to State::path(); exercise the status logic via a copy.
-        let _ = &path;
-        let before = state.agent_status.clone();
-        let mut statuses = plan.statuses.clone();
-        for (op, _) in &outcome.failed {
-            if let Some(agent) = op.profile_id().and_then(|id| plan.agents.get(id)) {
-                if let Some(old) = before.get(&agent.id) {
-                    statuses.insert(agent.id.clone(), old.clone());
-                }
-            }
-        }
-        state.agent_status = statuses;
+        let mut state = State::default();
+        state.agent_status = previous.clone();
+        remember(&mut state, &plan, &outcome);
+        state.save_to(&path).unwrap();
+        let state = State::load_from(&path).unwrap();
         assert_eq!(
             state.agent_status.get("a1").map(String::as_str),
             Some("sleeping")
@@ -783,7 +870,7 @@ mod tests {
             &BTreeMap::new(),
             &known(&agents, &machines),
         );
-        let outcome = apply(&herdr, &plan, false).await;
+        let outcome = apply(&herdr, &plan.ops);
         assert!(outcome.failed.is_empty(), "{:?}", outcome.failed);
         assert_eq!(outcome.applied.len(), 3);
         assert_eq!(
@@ -807,7 +894,7 @@ mod tests {
             ops: vec![Op::Disable("p1".into()), Op::Remove("p2".into())],
             ..Default::default()
         };
-        let outcome = apply(&herdr, &plan, false).await;
+        let outcome = apply(&herdr, &plan.ops);
         assert!(outcome.applied.is_empty());
         assert_eq!(outcome.failed.len(), 2);
         assert!(matches!(outcome.failed[0].0, Op::Disable(_)));
@@ -840,5 +927,123 @@ mod tests {
         assert!(!synced_within(&state, 30, now));
         state.last_sync = Some("not a date".into());
         assert!(!synced_within(&state, 30, now));
+    }
+
+    #[test]
+    fn pending_sleep_overrides_lagging_running_inventory() {
+        let agents = [agent("a1", Status::Running)];
+        let mut state = State::default();
+        state
+            .sleep_until
+            .insert("a1".into(), Utc::now() + chrono::Duration::seconds(60));
+        assert!(
+            plan_for(&agents, &[ours("p1", "a1", false)], &state)
+                .ops
+                .is_empty()
+        );
+        assert_eq!(
+            ops_of(&plan_for(&agents, &[ours("p1", "a1", true)], &state)),
+            ["disable p1"]
+        );
+        let asleep = plan_for(
+            &[agent("a1", Status::Sleeping)],
+            &[ours("p1", "a1", false)],
+            &state,
+        );
+        remember(&mut state, &asleep, &Outcome::default());
+        assert!(state.sleep_until.is_empty());
+        assert_eq!(
+            ops_of(&plan_for(&agents, &[ours("p1", "a1", false)], &state)),
+            ["enable p1"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn account_switch_does_not_remove_the_previous_accounts_profiles() {
+        let dir = tempfile::tempdir().unwrap();
+        let api = crate::testkit::MockBackboard::spawn();
+        let path = dir.path().join("state.json");
+        let old = Store::at(path.clone(), &api.url(), "account-a");
+        old.update(|s| {
+            s.machines.insert("a1".into(), "p1".into());
+        })
+        .await
+        .unwrap();
+        let new = Store::at(path, &api.url(), "account-b");
+        api.stub(
+            "MyCloudAgents",
+            serde_json::json!({"myCloudAgents": [{
+                "id": "a2", "name": "other-account", "status": "RUNNING",
+                "projectId": "p", "environmentId": "e", "createdAt": Utc::now(),
+            }]}),
+        );
+        let fake = super::super::herdr_cli::fake::FakeHerdr::with_machines(&format!(
+            r#"[{{"id":"p1","label":"first","target":"{}","enabled":true}}]"#,
+            target::target_for("env", "a1")
+        ));
+        resync(&reqwest::Client::new(), &api.url(), &fake.herdr(), &new)
+            .await
+            .unwrap();
+        assert_eq!(fake.calls(), ["machine list --json"]);
+        assert!(!new.load().unwrap().machines.contains_key("a1"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sleep_during_relay_wait_invalidates_the_enable_plan_without_blocking_sleep() {
+        let dir = tempfile::tempdir().unwrap();
+        let api = crate::testkit::MockBackboard::spawn();
+        let store = Store::at(dir.path().join("state.json"), &api.url(), "account");
+        api.stub(
+            "MyCloudAgents",
+            serde_json::json!({"myCloudAgents": [{
+                "id": "a1", "name": "first", "status": "RUNNING",
+                "projectId": "p", "environmentId": "env", "createdAt": Utc::now(),
+            }]}),
+        );
+        let fake = super::super::herdr_cli::fake::FakeHerdr::with_machines(&format!(
+            r#"[{{"id":"p1","label":"first","target":"{}","enabled":false}}]"#,
+            target::target_for("env", "a1")
+        ));
+        let args = Args {
+            dry_run: false,
+            json: false,
+            debounce: None,
+            spawn_watch: false,
+        };
+        let report = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            run_sync(
+                &reqwest::Client::new(),
+                &api.url(),
+                &fake.herdr(),
+                &store,
+                &args,
+                |_| async {
+                    // Represents a successful sleep acknowledgement while SSH is
+                    // being probed. This would deadlock if sync held the state lock.
+                    store
+                        .update(|s| {
+                            s.sleep_until
+                                .insert("a1".into(), Utc::now() + chrono::Duration::seconds(60));
+                        })
+                        .await?;
+                    Ok(())
+                },
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+        assert!(report.outcome.applied.is_empty());
+        assert_eq!(fake.calls(), ["machine list --json", "machine list --json"]);
+        assert_eq!(
+            api.requests().len(),
+            2,
+            "the old observation must be refetched"
+        );
+        assert!(store.load().unwrap().sleep_pending("a1", Utc::now()));
     }
 }

--- a/src/commands/cloud_agent/herdr/watch.rs
+++ b/src/commands/cloud_agent/herdr/watch.rs
@@ -3,8 +3,8 @@
 //! reconnect can park it in Attention, and a wake re-enables it once the
 //! relay answers. The signal is backboard's `cloudAgentInvalidation`
 //! subscription, one per environment holding one of the user's agents, on the
-//! unpublished internal graph the web and mobile apps use. No polling: a
-//! refused subscription is retried with backoff and said so. One watcher per
+//! unpublished internal graph the web and mobile apps use. Reconnects refetch,
+//! and a periodic sweep covers missed events or an unavailable subscription. One watcher per
 //! herdr session, started by `install` and the plugin's startup hook, told to
 //! re-list environments by SIGUSR1 (`nudge`), gone when the session's socket is.
 
@@ -23,7 +23,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 
 use super::herdr_cli::Herdr;
-use super::state::State;
+use super::state::{State, Store};
 use super::sync;
 use crate::client::GQLClient;
 use crate::config::Configs;
@@ -107,6 +107,7 @@ async fn run(socket: &Path, verbose: bool) -> Result<()> {
     let mut tasks: JoinSet<()> = JoinSet::new();
     let mut watched: BTreeSet<String> = BTreeSet::new();
     let mut liveness = tokio::time::interval(LIVENESS);
+    liveness.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut nudged = nudge_signal()?;
     let mut relist = true;
 
@@ -132,9 +133,10 @@ async fn run(socket: &Path, verbose: bool) -> Result<()> {
                     say(true, "herdr session gone; exiting");
                     return Ok(());
                 }
-                if watched.is_empty() {
-                    relist = true;
-                }
+                // Also discovers agents created in a previously empty
+                // environment, even when no local pane produces hook events.
+                relist = true;
+                resync(verbose, "periodic reconciliation").await;
             }
             _ = nudge_recv(&mut nudged) => {
                 say(verbose, "nudged: re-listing environments");
@@ -160,12 +162,27 @@ async fn watched_environments() -> Result<BTreeSet<String>> {
 }
 
 async fn subscribe(environment_id: String, tx: mpsc::Sender<Signal>, verbose: bool) {
+    subscribe_with(environment_id, tx, verbose, |environment_id| {
+        subscribe_graphql_internal::<CloudAgentInvalidation>(Variables { environment_id })
+    })
+    .await;
+}
+
+async fn subscribe_with<F, Fut, S>(
+    environment_id: String,
+    tx: mpsc::Sender<Signal>,
+    verbose: bool,
+    mut connect: F,
+) where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = Result<S>>,
+    S: futures::Stream<
+            Item = Result<graphql_client::Response<ResponseData>, graphql_ws_client::Error>,
+        > + Unpin,
+{
     let mut backoff = RESUBSCRIBE_MIN;
     loop {
-        let stream = subscribe_graphql_internal::<CloudAgentInvalidation>(Variables {
-            environment_id: environment_id.clone(),
-        })
-        .await;
+        let stream = connect(environment_id.clone()).await;
         let mut stream = match stream {
             Ok(s) => s,
             Err(e) => {
@@ -183,6 +200,15 @@ async fn subscribe(environment_id: String, tx: mpsc::Sender<Signal>, verbose: bo
         };
         backoff = RESUBSCRIBE_MIN;
         say(true, &format!("subscribed {environment_id}"));
+        if tx
+            .send(Signal::Changed(format!(
+                "subscribed {environment_id}: refetching"
+            )))
+            .await
+            .is_err()
+        {
+            return;
+        }
         while let Some(item) = stream.next().await {
             let what = match item {
                 Ok(response) => match response.data {
@@ -213,7 +239,14 @@ async fn resync(verbose: bool, cause: &str) {
     let run = async {
         let configs = Configs::new()?;
         let client = GQLClient::new_authorized(&configs)?;
-        sync::resync(&client, &configs.get_backboard(), &Herdr::from_env()).await
+        let store = Store::new(&configs)?;
+        sync::resync(
+            &client,
+            &configs.get_backboard(),
+            &Herdr::from_env(),
+            &store,
+        )
+        .await
     };
     match run.await {
         Ok(applied) if applied.is_empty() => say(verbose, "synced, nothing to change"),
@@ -378,6 +411,26 @@ pub fn spawn_detached() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn reconnect_refetches_even_when_no_invalidation_is_replayed() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let task = tokio::spawn(subscribe_with("env".into(), tx, false, |_| async {
+            // Each successful subscription closes without replaying any event.
+            Ok(futures::stream::empty())
+        }));
+        let result = tokio::time::timeout(RESUBSCRIBE_MIN + Duration::from_secs(2), async {
+            for _ in 0..2 {
+                let Some(Signal::Changed(cause)) = rx.recv().await else {
+                    panic!("watcher exited")
+                };
+                assert!(cause.contains("refetching"), "{cause}");
+            }
+        })
+        .await;
+        task.abort();
+        result.expect("both the initial subscription and reconnect must refetch");
+    }
 
     #[test]
     fn the_query_is_the_one_the_apps_send() {

--- a/src/commands/ssh/config.rs
+++ b/src/commands/ssh/config.rs
@@ -697,7 +697,7 @@ fn sanitize_alias(input: &str) -> String {
     }
 }
 
-fn quote_ssh_config_value(value: &str) -> String {
+pub(crate) fn quote_ssh_config_value(value: &str) -> String {
     if !value
         .chars()
         .any(|c| c.is_whitespace() || matches!(c, '"' | '\\'))


### PR DESCRIPTION
Closes recovery and setup gaps in #1176.

## Changes

- **Missed updates:** refresh after subscription reconnects and every 30 seconds, so missed events don't leave Herdr out of sync.
- **Stale state:** send wake/sleep requests to the server even when the picker thinks they're unnecessary. Discard sync plans overtaken by another action, and protect an acknowledged sleep from stale RUNNING responses for up to 60 seconds.
- **Account switching and overlapping commands:** scope saved state to the account and backend; lock updates and write atomically to prevent incorrect profile removal or lost updates.
- **SSH keys:** configure Herdr to use the same key Railway used to check the connection.
- **Incomplete setup:** show New when there are no agents, return bootstrap failures as errors, and let Connect retry setup with the selected harness.

## Validation

All **1,418 tests pass**, including regression coverage for stale wake decisions, account switching, concurrent writes, and sleep during an SSH wait. SSH key selection was checked with OpenSSH. Formatting and Clippy pass, with existing warnings.

## Still open

- Live create/sleep/wake and per-harness restoration need end-to-end testing.
- Automatic recovery from Herdr's Attention state needs upstream connection-status support.
- Locking covers one watcher session; cross-session coordination remains open.
- The watcher still uses the internal subscription API, with polling as a fallback.
