### PR TITLE
fix(code): restore Codex scrolling and hyperlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4061,6 +4061,7 @@ dependencies = [
  "indoc",
  "inquire",
  "is-terminal",
+ "itoa",
  "json_dotpath",
  "nix 0.30.1",
  "notify",
@@ -4101,8 +4102,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "unicode-width 0.2.2",
  "url",
- "vt100",
+ "vte",
  "which",
  "winapi",
  "zip",
@@ -6137,17 +6139,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vt100"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ff75fb8fa83e609e685106df4faeffdf3a735d3c74ebce97ec557d5d36fd9"
-dependencies = [
- "itoa",
- "unicode-width 0.2.2",
- "vte",
-]
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,9 @@ russh = { version = "0.60.2", default-features = false, features = [
 tempfile = "3.23.0"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 portable-pty = "0.8"
-vt100 = "0.16"
+itoa = "1.0.15"
+unicode-width = "0.2.1"
+vte = "0.15.0"
 terminal-colorsaurus = "1.0.3"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/commands/cloud_agent/client_sessions.rs
+++ b/src/commands/cloud_agent/client_sessions.rs
@@ -84,17 +84,16 @@ impl Connection {
     }
 
     pub(crate) fn args(&self, thread: Option<&str>) -> Vec<String> {
-        let mut args = match self {
-            Self::Codex(c) => codex::attach_args(c),
-            Self::OpenCode(c, beta) => opencode::attach_args(c, *beta),
-        };
-        if let Some(thread) = thread {
-            match self {
-                Self::Codex(_) => args.extend(["resume".into(), thread.into()]),
-                Self::OpenCode(_, _) => args.extend(["--session".into(), thread.into()]),
+        match self {
+            Self::Codex(c) => codex::attach_args(c, thread),
+            Self::OpenCode(c, beta) => {
+                let mut args = opencode::attach_args(c, *beta);
+                if let Some(thread) = thread {
+                    args.extend(["--session".into(), thread.into()]);
+                }
+                args
             }
         }
-        args
     }
 
     pub(crate) async fn list(&self) -> Result<Vec<Thread>> {
@@ -455,6 +454,60 @@ mod tests {
         }
     }
     use super::*;
+
+    #[test]
+    fn codex_resumes_keep_saved_permissions_while_new_threads_use_launch_defaults() {
+        let connection = Connection::Codex(codex::Connection {
+            url: "wss://agent.example.com".into(),
+            token: "secret".into(),
+            directory: "/app/a project".into(),
+            version: "0.154.0".into(),
+            reused: true,
+        });
+        let fresh = connection.args(None);
+        assert!(
+            fresh
+                .windows(2)
+                .any(|args| args == ["--ask-for-approval", "never"])
+        );
+        assert!(
+            fresh
+                .windows(2)
+                .any(|args| args == ["--sandbox", "danger-full-access"])
+        );
+        assert!(!fresh.iter().any(|arg| arg == "resume"));
+
+        let resumed = connection.args(Some("saved-thread"));
+        assert!(resumed.ends_with(&["resume".into(), "saved-thread".into()]));
+        for flag in [
+            "--ask-for-approval",
+            "--sandbox",
+            "--full-auto",
+            "--yolo",
+            "--dangerously-bypass-approvals-and-sandbox",
+        ] {
+            assert!(
+                !resumed.iter().any(|arg| arg == flag),
+                "remote resume must not override saved permissions with {flag}"
+            );
+        }
+        for args in [&fresh, &resumed] {
+            assert!(args.iter().any(|arg| arg == "--no-alt-screen"));
+            assert!(
+                args.windows(2)
+                    .any(|args| args == ["--remote", "wss://agent.example.com"])
+            );
+            assert!(
+                args.windows(2)
+                    .any(|args| args == ["--cd", "/app/a project"])
+            );
+            assert!(
+                args.windows(2)
+                    .any(|args| args == ["--remote-auth-token-env", codex::TOKEN_ENV])
+            );
+            assert!(!args.iter().any(|arg| arg == "secret"));
+        }
+    }
 
     #[test]
     fn native_titles_and_directories_win_over_previews_and_server_defaults() {

--- a/src/commands/cloud_agent/codex.rs
+++ b/src/commands/cloud_agent/codex.rs
@@ -347,6 +347,10 @@ pub(crate) fn attach_args(connection: &Connection) -> Vec<String> {
         // prompt can steal startup input and would break that version match.
         "-c".into(),
         "check_for_update_on_startup=false".into(),
+        // Codex relies on terminal scrollback rather than mouse reporting.
+        // Keep its transcript on the main screen so the Railway pane can
+        // retain history and scroll it with the wheel or Shift+Page Up/Down.
+        "--no-alt-screen".into(),
         "--remote".into(),
         connection.url.clone(),
         "--remote-auth-token-env".into(),

--- a/src/commands/cloud_agent/codex.rs
+++ b/src/commands/cloud_agent/codex.rs
@@ -341,8 +341,8 @@ async fn verify_websocket(client: &reqwest::Client, endpoint: &str, token: &str)
     .context("Codex initialization timed out")?
 }
 
-pub(crate) fn attach_args(connection: &Connection) -> Vec<String> {
-    vec![
+pub(crate) fn attach_args(connection: &Connection, thread: Option<&str>) -> Vec<String> {
+    let mut args = vec![
         // Railway pins the local client to its server. Codex's global-update
         // prompt can steal startup input and would break that version match.
         "-c".into(),
@@ -357,11 +357,20 @@ pub(crate) fn attach_args(connection: &Connection) -> Vec<String> {
         TOKEN_ENV.into(),
         "--cd".into(),
         connection.directory.clone(),
-        "--ask-for-approval".into(),
-        "never".into(),
-        "--sandbox".into(),
-        "danger-full-access".into(),
-    ]
+    ];
+    if let Some(thread) = thread {
+        // Remote resumes retain the task's saved permissions. Codex rejects
+        // approval or sandbox overrides even when they match those settings.
+        args.extend(["resume".into(), thread.into()]);
+    } else {
+        args.extend([
+            "--ask-for-approval".into(),
+            "never".into(),
+            "--sandbox".into(),
+            "danger-full-access".into(),
+        ]);
+    }
+    args
 }
 
 #[cfg(test)]

--- a/src/commands/cloud_agent/desktop/codex_config.rs
+++ b/src/commands/cloud_agent/desktop/codex_config.rs
@@ -295,13 +295,8 @@ pub(super) async fn configure(
             .unwrap_or_else(|| normalized_path(directory));
         Ok(())
     })?;
-    // Codex imports this declaration at startup. Keep setup entirely in the
-    // background, including when Desktop is already running. JSON stdout stays clean.
-    eprintln!(
-        "Saved Codex Desktop connection {alias} and project {} in {}",
-        normalized_path(directory),
-        path.display()
-    );
+    // Callers present this result in their own CLI summary or TUI. Writing to
+    // stderr here would corrupt the frame when setup runs behind an open pane.
     Ok(super::CodexDesktop {
         ssh_alias: alias.into(),
         ssh_config_path: ssh_config.into(),
@@ -500,6 +495,45 @@ mod tests {
                 0o600
             );
         }
+    }
+
+    #[tokio::test]
+    async fn background_setup_does_not_print_over_the_terminal_ui() {
+        const CHILD: &str = "RAILWAY_TEST_CODEX_CONFIG_QUIET";
+        if std::env::var_os(CHILD).is_some() {
+            crate::util::prompt::set_terminal_owned(true);
+            let result = configure(
+                "railway-test",
+                "test",
+                "/app",
+                Path::new("/tmp/test-ssh-config"),
+            )
+            .await
+            .unwrap();
+            assert_eq!(result.project_label, "Railway: test");
+            assert!(result.config_path.is_file());
+            return;
+        }
+
+        let root = tempfile::tempdir().unwrap();
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "commands::cloud_agent::desktop::codex_config::tests::background_setup_does_not_print_over_the_terminal_ui",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .env("CODEX_HOME", root.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "{output:?}");
+        assert!(
+            output.stderr.is_empty(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!String::from_utf8_lossy(&output.stdout).contains("Saved Codex Desktop"));
+        assert!(root.path().join("codex-app/config.json").is_file());
     }
 
     #[test]

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -7361,6 +7361,42 @@ mod tests {
         assert!(a.pending_copy.is_none(), "and it is not a copy");
     }
 
+    #[test]
+    fn clicking_a_codex_labeled_hyperlink_opens_its_destination() {
+        let mut a = loaded_app();
+        let mut session = super::super::session::Session::for_test("ca_1", "codex").unwrap();
+        session.resize(6, 60);
+        session.send(
+            b"\x1b[2J\x1b[H\x1b]8;;https://github.com/railwayapp/cli/pull/1194\x1b\\PR #1194\x1b]8;;\x1b\\\r\n",
+        );
+        for _ in 0..500 {
+            if session.url_at(0, 7).is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        a.attach_session(session, "ca_1".into());
+        a.panes.session = PaneBox {
+            x: 34,
+            y: 3,
+            w: 60,
+            h: 6,
+        };
+        a.panes.session_outer = PaneBox {
+            x: 33,
+            y: 2,
+            w: 62,
+            h: 8,
+        };
+        assert_eq!(a.on_mouse(MouseAction::Down, 35, 3), None);
+        assert_eq!(
+            a.on_mouse(MouseAction::Up, 35, 3),
+            Some(Effect::OpenUrl(
+                "https://github.com/railwayapp/cli/pull/1194".into()
+            ))
+        );
+    }
+
     /// Dragging from a link selects it instead. Copying a URL and opening one
     /// are both things people do; the pointer moving is what tells them apart.
     #[test]

--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -7364,17 +7364,15 @@ mod tests {
     #[test]
     fn clicking_a_codex_labeled_hyperlink_opens_its_destination() {
         let mut a = loaded_app();
-        let mut session = super::super::session::Session::for_test("ca_1", "codex").unwrap();
-        session.resize(6, 60);
-        session.send(
+        let mut session = super::super::session::Session::for_test_with_output(
+            "ca_1", "codex",
             b"\x1b[2J\x1b[H\x1b]8;;https://github.com/railwayapp/cli/pull/1194\x1b\\PR #1194\x1b]8;;\x1b\\\r\n",
+        ).unwrap();
+        session.resize(6, 60);
+        assert_eq!(
+            session.url_at(0, 1).as_deref(),
+            Some("https://github.com/railwayapp/cli/pull/1194")
         );
-        for _ in 0..500 {
-            if session.url_at(0, 7).is_some() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
         a.attach_session(session, "ca_1".into());
         a.panes.session = PaneBox {
             x: 34,

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -1212,6 +1212,16 @@ impl Session {
     /// A session backed by a local `cat` instead of ssh, so the state machine
     /// around sessions can be tested without a relay or a network.
     pub fn for_test(agent_id: &str, agent_name: &str) -> Result<Self> {
+        Self::for_test_inner(agent_id, agent_name, None)
+    }
+
+    /// Feed exact terminal output to the emulator without the host PTY
+    /// interpreting or rewriting escape sequences (notably OSC 8 on ConPTY).
+    pub fn for_test_with_output(agent_id: &str, agent_name: &str, output: &[u8]) -> Result<Self> {
+        Self::for_test_inner(agent_id, agent_name, Some(output))
+    }
+
+    fn for_test_inner(agent_id: &str, agent_name: &str, output: Option<&[u8]>) -> Result<Self> {
         let pty = NativePtySystem::default().openpty(PtySize {
             rows: 24,
             cols: 80,
@@ -1227,8 +1237,10 @@ impl Session {
         // The same reader the real session runs. Without it the emulator never
         // sees a byte, and a test against this fixture would be testing
         // nothing at all.
-        let mut reader = pty.master.try_clone_reader()?;
-        {
+        if let Some(output) = output {
+            parser.lock().unwrap().process(output);
+        } else {
+            let mut reader = pty.master.try_clone_reader()?;
             let parser = parser.clone();
             std::thread::spawn(move || {
                 let mut buf = [0u8; 8192];

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -1492,7 +1492,9 @@ assert os.isatty(0) and os.isatty(1)
 assert os.environ['RAILWAY_CODEX_SERVER_TOKEN'] == "secret ' $(echo injected)"
 backend = hashlib.sha256(b'wss://agent.example.com:443').hexdigest()[:16]
 assert pathlib.Path(os.environ['CODEX_HOME']) == pathlib.Path.home() / '.railway/codex-client' / backend
-assert sys.argv[1:] == ['-c', 'check_for_update_on_startup=false', '--remote', 'ws://127.0.0.1:54321', '--remote-auth-token-env', 'RAILWAY_CODEX_SERVER_TOKEN', '--cd', '/app/a project', '--ask-for-approval', 'never', '--sandbox', 'danger-full-access', 'resume', 'thread-1']
+assert sys.argv[1:] == ['-c', 'check_for_update_on_startup=false', '--no-alt-screen', '--remote', 'ws://127.0.0.1:54321', '--remote-auth-token-env', 'RAILWAY_CODEX_SERVER_TOKEN', '--cd', '/app/a project', '--ask-for-approval', 'never', '--sandbox', 'danger-full-access', 'resume', 'thread-1']
+for i in range(80):
+    print(f'transcript-{i}')
 print('Codex ready', flush=True)
 assert input() == 'hello'
 size = os.get_terminal_size()
@@ -1532,6 +1534,17 @@ print('Codex complete', flush=True)
             );
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
+        let live = pane.with_screen(|s| s.contents()).unwrap();
+        assert!(pane.scrollable());
+        pane.scroll(true, 10, (1, 1));
+        assert!(pane.scrolled_back());
+        let history = pane.with_screen(|s| s.contents()).unwrap();
+        assert_ne!(history, live);
+        assert!(history.contains("transcript-"));
+        pane.scroll(false, 10, (1, 1));
+        assert!(!pane.scrolled_back());
+        assert_eq!(pane.with_screen(|s| s.contents()).unwrap(), live);
+
         pane.resize(30, 100);
         pane.write_raw(b"hello\n");
         while !pane.finished() {

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -1013,7 +1013,12 @@ impl Session {
         let Ok(mut parser) = self.parser.lock() else {
             return;
         };
-        let wanted = (self.scroll as isize).saturating_add(delta).max(0) as usize;
+        // Output arriving while we read history advances the emulator's
+        // offset to hold the same rows. Continue from that live offset so the
+        // next wheel event does not jump back toward newer output.
+        let wanted = (parser.screen().scrollback() as isize)
+            .saturating_add(delta)
+            .max(0) as usize;
         parser.screen_mut().set_scrollback(wanted);
         self.scroll = parser.screen().scrollback();
     }
@@ -1495,7 +1500,7 @@ assert os.isatty(0) and os.isatty(1)
 assert os.environ['RAILWAY_CODEX_SERVER_TOKEN'] == "secret ' $(echo injected)"
 backend = hashlib.sha256(b'wss://agent.example.com:443').hexdigest()[:16]
 assert pathlib.Path(os.environ['CODEX_HOME']) == pathlib.Path.home() / '.railway/codex-client' / backend
-assert sys.argv[1:] == ['-c', 'check_for_update_on_startup=false', '--no-alt-screen', '--remote', 'ws://127.0.0.1:54321', '--remote-auth-token-env', 'RAILWAY_CODEX_SERVER_TOKEN', '--cd', '/app/a project', '--ask-for-approval', 'never', '--sandbox', 'danger-full-access', 'resume', 'thread-1']
+assert sys.argv[1:] == ['-c', 'check_for_update_on_startup=false', '--no-alt-screen', '--remote', 'ws://127.0.0.1:54321', '--remote-auth-token-env', 'RAILWAY_CODEX_SERVER_TOKEN', '--cd', '/app/a project', 'resume', 'thread-1']
 for i in range(80):
     print(f'transcript-{i}')
 print('Codex ready', flush=True)
@@ -2250,6 +2255,69 @@ assert (size.lines, size.columns) == (30, 100)
         // Typing returns to the live view.
         session.send(b"x");
         assert!(!session.scrolled_back());
+    }
+
+    #[test]
+    fn scrolling_retains_transcript_above_a_fixed_composer() {
+        for scroll_sequence in ["\r\n", "\x1b[1S"] {
+            let mut session = Session::for_test("ca", "codex").unwrap();
+            session.resize(6, 40);
+            {
+                let mut parser = session.parser.lock().unwrap();
+                parser.process(b"\x1b[5;1HAsk Codex\x1b[6;1Hstatus\x1b[1;4r\x1b[1;1H");
+                parser.process(b"\x1b]8;;https://example.com/first\x07transcript-0\x1b]8;;\x07\r\ntranscript-1\r\ntranscript-2\r\n");
+                for i in 3..40 {
+                    parser.process(format!("\rtranscript-{i}{scroll_sequence}").as_bytes());
+                }
+                parser.process(b"\x1b[r\x1b[5;1H");
+            }
+            let live = session.with_screen(|s| s.contents()).unwrap();
+            assert!(live.contains("transcript-39"));
+            assert!(live.contains("Ask Codex\nstatus"));
+
+            session.scroll(true, 100, (1, 1));
+            assert!(
+                session.scrolled_back(),
+                "scroll sequence {scroll_sequence:?}"
+            );
+            let history = session.with_screen(|s| s.contents()).unwrap();
+            assert!(history.contains("transcript-0"), "{history}");
+            assert_eq!(
+                session.url_at(0, 0).as_deref(),
+                Some("https://example.com/first")
+            );
+            session.scroll(false, 100, (1, 1));
+            assert_eq!(session.with_screen(|s| s.contents()).unwrap(), live);
+
+            session.scroll(true, 10, (1, 1));
+            let held = session.with_screen(|s| s.contents()).unwrap();
+            session
+                .parser
+                .lock()
+                .unwrap()
+                .process(b"\x1b[1;4r\x1b[4;1Htranscript-40\r\ntranscript-41\r\n\x1b[r");
+            assert_eq!(session.with_screen(|s| s.contents()).unwrap(), held);
+            let offset = session.with_screen(|s| s.scrollback()).unwrap();
+            assert!(offset > 10);
+            session.scroll(true, 3, (1, 1));
+            assert_eq!(session.with_screen(|s| s.scrollback()).unwrap(), offset + 3);
+        }
+    }
+
+    #[test]
+    fn interior_scroll_regions_and_alternate_screens_do_not_add_history() {
+        for setup in ["\x1b[2;4r\x1b[2;1H", "\x1b[?1049h\x1b[1;4r"] {
+            let mut parser = pane_parser(6, 40, 100);
+            parser.process(setup.as_bytes());
+            for i in 0..40 {
+                parser.process(format!("line-{i}\r\n").as_bytes());
+            }
+            parser.screen_mut().set_scrollback(100);
+            assert_eq!(parser.screen().scrollback(), 0);
+            parser.process(b"\x1b[?1049l");
+            parser.screen_mut().set_scrollback(100);
+            assert_eq!(parser.screen().scrollback(), 0);
+        }
     }
 
     /// The whole retained history is reachable, not one screenful. The old

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -15,6 +15,7 @@
 //! session on purpose is what sleeps the agent, and that is the caller's call,
 //! not this module's.
 
+use crate::vt100;
 use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -912,13 +913,15 @@ impl Session {
     /// routinely longer than the pane is wide, so the interesting case is
     /// always a link split across two or three rows; matching within one row
     /// finds only the fragment up to the wrap, which is not a URL anybody can
-    /// open. Text only: vt100 0.15 does not surface OSC 8 hyperlinks, so a link
-    /// whose visible text is not the URL cannot be found this way.
+    /// open. Explicit OSC 8 destinations take precedence over visible text.
     pub fn url_at(&self, row: u16, col: u16) -> Option<String> {
         self.with_screen(|screen| {
             let (rows, cols) = screen.size();
             if row >= rows || col >= cols {
                 return None;
+            }
+            if let Some(url) = screen.cell(row, col).and_then(|cell| cell.hyperlink()) {
+                return Some(url.to_owned());
             }
             // The run of rows the emulator says are one wrapped line.
             let mut start = row;
@@ -2057,6 +2060,71 @@ assert (size.lines, size.columns) == (30, 100)
         assert_eq!(url_in("railway.com", 3), None, "no scheme, no click");
         assert_eq!(url_in("", 0), None);
         assert_eq!(url_in("https://railway.com", 99), None, "past the end");
+    }
+
+    #[test]
+    fn osc8_links_survive_split_reads_wrap_scrollback_and_resize() {
+        let mut session = Session::for_test("ca", "codex").unwrap();
+        session.resize(3, 10);
+        let target = "https://github.com/railwayapp/cli/pull/1194?a=1;b=2";
+        let output = format!("\x1b]8;id=pr;{target}\x1b\\PR #1194 界\x1b]8;;\x07");
+        {
+            let mut parser = session.parser.lock().unwrap();
+            for byte in output.as_bytes() {
+                parser.process(&[*byte]);
+            }
+        }
+        assert_eq!(session.url_at(0, 0).as_deref(), Some(target));
+        assert_eq!(session.url_at(1, 0).as_deref(), Some(target));
+        assert_eq!(session.url_at(1, 1).as_deref(), Some(target));
+        assert_eq!(session.url_at(1, 2), None);
+        session
+            .parser
+            .lock()
+            .unwrap()
+            .process(b"\r\nend\r\nlast\r\n");
+        session.scroll(true, 20, (1, 1));
+        assert_eq!(session.url_at(0, 0).as_deref(), Some(target));
+        session.resize(4, 10);
+        assert_eq!(session.url_at(0, 0).as_deref(), Some(target));
+    }
+
+    #[test]
+    fn osc8_targets_are_cell_specific_and_cleared_by_overwrite_and_erase() {
+        let session = Session::for_test("ca", "codex").unwrap();
+        session.parser.lock().unwrap().process(
+            b"\x1b]8;;https://one.example\x07same\x1b]8;;\x07 \x1b]8;;https://two.example\x07same\x1b]8;;\x07",
+        );
+        assert_eq!(session.url_at(0, 0).as_deref(), Some("https://one.example"));
+        assert_eq!(session.url_at(0, 5).as_deref(), Some("https://two.example"));
+        assert_eq!(session.url_at(0, 4), None);
+        session.parser.lock().unwrap().process(b"\rplain\x1b[K");
+        assert_eq!(session.url_at(0, 0), None);
+        assert_eq!(session.url_at(0, 5), None);
+    }
+
+    #[test]
+    fn osc8_links_stay_with_their_screen_and_reject_non_web_targets() {
+        let mut parser = pane_parser(3, 20, 10);
+        parser.process(b"\x1b]8;;https://one.example\x07main\x1b]8;;\x07");
+        parser.process(b"\x1b[?1049hother");
+        assert_eq!(parser.screen().cell(0, 0).unwrap().hyperlink(), None);
+        parser.process(b"\x1b[?1049l");
+        assert_eq!(
+            parser.screen().cell(0, 0).unwrap().hyperlink(),
+            Some("https://one.example")
+        );
+        for target in ["file:///tmp/example", "javascript:alert(1)"] {
+            parser.process(format!("\r\x1b]8;;{target}\x07label\x1b]8;;\x07").as_bytes());
+            assert_eq!(parser.screen().cell(0, 0).unwrap().hyperlink(), None);
+        }
+        parser
+            .screen_mut()
+            .set_hyperlink(b"https://example.com/\nunsafe");
+        parser.process(b"\rlabel");
+        assert_eq!(parser.screen().cell(0, 0).unwrap().hyperlink(), None);
+        parser.process(b"\x1b]8;;https://one.example\x07\x1bcreset");
+        assert_eq!(parser.screen().cell(0, 0).unwrap().hyperlink(), None);
     }
 
     /// The whole point: a link on the emulated screen can be found by where it

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -1,6 +1,7 @@
 //! Rendering for the `railway ca` TUI. Pure draw code — every decision it
 //! needs has already been made in [`super::app`].
 
+use crate::vt100;
 use ratatui::Frame;
 use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod table;
 #[cfg(test)]
 mod testkit;
 mod util;
+mod vt100;
 mod workspace;
 
 #[macro_use]

--- a/src/util/reporter.rs
+++ b/src/util/reporter.rs
@@ -62,13 +62,34 @@ pub fn emit_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
 /// terminal back. Deduplicated by rendered text and kept in first-seen order,
 /// so a condition that recurs on a timer surfaces once with a count instead of
 /// as a wall of identical lines.
-static DEFERRED: std::sync::Mutex<Vec<(String, usize)>> = std::sync::Mutex::new(Vec::new());
+static DEFERRED: std::sync::Mutex<DeferredWarnings> = std::sync::Mutex::new(DeferredWarnings {
+    entries: Vec::new(),
+});
 
 /// Cap on distinct deferred warnings. A TUI session runs for hours; without a
 /// bound, a warning raised from a loop would hold unbounded memory for all of
 /// it. Past the cap, further *distinct* warnings are dropped — repeats of ones
 /// already held still count up, which is the case that actually matters.
 const MAX_DEFERRED: usize = 20;
+
+#[derive(Default)]
+struct DeferredWarnings {
+    entries: Vec<(String, usize)>,
+}
+
+impl DeferredWarnings {
+    fn push(&mut self, rendered: String) {
+        if let Some(entry) = self.entries.iter_mut().find(|(text, _)| *text == rendered) {
+            entry.1 += 1;
+        } else if self.entries.len() < MAX_DEFERRED {
+            self.entries.push((rendered, 1));
+        }
+    }
+
+    fn take(&mut self) -> Vec<(String, usize)> {
+        std::mem::take(&mut self.entries)
+    }
+}
 
 /// Emit a non-fatal warning. Always goes to stderr so it never pollutes
 /// a result on stdout: a yellow line in human mode, a structured object
@@ -125,11 +146,7 @@ fn defer(rendered: String) {
     let Ok(mut held) = DEFERRED.lock() else {
         return;
     };
-    if let Some(entry) = held.iter_mut().find(|(text, _)| *text == rendered) {
-        entry.1 += 1;
-    } else if held.len() < MAX_DEFERRED {
-        held.push((rendered, 1));
-    }
+    held.push(rendered);
 }
 
 /// Write out everything [`warn`] held back while a TUI owned the terminal, and
@@ -139,7 +156,7 @@ pub fn flush_deferred() {
     let Ok(mut held) = DEFERRED.lock() else {
         return;
     };
-    for (rendered, count) in held.drain(..) {
+    for (rendered, count) in held.take() {
         eprint!("{rendered}");
         if count > 1 {
             eprintln!(
@@ -205,10 +222,6 @@ mod tests {
     use super::*;
     use crate::errors::RailwayError;
 
-    /// `DEFERRED` is process-global, so the tests that drive it directly have
-    /// to run one at a time or they consume each other's entries.
-    static DEFERRED_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     /// A warning raised under a TUI must survive to be read, not vanish — and a
     /// condition that recurs on a timer (the config-lock timeout fired every
     /// few seconds in a long `railway ca` session) must come back as one line
@@ -216,17 +229,15 @@ mod tests {
     /// queued.
     #[test]
     fn deferred_warnings_are_deduplicated_and_counted() {
-        let _guard = DEFERRED_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        flush_deferred(); // start from a clean slate
+        // Other tests release terminal ownership and flush the global queue.
+        // Exercise the same buffer logic with an instance owned by this test.
+        let mut warnings = DeferredWarnings::default();
+        warnings.push("lock timed out\n".to_string());
+        warnings.push("lock timed out\n".to_string());
+        warnings.push("lock timed out\n".to_string());
+        warnings.push("something else\n".to_string());
 
-        defer("lock timed out\n".to_string());
-        defer("lock timed out\n".to_string());
-        defer("lock timed out\n".to_string());
-        defer("something else\n".to_string());
-
-        let held = DEFERRED.lock().unwrap().clone();
+        let held = warnings.take();
         assert_eq!(
             held,
             vec![
@@ -236,9 +247,8 @@ mod tests {
             "repeats collapse into a count, and first-seen order is kept"
         );
 
-        flush_deferred();
         assert!(
-            DEFERRED.lock().unwrap().is_empty(),
+            warnings.take().is_empty(),
             "flushing must drain, or the next TUI exit replays them"
         );
     }
@@ -246,23 +256,18 @@ mod tests {
     /// An unbounded buffer would be a slow leak across an hours-long session.
     #[test]
     fn deferred_warnings_are_capped() {
-        let _guard = DEFERRED_TEST_LOCK
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        flush_deferred();
+        let mut warnings = DeferredWarnings::default();
 
         for i in 0..(MAX_DEFERRED + 10) {
-            defer(format!("distinct warning {i}\n"));
+            warnings.push(format!("distinct warning {i}\n"));
         }
         // The cap bounds distinct entries, but a repeat of one already held
         // still counts up — that is the case worth keeping.
-        defer("distinct warning 0\n".to_string());
+        warnings.push("distinct warning 0\n".to_string());
 
-        let held = DEFERRED.lock().unwrap().clone();
+        let held = warnings.take();
         assert_eq!(held.len(), MAX_DEFERRED);
         assert_eq!(held[0].1, 2);
-
-        flush_deferred();
     }
 
     #[test]

--- a/src/vt100/LICENSE
+++ b/src/vt100/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Jesse Luehrs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/vt100/README.md
+++ b/src/vt100/README.md
@@ -11,6 +11,9 @@ Local changes:
   overwrite/erase. Cell ownership naturally preserves links through scrolling,
   alternate screens, line insertion/deletion, and resize.
 - Bound and validate web hyperlink destinations; ignore unsupported schemes.
+- Retain main-screen scrollback for regions that start at the top, including
+  inline transcripts above a fixed composer. Interior and alternate-screen
+  regions do not contribute history.
 
 Hyperlinks are consumed by Railway's pane click handler, not serialized into
 terminal screen dumps. Regression coverage lives in the pane session tests.

--- a/src/vt100/README.md
+++ b/src/vt100/README.md
@@ -1,0 +1,16 @@
+# Embedded vt100 terminal emulator
+
+Source: vt100 0.16.2, https://github.com/doy/vt100-rust, MIT (see LICENSE).
+
+Embedded as a module so Railway binaries and published source packages use the
+same implementation. Upstream does not retain OSC 8 hyperlink destinations.
+
+Local changes:
+- Rewrite internal crate paths to `crate::vt100` and remove upstream lint policy.
+- Retain OSC 8 targets on cells, including wide continuations, and clear them on
+  overwrite/erase. Cell ownership naturally preserves links through scrolling,
+  alternate screens, line insertion/deletion, and resize.
+- Bound and validate web hyperlink destinations; ignore unsupported schemes.
+
+Hyperlinks are consumed by Railway's pane click handler, not serialized into
+terminal screen dumps. Regression coverage lives in the pane session tests.

--- a/src/vt100/attrs.rs
+++ b/src/vt100/attrs.rs
@@ -1,0 +1,140 @@
+use crate::vt100::term::BufWrite as _;
+
+/// Represents a foreground or background color for cells.
+#[derive(Eq, PartialEq, Debug, Copy, Clone, Default)]
+pub enum Color {
+    /// The default terminal color.
+    #[default]
+    Default,
+
+    /// An indexed terminal color.
+    Idx(u8),
+
+    /// An RGB terminal color. The parameters are (red, green, blue).
+    Rgb(u8, u8, u8),
+}
+
+const TEXT_MODE_INTENSITY: u8 = 0b0000_0011;
+const TEXT_MODE_BOLD: u8 = 0b0000_0001;
+const TEXT_MODE_DIM: u8 = 0b0000_0010;
+const TEXT_MODE_ITALIC: u8 = 0b0000_0100;
+const TEXT_MODE_UNDERLINE: u8 = 0b0000_1000;
+const TEXT_MODE_INVERSE: u8 = 0b0001_0000;
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Attrs {
+    pub fgcolor: Color,
+    pub bgcolor: Color,
+    pub mode: u8,
+}
+
+impl Attrs {
+    pub fn bold(&self) -> bool {
+        self.mode & TEXT_MODE_BOLD != 0
+    }
+
+    pub fn dim(&self) -> bool {
+        self.mode & TEXT_MODE_DIM != 0
+    }
+
+    fn intensity(&self) -> u8 {
+        self.mode & TEXT_MODE_INTENSITY
+    }
+
+    pub fn set_bold(&mut self) {
+        self.mode &= !TEXT_MODE_INTENSITY;
+        self.mode |= TEXT_MODE_BOLD;
+    }
+
+    pub fn set_dim(&mut self) {
+        self.mode &= !TEXT_MODE_INTENSITY;
+        self.mode |= TEXT_MODE_DIM;
+    }
+
+    pub fn set_normal_intensity(&mut self) {
+        self.mode &= !TEXT_MODE_INTENSITY;
+    }
+
+    pub fn italic(&self) -> bool {
+        self.mode & TEXT_MODE_ITALIC != 0
+    }
+
+    pub fn set_italic(&mut self, italic: bool) {
+        if italic {
+            self.mode |= TEXT_MODE_ITALIC;
+        } else {
+            self.mode &= !TEXT_MODE_ITALIC;
+        }
+    }
+
+    pub fn underline(&self) -> bool {
+        self.mode & TEXT_MODE_UNDERLINE != 0
+    }
+
+    pub fn set_underline(&mut self, underline: bool) {
+        if underline {
+            self.mode |= TEXT_MODE_UNDERLINE;
+        } else {
+            self.mode &= !TEXT_MODE_UNDERLINE;
+        }
+    }
+
+    pub fn inverse(&self) -> bool {
+        self.mode & TEXT_MODE_INVERSE != 0
+    }
+
+    pub fn set_inverse(&mut self, inverse: bool) {
+        if inverse {
+            self.mode |= TEXT_MODE_INVERSE;
+        } else {
+            self.mode &= !TEXT_MODE_INVERSE;
+        }
+    }
+
+    pub fn write_escape_code_diff(&self, contents: &mut Vec<u8>, other: &Self) {
+        if self != other && self == &Self::default() {
+            crate::vt100::term::ClearAttrs.write_buf(contents);
+            return;
+        }
+
+        let attrs = crate::vt100::term::Attrs::default();
+
+        let attrs = if self.fgcolor == other.fgcolor {
+            attrs
+        } else {
+            attrs.fgcolor(self.fgcolor)
+        };
+        let attrs = if self.bgcolor == other.bgcolor {
+            attrs
+        } else {
+            attrs.bgcolor(self.bgcolor)
+        };
+        let attrs = if self.intensity() == other.intensity() {
+            attrs
+        } else {
+            attrs.intensity(match self.intensity() {
+                0 => crate::vt100::term::Intensity::Normal,
+                TEXT_MODE_BOLD => crate::vt100::term::Intensity::Bold,
+                TEXT_MODE_DIM => crate::vt100::term::Intensity::Dim,
+                _ => unreachable!(),
+            })
+        };
+        let attrs = if self.italic() == other.italic() {
+            attrs
+        } else {
+            attrs.italic(self.italic())
+        };
+        let attrs = if self.underline() == other.underline() {
+            attrs
+        } else {
+            attrs.underline(self.underline())
+        };
+        let attrs = if self.inverse() == other.inverse() {
+            attrs
+        } else {
+            attrs.inverse(self.inverse())
+        };
+
+        attrs.write_buf(contents);
+    }
+}

--- a/src/vt100/callbacks.rs
+++ b/src/vt100/callbacks.rs
@@ -1,0 +1,58 @@
+/// This trait is used by the parser to handle extra escape sequences that
+/// don't have an impact on the terminal screen directly.
+pub trait Callbacks {
+    /// This callback is called when the terminal requests an audible bell
+    /// (typically with `^G`).
+    fn audible_bell(&mut self, _: &mut crate::vt100::Screen) {}
+    /// This callback is called when the terminal requests a visual bell
+    /// (typically with `\eg`).
+    fn visual_bell(&mut self, _: &mut crate::vt100::Screen) {}
+    /// This callback is called when the terminal requests a resize
+    /// (typically with `\e[8;<rows>;<cols>t`).
+    fn resize(&mut self, _: &mut crate::vt100::Screen, _request: (u16, u16)) {}
+    /// This callback is called when the terminal requests the window title
+    /// to be set (typically with `\e]1;<icon_name>\a`)
+    fn set_window_icon_name(&mut self, _: &mut crate::vt100::Screen, _icon_name: &[u8]) {}
+    /// This callback is called when the terminal requests the window title
+    /// to be set (typically with `\e]2;<title>\a`)
+    fn set_window_title(&mut self, _: &mut crate::vt100::Screen, _title: &[u8]) {}
+    /// This callback is called when the terminal requests data to be copied
+    /// to the system clipboard (typically with `\e]52;<ty>;<data>\a`). Note
+    /// that `data` will be encoded as base64.
+    fn copy_to_clipboard(&mut self, _: &mut crate::vt100::Screen, _ty: &[u8], _data: &[u8]) {}
+    /// This callback is called when the terminal requests data to be pasted
+    /// from the system clipboard (typically with `\e]52;<ty>;?\a`).
+    fn paste_from_clipboard(&mut self, _: &mut crate::vt100::Screen, _ty: &[u8]) {}
+    /// This callback is called when the terminal receives an escape sequence
+    /// which is otherwise not implemented.
+    fn unhandled_char(&mut self, _: &mut crate::vt100::Screen, _c: char) {}
+    /// This callback is called when the terminal receives a control
+    /// character which is otherwise not implemented.
+    fn unhandled_control(&mut self, _: &mut crate::vt100::Screen, _b: u8) {}
+    /// This callback is called when the terminal receives an escape sequence
+    /// which is otherwise not implemented.
+    fn unhandled_escape(
+        &mut self,
+        _: &mut crate::vt100::Screen,
+        _i1: Option<u8>,
+        _i2: Option<u8>,
+        _b: u8,
+    ) {
+    }
+    /// This callback is called when the terminal receives a CSI sequence
+    /// (`\e[`) which is otherwise not implemented.
+    fn unhandled_csi(
+        &mut self,
+        _: &mut crate::vt100::Screen,
+        _i1: Option<u8>,
+        _i2: Option<u8>,
+        _params: &[&[u16]],
+        _c: char,
+    ) {
+    }
+    /// This callback is called when the terminal receives a OSC sequence
+    /// (`\e]`) which is otherwise not implemented.
+    fn unhandled_osc(&mut self, _: &mut crate::vt100::Screen, _params: &[&[u8]]) {}
+}
+
+impl Callbacks for () {}

--- a/src/vt100/cell.rs
+++ b/src/vt100/cell.rs
@@ -1,0 +1,191 @@
+use unicode_width::UnicodeWidthChar as _;
+
+// Keep upstream's inline text capacity; hyperlink metadata is stored separately.
+const CONTENT_BYTES: usize = 22;
+
+const IS_WIDE: u8 = 0b1000_0000;
+const IS_WIDE_CONTINUATION: u8 = 0b0100_0000;
+const LEN_BITS: u8 = 0b0001_1111;
+
+/// Represents a single terminal cell.
+#[derive(Clone, Debug, Eq)]
+pub struct Cell {
+    contents: [u8; CONTENT_BYTES],
+    len: u8,
+    attrs: crate::vt100::attrs::Attrs,
+    hyperlink: Option<std::sync::Arc<str>>,
+}
+
+impl PartialEq<Self> for Cell {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len != other.len {
+            return false;
+        }
+        if self.attrs != other.attrs || self.hyperlink != other.hyperlink {
+            return false;
+        }
+        let len = self.len();
+        self.contents[..len] == other.contents[..len]
+    }
+}
+
+impl Cell {
+    pub(crate) fn new() -> Self {
+        Self {
+            contents: Default::default(),
+            len: 0,
+            hyperlink: None,
+            attrs: crate::vt100::attrs::Attrs::default(),
+        }
+    }
+
+    /// The OSC 8 web destination attached to this cell.
+    pub fn hyperlink(&self) -> Option<&str> {
+        self.hyperlink.as_deref()
+    }
+
+    pub(crate) fn set_hyperlink(&mut self, hyperlink: Option<std::sync::Arc<str>>) {
+        self.hyperlink = hyperlink;
+    }
+
+    fn len(&self) -> usize {
+        usize::from(self.len & LEN_BITS)
+    }
+
+    pub(crate) fn set(&mut self, c: char, a: crate::vt100::attrs::Attrs) {
+        self.hyperlink = None;
+        self.len = 0;
+        self.append_char(0, c);
+        // strings in this context should always be an arbitrary character
+        // followed by zero or more zero-width characters, so we should only
+        // have to look at the first character
+        self.set_wide(c.width().unwrap_or(1) > 1);
+        self.attrs = a;
+    }
+
+    pub(crate) fn append(&mut self, c: char) {
+        let len = self.len();
+        if len >= CONTENT_BYTES - 4 {
+            return;
+        }
+        if len == 0 {
+            self.contents[0] = b' ';
+            self.len += 1;
+        }
+
+        // we already checked that we have space for another codepoint
+        self.append_char(self.len(), c);
+    }
+
+    // Writes bytes representing c at start
+    // Requires caller to verify start <= CODEPOINTS_IN_CELL * 4
+    fn append_char(&mut self, start: usize, c: char) {
+        c.encode_utf8(&mut self.contents[start..]);
+        self.len += u8::try_from(c.len_utf8()).unwrap();
+    }
+
+    pub(crate) fn clear(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        self.hyperlink = None;
+        self.len = 0;
+        self.attrs = attrs;
+    }
+
+    /// Returns the text contents of the cell.
+    ///
+    /// Can include multiple unicode characters if combining characters are
+    /// used, but will contain at most one character with a non-zero character
+    /// width.
+    // Since contents has been constructed by appending chars encoded as UTF-8 it will be valid UTF-8
+    #[allow(clippy::missing_panics_doc)]
+    #[must_use]
+    pub fn contents(&self) -> &str {
+        std::str::from_utf8(&self.contents[..self.len()]).unwrap()
+    }
+
+    /// Returns whether the cell contains any text data.
+    #[must_use]
+    pub fn has_contents(&self) -> bool {
+        self.len() > 0
+    }
+
+    /// Returns whether the text data in the cell represents a wide character.
+    #[must_use]
+    pub fn is_wide(&self) -> bool {
+        self.len & IS_WIDE != 0
+    }
+
+    /// Returns whether the cell contains the second half of a wide character
+    /// (in other words, whether the previous cell in the row contains a wide
+    /// character)
+    #[must_use]
+    pub fn is_wide_continuation(&self) -> bool {
+        self.len & IS_WIDE_CONTINUATION != 0
+    }
+
+    fn set_wide(&mut self, wide: bool) {
+        if wide {
+            self.len |= IS_WIDE;
+        } else {
+            self.len &= !IS_WIDE;
+        }
+    }
+
+    pub(crate) fn set_wide_continuation(&mut self, wide: bool) {
+        if wide {
+            self.len |= IS_WIDE_CONTINUATION;
+        } else {
+            self.len &= !IS_WIDE_CONTINUATION;
+        }
+    }
+
+    pub(crate) fn attrs(&self) -> &crate::vt100::attrs::Attrs {
+        &self.attrs
+    }
+
+    /// Returns the foreground color of the cell.
+    #[must_use]
+    pub fn fgcolor(&self) -> crate::vt100::Color {
+        self.attrs.fgcolor
+    }
+
+    /// Returns the background color of the cell.
+    #[must_use]
+    pub fn bgcolor(&self) -> crate::vt100::Color {
+        self.attrs.bgcolor
+    }
+
+    /// Returns whether the cell should be rendered with the bold text
+    /// attribute.
+    #[must_use]
+    pub fn bold(&self) -> bool {
+        self.attrs.bold()
+    }
+
+    /// Returns whether the cell should be rendered with the dim text
+    /// attribute.
+    #[must_use]
+    pub fn dim(&self) -> bool {
+        self.attrs.dim()
+    }
+
+    /// Returns whether the cell should be rendered with the italic text
+    /// attribute.
+    #[must_use]
+    pub fn italic(&self) -> bool {
+        self.attrs.italic()
+    }
+
+    /// Returns whether the cell should be rendered with the underlined text
+    /// attribute.
+    #[must_use]
+    pub fn underline(&self) -> bool {
+        self.attrs.underline()
+    }
+
+    /// Returns whether the cell should be rendered with the inverse text
+    /// attribute.
+    #[must_use]
+    pub fn inverse(&self) -> bool {
+        self.attrs.inverse()
+    }
+}

--- a/src/vt100/grid.rs
+++ b/src/vt100/grid.rs
@@ -522,7 +522,11 @@ impl Grid {
             self.rows
                 .insert(usize::from(self.scroll_bottom) + 1, self.new_row());
             let removed = self.rows.remove(usize::from(self.scroll_top));
-            if self.scrollback_len > 0 && !self.scroll_region_active() {
+            // Inline TUIs keep their composer below a scrolling transcript.
+            // Rows leaving the top of the main screen still belong in history
+            // when the region stops above the bottom row. Interior regions do
+            // not contribute history; the alternate grid has no scrollback.
+            if self.scrollback_len > 0 && self.scroll_top == 0 {
                 self.scrollback.push_back(removed);
                 while self.scrollback.len() > self.scrollback_len {
                     self.scrollback.pop_front();
@@ -559,10 +563,6 @@ impl Grid {
 
     fn in_scroll_region(&self) -> bool {
         self.pos.row >= self.scroll_top && self.pos.row <= self.scroll_bottom
-    }
-
-    fn scroll_region_active(&self) -> bool {
-        self.scroll_top != 0 || self.scroll_bottom != self.size.rows - 1
     }
 
     pub fn set_origin_mode(&mut self, mode: bool) {

--- a/src/vt100/grid.rs
+++ b/src/vt100/grid.rs
@@ -1,0 +1,700 @@
+use crate::vt100::term::BufWrite as _;
+
+#[derive(Clone, Debug)]
+pub struct Grid {
+    size: Size,
+    pos: Pos,
+    saved_pos: Pos,
+    rows: Vec<crate::vt100::row::Row>,
+    scroll_top: u16,
+    scroll_bottom: u16,
+    origin_mode: bool,
+    saved_origin_mode: bool,
+    scrollback: std::collections::VecDeque<crate::vt100::row::Row>,
+    scrollback_len: usize,
+    scrollback_offset: usize,
+}
+
+impl Grid {
+    pub fn new(size: Size, scrollback_len: usize) -> Self {
+        Self {
+            size,
+            pos: Pos::default(),
+            saved_pos: Pos::default(),
+            rows: vec![],
+            scroll_top: 0,
+            scroll_bottom: size.rows - 1,
+            origin_mode: false,
+            saved_origin_mode: false,
+            scrollback: std::collections::VecDeque::new(),
+            scrollback_len,
+            scrollback_offset: 0,
+        }
+    }
+
+    pub fn allocate_rows(&mut self) {
+        if self.rows.is_empty() {
+            self.rows.extend(
+                std::iter::repeat_with(|| crate::vt100::row::Row::new(self.size.cols))
+                    .take(usize::from(self.size.rows)),
+            );
+        }
+    }
+
+    fn new_row(&self) -> crate::vt100::row::Row {
+        crate::vt100::row::Row::new(self.size.cols)
+    }
+
+    pub fn clear(&mut self) {
+        self.pos = Pos::default();
+        self.saved_pos = Pos::default();
+        for row in self.drawing_rows_mut() {
+            row.clear(crate::vt100::attrs::Attrs::default());
+        }
+        self.scroll_top = 0;
+        self.scroll_bottom = self.size.rows - 1;
+        self.origin_mode = false;
+        self.saved_origin_mode = false;
+    }
+
+    pub fn size(&self) -> Size {
+        self.size
+    }
+
+    pub fn set_size(&mut self, size: Size) {
+        if size.cols != self.size.cols {
+            for row in &mut self.rows {
+                row.wrap(false);
+            }
+        }
+
+        if self.scroll_bottom == self.size.rows - 1 {
+            self.scroll_bottom = size.rows - 1;
+        }
+
+        self.size = size;
+        for row in &mut self.rows {
+            row.resize(size.cols, crate::vt100::Cell::new());
+        }
+        self.rows.resize(usize::from(size.rows), self.new_row());
+
+        if self.scroll_bottom >= size.rows {
+            self.scroll_bottom = size.rows - 1;
+        }
+        if self.scroll_bottom < self.scroll_top {
+            self.scroll_top = 0;
+        }
+
+        self.row_clamp_top(false);
+        self.row_clamp_bottom(false);
+        self.col_clamp();
+
+        if self.saved_pos.row > self.size.rows - 1 {
+            self.saved_pos.row = self.size.rows - 1;
+        }
+        if self.saved_pos.col > self.size.cols - 1 {
+            self.saved_pos.col = self.size.cols - 1;
+        }
+    }
+
+    pub fn pos(&self) -> Pos {
+        self.pos
+    }
+
+    pub fn set_pos(&mut self, mut pos: Pos) {
+        if self.origin_mode {
+            pos.row = pos.row.saturating_add(self.scroll_top);
+        }
+        self.pos = pos;
+        self.row_clamp_top(self.origin_mode);
+        self.row_clamp_bottom(self.origin_mode);
+        self.col_clamp();
+    }
+
+    pub fn save_cursor(&mut self) {
+        self.saved_pos = self.pos;
+        self.saved_origin_mode = self.origin_mode;
+    }
+
+    pub fn restore_cursor(&mut self) {
+        self.pos = self.saved_pos;
+        self.origin_mode = self.saved_origin_mode;
+    }
+
+    pub fn visible_rows(&self) -> impl Iterator<Item = &crate::vt100::row::Row> {
+        let scrollback_len = self.scrollback.len();
+        let rows_len = self.rows.len();
+        self.scrollback
+            .iter()
+            .skip(scrollback_len - self.scrollback_offset)
+            // when scrollback_offset > rows_len (e.g. rows = 3,
+            // scrollback_len = 10, offset = 9) the skip(10 - 9)
+            // will take 9 rows instead of 3. we need to set
+            // the upper bound to rows_len (e.g. 3)
+            .take(rows_len)
+            // same for rows_len - scrollback_offset (e.g. 3 - 9).
+            // it'll panic with overflow. we have to saturate the subtraction.
+            .chain(
+                self.rows
+                    .iter()
+                    .take(rows_len.saturating_sub(self.scrollback_offset)),
+            )
+    }
+
+    pub fn drawing_rows(&self) -> impl Iterator<Item = &crate::vt100::row::Row> {
+        self.rows.iter()
+    }
+
+    pub fn drawing_rows_mut(&mut self) -> impl Iterator<Item = &mut crate::vt100::row::Row> {
+        self.rows.iter_mut()
+    }
+
+    pub fn visible_row(&self, row: u16) -> Option<&crate::vt100::row::Row> {
+        self.visible_rows().nth(usize::from(row))
+    }
+
+    pub fn drawing_row(&self, row: u16) -> Option<&crate::vt100::row::Row> {
+        self.drawing_rows().nth(usize::from(row))
+    }
+
+    pub fn drawing_row_mut(&mut self, row: u16) -> Option<&mut crate::vt100::row::Row> {
+        self.drawing_rows_mut().nth(usize::from(row))
+    }
+
+    pub fn current_row_mut(&mut self) -> &mut crate::vt100::row::Row {
+        self.drawing_row_mut(self.pos.row)
+            // we assume self.pos.row is always valid
+            .unwrap()
+    }
+
+    pub fn visible_cell(&self, pos: Pos) -> Option<&crate::vt100::Cell> {
+        self.visible_row(pos.row).and_then(|r| r.get(pos.col))
+    }
+
+    pub fn drawing_cell(&self, pos: Pos) -> Option<&crate::vt100::Cell> {
+        self.drawing_row(pos.row).and_then(|r| r.get(pos.col))
+    }
+
+    pub fn drawing_cell_mut(&mut self, pos: Pos) -> Option<&mut crate::vt100::Cell> {
+        self.drawing_row_mut(pos.row)
+            .and_then(|r| r.get_mut(pos.col))
+    }
+
+    pub fn scrollback_len(&self) -> usize {
+        self.scrollback_len
+    }
+
+    pub fn scrollback(&self) -> usize {
+        self.scrollback_offset
+    }
+
+    pub fn set_scrollback(&mut self, rows: usize) {
+        self.scrollback_offset = rows.min(self.scrollback.len());
+    }
+
+    pub fn write_contents(&self, contents: &mut String) {
+        let mut wrapping = false;
+        for row in self.visible_rows() {
+            row.write_contents(contents, 0, self.size.cols, wrapping);
+            if !row.wrapped() {
+                contents.push('\n');
+            }
+            wrapping = row.wrapped();
+        }
+
+        while contents.ends_with('\n') {
+            contents.truncate(contents.len() - 1);
+        }
+    }
+
+    pub fn write_contents_formatted(&self, contents: &mut Vec<u8>) -> crate::vt100::attrs::Attrs {
+        crate::vt100::term::ClearAttrs.write_buf(contents);
+        crate::vt100::term::ClearScreen.write_buf(contents);
+
+        let mut prev_attrs = crate::vt100::attrs::Attrs::default();
+        let mut prev_pos = Pos::default();
+        let mut wrapping = false;
+        for (i, row) in self.visible_rows().enumerate() {
+            // we limit the number of cols to a u16 (see Size), so
+            // visible_rows() can never return more rows than will fit
+            let i = i.try_into().unwrap();
+            let (new_pos, new_attrs) = row.write_contents_formatted(
+                contents,
+                0,
+                self.size.cols,
+                i,
+                wrapping,
+                Some(prev_pos),
+                Some(prev_attrs),
+            );
+            prev_pos = new_pos;
+            prev_attrs = new_attrs;
+            wrapping = row.wrapped();
+        }
+
+        self.write_cursor_position_formatted(contents, Some(prev_pos), Some(prev_attrs));
+
+        prev_attrs
+    }
+
+    pub fn write_contents_diff(
+        &self,
+        contents: &mut Vec<u8>,
+        prev: &Self,
+        mut prev_attrs: crate::vt100::attrs::Attrs,
+    ) -> crate::vt100::attrs::Attrs {
+        let mut prev_pos = prev.pos;
+        let mut wrapping = false;
+        let mut prev_wrapping = false;
+        for (i, (row, prev_row)) in self.visible_rows().zip(prev.visible_rows()).enumerate() {
+            // we limit the number of cols to a u16 (see Size), so
+            // visible_rows() can never return more rows than will fit
+            let i = i.try_into().unwrap();
+            let (new_pos, new_attrs) = row.write_contents_diff(
+                contents,
+                prev_row,
+                0,
+                self.size.cols,
+                i,
+                wrapping,
+                prev_wrapping,
+                prev_pos,
+                prev_attrs,
+            );
+            prev_pos = new_pos;
+            prev_attrs = new_attrs;
+            wrapping = row.wrapped();
+            prev_wrapping = prev_row.wrapped();
+        }
+
+        self.write_cursor_position_formatted(contents, Some(prev_pos), Some(prev_attrs));
+
+        prev_attrs
+    }
+
+    pub fn write_cursor_position_formatted(
+        &self,
+        contents: &mut Vec<u8>,
+        prev_pos: Option<Pos>,
+        prev_attrs: Option<crate::vt100::attrs::Attrs>,
+    ) {
+        let prev_attrs = prev_attrs.unwrap_or_default();
+        // writing a character to the last column of a row doesn't wrap the
+        // cursor immediately - it waits until the next character is actually
+        // drawn. it is only possible for the cursor to have this kind of
+        // position after drawing a character though, so if we end in this
+        // position, we need to redraw the character at the end of the row.
+        if prev_pos != Some(self.pos) && self.pos.col >= self.size.cols {
+            let mut pos = Pos {
+                row: self.pos.row,
+                col: self.size.cols - 1,
+            };
+            if self
+                .drawing_cell(pos)
+                // we assume self.pos.row is always valid, and self.size.cols
+                // - 1 is always a valid column
+                .unwrap()
+                .is_wide_continuation()
+            {
+                pos.col = self.size.cols - 2;
+            }
+            let cell =
+                // we assume self.pos.row is always valid, and self.size.cols
+                // - 2 must be a valid column because self.size.cols - 1 is
+                // always valid and we just checked that the cell at
+                // self.size.cols - 1 is a wide continuation character, which
+                // means that the first half of the wide character must be
+                // before it
+                self.drawing_cell(pos).unwrap();
+            if cell.has_contents() {
+                if let Some(prev_pos) = prev_pos {
+                    crate::vt100::term::MoveFromTo::new(prev_pos, pos).write_buf(contents);
+                } else {
+                    crate::vt100::term::MoveTo::new(pos).write_buf(contents);
+                }
+                cell.attrs().write_escape_code_diff(contents, &prev_attrs);
+                contents.extend(cell.contents().as_bytes());
+                prev_attrs.write_escape_code_diff(contents, cell.attrs());
+            } else {
+                // if the cell doesn't have contents, we can't have gotten
+                // here by drawing a character in the last column. this means
+                // that as far as i'm aware, we have to have reached here from
+                // a newline when we were already after the end of an earlier
+                // row. in the case where we are already after the end of an
+                // earlier row, we can just write a few newlines, otherwise we
+                // also need to do the same as above to get ourselves to after
+                // the end of a row.
+                let mut found = false;
+                for i in (0..self.pos.row).rev() {
+                    pos.row = i;
+                    pos.col = self.size.cols - 1;
+                    if self
+                        .drawing_cell(pos)
+                        // i is always less than self.pos.row, which we assume
+                        // to be always valid, so it must also be valid.
+                        // self.size.cols - 1 is always a valid col.
+                        .unwrap()
+                        .is_wide_continuation()
+                    {
+                        pos.col = self.size.cols - 2;
+                    }
+                    let cell = self
+                        .drawing_cell(pos)
+                        // i is always less than self.pos.row, which we assume
+                        // to be always valid, so it must also be valid.
+                        // self.size.cols - 2 is valid because self.size.cols
+                        // - 1 is always valid, and col gets set to
+                        // self.size.cols - 2 when the cell at self.size.cols
+                        // - 1 is a wide continuation character, meaning that
+                        // the first half of the wide character must be before
+                        // it
+                        .unwrap();
+                    if cell.has_contents() {
+                        if let Some(prev_pos) = prev_pos {
+                            if prev_pos.row != i || prev_pos.col < self.size.cols {
+                                crate::vt100::term::MoveFromTo::new(prev_pos, pos)
+                                    .write_buf(contents);
+                                cell.attrs().write_escape_code_diff(contents, &prev_attrs);
+                                contents.extend(cell.contents().as_bytes());
+                                prev_attrs.write_escape_code_diff(contents, cell.attrs());
+                            }
+                        } else {
+                            crate::vt100::term::MoveTo::new(pos).write_buf(contents);
+                            cell.attrs().write_escape_code_diff(contents, &prev_attrs);
+                            contents.extend(cell.contents().as_bytes());
+                            prev_attrs.write_escape_code_diff(contents, cell.attrs());
+                        }
+                        contents.extend("\n".repeat(usize::from(self.pos.row - i)).as_bytes());
+                        found = true;
+                        break;
+                    }
+                }
+
+                // this can happen if you get the cursor off the end of a row,
+                // and then do something to clear the end of the current row
+                // without moving the cursor (IL, DL, ED, EL, etc). we know
+                // there can't be something in the last column because we
+                // would have caught that above, so it should be safe to
+                // overwrite it.
+                if !found {
+                    pos = Pos {
+                        row: self.pos.row,
+                        col: self.size.cols - 1,
+                    };
+                    if let Some(prev_pos) = prev_pos {
+                        crate::vt100::term::MoveFromTo::new(prev_pos, pos).write_buf(contents);
+                    } else {
+                        crate::vt100::term::MoveTo::new(pos).write_buf(contents);
+                    }
+                    contents.push(b' ');
+                    // we know that the cell has no contents, but it still may
+                    // have drawing attributes (background color, etc)
+                    let end_cell = self
+                        .drawing_cell(pos)
+                        // we assume self.pos.row is always valid, and
+                        // self.size.cols - 1 is always a valid column
+                        .unwrap();
+                    end_cell
+                        .attrs()
+                        .write_escape_code_diff(contents, &prev_attrs);
+                    crate::vt100::term::SaveCursor.write_buf(contents);
+                    crate::vt100::term::Backspace.write_buf(contents);
+                    crate::vt100::term::EraseChar::new(1).write_buf(contents);
+                    crate::vt100::term::RestoreCursor.write_buf(contents);
+                    prev_attrs.write_escape_code_diff(contents, end_cell.attrs());
+                }
+            }
+        } else if let Some(prev_pos) = prev_pos {
+            crate::vt100::term::MoveFromTo::new(prev_pos, self.pos).write_buf(contents);
+        } else {
+            crate::vt100::term::MoveTo::new(self.pos).write_buf(contents);
+        }
+    }
+
+    pub fn erase_all(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        for row in self.drawing_rows_mut() {
+            row.clear(attrs);
+        }
+    }
+
+    pub fn erase_all_forward(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        let pos = self.pos;
+        for row in self.drawing_rows_mut().skip(usize::from(pos.row) + 1) {
+            row.clear(attrs);
+        }
+
+        self.erase_row_forward(attrs);
+    }
+
+    pub fn erase_all_backward(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        let pos = self.pos;
+        for row in self.drawing_rows_mut().take(usize::from(pos.row)) {
+            row.clear(attrs);
+        }
+
+        self.erase_row_backward(attrs);
+    }
+
+    pub fn erase_row(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        self.current_row_mut().clear(attrs);
+    }
+
+    pub fn erase_row_forward(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for col in pos.col..size.cols {
+            row.erase(col, attrs);
+        }
+    }
+
+    pub fn erase_row_backward(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for col in 0..=pos.col.min(size.cols - 1) {
+            row.erase(col, attrs);
+        }
+    }
+
+    pub fn insert_cells(&mut self, count: u16) {
+        let size = self.size;
+        let pos = self.pos;
+        let wide = pos.col < size.cols
+            && self
+                .drawing_cell(pos)
+                // we assume self.pos.row is always valid, and we know we are
+                // not off the end of a row because we just checked pos.col <
+                // size.cols
+                .unwrap()
+                .is_wide_continuation();
+        let row = self.current_row_mut();
+        for _ in 0..count {
+            if wide {
+                row.get_mut(pos.col).unwrap().set_wide_continuation(false);
+            }
+            row.insert(pos.col, crate::vt100::Cell::new());
+            if wide {
+                row.get_mut(pos.col).unwrap().set_wide_continuation(true);
+            }
+        }
+        row.truncate(size.cols);
+    }
+
+    pub fn delete_cells(&mut self, count: u16) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for _ in 0..(count.min(size.cols - pos.col)) {
+            row.remove(pos.col);
+        }
+        row.resize(size.cols, crate::vt100::Cell::new());
+    }
+
+    pub fn erase_cells(&mut self, count: u16, attrs: crate::vt100::attrs::Attrs) {
+        let size = self.size;
+        let pos = self.pos;
+        let row = self.current_row_mut();
+        for col in pos.col..((pos.col.saturating_add(count)).min(size.cols)) {
+            row.erase(col, attrs);
+        }
+    }
+
+    pub fn insert_lines(&mut self, count: u16) {
+        for _ in 0..count {
+            self.rows.remove(usize::from(self.scroll_bottom));
+            self.rows.insert(usize::from(self.pos.row), self.new_row());
+            // self.scroll_bottom is maintained to always be a valid row
+            self.rows[usize::from(self.scroll_bottom)].wrap(false);
+        }
+    }
+
+    pub fn delete_lines(&mut self, count: u16) {
+        for _ in 0..(count.min(self.size.rows - self.pos.row)) {
+            self.rows
+                .insert(usize::from(self.scroll_bottom) + 1, self.new_row());
+            self.rows.remove(usize::from(self.pos.row));
+        }
+    }
+
+    pub fn scroll_up(&mut self, count: u16) {
+        for _ in 0..(count.min(self.size.rows - self.scroll_top)) {
+            self.rows
+                .insert(usize::from(self.scroll_bottom) + 1, self.new_row());
+            let removed = self.rows.remove(usize::from(self.scroll_top));
+            if self.scrollback_len > 0 && !self.scroll_region_active() {
+                self.scrollback.push_back(removed);
+                while self.scrollback.len() > self.scrollback_len {
+                    self.scrollback.pop_front();
+                }
+                if self.scrollback_offset > 0 {
+                    self.scrollback_offset = self.scrollback.len().min(self.scrollback_offset + 1);
+                }
+            }
+        }
+    }
+
+    pub fn scroll_down(&mut self, count: u16) {
+        for _ in 0..count {
+            self.rows.remove(usize::from(self.scroll_bottom));
+            self.rows
+                .insert(usize::from(self.scroll_top), self.new_row());
+            // self.scroll_bottom is maintained to always be a valid row
+            self.rows[usize::from(self.scroll_bottom)].wrap(false);
+        }
+    }
+
+    pub fn set_scroll_region(&mut self, top: u16, bottom: u16) {
+        let bottom = bottom.min(self.size().rows - 1);
+        if top < bottom {
+            self.scroll_top = top;
+            self.scroll_bottom = bottom;
+        } else {
+            self.scroll_top = 0;
+            self.scroll_bottom = self.size().rows - 1;
+        }
+        self.pos.row = self.scroll_top;
+        self.pos.col = 0;
+    }
+
+    fn in_scroll_region(&self) -> bool {
+        self.pos.row >= self.scroll_top && self.pos.row <= self.scroll_bottom
+    }
+
+    fn scroll_region_active(&self) -> bool {
+        self.scroll_top != 0 || self.scroll_bottom != self.size.rows - 1
+    }
+
+    pub fn set_origin_mode(&mut self, mode: bool) {
+        self.origin_mode = mode;
+        self.set_pos(Pos { row: 0, col: 0 });
+    }
+
+    pub fn row_inc_clamp(&mut self, count: u16) {
+        let in_scroll_region = self.in_scroll_region();
+        self.pos.row = self.pos.row.saturating_add(count);
+        self.row_clamp_bottom(in_scroll_region);
+    }
+
+    pub fn row_inc_scroll(&mut self, count: u16) -> u16 {
+        let in_scroll_region = self.in_scroll_region();
+        self.pos.row = self.pos.row.saturating_add(count);
+        let lines = self.row_clamp_bottom(in_scroll_region);
+        if in_scroll_region {
+            self.scroll_up(lines);
+            lines
+        } else {
+            0
+        }
+    }
+
+    pub fn row_dec_clamp(&mut self, count: u16) {
+        let in_scroll_region = self.in_scroll_region();
+        self.pos.row = self.pos.row.saturating_sub(count);
+        self.row_clamp_top(in_scroll_region);
+    }
+
+    pub fn row_dec_scroll(&mut self, count: u16) {
+        let in_scroll_region = self.in_scroll_region();
+        // need to account for clamping by both row_clamp_top and by
+        // saturating_sub
+        let extra_lines = count.saturating_sub(self.pos.row);
+        self.pos.row = self.pos.row.saturating_sub(count);
+        let lines = self.row_clamp_top(in_scroll_region);
+        self.scroll_down(lines + extra_lines);
+    }
+
+    pub fn row_set(&mut self, i: u16) {
+        self.pos.row = i;
+        self.row_clamp();
+    }
+
+    pub fn col_inc(&mut self, count: u16) {
+        self.pos.col = self.pos.col.saturating_add(count);
+    }
+
+    pub fn col_inc_clamp(&mut self, count: u16) {
+        self.pos.col = self.pos.col.saturating_add(count);
+        self.col_clamp();
+    }
+
+    pub fn col_dec(&mut self, count: u16) {
+        self.pos.col = self.pos.col.saturating_sub(count);
+    }
+
+    pub fn col_tab(&mut self) {
+        self.pos.col -= self.pos.col % 8;
+        self.pos.col += 8;
+        self.col_clamp();
+    }
+
+    pub fn col_set(&mut self, i: u16) {
+        self.pos.col = i;
+        self.col_clamp();
+    }
+
+    pub fn col_wrap(&mut self, width: u16, wrap: bool) {
+        if self.pos.col > self.size.cols - width {
+            let mut prev_pos = self.pos;
+            self.pos.col = 0;
+            let scrolled = self.row_inc_scroll(1);
+            prev_pos.row -= scrolled;
+            let new_pos = self.pos;
+            self.drawing_row_mut(prev_pos.row)
+                // we assume self.pos.row is always valid, and so prev_pos.row
+                // must be valid because it is always less than or equal to
+                // self.pos.row
+                .unwrap()
+                .wrap(wrap && prev_pos.row + 1 == new_pos.row);
+        }
+    }
+
+    fn row_clamp_top(&mut self, limit_to_scroll_region: bool) -> u16 {
+        if limit_to_scroll_region && self.pos.row < self.scroll_top {
+            let rows = self.scroll_top - self.pos.row;
+            self.pos.row = self.scroll_top;
+            rows
+        } else {
+            0
+        }
+    }
+
+    fn row_clamp_bottom(&mut self, limit_to_scroll_region: bool) -> u16 {
+        let bottom = if limit_to_scroll_region {
+            self.scroll_bottom
+        } else {
+            self.size.rows - 1
+        };
+        if self.pos.row > bottom {
+            let rows = self.pos.row - bottom;
+            self.pos.row = bottom;
+            rows
+        } else {
+            0
+        }
+    }
+
+    fn row_clamp(&mut self) {
+        if self.pos.row > self.size.rows - 1 {
+            self.pos.row = self.size.rows - 1;
+        }
+    }
+
+    fn col_clamp(&mut self) {
+        if self.pos.col > self.size.cols - 1 {
+            self.pos.col = self.size.cols - 1;
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Size {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Pos {
+    pub row: u16,
+    pub col: u16,
+}

--- a/src/vt100/mod.rs
+++ b/src/vt100/mod.rs
@@ -1,0 +1,53 @@
+//! This crate parses a terminal byte stream and provides an in-memory
+//! representation of the rendered contents.
+//!
+//! # Overview
+//!
+//! This is essentially the terminal parser component of a graphical terminal
+//! emulator pulled out into a separate crate. Although you can use this crate
+//! to build a graphical terminal emulator, it also contains functionality
+//! necessary for implementing terminal applications that want to run other
+//! terminal applications - programs like `screen` or `tmux` for example.
+//!
+//! # Synopsis
+//!
+//! ```
+//! let mut parser = vt100::Parser::new(24, 80, 0);
+//!
+//! let screen = parser.screen().clone();
+//! parser.process(b"this text is \x1b[31mRED\x1b[m");
+//! assert_eq!(
+//!     parser.screen().cell(0, 13).unwrap().fgcolor(),
+//!     vt100::Color::Idx(1),
+//! );
+//!
+//! let screen = parser.screen().clone();
+//! parser.process(b"\x1b[3D\x1b[32mGREEN");
+//! assert_eq!(
+//!     parser.screen().contents_formatted(),
+//!     &b"\x1b[?25h\x1b[m\x1b[H\x1b[Jthis text is \x1b[32mGREEN"[..],
+//! );
+//! assert_eq!(
+//!     parser.screen().contents_diff(&screen),
+//!     &b"\x1b[1;14H\x1b[32mGREEN"[..],
+//! );
+//! ```
+
+// Vendored vt100 0.16.2; see README.md for local changes.
+#![allow(dead_code, unused_imports, clippy::all)]
+
+mod attrs;
+mod callbacks;
+mod cell;
+mod grid;
+mod parser;
+mod perform;
+mod row;
+mod screen;
+mod term;
+
+pub use attrs::Color;
+pub use callbacks::Callbacks;
+pub use cell::Cell;
+pub use parser::Parser;
+pub use screen::{MouseProtocolEncoding, MouseProtocolMode, Screen};

--- a/src/vt100/parser.rs
+++ b/src/vt100/parser.rs
@@ -1,0 +1,87 @@
+/// A parser for terminal output which produces an in-memory representation of
+/// the terminal contents.
+pub struct Parser<CB: crate::vt100::callbacks::Callbacks = ()> {
+    parser: vte::Parser,
+    screen: crate::vt100::perform::WrappedScreen<CB>,
+}
+
+impl Parser {
+    /// Creates a new terminal parser of the given size and with the given
+    /// amount of scrollback.
+    #[must_use]
+    pub fn new(rows: u16, cols: u16, scrollback_len: usize) -> Self {
+        Self {
+            parser: vte::Parser::new(),
+            screen: crate::vt100::perform::WrappedScreen::new(rows, cols, scrollback_len),
+        }
+    }
+}
+
+impl<CB: crate::vt100::callbacks::Callbacks> Parser<CB> {
+    /// Creates a new terminal parser of the given size and with the given
+    /// amount of scrollback. Terminal events will be reported via method
+    /// calls on the provided [`Callbacks`](crate::vt100::callbacks::Callbacks)
+    /// implementation.
+    pub fn new_with_callbacks(rows: u16, cols: u16, scrollback_len: usize, callbacks: CB) -> Self {
+        Self {
+            parser: vte::Parser::new(),
+            screen: crate::vt100::perform::WrappedScreen::new_with_callbacks(
+                rows,
+                cols,
+                scrollback_len,
+                callbacks,
+            ),
+        }
+    }
+
+    /// Processes the contents of the given byte string, and updates the
+    /// in-memory terminal state.
+    pub fn process(&mut self, bytes: &[u8]) {
+        self.parser.advance(&mut self.screen, bytes);
+    }
+
+    /// Returns a reference to a [`Screen`](crate::vt100::Screen) object containing
+    /// the terminal state.
+    #[must_use]
+    pub fn screen(&self) -> &crate::vt100::Screen {
+        &self.screen.screen
+    }
+
+    /// Returns a mutable reference to a [`Screen`](crate::vt100::Screen) object
+    /// containing the terminal state.
+    #[must_use]
+    pub fn screen_mut(&mut self) -> &mut crate::vt100::Screen {
+        &mut self.screen.screen
+    }
+
+    /// Returns a reference to the [`Callbacks`](crate::vt100::callbacks::Callbacks)
+    /// state object passed into the constructor.
+    pub fn callbacks(&self) -> &CB {
+        &self.screen.callbacks
+    }
+
+    /// Returns a mutable reference to the
+    /// [`Callbacks`](crate::vt100::callbacks::Callbacks) state object passed into
+    /// the constructor.
+    pub fn callbacks_mut(&mut self) -> &mut CB {
+        &mut self.screen.callbacks
+    }
+}
+
+impl Default for Parser {
+    /// Returns a parser with dimensions 80x24 and no scrollback.
+    fn default() -> Self {
+        Self::new(24, 80, 0)
+    }
+}
+
+impl std::io::Write for Parser {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.process(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/vt100/perform.rs
+++ b/src/vt100/perform.rs
@@ -1,0 +1,234 @@
+const BASE64: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+const CLIPBOARD_SELECTOR: &[u8] = b"cpqs01234567";
+
+pub struct WrappedScreen<CB: crate::vt100::callbacks::Callbacks = ()> {
+    pub screen: crate::vt100::screen::Screen,
+    pub callbacks: CB,
+}
+
+impl WrappedScreen<()> {
+    pub fn new(rows: u16, cols: u16, scrollback_len: usize) -> Self {
+        Self::new_with_callbacks(rows, cols, scrollback_len, ())
+    }
+}
+
+impl<CB: crate::vt100::callbacks::Callbacks> WrappedScreen<CB> {
+    pub fn new_with_callbacks(rows: u16, cols: u16, scrollback_len: usize, callbacks: CB) -> Self {
+        Self {
+            screen: crate::vt100::screen::Screen::new(
+                crate::vt100::grid::Size { rows, cols },
+                scrollback_len,
+            ),
+            callbacks,
+        }
+    }
+}
+
+impl<CB: crate::vt100::callbacks::Callbacks> vte::Perform for WrappedScreen<CB> {
+    fn print(&mut self, c: char) {
+        if c == '\u{fffd}' || ('\u{80}'..'\u{a0}').contains(&c) {
+            self.callbacks.unhandled_char(&mut self.screen, c);
+        } else {
+            self.screen.text(c);
+        }
+    }
+
+    fn execute(&mut self, b: u8) {
+        match b {
+            7 => self.callbacks.audible_bell(&mut self.screen),
+            8 => self.screen.bs(),
+            9 => self.screen.tab(),
+            10 => self.screen.lf(),
+            11 => self.screen.vt(),
+            12 => self.screen.ff(),
+            13 => self.screen.cr(),
+            // we don't implement shift in/out alternate character sets, but
+            // it shouldn't count as an "error"
+            14 | 15 => {}
+            _ => self.callbacks.unhandled_control(&mut self.screen, b),
+        }
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], _ignore: bool, b: u8) {
+        if let Some(i) = intermediates.first() {
+            self.callbacks.unhandled_escape(
+                &mut self.screen,
+                Some(*i),
+                intermediates.get(1).copied(),
+                b,
+            );
+        } else {
+            match b {
+                b'7' => self.screen.decsc(),
+                b'8' => self.screen.decrc(),
+                b'=' => self.screen.deckpam(),
+                b'>' => self.screen.deckpnm(),
+                b'M' => self.screen.ri(),
+                b'c' => self.screen.ris(),
+                b'g' => self.callbacks.visual_bell(&mut self.screen),
+                _ => {
+                    self.callbacks
+                        .unhandled_escape(&mut self.screen, None, None, b);
+                }
+            }
+        }
+    }
+
+    fn csi_dispatch(&mut self, params: &vte::Params, intermediates: &[u8], _ignore: bool, c: char) {
+        let unhandled = |screen: &mut crate::vt100::screen::Screen| {
+            self.callbacks.unhandled_csi(
+                screen,
+                intermediates.first().copied(),
+                intermediates.get(1).copied(),
+                &params.iter().collect::<Vec<_>>(),
+                c,
+            );
+        };
+        match intermediates.first() {
+            None => match c {
+                '@' => self.screen.ich(canonicalize_params_1(params, 1)),
+                'A' => self.screen.cuu(canonicalize_params_1(params, 1)),
+                'B' => self.screen.cud(canonicalize_params_1(params, 1)),
+                'C' => self.screen.cuf(canonicalize_params_1(params, 1)),
+                'D' => self.screen.cub(canonicalize_params_1(params, 1)),
+                'E' => self.screen.cnl(canonicalize_params_1(params, 1)),
+                'F' => self.screen.cpl(canonicalize_params_1(params, 1)),
+                'G' => self.screen.cha(canonicalize_params_1(params, 1)),
+                'H' => self.screen.cup(canonicalize_params_2(params, 1, 1)),
+                'J' => self.screen.ed(canonicalize_params_1(params, 0), unhandled),
+                'K' => self.screen.el(canonicalize_params_1(params, 0), unhandled),
+                'L' => self.screen.il(canonicalize_params_1(params, 1)),
+                'M' => self.screen.dl(canonicalize_params_1(params, 1)),
+                'P' => self.screen.dch(canonicalize_params_1(params, 1)),
+                'S' => self.screen.su(canonicalize_params_1(params, 1)),
+                'T' => self.screen.sd(canonicalize_params_1(params, 1)),
+                'X' => self.screen.ech(canonicalize_params_1(params, 1)),
+                'd' => self.screen.vpa(canonicalize_params_1(params, 1)),
+                'm' => self.screen.sgr(params, unhandled),
+                'r' => self.screen.decstbm(canonicalize_params_decstbm(
+                    params,
+                    self.screen.grid().size(),
+                )),
+                't' => {
+                    let mut params_iter = params.iter();
+                    let op = params_iter.next().and_then(|x| x.first().copied());
+                    if op == Some(8) {
+                        let (screen_rows, screen_cols) = self.screen.size();
+                        let rows = params_iter
+                            .next()
+                            .map_or(screen_rows, |x| *x.first().unwrap_or(&screen_rows));
+                        let cols = params_iter
+                            .next()
+                            .map_or(screen_cols, |x| *x.first().unwrap_or(&screen_cols));
+                        self.callbacks.resize(&mut self.screen, (rows, cols));
+                    } else {
+                        self.callbacks.unhandled_csi(
+                            &mut self.screen,
+                            None,
+                            None,
+                            &params.iter().collect::<Vec<_>>(),
+                            c,
+                        );
+                    }
+                }
+                _ => {
+                    self.callbacks.unhandled_csi(
+                        &mut self.screen,
+                        None,
+                        None,
+                        &params.iter().collect::<Vec<_>>(),
+                        c,
+                    );
+                }
+            },
+            Some(b'?') => match c {
+                'J' => self
+                    .screen
+                    .decsed(canonicalize_params_1(params, 0), unhandled),
+                'K' => self
+                    .screen
+                    .decsel(canonicalize_params_1(params, 0), unhandled),
+                'h' => self.screen.decset(params, unhandled),
+                'l' => self.screen.decrst(params, unhandled),
+                _ => {
+                    self.callbacks.unhandled_csi(
+                        &mut self.screen,
+                        Some(b'?'),
+                        intermediates.get(1).copied(),
+                        &params.iter().collect::<Vec<_>>(),
+                        c,
+                    );
+                }
+            },
+            Some(i) => {
+                self.callbacks.unhandled_csi(
+                    &mut self.screen,
+                    Some(*i),
+                    intermediates.get(1).copied(),
+                    &params.iter().collect::<Vec<_>>(),
+                    c,
+                );
+            }
+        }
+    }
+
+    fn osc_dispatch(&mut self, params: &[&[u8]], _bel_terminated: bool) {
+        match params {
+            [b"8", _, destination @ ..] => {
+                // Semicolons are legal in URIs; vte splits OSC parameters there.
+                self.screen.set_hyperlink(&destination.join(&b';'));
+            }
+            [b"0", s] => {
+                self.callbacks.set_window_icon_name(&mut self.screen, s);
+                self.callbacks.set_window_title(&mut self.screen, s);
+            }
+            [b"1", s] => {
+                self.callbacks.set_window_icon_name(&mut self.screen, s);
+            }
+            [b"2", s] => {
+                self.callbacks.set_window_title(&mut self.screen, s);
+            }
+            [b"52", ty, data] => match (ty.iter().all(|c| CLIPBOARD_SELECTOR.contains(c)), *data) {
+                (true, b"?") => {
+                    self.callbacks.paste_from_clipboard(&mut self.screen, ty);
+                }
+                (true, data) if data.iter().all(|c| BASE64.contains(c)) => {
+                    self.callbacks.copy_to_clipboard(&mut self.screen, ty, data);
+                }
+                _ => {
+                    self.callbacks.unhandled_osc(&mut self.screen, params);
+                }
+            },
+            _ => {
+                self.callbacks.unhandled_osc(&mut self.screen, params);
+            }
+        }
+    }
+}
+
+fn canonicalize_params_1(params: &vte::Params, default: u16) -> u16 {
+    let first = params.iter().next().map_or(0, |x| *x.first().unwrap_or(&0));
+    if first == 0 { default } else { first }
+}
+
+fn canonicalize_params_2(params: &vte::Params, default1: u16, default2: u16) -> (u16, u16) {
+    let mut iter = params.iter();
+    let first = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let first = if first == 0 { default1 } else { first };
+
+    let second = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let second = if second == 0 { default2 } else { second };
+
+    (first, second)
+}
+
+fn canonicalize_params_decstbm(params: &vte::Params, size: crate::vt100::grid::Size) -> (u16, u16) {
+    let mut iter = params.iter();
+    let top = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let top = if top == 0 { 1 } else { top };
+
+    let bottom = iter.next().map_or(0, |x| *x.first().unwrap_or(&0));
+    let bottom = if bottom == 0 { size.rows } else { bottom };
+
+    (top, bottom)
+}

--- a/src/vt100/row.rs
+++ b/src/vt100/row.rs
@@ -1,0 +1,430 @@
+use crate::vt100::term::BufWrite as _;
+
+#[derive(Clone, Debug)]
+pub struct Row {
+    cells: Vec<crate::vt100::Cell>,
+    wrapped: bool,
+}
+
+impl Row {
+    pub fn new(cols: u16) -> Self {
+        Self {
+            cells: vec![crate::vt100::Cell::new(); usize::from(cols)],
+            wrapped: false,
+        }
+    }
+
+    fn cols(&self) -> u16 {
+        self.cells
+            .len()
+            .try_into()
+            // we limit the number of cols to a u16 (see Size)
+            .unwrap()
+    }
+
+    pub fn clear(&mut self, attrs: crate::vt100::attrs::Attrs) {
+        for cell in &mut self.cells {
+            cell.clear(attrs);
+        }
+        self.wrapped = false;
+    }
+
+    fn cells(&self) -> impl Iterator<Item = &crate::vt100::Cell> {
+        self.cells.iter()
+    }
+
+    pub fn get(&self, col: u16) -> Option<&crate::vt100::Cell> {
+        self.cells.get(usize::from(col))
+    }
+
+    pub fn get_mut(&mut self, col: u16) -> Option<&mut crate::vt100::Cell> {
+        self.cells.get_mut(usize::from(col))
+    }
+
+    pub fn insert(&mut self, i: u16, cell: crate::vt100::Cell) {
+        self.cells.insert(usize::from(i), cell);
+        self.wrapped = false;
+    }
+
+    pub fn remove(&mut self, i: u16) {
+        self.clear_wide(i);
+        self.cells.remove(usize::from(i));
+        self.wrapped = false;
+    }
+
+    pub fn erase(&mut self, i: u16, attrs: crate::vt100::attrs::Attrs) {
+        let wide = self.cells[usize::from(i)].is_wide();
+        self.clear_wide(i);
+        self.cells[usize::from(i)].clear(attrs);
+        if i == self.cols() - if wide { 2 } else { 1 } {
+            self.wrapped = false;
+        }
+    }
+
+    pub fn truncate(&mut self, len: u16) {
+        self.cells.truncate(usize::from(len));
+        self.wrapped = false;
+        let last_cell = &mut self.cells[usize::from(len) - 1];
+        if last_cell.is_wide() {
+            last_cell.clear(*last_cell.attrs());
+        }
+    }
+
+    pub fn resize(&mut self, len: u16, cell: crate::vt100::Cell) {
+        self.cells.resize(usize::from(len), cell);
+        self.wrapped = false;
+    }
+
+    pub fn wrap(&mut self, wrap: bool) {
+        self.wrapped = wrap;
+    }
+
+    pub fn wrapped(&self) -> bool {
+        self.wrapped
+    }
+
+    pub fn clear_wide(&mut self, col: u16) {
+        let cell = &self.cells[usize::from(col)];
+        let other = if cell.is_wide() {
+            &mut self.cells[usize::from(col + 1)]
+        } else if cell.is_wide_continuation() {
+            &mut self.cells[usize::from(col - 1)]
+        } else {
+            return;
+        };
+        other.clear(*other.attrs());
+    }
+
+    pub fn write_contents(&self, contents: &mut String, start: u16, width: u16, wrapping: bool) {
+        let mut prev_was_wide = false;
+
+        let mut prev_col = start;
+        for (col, cell) in self
+            .cells()
+            .enumerate()
+            .skip(usize::from(start))
+            .take(usize::from(width))
+        {
+            if prev_was_wide {
+                prev_was_wide = false;
+                continue;
+            }
+            prev_was_wide = cell.is_wide();
+
+            // we limit the number of cols to a u16 (see Size)
+            let col: u16 = col.try_into().unwrap();
+            if cell.has_contents() {
+                for _ in 0..(col - prev_col) {
+                    contents.push(' ');
+                }
+                prev_col += col - prev_col;
+
+                contents.push_str(cell.contents());
+                prev_col += if cell.is_wide() { 2 } else { 1 };
+            }
+        }
+        if prev_col == start && wrapping {
+            contents.push('\n');
+        }
+    }
+
+    pub fn write_contents_formatted(
+        &self,
+        contents: &mut Vec<u8>,
+        start: u16,
+        width: u16,
+        row: u16,
+        wrapping: bool,
+        prev_pos: Option<crate::vt100::grid::Pos>,
+        prev_attrs: Option<crate::vt100::attrs::Attrs>,
+    ) -> (crate::vt100::grid::Pos, crate::vt100::attrs::Attrs) {
+        let mut prev_was_wide = false;
+        let default_cell = crate::vt100::Cell::new();
+
+        let mut prev_pos = prev_pos.unwrap_or_else(|| {
+            if wrapping {
+                crate::vt100::grid::Pos {
+                    row: row - 1,
+                    col: self.cols(),
+                }
+            } else {
+                crate::vt100::grid::Pos { row, col: start }
+            }
+        });
+        let mut prev_attrs = prev_attrs.unwrap_or_default();
+
+        let first_cell = &self.cells[usize::from(start)];
+        if wrapping && first_cell == &default_cell {
+            let default_attrs = default_cell.attrs();
+            if &prev_attrs != default_attrs {
+                default_attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *default_attrs;
+            }
+            contents.push(b' ');
+            crate::vt100::term::Backspace.write_buf(contents);
+            crate::vt100::term::EraseChar::new(1).write_buf(contents);
+            prev_pos = crate::vt100::grid::Pos { row, col: 0 };
+        }
+
+        let mut erase: Option<(u16, &crate::vt100::attrs::Attrs)> = None;
+        for (col, cell) in self
+            .cells()
+            .enumerate()
+            .skip(usize::from(start))
+            .take(usize::from(width))
+        {
+            if prev_was_wide {
+                prev_was_wide = false;
+                continue;
+            }
+            prev_was_wide = cell.is_wide();
+
+            // we limit the number of cols to a u16 (see Size)
+            let col: u16 = col.try_into().unwrap();
+            let pos = crate::vt100::grid::Pos { row, col };
+
+            if let Some((prev_col, attrs)) = erase {
+                if cell.has_contents() || cell.attrs() != attrs {
+                    let new_pos = crate::vt100::grid::Pos { row, col: prev_col };
+                    if wrapping && prev_pos.row + 1 == new_pos.row && prev_pos.col >= self.cols() {
+                        if new_pos.col > 0 {
+                            contents.extend(" ".repeat(usize::from(new_pos.col)).as_bytes());
+                        } else {
+                            contents.extend(b" ");
+                            crate::vt100::term::Backspace.write_buf(contents);
+                        }
+                    } else {
+                        crate::vt100::term::MoveFromTo::new(prev_pos, new_pos).write_buf(contents);
+                    }
+                    prev_pos = new_pos;
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+                    crate::vt100::term::EraseChar::new(pos.col - prev_col).write_buf(contents);
+                    erase = None;
+                }
+            }
+
+            if cell != &default_cell {
+                let attrs = cell.attrs();
+                if cell.has_contents() {
+                    if pos != prev_pos {
+                        if !wrapping
+                            || prev_pos.row + 1 != pos.row
+                            || prev_pos.col < self.cols() - u16::from(cell.is_wide())
+                            || pos.col != 0
+                        {
+                            crate::vt100::term::MoveFromTo::new(prev_pos, pos).write_buf(contents);
+                        }
+                        prev_pos = pos;
+                    }
+
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+
+                    prev_pos.col += if cell.is_wide() { 2 } else { 1 };
+                    let cell_contents = cell.contents();
+                    contents.extend(cell_contents.as_bytes());
+                } else if erase.is_none() {
+                    erase = Some((pos.col, attrs));
+                }
+            }
+        }
+        if let Some((prev_col, attrs)) = erase {
+            let new_pos = crate::vt100::grid::Pos { row, col: prev_col };
+            if wrapping && prev_pos.row + 1 == new_pos.row && prev_pos.col >= self.cols() {
+                if new_pos.col > 0 {
+                    contents.extend(" ".repeat(usize::from(new_pos.col)).as_bytes());
+                } else {
+                    contents.extend(b" ");
+                    crate::vt100::term::Backspace.write_buf(contents);
+                }
+            } else {
+                crate::vt100::term::MoveFromTo::new(prev_pos, new_pos).write_buf(contents);
+            }
+            prev_pos = new_pos;
+            if &prev_attrs != attrs {
+                attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *attrs;
+            }
+            crate::vt100::term::ClearRowForward.write_buf(contents);
+        }
+
+        (prev_pos, prev_attrs)
+    }
+
+    // while it's true that most of the logic in this is identical to
+    // write_contents_formatted, i can't figure out how to break out the
+    // common parts without making things noticeably slower.
+    pub fn write_contents_diff(
+        &self,
+        contents: &mut Vec<u8>,
+        prev: &Self,
+        start: u16,
+        width: u16,
+        row: u16,
+        wrapping: bool,
+        prev_wrapping: bool,
+        mut prev_pos: crate::vt100::grid::Pos,
+        mut prev_attrs: crate::vt100::attrs::Attrs,
+    ) -> (crate::vt100::grid::Pos, crate::vt100::attrs::Attrs) {
+        let mut prev_was_wide = false;
+
+        let first_cell = &self.cells[usize::from(start)];
+        let prev_first_cell = &prev.cells[usize::from(start)];
+        if wrapping
+            && !prev_wrapping
+            && first_cell == prev_first_cell
+            && prev_pos.row + 1 == row
+            && prev_pos.col >= self.cols() - u16::from(prev_first_cell.is_wide())
+        {
+            let first_cell_attrs = first_cell.attrs();
+            if &prev_attrs != first_cell_attrs {
+                first_cell_attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *first_cell_attrs;
+            }
+            let mut cell_contents = prev_first_cell.contents();
+            let need_erase = if cell_contents.is_empty() {
+                cell_contents = " ";
+                true
+            } else {
+                false
+            };
+            contents.extend(cell_contents.as_bytes());
+            crate::vt100::term::Backspace.write_buf(contents);
+            if prev_first_cell.is_wide() {
+                crate::vt100::term::Backspace.write_buf(contents);
+            }
+            if need_erase {
+                crate::vt100::term::EraseChar::new(1).write_buf(contents);
+            }
+            prev_pos = crate::vt100::grid::Pos { row, col: 0 };
+        }
+
+        let mut erase: Option<(u16, &crate::vt100::attrs::Attrs)> = None;
+        for (col, (cell, prev_cell)) in self
+            .cells()
+            .zip(prev.cells())
+            .enumerate()
+            .skip(usize::from(start))
+            .take(usize::from(width))
+        {
+            if prev_was_wide {
+                prev_was_wide = false;
+                continue;
+            }
+            prev_was_wide = cell.is_wide();
+
+            // we limit the number of cols to a u16 (see Size)
+            let col: u16 = col.try_into().unwrap();
+            let pos = crate::vt100::grid::Pos { row, col };
+
+            if let Some((prev_col, attrs)) = erase {
+                if cell.has_contents() || cell.attrs() != attrs {
+                    let new_pos = crate::vt100::grid::Pos { row, col: prev_col };
+                    if wrapping && prev_pos.row + 1 == new_pos.row && prev_pos.col >= self.cols() {
+                        if new_pos.col > 0 {
+                            contents.extend(" ".repeat(usize::from(new_pos.col)).as_bytes());
+                        } else {
+                            contents.extend(b" ");
+                            crate::vt100::term::Backspace.write_buf(contents);
+                        }
+                    } else {
+                        crate::vt100::term::MoveFromTo::new(prev_pos, new_pos).write_buf(contents);
+                    }
+                    prev_pos = new_pos;
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+                    crate::vt100::term::EraseChar::new(pos.col - prev_col).write_buf(contents);
+                    erase = None;
+                }
+            }
+
+            if cell != prev_cell {
+                let attrs = cell.attrs();
+                if cell.has_contents() {
+                    if pos != prev_pos {
+                        if !wrapping
+                            || prev_pos.row + 1 != pos.row
+                            || prev_pos.col < self.cols() - u16::from(cell.is_wide())
+                            || pos.col != 0
+                        {
+                            crate::vt100::term::MoveFromTo::new(prev_pos, pos).write_buf(contents);
+                        }
+                        prev_pos = pos;
+                    }
+
+                    if &prev_attrs != attrs {
+                        attrs.write_escape_code_diff(contents, &prev_attrs);
+                        prev_attrs = *attrs;
+                    }
+
+                    prev_pos.col += if cell.is_wide() { 2 } else { 1 };
+                    contents.extend(cell.contents().as_bytes());
+                } else if erase.is_none() {
+                    erase = Some((pos.col, attrs));
+                }
+            }
+        }
+        if let Some((prev_col, attrs)) = erase {
+            let new_pos = crate::vt100::grid::Pos { row, col: prev_col };
+            if wrapping && prev_pos.row + 1 == new_pos.row && prev_pos.col >= self.cols() {
+                if new_pos.col > 0 {
+                    contents.extend(" ".repeat(usize::from(new_pos.col)).as_bytes());
+                } else {
+                    contents.extend(b" ");
+                    crate::vt100::term::Backspace.write_buf(contents);
+                }
+            } else {
+                crate::vt100::term::MoveFromTo::new(prev_pos, new_pos).write_buf(contents);
+            }
+            prev_pos = new_pos;
+            if &prev_attrs != attrs {
+                attrs.write_escape_code_diff(contents, &prev_attrs);
+                prev_attrs = *attrs;
+            }
+            crate::vt100::term::ClearRowForward.write_buf(contents);
+        }
+
+        // if this row is going from wrapped to not wrapped, we need to erase
+        // and redraw the last character to break wrapping. if this row is
+        // wrapped, we need to redraw the last character without erasing it to
+        // position the cursor after the end of the line correctly so that
+        // drawing the next line can just start writing and be wrapped.
+        if (!self.wrapped && prev.wrapped) || (!prev.wrapped && self.wrapped) {
+            let end_pos = if self.cells[usize::from(self.cols() - 1)].is_wide_continuation() {
+                crate::vt100::grid::Pos {
+                    row,
+                    col: self.cols() - 2,
+                }
+            } else {
+                crate::vt100::grid::Pos {
+                    row,
+                    col: self.cols() - 1,
+                }
+            };
+            crate::vt100::term::MoveFromTo::new(prev_pos, end_pos).write_buf(contents);
+            prev_pos = end_pos;
+            if !self.wrapped {
+                crate::vt100::term::EraseChar::new(1).write_buf(contents);
+            }
+            let end_cell = &self.cells[usize::from(end_pos.col)];
+            if end_cell.has_contents() {
+                let attrs = end_cell.attrs();
+                if &prev_attrs != attrs {
+                    attrs.write_escape_code_diff(contents, &prev_attrs);
+                    prev_attrs = *attrs;
+                }
+                contents.extend(end_cell.contents().as_bytes());
+                prev_pos.col += if end_cell.is_wide() { 2 } else { 1 };
+            }
+        }
+
+        (prev_pos, prev_attrs)
+    }
+}

--- a/src/vt100/screen.rs
+++ b/src/vt100/screen.rs
@@ -1,0 +1,1301 @@
+use crate::vt100::term::BufWrite as _;
+use unicode_width::UnicodeWidthChar as _;
+
+const MODE_APPLICATION_KEYPAD: u8 = 0b0000_0001;
+const MODE_APPLICATION_CURSOR: u8 = 0b0000_0010;
+const MODE_HIDE_CURSOR: u8 = 0b0000_0100;
+const MODE_ALTERNATE_SCREEN: u8 = 0b0000_1000;
+const MODE_BRACKETED_PASTE: u8 = 0b0001_0000;
+
+/// The xterm mouse handling mode currently in use.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub enum MouseProtocolMode {
+    /// Mouse handling is disabled.
+    #[default]
+    None,
+
+    /// Mouse button events should be reported on button press. Also known as
+    /// X10 mouse mode.
+    Press,
+
+    /// Mouse button events should be reported on button press and release.
+    /// Also known as VT200 mouse mode.
+    PressRelease,
+
+    // Highlight,
+    /// Mouse button events should be reported on button press and release, as
+    /// well as when the mouse moves between cells while a button is held
+    /// down.
+    ButtonMotion,
+
+    /// Mouse button events should be reported on button press and release,
+    /// and mouse motion events should be reported when the mouse moves
+    /// between cells regardless of whether a button is held down or not.
+    AnyMotion,
+    // DecLocator,
+}
+
+/// The encoding to use for the enabled [`MouseProtocolMode`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+pub enum MouseProtocolEncoding {
+    /// Default single-printable-byte encoding.
+    #[default]
+    Default,
+
+    /// UTF-8-based encoding.
+    Utf8,
+
+    /// SGR-like encoding.
+    Sgr,
+    // Urxvt,
+}
+
+/// Represents the overall terminal state.
+#[derive(Clone, Debug)]
+pub struct Screen {
+    grid: crate::vt100::grid::Grid,
+    alternate_grid: crate::vt100::grid::Grid,
+
+    attrs: crate::vt100::attrs::Attrs,
+    saved_attrs: crate::vt100::attrs::Attrs,
+    hyperlink: Option<std::sync::Arc<str>>,
+
+    modes: u8,
+    mouse_protocol_mode: MouseProtocolMode,
+    mouse_protocol_encoding: MouseProtocolEncoding,
+}
+
+impl Screen {
+    pub(crate) fn new(size: crate::vt100::grid::Size, scrollback_len: usize) -> Self {
+        let mut grid = crate::vt100::grid::Grid::new(size, scrollback_len);
+        grid.allocate_rows();
+        Self {
+            grid,
+            alternate_grid: crate::vt100::grid::Grid::new(size, 0),
+
+            attrs: crate::vt100::attrs::Attrs::default(),
+            saved_attrs: crate::vt100::attrs::Attrs::default(),
+            hyperlink: None,
+
+            modes: 0,
+            mouse_protocol_mode: MouseProtocolMode::default(),
+            mouse_protocol_encoding: MouseProtocolEncoding::default(),
+        }
+    }
+
+    /// Resizes the terminal.
+    pub fn set_size(&mut self, rows: u16, cols: u16) {
+        self.grid.set_size(crate::vt100::grid::Size { rows, cols });
+        self.alternate_grid
+            .set_size(crate::vt100::grid::Size { rows, cols });
+    }
+
+    /// Returns the current size of the terminal.
+    ///
+    /// The return value will be (rows, cols).
+    #[must_use]
+    pub fn size(&self) -> (u16, u16) {
+        let size = self.grid().size();
+        (size.rows, size.cols)
+    }
+
+    /// Scrolls to the given position in the scrollback.
+    ///
+    /// This position indicates the offset from the top of the screen, and
+    /// should be `0` to put the normal screen in view.
+    ///
+    /// This affects the return values of methods called on the screen: for
+    /// instance, `screen.cell(0, 0)` will return the top left corner of the
+    /// screen after taking the scrollback offset into account.
+    ///
+    /// The value given will be clamped to the actual size of the scrollback.
+    pub fn set_scrollback(&mut self, rows: usize) {
+        self.grid_mut().set_scrollback(rows);
+    }
+
+    /// Returns the current position in the scrollback.
+    ///
+    /// This position indicates the offset from the top of the screen, and is
+    /// `0` when the normal screen is in view.
+    #[must_use]
+    pub fn scrollback(&self) -> usize {
+        self.grid().scrollback()
+    }
+
+    /// Returns the text contents of the terminal.
+    ///
+    /// This will not include any formatting information, and will be in plain
+    /// text format.
+    #[must_use]
+    pub fn contents(&self) -> String {
+        let mut contents = String::new();
+        self.write_contents(&mut contents);
+        contents
+    }
+
+    fn write_contents(&self, contents: &mut String) {
+        self.grid().write_contents(contents);
+    }
+
+    /// Returns the text contents of the terminal by row, restricted to the
+    /// given subset of columns.
+    ///
+    /// This will not include any formatting information, and will be in plain
+    /// text format.
+    ///
+    /// Newlines will not be included.
+    pub fn rows(&self, start: u16, width: u16) -> impl Iterator<Item = String> + '_ {
+        self.grid().visible_rows().map(move |row| {
+            let mut contents = String::new();
+            row.write_contents(&mut contents, start, width, false);
+            contents
+        })
+    }
+
+    /// Returns the text contents of the terminal logically between two cells.
+    /// This will include the remainder of the starting row after `start_col`,
+    /// followed by the entire contents of the rows between `start_row` and
+    /// `end_row`, followed by the beginning of the `end_row` up until
+    /// `end_col`. This is useful for things like determining the contents of
+    /// a clipboard selection.
+    #[must_use]
+    pub fn contents_between(
+        &self,
+        start_row: u16,
+        start_col: u16,
+        end_row: u16,
+        end_col: u16,
+    ) -> String {
+        match start_row.cmp(&end_row) {
+            std::cmp::Ordering::Less => {
+                let (_, cols) = self.size();
+                let mut contents = String::new();
+                for (i, row) in self
+                    .grid()
+                    .visible_rows()
+                    .enumerate()
+                    .skip(usize::from(start_row))
+                    .take(usize::from(end_row) - usize::from(start_row) + 1)
+                {
+                    if i == usize::from(start_row) {
+                        row.write_contents(&mut contents, start_col, cols - start_col, false);
+                        if !row.wrapped() {
+                            contents.push('\n');
+                        }
+                    } else if i == usize::from(end_row) {
+                        row.write_contents(&mut contents, 0, end_col, false);
+                    } else {
+                        row.write_contents(&mut contents, 0, cols, false);
+                        if !row.wrapped() {
+                            contents.push('\n');
+                        }
+                    }
+                }
+                contents
+            }
+            std::cmp::Ordering::Equal => {
+                if start_col < end_col {
+                    self.rows(start_col, end_col - start_col)
+                        .nth(usize::from(start_row))
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                }
+            }
+            std::cmp::Ordering::Greater => String::new(),
+        }
+    }
+
+    /// Return escape codes sufficient to reproduce the entire contents of the
+    /// current terminal state. This is a convenience wrapper around
+    /// [`contents_formatted`](Self::contents_formatted) and
+    /// [`input_mode_formatted`](Self::input_mode_formatted).
+    #[must_use]
+    pub fn state_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_formatted(&mut contents);
+        self.write_input_mode_formatted(&mut contents);
+        contents
+    }
+
+    /// Return escape codes sufficient to turn the terminal state of the
+    /// screen `prev` into the current terminal state. This is a convenience
+    /// wrapper around [`contents_diff`](Self::contents_diff) and
+    /// [`input_mode_diff`](Self::input_mode_diff).
+    #[must_use]
+    pub fn state_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_diff(&mut contents, prev);
+        self.write_input_mode_diff(&mut contents, prev);
+        contents
+    }
+
+    /// Returns the formatted visible contents of the terminal.
+    ///
+    /// Formatting information will be included inline as terminal escape
+    /// codes. The result will be suitable for feeding directly to a raw
+    /// terminal parser, and will result in the same visual output.
+    #[must_use]
+    pub fn contents_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_formatted(&mut contents);
+        contents
+    }
+
+    fn write_contents_formatted(&self, contents: &mut Vec<u8>) {
+        crate::vt100::term::HideCursor::new(self.hide_cursor()).write_buf(contents);
+        let prev_attrs = self.grid().write_contents_formatted(contents);
+        self.attrs.write_escape_code_diff(contents, &prev_attrs);
+    }
+
+    /// Returns the formatted visible contents of the terminal by row,
+    /// restricted to the given subset of columns.
+    ///
+    /// Formatting information will be included inline as terminal escape
+    /// codes. The result will be suitable for feeding directly to a raw
+    /// terminal parser, and will result in the same visual output.
+    ///
+    /// You are responsible for positioning the cursor before printing each
+    /// row, and the final cursor position after displaying each row is
+    /// unspecified.
+    // the unwraps in this method shouldn't be reachable
+    #[allow(clippy::missing_panics_doc)]
+    pub fn rows_formatted(&self, start: u16, width: u16) -> impl Iterator<Item = Vec<u8>> + '_ {
+        let mut wrapping = false;
+        self.grid().visible_rows().enumerate().map(move |(i, row)| {
+            // number of rows in a grid is stored in a u16 (see Size), so
+            // visible_rows can never return enough rows to overflow here
+            let i = i.try_into().unwrap();
+            let mut contents = vec![];
+            row.write_contents_formatted(&mut contents, start, width, i, wrapping, None, None);
+            if start == 0 && width == self.grid.size().cols {
+                wrapping = row.wrapped();
+            }
+            contents
+        })
+    }
+
+    /// Returns a terminal byte stream sufficient to turn the visible contents
+    /// of the screen described by `prev` into the visible contents of the
+    /// screen described by `self`.
+    ///
+    /// The result of rendering `prev.contents_formatted()` followed by
+    /// `self.contents_diff(prev)` should be equivalent to the result of
+    /// rendering `self.contents_formatted()`. This is primarily useful when
+    /// you already have a terminal parser whose state is described by `prev`,
+    /// since the diff will likely require less memory and cause less
+    /// flickering than redrawing the entire screen contents.
+    #[must_use]
+    pub fn contents_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_contents_diff(&mut contents, prev);
+        contents
+    }
+
+    fn write_contents_diff(&self, contents: &mut Vec<u8>, prev: &Self) {
+        if self.hide_cursor() != prev.hide_cursor() {
+            crate::vt100::term::HideCursor::new(self.hide_cursor()).write_buf(contents);
+        }
+        let prev_attrs = self
+            .grid()
+            .write_contents_diff(contents, prev.grid(), prev.attrs);
+        self.attrs.write_escape_code_diff(contents, &prev_attrs);
+    }
+
+    /// Returns a sequence of terminal byte streams sufficient to turn the
+    /// visible contents of the subset of each row from `prev` (as described
+    /// by `start` and `width`) into the visible contents of the corresponding
+    /// row subset in `self`.
+    ///
+    /// You are responsible for positioning the cursor before printing each
+    /// row, and the final cursor position after displaying each row is
+    /// unspecified.
+    // the unwraps in this method shouldn't be reachable
+    #[allow(clippy::missing_panics_doc)]
+    pub fn rows_diff<'a>(
+        &'a self,
+        prev: &'a Self,
+        start: u16,
+        width: u16,
+    ) -> impl Iterator<Item = Vec<u8>> + 'a {
+        self.grid()
+            .visible_rows()
+            .zip(prev.grid().visible_rows())
+            .enumerate()
+            .map(move |(i, (row, prev_row))| {
+                // number of rows in a grid is stored in a u16 (see Size), so
+                // visible_rows can never return enough rows to overflow here
+                let i = i.try_into().unwrap();
+                let mut contents = vec![];
+                row.write_contents_diff(
+                    &mut contents,
+                    prev_row,
+                    start,
+                    width,
+                    i,
+                    false,
+                    false,
+                    crate::vt100::grid::Pos { row: i, col: start },
+                    crate::vt100::attrs::Attrs::default(),
+                );
+                contents
+            })
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// terminal's input modes.
+    ///
+    /// Supported modes are:
+    /// * application keypad
+    /// * application cursor
+    /// * bracketed paste
+    /// * xterm mouse support
+    #[must_use]
+    pub fn input_mode_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_input_mode_formatted(&mut contents);
+        contents
+    }
+
+    fn write_input_mode_formatted(&self, contents: &mut Vec<u8>) {
+        crate::vt100::term::ApplicationKeypad::new(self.mode(MODE_APPLICATION_KEYPAD))
+            .write_buf(contents);
+        crate::vt100::term::ApplicationCursor::new(self.mode(MODE_APPLICATION_CURSOR))
+            .write_buf(contents);
+        crate::vt100::term::BracketedPaste::new(self.mode(MODE_BRACKETED_PASTE))
+            .write_buf(contents);
+        crate::vt100::term::MouseProtocolMode::new(
+            self.mouse_protocol_mode,
+            MouseProtocolMode::None,
+        )
+        .write_buf(contents);
+        crate::vt100::term::MouseProtocolEncoding::new(
+            self.mouse_protocol_encoding,
+            MouseProtocolEncoding::Default,
+        )
+        .write_buf(contents);
+    }
+
+    /// Returns terminal escape sequences sufficient to change the previous
+    /// terminal's input modes to the input modes enabled in the current
+    /// terminal.
+    #[must_use]
+    pub fn input_mode_diff(&self, prev: &Self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_input_mode_diff(&mut contents, prev);
+        contents
+    }
+
+    fn write_input_mode_diff(&self, contents: &mut Vec<u8>, prev: &Self) {
+        if self.mode(MODE_APPLICATION_KEYPAD) != prev.mode(MODE_APPLICATION_KEYPAD) {
+            crate::vt100::term::ApplicationKeypad::new(self.mode(MODE_APPLICATION_KEYPAD))
+                .write_buf(contents);
+        }
+        if self.mode(MODE_APPLICATION_CURSOR) != prev.mode(MODE_APPLICATION_CURSOR) {
+            crate::vt100::term::ApplicationCursor::new(self.mode(MODE_APPLICATION_CURSOR))
+                .write_buf(contents);
+        }
+        if self.mode(MODE_BRACKETED_PASTE) != prev.mode(MODE_BRACKETED_PASTE) {
+            crate::vt100::term::BracketedPaste::new(self.mode(MODE_BRACKETED_PASTE))
+                .write_buf(contents);
+        }
+        crate::vt100::term::MouseProtocolMode::new(
+            self.mouse_protocol_mode,
+            prev.mouse_protocol_mode,
+        )
+        .write_buf(contents);
+        crate::vt100::term::MouseProtocolEncoding::new(
+            self.mouse_protocol_encoding,
+            prev.mouse_protocol_encoding,
+        )
+        .write_buf(contents);
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// terminal's drawing attributes.
+    ///
+    /// Supported drawing attributes are:
+    /// * fgcolor
+    /// * bgcolor
+    /// * bold
+    /// * dim
+    /// * italic
+    /// * underline
+    /// * inverse
+    ///
+    /// This is not typically necessary, since
+    /// [`contents_formatted`](Self::contents_formatted) will leave
+    /// the current active drawing attributes in the correct state, but this
+    /// can be useful in the case of drawing additional things on top of a
+    /// terminal output, since you will need to restore the terminal state
+    /// without the terminal contents necessarily being the same.
+    #[must_use]
+    pub fn attributes_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_attributes_formatted(&mut contents);
+        contents
+    }
+
+    fn write_attributes_formatted(&self, contents: &mut Vec<u8>) {
+        crate::vt100::term::ClearAttrs.write_buf(contents);
+        self.attrs
+            .write_escape_code_diff(contents, &crate::vt100::attrs::Attrs::default());
+    }
+
+    /// Returns the current cursor position of the terminal.
+    ///
+    /// The return value will be (row, col).
+    #[must_use]
+    pub fn cursor_position(&self) -> (u16, u16) {
+        let pos = self.grid().pos();
+        (pos.row, pos.col)
+    }
+
+    /// Returns terminal escape sequences sufficient to set the current
+    /// cursor state of the terminal.
+    ///
+    /// This is not typically necessary, since
+    /// [`contents_formatted`](Self::contents_formatted) will leave
+    /// the cursor in the correct state, but this can be useful in the case of
+    /// drawing additional things on top of a terminal output, since you will
+    /// need to restore the terminal state without the terminal contents
+    /// necessarily being the same.
+    ///
+    /// Note that the bytes returned by this function may alter the active
+    /// drawing attributes, because it may require redrawing existing cells in
+    /// order to position the cursor correctly (for instance, in the case
+    /// where the cursor is past the end of a row). Therefore, you should
+    /// ensure to reset the active drawing attributes if necessary after
+    /// processing this data, for instance by using
+    /// [`attributes_formatted`](Self::attributes_formatted).
+    #[must_use]
+    pub fn cursor_state_formatted(&self) -> Vec<u8> {
+        let mut contents = vec![];
+        self.write_cursor_state_formatted(&mut contents);
+        contents
+    }
+
+    fn write_cursor_state_formatted(&self, contents: &mut Vec<u8>) {
+        crate::vt100::term::HideCursor::new(self.hide_cursor()).write_buf(contents);
+        self.grid()
+            .write_cursor_position_formatted(contents, None, None);
+
+        // we don't just call write_attributes_formatted here, because that
+        // would still be confusing - consider the case where the user sets
+        // their own unrelated drawing attributes (on a different parser
+        // instance) and then calls cursor_state_formatted. just documenting
+        // it and letting the user handle it on their own is more
+        // straightforward.
+    }
+
+    /// Returns the [`Cell`](crate::vt100::Cell) object at the given location in the
+    /// terminal, if it exists.
+    #[must_use]
+    pub fn cell(&self, row: u16, col: u16) -> Option<&crate::vt100::Cell> {
+        self.grid()
+            .visible_cell(crate::vt100::grid::Pos { row, col })
+    }
+
+    /// Returns whether the text in row `row` should wrap to the next line.
+    #[must_use]
+    pub fn row_wrapped(&self, row: u16) -> bool {
+        self.grid()
+            .visible_row(row)
+            .is_some_and(crate::vt100::row::Row::wrapped)
+    }
+
+    /// Returns whether the alternate screen is currently in use.
+    #[must_use]
+    pub fn alternate_screen(&self) -> bool {
+        self.mode(MODE_ALTERNATE_SCREEN)
+    }
+
+    /// Returns whether the terminal should be in application keypad mode.
+    #[must_use]
+    pub fn application_keypad(&self) -> bool {
+        self.mode(MODE_APPLICATION_KEYPAD)
+    }
+
+    /// Returns whether the terminal should be in application cursor mode.
+    #[must_use]
+    pub fn application_cursor(&self) -> bool {
+        self.mode(MODE_APPLICATION_CURSOR)
+    }
+
+    /// Returns whether the terminal should be in hide cursor mode.
+    #[must_use]
+    pub fn hide_cursor(&self) -> bool {
+        self.mode(MODE_HIDE_CURSOR)
+    }
+
+    /// Returns whether the terminal should be in bracketed paste mode.
+    #[must_use]
+    pub fn bracketed_paste(&self) -> bool {
+        self.mode(MODE_BRACKETED_PASTE)
+    }
+
+    /// Returns the currently active [`MouseProtocolMode`].
+    #[must_use]
+    pub fn mouse_protocol_mode(&self) -> MouseProtocolMode {
+        self.mouse_protocol_mode
+    }
+
+    /// Returns the currently active [`MouseProtocolEncoding`].
+    #[must_use]
+    pub fn mouse_protocol_encoding(&self) -> MouseProtocolEncoding {
+        self.mouse_protocol_encoding
+    }
+
+    /// Returns the currently active foreground color.
+    #[must_use]
+    pub fn fgcolor(&self) -> crate::vt100::Color {
+        self.attrs.fgcolor
+    }
+
+    /// Returns the currently active background color.
+    #[must_use]
+    pub fn bgcolor(&self) -> crate::vt100::Color {
+        self.attrs.bgcolor
+    }
+
+    /// Returns whether newly drawn text should be rendered with the bold text
+    /// attribute.
+    #[must_use]
+    pub fn bold(&self) -> bool {
+        self.attrs.bold()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the dim text
+    /// attribute.
+    #[must_use]
+    pub fn dim(&self) -> bool {
+        self.attrs.dim()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the italic
+    /// text attribute.
+    #[must_use]
+    pub fn italic(&self) -> bool {
+        self.attrs.italic()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the
+    /// underlined text attribute.
+    #[must_use]
+    pub fn underline(&self) -> bool {
+        self.attrs.underline()
+    }
+
+    /// Returns whether newly drawn text should be rendered with the inverse
+    /// text attribute.
+    #[must_use]
+    pub fn inverse(&self) -> bool {
+        self.attrs.inverse()
+    }
+
+    pub(crate) fn grid(&self) -> &crate::vt100::grid::Grid {
+        if self.mode(MODE_ALTERNATE_SCREEN) {
+            &self.alternate_grid
+        } else {
+            &self.grid
+        }
+    }
+
+    fn grid_mut(&mut self) -> &mut crate::vt100::grid::Grid {
+        if self.mode(MODE_ALTERNATE_SCREEN) {
+            &mut self.alternate_grid
+        } else {
+            &mut self.grid
+        }
+    }
+
+    fn enter_alternate_grid(&mut self) {
+        self.grid_mut().set_scrollback(0);
+        self.set_mode(MODE_ALTERNATE_SCREEN);
+        self.alternate_grid.allocate_rows();
+    }
+
+    fn exit_alternate_grid(&mut self) {
+        self.clear_mode(MODE_ALTERNATE_SCREEN);
+    }
+
+    fn save_cursor(&mut self) {
+        self.grid_mut().save_cursor();
+        self.saved_attrs = self.attrs;
+    }
+
+    fn restore_cursor(&mut self) {
+        self.grid_mut().restore_cursor();
+        self.attrs = self.saved_attrs;
+    }
+
+    fn set_mode(&mut self, mode: u8) {
+        self.modes |= mode;
+    }
+
+    fn clear_mode(&mut self, mode: u8) {
+        self.modes &= !mode;
+    }
+
+    fn mode(&self, mode: u8) -> bool {
+        self.modes & mode != 0
+    }
+
+    fn set_mouse_mode(&mut self, mode: MouseProtocolMode) {
+        self.mouse_protocol_mode = mode;
+    }
+
+    fn clear_mouse_mode(&mut self, mode: MouseProtocolMode) {
+        if self.mouse_protocol_mode == mode {
+            self.mouse_protocol_mode = MouseProtocolMode::default();
+        }
+    }
+
+    fn set_mouse_encoding(&mut self, encoding: MouseProtocolEncoding) {
+        self.mouse_protocol_encoding = encoding;
+    }
+
+    fn clear_mouse_encoding(&mut self, encoding: MouseProtocolEncoding) {
+        if self.mouse_protocol_encoding == encoding {
+            self.mouse_protocol_encoding = MouseProtocolEncoding::default();
+        }
+    }
+}
+
+impl Screen {
+    pub(crate) fn text(&mut self, c: char) {
+        let hyperlink = self.hyperlink.clone();
+        let pos = self.grid().pos();
+        let size = self.grid().size();
+        let attrs = self.attrs;
+
+        let width = c.width();
+        if width.is_none() && (u32::from(c)) < 256 {
+            // don't even try to draw control characters
+            return;
+        }
+        let width = width
+            .unwrap_or(1)
+            .try_into()
+            // width() can only return 0, 1, or 2
+            .unwrap();
+
+        // it doesn't make any sense to wrap if the last column in a row
+        // didn't already have contents. don't try to handle the case where a
+        // character wraps because there was only one column left in the
+        // previous row - literally everything handles this case differently,
+        // and this is tmux behavior (and also the simplest). i'm open to
+        // reconsidering this behavior, but only with a really good reason
+        // (xterm handles this by introducing the concept of triple width
+        // cells, which i really don't want to do).
+        let mut wrap = false;
+        if pos.col > size.cols - width {
+            let last_cell = self
+                .grid()
+                .drawing_cell(crate::vt100::grid::Pos {
+                    row: pos.row,
+                    col: size.cols - 1,
+                })
+                // pos.row is valid, since it comes directly from
+                // self.grid().pos() which we assume to always have a valid
+                // row value. size.cols - 1 is also always a valid column.
+                .unwrap();
+            if last_cell.has_contents() || last_cell.is_wide_continuation() {
+                wrap = true;
+            }
+        }
+        self.grid_mut().col_wrap(width, wrap);
+        let pos = self.grid().pos();
+
+        if width == 0 {
+            if pos.col > 0 {
+                let mut prev_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::vt100::grid::Pos {
+                        row: pos.row,
+                        col: pos.col - 1,
+                    })
+                    // pos.row is valid, since it comes directly from
+                    // self.grid().pos() which we assume to always have a
+                    // valid row value. pos.col - 1 is valid because we just
+                    // checked for pos.col > 0.
+                    .unwrap();
+                if prev_cell.is_wide_continuation() {
+                    prev_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(crate::vt100::grid::Pos {
+                            row: pos.row,
+                            col: pos.col - 2,
+                        })
+                        // pos.row is valid, since it comes directly from
+                        // self.grid().pos() which we assume to always have a
+                        // valid row value. we know pos.col - 2 is valid
+                        // because the cell at pos.col - 1 is a wide
+                        // continuation character, which means there must be
+                        // the first half of the wide character before it.
+                        .unwrap();
+                }
+                prev_cell.append(c);
+            } else if pos.row > 0 {
+                let prev_row = self
+                    .grid()
+                    .drawing_row(pos.row - 1)
+                    // pos.row is valid, since it comes directly from
+                    // self.grid().pos() which we assume to always have a
+                    // valid row value. pos.row - 1 is valid because we just
+                    // checked for pos.row > 0.
+                    .unwrap();
+                if prev_row.wrapped() {
+                    let mut prev_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(crate::vt100::grid::Pos {
+                            row: pos.row - 1,
+                            col: size.cols - 1,
+                        })
+                        // pos.row is valid, since it comes directly from
+                        // self.grid().pos() which we assume to always have a
+                        // valid row value. pos.row - 1 is valid because we
+                        // just checked for pos.row > 0. col of size.cols - 1
+                        // is always valid.
+                        .unwrap();
+                    if prev_cell.is_wide_continuation() {
+                        prev_cell = self
+                            .grid_mut()
+                            .drawing_cell_mut(crate::vt100::grid::Pos {
+                                row: pos.row - 1,
+                                col: size.cols - 2,
+                            })
+                            // pos.row is valid, since it comes directly from
+                            // self.grid().pos() which we assume to always
+                            // have a valid row value. pos.row - 1 is valid
+                            // because we just checked for pos.row > 0. col of
+                            // size.cols - 2 is valid because the cell at
+                            // size.cols - 1 is a wide continuation character,
+                            // so it must have the first half of the wide
+                            // character before it.
+                            .unwrap();
+                    }
+                    prev_cell.append(c);
+                }
+            }
+        } else {
+            if self
+                .grid()
+                .drawing_cell(pos)
+                // pos.row is valid because we assume self.grid().pos() to
+                // always have a valid row value. pos.col is valid because we
+                // called col_wrap() immediately before this, which ensures
+                // that self.grid().pos().col has a valid value.
+                .unwrap()
+                .is_wide_continuation()
+            {
+                let prev_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::vt100::grid::Pos {
+                        row: pos.row,
+                        col: pos.col - 1,
+                    })
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() immediately before this, which
+                    // ensures that self.grid().pos().col has a valid value.
+                    // pos.col - 1 is valid because the cell at pos.col is a
+                    // wide continuation character, so it must have the first
+                    // half of the wide character before it.
+                    .unwrap();
+                prev_cell.clear(attrs);
+            }
+
+            if self
+                .grid()
+                .drawing_cell(pos)
+                // pos.row is valid because we assume self.grid().pos() to
+                // always have a valid row value. pos.col is valid because we
+                // called col_wrap() immediately before this, which ensures
+                // that self.grid().pos().col has a valid value.
+                .unwrap()
+                .is_wide()
+            {
+                let next_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(crate::vt100::grid::Pos {
+                        row: pos.row,
+                        col: pos.col + 1,
+                    })
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() immediately before this, which
+                    // ensures that self.grid().pos().col has a valid value.
+                    // pos.col + 1 is valid because the cell at pos.col is a
+                    // wide character, so it must have the second half of the
+                    // wide character after it.
+                    .unwrap();
+                next_cell.set(' ', attrs);
+            }
+
+            let cell = self
+                .grid_mut()
+                .drawing_cell_mut(pos)
+                // pos.row is valid because we assume self.grid().pos() to
+                // always have a valid row value. pos.col is valid because we
+                // called col_wrap() immediately before this, which ensures
+                // that self.grid().pos().col has a valid value.
+                .unwrap();
+            cell.set(c, attrs);
+            cell.set_hyperlink(hyperlink.clone());
+            self.grid_mut().col_inc(1);
+            if width > 1 {
+                let pos = self.grid().pos();
+                if self
+                    .grid()
+                    .drawing_cell(pos)
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() earlier, which ensures that
+                    // self.grid().pos().col has a valid value. this is true
+                    // even though we just called col_inc, because this branch
+                    // only happens if width > 1, and col_wrap takes width
+                    // into account.
+                    .unwrap()
+                    .is_wide()
+                {
+                    let next_next_pos = crate::vt100::grid::Pos {
+                        row: pos.row,
+                        col: pos.col + 1,
+                    };
+                    let next_next_cell = self
+                        .grid_mut()
+                        .drawing_cell_mut(next_next_pos)
+                        // pos.row is valid because we assume
+                        // self.grid().pos() to always have a valid row value.
+                        // pos.col is valid because we called col_wrap()
+                        // earlier, which ensures that self.grid().pos().col
+                        // has a valid value. this is true even though we just
+                        // called col_inc, because this branch only happens if
+                        // width > 1, and col_wrap takes width into account.
+                        // pos.col + 1 is valid because the cell at pos.col is
+                        // wide, and so it must have the second half of the
+                        // wide character after it.
+                        .unwrap();
+                    next_next_cell.clear(attrs);
+                    if next_next_pos.col == size.cols - 1 {
+                        self.grid_mut()
+                            .drawing_row_mut(pos.row)
+                            // we assume self.grid().pos().row is always valid
+                            .unwrap()
+                            .wrap(false);
+                    }
+                }
+                let next_cell = self
+                    .grid_mut()
+                    .drawing_cell_mut(pos)
+                    // pos.row is valid because we assume self.grid().pos() to
+                    // always have a valid row value. pos.col is valid because
+                    // we called col_wrap() earlier, which ensures that
+                    // self.grid().pos().col has a valid value. this is true
+                    // even though we just called col_inc, because this branch
+                    // only happens if width > 1, and col_wrap takes width
+                    // into account.
+                    .unwrap();
+                next_cell.clear(crate::vt100::attrs::Attrs::default());
+                next_cell.set_wide_continuation(true);
+                next_cell.set_hyperlink(hyperlink);
+                self.grid_mut().col_inc(1);
+            }
+        }
+    }
+
+    // control codes
+
+    pub(crate) fn bs(&mut self) {
+        self.grid_mut().col_dec(1);
+    }
+
+    pub(crate) fn tab(&mut self) {
+        self.grid_mut().col_tab();
+    }
+
+    pub(crate) fn lf(&mut self) {
+        self.grid_mut().row_inc_scroll(1);
+    }
+
+    pub(crate) fn vt(&mut self) {
+        self.lf();
+    }
+
+    pub(crate) fn ff(&mut self) {
+        self.lf();
+    }
+
+    pub(crate) fn cr(&mut self) {
+        self.grid_mut().col_set(0);
+    }
+
+    // escape codes
+
+    // ESC 7
+    pub(crate) fn decsc(&mut self) {
+        self.save_cursor();
+    }
+
+    // ESC 8
+    pub(crate) fn decrc(&mut self) {
+        self.restore_cursor();
+    }
+
+    // ESC =
+    pub(crate) fn deckpam(&mut self) {
+        self.set_mode(MODE_APPLICATION_KEYPAD);
+    }
+
+    // ESC >
+    pub(crate) fn deckpnm(&mut self) {
+        self.clear_mode(MODE_APPLICATION_KEYPAD);
+    }
+
+    // ESC M
+    pub(crate) fn ri(&mut self) {
+        self.grid_mut().row_dec_scroll(1);
+    }
+
+    // ESC c
+    pub(crate) fn set_hyperlink(&mut self, destination: &[u8]) {
+        // Match the pane's existing web-only link handling. Never pass arbitrary
+        // terminal-controlled URI schemes or control characters to the opener.
+        self.hyperlink = std::str::from_utf8(destination)
+            .ok()
+            .filter(|url| {
+                url.len() <= 8192
+                    && (url.starts_with("https://") || url.starts_with("http://"))
+                    && !url.chars().any(char::is_control)
+            })
+            .map(std::sync::Arc::from);
+    }
+
+    pub(crate) fn ris(&mut self) {
+        *self = Self::new(self.grid.size(), self.grid.scrollback_len());
+    }
+
+    // csi codes
+
+    // CSI @
+    pub(crate) fn ich(&mut self, count: u16) {
+        self.grid_mut().insert_cells(count);
+    }
+
+    // CSI A
+    pub(crate) fn cuu(&mut self, offset: u16) {
+        self.grid_mut().row_dec_clamp(offset);
+    }
+
+    // CSI B
+    pub(crate) fn cud(&mut self, offset: u16) {
+        self.grid_mut().row_inc_clamp(offset);
+    }
+
+    // CSI C
+    pub(crate) fn cuf(&mut self, offset: u16) {
+        self.grid_mut().col_inc_clamp(offset);
+    }
+
+    // CSI D
+    pub(crate) fn cub(&mut self, offset: u16) {
+        self.grid_mut().col_dec(offset);
+    }
+
+    // CSI E
+    pub(crate) fn cnl(&mut self, offset: u16) {
+        self.grid_mut().col_set(0);
+        self.grid_mut().row_inc_clamp(offset);
+    }
+
+    // CSI F
+    pub(crate) fn cpl(&mut self, offset: u16) {
+        self.grid_mut().col_set(0);
+        self.grid_mut().row_dec_clamp(offset);
+    }
+
+    // CSI G
+    pub(crate) fn cha(&mut self, col: u16) {
+        self.grid_mut().col_set(col - 1);
+    }
+
+    // CSI H
+    pub(crate) fn cup(&mut self, (row, col): (u16, u16)) {
+        self.grid_mut().set_pos(crate::vt100::grid::Pos {
+            row: row - 1,
+            col: col - 1,
+        });
+    }
+
+    // CSI J
+    pub(crate) fn ed(&mut self, mode: u16, mut unhandled: impl FnMut(&mut Self)) {
+        let attrs = self.attrs;
+        match mode {
+            0 => self.grid_mut().erase_all_forward(attrs),
+            1 => self.grid_mut().erase_all_backward(attrs),
+            2 => self.grid_mut().erase_all(attrs),
+            _ => unhandled(self),
+        }
+    }
+
+    // CSI ? J
+    pub(crate) fn decsed(&mut self, mode: u16, unhandled: impl FnMut(&mut Self)) {
+        self.ed(mode, unhandled);
+    }
+
+    // CSI K
+    pub(crate) fn el(&mut self, mode: u16, mut unhandled: impl FnMut(&mut Self)) {
+        let attrs = self.attrs;
+        match mode {
+            0 => self.grid_mut().erase_row_forward(attrs),
+            1 => self.grid_mut().erase_row_backward(attrs),
+            2 => self.grid_mut().erase_row(attrs),
+            _ => unhandled(self),
+        }
+    }
+
+    // CSI ? K
+    pub(crate) fn decsel(&mut self, mode: u16, unhandled: impl FnMut(&mut Self)) {
+        self.el(mode, unhandled);
+    }
+
+    // CSI L
+    pub(crate) fn il(&mut self, count: u16) {
+        self.grid_mut().insert_lines(count);
+    }
+
+    // CSI M
+    pub(crate) fn dl(&mut self, count: u16) {
+        self.grid_mut().delete_lines(count);
+    }
+
+    // CSI P
+    pub(crate) fn dch(&mut self, count: u16) {
+        self.grid_mut().delete_cells(count);
+    }
+
+    // CSI S
+    pub(crate) fn su(&mut self, count: u16) {
+        self.grid_mut().scroll_up(count);
+    }
+
+    // CSI T
+    pub(crate) fn sd(&mut self, count: u16) {
+        self.grid_mut().scroll_down(count);
+    }
+
+    // CSI X
+    pub(crate) fn ech(&mut self, count: u16) {
+        let attrs = self.attrs;
+        self.grid_mut().erase_cells(count, attrs);
+    }
+
+    // CSI d
+    pub(crate) fn vpa(&mut self, row: u16) {
+        self.grid_mut().row_set(row - 1);
+    }
+
+    // CSI ? h
+    pub(crate) fn decset(&mut self, params: &vte::Params, mut unhandled: impl FnMut(&mut Self)) {
+        for param in params {
+            match param {
+                [1] => self.set_mode(MODE_APPLICATION_CURSOR),
+                [6] => self.grid_mut().set_origin_mode(true),
+                [9] => self.set_mouse_mode(MouseProtocolMode::Press),
+                [25] => self.clear_mode(MODE_HIDE_CURSOR),
+                [47] => self.enter_alternate_grid(),
+                [1000] => {
+                    self.set_mouse_mode(MouseProtocolMode::PressRelease);
+                }
+                [1002] => {
+                    self.set_mouse_mode(MouseProtocolMode::ButtonMotion);
+                }
+                [1003] => self.set_mouse_mode(MouseProtocolMode::AnyMotion),
+                [1005] => {
+                    self.set_mouse_encoding(MouseProtocolEncoding::Utf8);
+                }
+                [1006] => {
+                    self.set_mouse_encoding(MouseProtocolEncoding::Sgr);
+                }
+                [1049] => {
+                    self.decsc();
+                    self.alternate_grid.clear();
+                    self.enter_alternate_grid();
+                }
+                [2004] => self.set_mode(MODE_BRACKETED_PASTE),
+                _ => unhandled(self),
+            }
+        }
+    }
+
+    // CSI ? l
+    pub(crate) fn decrst(&mut self, params: &vte::Params, mut unhandled: impl FnMut(&mut Self)) {
+        for param in params {
+            match param {
+                [1] => self.clear_mode(MODE_APPLICATION_CURSOR),
+                [6] => self.grid_mut().set_origin_mode(false),
+                [9] => self.clear_mouse_mode(MouseProtocolMode::Press),
+                [25] => self.set_mode(MODE_HIDE_CURSOR),
+                [47] => {
+                    self.exit_alternate_grid();
+                }
+                [1000] => {
+                    self.clear_mouse_mode(MouseProtocolMode::PressRelease);
+                }
+                [1002] => {
+                    self.clear_mouse_mode(MouseProtocolMode::ButtonMotion);
+                }
+                [1003] => {
+                    self.clear_mouse_mode(MouseProtocolMode::AnyMotion);
+                }
+                [1005] => {
+                    self.clear_mouse_encoding(MouseProtocolEncoding::Utf8);
+                }
+                [1006] => {
+                    self.clear_mouse_encoding(MouseProtocolEncoding::Sgr);
+                }
+                [1049] => {
+                    self.exit_alternate_grid();
+                    self.decrc();
+                }
+                [2004] => self.clear_mode(MODE_BRACKETED_PASTE),
+                _ => unhandled(self),
+            }
+        }
+    }
+
+    // CSI m
+    pub(crate) fn sgr(&mut self, params: &vte::Params, mut unhandled: impl FnMut(&mut Self)) {
+        // XXX really i want to just be able to pass in a default Params
+        // instance with a 0 in it, but vte doesn't allow creating new Params
+        // instances
+        if params.is_empty() {
+            self.attrs = crate::vt100::attrs::Attrs::default();
+            return;
+        }
+
+        let mut iter = params.iter();
+
+        macro_rules! next_param {
+            () => {
+                match iter.next() {
+                    Some(n) => n,
+                    _ => return,
+                }
+            };
+        }
+
+        macro_rules! to_u8 {
+            ($n:expr) => {
+                if let Some(n) = u16_to_u8($n) {
+                    n
+                } else {
+                    return;
+                }
+            };
+        }
+
+        macro_rules! next_param_u8 {
+            () => {
+                if let &[n] = next_param!() {
+                    to_u8!(n)
+                } else {
+                    return;
+                }
+            };
+        }
+
+        loop {
+            match next_param!() {
+                [0] => self.attrs = crate::vt100::attrs::Attrs::default(),
+                [1] => self.attrs.set_bold(),
+                [2] => self.attrs.set_dim(),
+                [3] => self.attrs.set_italic(true),
+                [4] => self.attrs.set_underline(true),
+                [7] => self.attrs.set_inverse(true),
+                [22] => self.attrs.set_normal_intensity(),
+                [23] => self.attrs.set_italic(false),
+                [24] => self.attrs.set_underline(false),
+                [27] => self.attrs.set_inverse(false),
+                [n] if (30..=37).contains(n) => {
+                    self.attrs.fgcolor = crate::vt100::Color::Idx(to_u8!(*n) - 30);
+                }
+                [38, 2, r, g, b] => {
+                    self.attrs.fgcolor =
+                        crate::vt100::Color::Rgb(to_u8!(*r), to_u8!(*g), to_u8!(*b));
+                }
+                [38, 5, i] => {
+                    self.attrs.fgcolor = crate::vt100::Color::Idx(to_u8!(*i));
+                }
+                [38] => match next_param!() {
+                    [2] => {
+                        let r = next_param_u8!();
+                        let g = next_param_u8!();
+                        let b = next_param_u8!();
+                        self.attrs.fgcolor = crate::vt100::Color::Rgb(r, g, b);
+                    }
+                    [5] => {
+                        self.attrs.fgcolor = crate::vt100::Color::Idx(next_param_u8!());
+                    }
+                    _ => {
+                        unhandled(self);
+                        return;
+                    }
+                },
+                [39] => {
+                    self.attrs.fgcolor = crate::vt100::Color::Default;
+                }
+                [n] if (40..=47).contains(n) => {
+                    self.attrs.bgcolor = crate::vt100::Color::Idx(to_u8!(*n) - 40);
+                }
+                [48, 2, r, g, b] => {
+                    self.attrs.bgcolor =
+                        crate::vt100::Color::Rgb(to_u8!(*r), to_u8!(*g), to_u8!(*b));
+                }
+                [48, 5, i] => {
+                    self.attrs.bgcolor = crate::vt100::Color::Idx(to_u8!(*i));
+                }
+                [48] => match next_param!() {
+                    [2] => {
+                        let r = next_param_u8!();
+                        let g = next_param_u8!();
+                        let b = next_param_u8!();
+                        self.attrs.bgcolor = crate::vt100::Color::Rgb(r, g, b);
+                    }
+                    [5] => {
+                        self.attrs.bgcolor = crate::vt100::Color::Idx(next_param_u8!());
+                    }
+                    _ => {
+                        unhandled(self);
+                        return;
+                    }
+                },
+                [49] => {
+                    self.attrs.bgcolor = crate::vt100::Color::Default;
+                }
+                [n] if (90..=97).contains(n) => {
+                    self.attrs.fgcolor = crate::vt100::Color::Idx(to_u8!(*n) - 82);
+                }
+                [n] if (100..=107).contains(n) => {
+                    self.attrs.bgcolor = crate::vt100::Color::Idx(to_u8!(*n) - 92);
+                }
+                _ => unhandled(self),
+            }
+        }
+    }
+
+    // CSI r
+    pub(crate) fn decstbm(&mut self, (top, bottom): (u16, u16)) {
+        self.grid_mut().set_scroll_region(top - 1, bottom - 1);
+    }
+}
+
+fn u16_to_u8(i: u16) -> Option<u8> {
+    if i > u16::from(u8::MAX) {
+        None
+    } else {
+        // safe because we just ensured that the value fits in a u8
+        Some(i.try_into().unwrap())
+    }
+}

--- a/src/vt100/term.rs
+++ b/src/vt100/term.rs
@@ -1,0 +1,549 @@
+// TODO: read all of this from terminfo
+
+pub trait BufWrite {
+    fn write_buf(&self, buf: &mut Vec<u8>);
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ClearScreen;
+
+impl BufWrite for ClearScreen {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[H\x1b[J");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ClearRowForward;
+
+impl BufWrite for ClearRowForward {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[K");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct Crlf;
+
+impl BufWrite for Crlf {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\r\n");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct Backspace;
+
+impl BufWrite for Backspace {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x08");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct SaveCursor;
+
+impl BufWrite for SaveCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b7");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct RestoreCursor;
+
+impl BufWrite for RestoreCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b8");
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MoveTo {
+    row: u16,
+    col: u16,
+}
+
+impl MoveTo {
+    pub fn new(pos: crate::vt100::grid::Pos) -> Self {
+        Self {
+            row: pos.row,
+            col: pos.col,
+        }
+    }
+}
+
+impl BufWrite for MoveTo {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.row == 0 && self.col == 0 {
+            buf.extend_from_slice(b"\x1b[H");
+        } else {
+            buf.extend_from_slice(b"\x1b[");
+            extend_itoa(buf, self.row + 1);
+            buf.push(b';');
+            extend_itoa(buf, self.col + 1);
+            buf.push(b'H');
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ClearAttrs;
+
+impl BufWrite for ClearAttrs {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(b"\x1b[m");
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Intensity {
+    Normal,
+    Bold,
+    Dim,
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct Attrs {
+    fgcolor: Option<crate::vt100::Color>,
+    bgcolor: Option<crate::vt100::Color>,
+    intensity: Option<Intensity>,
+    italic: Option<bool>,
+    underline: Option<bool>,
+    inverse: Option<bool>,
+}
+
+impl Attrs {
+    pub fn fgcolor(mut self, fgcolor: crate::vt100::Color) -> Self {
+        self.fgcolor = Some(fgcolor);
+        self
+    }
+
+    pub fn bgcolor(mut self, bgcolor: crate::vt100::Color) -> Self {
+        self.bgcolor = Some(bgcolor);
+        self
+    }
+
+    pub fn intensity(mut self, intensity: Intensity) -> Self {
+        self.intensity = Some(intensity);
+        self
+    }
+
+    pub fn italic(mut self, italic: bool) -> Self {
+        self.italic = Some(italic);
+        self
+    }
+
+    pub fn underline(mut self, underline: bool) -> Self {
+        self.underline = Some(underline);
+        self
+    }
+
+    pub fn inverse(mut self, inverse: bool) -> Self {
+        self.inverse = Some(inverse);
+        self
+    }
+}
+
+impl BufWrite for Attrs {
+    #[allow(unused_assignments)]
+    #[allow(clippy::branches_sharing_code)]
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.fgcolor.is_none()
+            && self.bgcolor.is_none()
+            && self.intensity.is_none()
+            && self.italic.is_none()
+            && self.underline.is_none()
+            && self.inverse.is_none()
+        {
+            return;
+        }
+
+        buf.extend_from_slice(b"\x1b[");
+        let mut first = true;
+
+        macro_rules! write_param {
+            ($i:expr) => {{
+                if first {
+                    first = false;
+                } else {
+                    buf.push(b';');
+                }
+                extend_itoa(buf, $i);
+            }};
+        }
+
+        if let Some(fgcolor) = self.fgcolor {
+            match fgcolor {
+                crate::vt100::Color::Default => {
+                    write_param!(39);
+                }
+                crate::vt100::Color::Idx(i) => {
+                    if i < 8 {
+                        write_param!(i + 30);
+                    } else if i < 16 {
+                        write_param!(i + 82);
+                    } else {
+                        write_param!(38);
+                        write_param!(5);
+                        write_param!(i);
+                    }
+                }
+                crate::vt100::Color::Rgb(r, g, b) => {
+                    write_param!(38);
+                    write_param!(2);
+                    write_param!(r);
+                    write_param!(g);
+                    write_param!(b);
+                }
+            }
+        }
+
+        if let Some(bgcolor) = self.bgcolor {
+            match bgcolor {
+                crate::vt100::Color::Default => {
+                    write_param!(49);
+                }
+                crate::vt100::Color::Idx(i) => {
+                    if i < 8 {
+                        write_param!(i + 40);
+                    } else if i < 16 {
+                        write_param!(i + 92);
+                    } else {
+                        write_param!(48);
+                        write_param!(5);
+                        write_param!(i);
+                    }
+                }
+                crate::vt100::Color::Rgb(r, g, b) => {
+                    write_param!(48);
+                    write_param!(2);
+                    write_param!(r);
+                    write_param!(g);
+                    write_param!(b);
+                }
+            }
+        }
+
+        if let Some(intensity) = self.intensity {
+            match intensity {
+                Intensity::Normal => write_param!(22),
+                Intensity::Bold => write_param!(1),
+                Intensity::Dim => write_param!(2),
+            }
+        }
+
+        if let Some(italic) = self.italic {
+            if italic {
+                write_param!(3);
+            } else {
+                write_param!(23);
+            }
+        }
+
+        if let Some(underline) = self.underline {
+            if underline {
+                write_param!(4);
+            } else {
+                write_param!(24);
+            }
+        }
+
+        if let Some(inverse) = self.inverse {
+            if inverse {
+                write_param!(7);
+            } else {
+                write_param!(27);
+            }
+        }
+
+        buf.push(b'm');
+    }
+}
+
+#[derive(Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MoveRight {
+    count: u16,
+}
+
+impl MoveRight {
+    pub fn new(count: u16) -> Self {
+        Self { count }
+    }
+}
+
+impl Default for MoveRight {
+    fn default() -> Self {
+        Self { count: 1 }
+    }
+}
+
+impl BufWrite for MoveRight {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        match self.count {
+            0 => {}
+            1 => buf.extend_from_slice(b"\x1b[C"),
+            n => {
+                buf.extend_from_slice(b"\x1b[");
+                extend_itoa(buf, n);
+                buf.push(b'C');
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct EraseChar {
+    count: u16,
+}
+
+impl EraseChar {
+    pub fn new(count: u16) -> Self {
+        Self { count }
+    }
+}
+
+impl Default for EraseChar {
+    fn default() -> Self {
+        Self { count: 1 }
+    }
+}
+
+impl BufWrite for EraseChar {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        match self.count {
+            0 => {}
+            1 => buf.extend_from_slice(b"\x1b[X"),
+            n => {
+                buf.extend_from_slice(b"\x1b[");
+                extend_itoa(buf, n);
+                buf.push(b'X');
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct HideCursor {
+    state: bool,
+}
+
+impl HideCursor {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for HideCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b[?25l");
+        } else {
+            buf.extend_from_slice(b"\x1b[?25h");
+        }
+    }
+}
+
+#[derive(Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MoveFromTo {
+    from: crate::vt100::grid::Pos,
+    to: crate::vt100::grid::Pos,
+}
+
+impl MoveFromTo {
+    pub fn new(from: crate::vt100::grid::Pos, to: crate::vt100::grid::Pos) -> Self {
+        Self { from, to }
+    }
+}
+
+impl BufWrite for MoveFromTo {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.to.row == self.from.row + 1 && self.to.col == 0 {
+            crate::vt100::term::Crlf.write_buf(buf);
+        } else if self.from.row == self.to.row && self.from.col < self.to.col {
+            crate::vt100::term::MoveRight::new(self.to.col - self.from.col).write_buf(buf);
+        } else if self.to != self.from {
+            crate::vt100::term::MoveTo::new(self.to).write_buf(buf);
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ApplicationKeypad {
+    state: bool,
+}
+
+impl ApplicationKeypad {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for ApplicationKeypad {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b=");
+        } else {
+            buf.extend_from_slice(b"\x1b>");
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct ApplicationCursor {
+    state: bool,
+}
+
+impl ApplicationCursor {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for ApplicationCursor {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b[?1h");
+        } else {
+            buf.extend_from_slice(b"\x1b[?1l");
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct BracketedPaste {
+    state: bool,
+}
+
+impl BracketedPaste {
+    pub fn new(state: bool) -> Self {
+        Self { state }
+    }
+}
+
+impl BufWrite for BracketedPaste {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.state {
+            buf.extend_from_slice(b"\x1b[?2004h");
+        } else {
+            buf.extend_from_slice(b"\x1b[?2004l");
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MouseProtocolMode {
+    mode: crate::vt100::MouseProtocolMode,
+    prev: crate::vt100::MouseProtocolMode,
+}
+
+impl MouseProtocolMode {
+    pub fn new(
+        mode: crate::vt100::MouseProtocolMode,
+        prev: crate::vt100::MouseProtocolMode,
+    ) -> Self {
+        Self { mode, prev }
+    }
+}
+
+impl BufWrite for MouseProtocolMode {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.mode == self.prev {
+            return;
+        }
+
+        match self.mode {
+            crate::vt100::MouseProtocolMode::None => match self.prev {
+                crate::vt100::MouseProtocolMode::None => {}
+                crate::vt100::MouseProtocolMode::Press => {
+                    buf.extend_from_slice(b"\x1b[?9l");
+                }
+                crate::vt100::MouseProtocolMode::PressRelease => {
+                    buf.extend_from_slice(b"\x1b[?1000l");
+                }
+                crate::vt100::MouseProtocolMode::ButtonMotion => {
+                    buf.extend_from_slice(b"\x1b[?1002l");
+                }
+                crate::vt100::MouseProtocolMode::AnyMotion => {
+                    buf.extend_from_slice(b"\x1b[?1003l");
+                }
+            },
+            crate::vt100::MouseProtocolMode::Press => {
+                buf.extend_from_slice(b"\x1b[?9h");
+            }
+            crate::vt100::MouseProtocolMode::PressRelease => {
+                buf.extend_from_slice(b"\x1b[?1000h");
+            }
+            crate::vt100::MouseProtocolMode::ButtonMotion => {
+                buf.extend_from_slice(b"\x1b[?1002h");
+            }
+            crate::vt100::MouseProtocolMode::AnyMotion => {
+                buf.extend_from_slice(b"\x1b[?1003h");
+            }
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+#[must_use = "this struct does nothing unless you call write_buf"]
+pub struct MouseProtocolEncoding {
+    encoding: crate::vt100::MouseProtocolEncoding,
+    prev: crate::vt100::MouseProtocolEncoding,
+}
+
+impl MouseProtocolEncoding {
+    pub fn new(
+        encoding: crate::vt100::MouseProtocolEncoding,
+        prev: crate::vt100::MouseProtocolEncoding,
+    ) -> Self {
+        Self { encoding, prev }
+    }
+}
+
+impl BufWrite for MouseProtocolEncoding {
+    fn write_buf(&self, buf: &mut Vec<u8>) {
+        if self.encoding == self.prev {
+            return;
+        }
+
+        match self.encoding {
+            crate::vt100::MouseProtocolEncoding::Default => match self.prev {
+                crate::vt100::MouseProtocolEncoding::Default => {}
+                crate::vt100::MouseProtocolEncoding::Utf8 => {
+                    buf.extend_from_slice(b"\x1b[?1005l");
+                }
+                crate::vt100::MouseProtocolEncoding::Sgr => {
+                    buf.extend_from_slice(b"\x1b[?1006l");
+                }
+            },
+            crate::vt100::MouseProtocolEncoding::Utf8 => {
+                buf.extend_from_slice(b"\x1b[?1005h");
+            }
+            crate::vt100::MouseProtocolEncoding::Sgr => {
+                buf.extend_from_slice(b"\x1b[?1006h");
+            }
+        }
+    }
+}
+
+fn extend_itoa<I: itoa::Integer>(buf: &mut Vec<u8>, i: I) {
+    let mut itoa_buf = itoa::Buffer::new();
+    buf.extend_from_slice(itoa_buf.format(i).as_bytes());
+}


### PR DESCRIPTION
`railway code --codex` loses scrollback in the alternate screen and cannot open labeled links such as “PR #1194”. This restores both behaviors in the Railway CA TUI.

- Launch Codex with `--no-alt-screen`, keeping the transcript available to mouse-wheel and Shift+Page Up/Down scrolling for new and resumed conversations.
- Retain OSC 8 hyperlink destinations on emulator cells and prefer them when resolving clicks. Visible URLs continue to use the existing text matcher. Links follow their cells through wrapping, scrollback, resize, and alternate screens; overwrite and erase remove stale targets.
- Embed the existing vt100 0.16.2 source under `src/vt100` with the hyperlink extension because the upstream API discards OSC 8 metadata. This accounts for most of the diff. Provenance, MIT license, and local changes are documented there; Cargo source packages include the implementation. Targets are limited to HTTP(S), bounded in length, and reject control characters. Each cell now holds an optional shared destination, increasing its memory footprint.

Validation: all 368 cloud-agent TUI tests pass, including Codex PTY scrolling, labeled-link clicks, split OSC reads, duplicate labels, wide characters, wrap/scrollback/resize, overwrite/erase, alternate screens, and unsupported schemes. `cargo fmt --check` and `git diff --check` pass; `cargo package --list --allow-dirty` confirms the embedded source and license are included. Live Codex/backend/browser interaction has not been manually tested.
