### PR TITLE
Fix custom database image on initial IaC apply

### DIFF
--- a/src/iac/change_set.rs
+++ b/src/iac/change_set.rs
@@ -120,6 +120,23 @@ pub fn diff_graphs(options: DiffOptions<'_>) -> ChangeSet {
                 "severity": "safe",
                 "deployEffect": if matches!(resource_type(resource), "service" | "database") { "deploy" } else { "none" },
             }));
+            // Database creation selects the current engine default before applying the
+            // rest of the resource. Reassert the authored source in the same change set
+            // so an explicitly pinned image is used by the first deployment instead of
+            // appearing as drift on the next plan.
+            if let ("database", Some(source)) =
+                (resource_type(resource), resource.get("source"))
+            {
+                changes.push(update(
+                    &address,
+                    "source",
+                    Value::Null,
+                    source.clone(),
+                    format!("Set {} source during creation", resource_name(resource)),
+                    None,
+                    "safe",
+                ));
+            }
             continue;
         }
         let previous = previous.unwrap();

--- a/src/iac/tests.rs
+++ b/src/iac/tests.rs
@@ -149,6 +149,27 @@ fn emits_change_set_wire_version() {
 }
 
 #[test]
+fn reasserts_a_custom_database_image_during_creation() {
+    let current = graph_from(vec![]);
+    let mut database = postgres("Postgres", Some("us-west2"));
+    let pinned_image = "ghcr.io/railwayapp-templates/postgres-ssl:17";
+    database["image"] = json!(pinned_image);
+    database["source"] = image(pinned_image);
+    let desired = graph_from(vec![database]);
+
+    let change_set = diff(&current, &desired);
+    let changes = &change_set.changes;
+
+    assert_eq!(
+        kinds(&change_set),
+        vec!["resource.create", "resource.update"]
+    );
+    assert_eq!(changes[1]["address"], "database.Postgres");
+    assert_eq!(changes[1]["field"], "source");
+    assert_eq!(changes[1]["after"], image(pinned_image));
+}
+
+#[test]
 fn numeric_replicas_are_count_only() {
     let graph = graph_from(vec![service(
         "web",


### PR DESCRIPTION
## Summary

- reassert a database's authored `source` in the same change set that creates it
- prevent a custom database image from being replaced by the current engine default on first apply
- add an offline regression test covering a PostgreSQL 17 image pin

Fixes railwayapp/railway-ts-sdk#81

## Why this is in the CLI

The TypeScript SDK already emits the requested image in both `database.image` and `database.source.image`. The observed divergence happens when the initial `resource.create` change is applied. Subsequent `resource.update` changes already reconcile the source correctly, so this patch makes that source update explicit during database creation.

## Testing

- `git diff --check`
- `cargo test iac::tests::reasserts_a_custom_database_image_during_creation` (Rust 1.90 container; 1 passed)

## Integration validation

Please validate against the server-side change-set executor that a `resource.update` for the newly created database address is ordered after `resource.create` and that the first deployment starts with the authored image.

Maintainer note: external contributors cannot apply repository labels; please add `release/patch` for the required label check.
