### PR TITLE
test(ca): stabilize Windows terminal regression tests

### DIFF
--- a/src/commands/cloud_agent/tui/app.rs
+++ b/src/commands/cloud_agent/tui/app.rs
@@ -8321,14 +8321,7 @@ mod tests {
         let mut session = super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap();
         session.resize(6, 60);
         session.send(b"see https://railway.com/deploy now\r\n");
-        // ConPTY can deliver the echoed URL in several reads on a busy runner.
-        // Wait for the complete link, rather than clicking a partial hostname.
-        for _ in 0..500 {
-            if session.url_at(0, 8).as_deref() == Some("https://railway.com/deploy") {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
+        session.wait_for_output("see https://railway.com/deploy now");
         assert_eq!(
             session.url_at(0, 8).as_deref(),
             Some("https://railway.com/deploy")
@@ -8366,15 +8359,7 @@ mod tests {
         let mut session = super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap();
         session.resize(6, 60);
         session.send(b"see https://railway.com/deploy now\r\n");
-        for _ in 0..40 {
-            if session
-                .with_screen(|s| s.contents_between(0, 0, 0, u16::MAX))
-                .is_some_and(|line| line.contains("railway.com"))
-            {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
+        session.wait_for_output("see https://railway.com/deploy now");
         a.attach_session(session, "ca_1".into());
         a.panes.session = PaneBox {
             x: 34,
@@ -8403,7 +8388,7 @@ mod tests {
         let mut session = super::super::session::Session::for_test("ca_1", "nimble-otter").unwrap();
         session.resize(6, 60);
         session.send(b"just some output\r\n");
-        std::thread::sleep(std::time::Duration::from_millis(80));
+        session.wait_for_output("just some output");
         a.attach_session(session, "ca_1".into());
         a.panes.session = PaneBox {
             x: 34,

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -1202,6 +1202,26 @@ impl Session {
         self.spawned_at = std::time::Instant::now() - by;
     }
 
+    /// Wait for complete fixture output before inspecting links or history.
+    /// ConPTY startup and delivery can take seconds on a loaded Windows runner.
+    /// Check the screen rather than sleeping a fixed amount or silently moving
+    /// on after a polling loop expires. Call this with the live view selected.
+    #[track_caller]
+    pub fn wait_for_output(&self, text: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            let contents = self.with_screen(|s| s.contents()).expect("fixture screen");
+            if contents.contains(text) {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "PTY did not deliver {text:?}; screen contents: {contents:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
     /// A session backed by a local `cat` instead of ssh, so the state machine
     /// around sessions can be tested without a relay or a network.
     pub fn for_test(agent_id: &str, agent_name: &str) -> Result<Self> {
@@ -2157,24 +2177,8 @@ assert (size.lines, size.columns) == (30, 100)
         let mut session = Session::for_test("ca", "test").unwrap();
         session.resize(6, 60);
         session.send(b"open https://railway.com/deploy now\r\n");
-        // PTY startup and delivery can exceed 400 ms on a loaded Windows
-        // runner. Wait for the entire line (including the URL's terminator)
-        // so this checks hit testing rather than process scheduling or a
-        // partially delivered URL.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            let line = session
-                .with_screen(|s| s.contents_between(0, 0, 0, u16::MAX))
-                .unwrap_or_default();
-            if line.contains("open https://railway.com/deploy now") {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "PTY did not deliver the complete link line: {line:?}"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
+        // Include the URL's terminator so a partial delivery cannot look ready.
+        session.wait_for_output("open https://railway.com/deploy now");
 
         assert_eq!(
             session.url_at(0, 10).as_deref(),
@@ -2198,15 +2202,8 @@ assert (size.lines, size.columns) == (30, 100)
         let mut session = Session::for_test("ca", "test").unwrap();
         session.resize(24, 40);
         session.send(format!("{url}\r\n").as_bytes());
+        session.wait_for_output(url);
         let rows = url.len().div_ceil(40) as u16;
-        for _ in 0..100 {
-            // The echo, then the copy: waiting for the second guarantees the
-            // first is whole.
-            if session.url_at(rows, 0).is_some() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
 
         // Every row it covers, and every column within them, resolves to the
         // whole link — clicking the tail is as natural as clicking the head.
@@ -2232,7 +2229,7 @@ assert (size.lines, size.columns) == (30, 100)
         let mut session = Session::for_test("ca", "test").unwrap();
         session.resize(8, 20);
         session.send(b"the quick brown fox jumps over the lazy dog\r\n");
-        std::thread::sleep(std::time::Duration::from_millis(80));
+        session.wait_for_output("the quick brown fox jumps over the lazy dog");
         for row in 0..3 {
             for col in 0..20 {
                 assert_eq!(session.url_at(row, col), None, "row {row} col {col}");
@@ -2253,16 +2250,7 @@ assert (size.lines, size.columns) == (30, 100)
         for i in 0..40 {
             session.send(format!("line-{i}\r\n").as_bytes());
         }
-        // Give the reader thread a moment to fold them in.
-        for _ in 0..50 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("line-39"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        session.wait_for_output("line-39");
         let live = session.with_screen(|s| s.contents()).unwrap();
         assert!(live.contains("line-39"), "expected the tail:\n{live}");
         assert!(!session.scrolled_back());
@@ -2292,15 +2280,7 @@ assert (size.lines, size.columns) == (30, 100)
         for i in 0..120 {
             session.send(format!("line-{i}\r\n").as_bytes());
         }
-        for _ in 0..100 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("line-119"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        session.wait_for_output("line-119");
 
         // Ask for infinitely far back; the emulator clamps to what exists.
         session.scroll_by(isize::MAX);
@@ -2385,15 +2365,7 @@ assert (size.lines, size.columns) == (30, 100)
         for i in 0..60 {
             session.send(format!("line-{i}\r\n").as_bytes());
         }
-        for _ in 0..100 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("line-59"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        session.wait_for_output("line-59");
 
         // No mouse reporting and no alternate screen here, so each wheel goes
         // to the emulator's own scrollback.
@@ -2427,15 +2399,7 @@ assert (size.lines, size.columns) == (30, 100)
         for i in 0..100 {
             session.send(format!("line-{i}\r\n").as_bytes());
         }
-        for _ in 0..100 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("line-99"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        session.wait_for_output("line-99");
 
         session.scroll_by(60);
         assert!(session.scroll > 10, "start well past one screen");
@@ -2493,16 +2457,10 @@ assert (size.lines, size.columns) == (30, 100)
             );
         }
 
-        // Wait for the tail so the final checks see settled history.
-        for _ in 0..100 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("round-4-line-39"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        // Return to the live view before waiting: the tail cannot be visible
+        // while the viewport is pinned to older history.
+        session.scroll_by(isize::MIN);
+        session.wait_for_output("round-4-line-39");
 
         session.scroll_by(isize::MAX);
         let top = session.with_screen(|s| s.contents()).unwrap();
@@ -2526,15 +2484,7 @@ assert (size.lines, size.columns) == (30, 100)
         for i in 0..4200 {
             session.send(format!("line-{i}\r\n").as_bytes());
         }
-        for _ in 0..300 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("line-4199"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        session.wait_for_output("line-4199");
 
         session.scroll_by(isize::MAX);
         assert_eq!(

--- a/src/commands/cloud_agent/tui/session.rs
+++ b/src/commands/cloud_agent/tui/session.rs
@@ -2457,10 +2457,11 @@ assert (size.lines, size.columns) == (30, 100)
             );
         }
 
-        // Return to the live view before waiting: the tail cannot be visible
-        // while the viewport is pinned to older history.
-        session.scroll_by(isize::MIN);
-        session.wait_for_output("round-4-line-39");
+        // Send a fresh marker after the final resize. Shrinking the screen can
+        // discard its bottom rows, including the last round's tail if it was
+        // already delivered. Sending also returns the viewport to live output.
+        session.send(b"CHURN-DRAINED-MARKER\r\n");
+        session.wait_for_output("CHURN-DRAINED-MARKER");
 
         session.scroll_by(isize::MAX);
         let top = session.with_screen(|s| s.contents()).unwrap();

--- a/src/commands/cloud_agent/tui/ui.rs
+++ b/src/commands/cloud_agent/tui/ui.rs
@@ -2852,17 +2852,7 @@ mod tests {
         for i in 0..100 {
             session.send(format!("scroll-line-{i:03}\r\n").as_bytes());
         }
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        while !session
-            .with_screen(|s| s.contents().contains("scroll-line-099"))
-            .unwrap_or(false)
-        {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "fixture output must arrive"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
+        session.wait_for_output("scroll-line-099");
         app.attach_session(session, "ca_1".into());
         for width in [None, Some(58)] {
             app.sidebar_width = width;
@@ -3458,15 +3448,7 @@ mod tests {
         for i in 0..80 {
             session.send(format!("line-{i}\r\n").as_bytes());
         }
-        for _ in 0..100 {
-            std::thread::sleep(std::time::Duration::from_millis(20));
-            let seen = session
-                .with_screen(|screen| screen.contents().contains("line-79"))
-                .unwrap_or(false);
-            if seen {
-                break;
-            }
-        }
+        session.wait_for_output("line-79");
         session.scroll_by(isize::MAX);
         assert!(session.scrolled_back());
 


### PR DESCRIPTION
## Summary

Stabilize the Windows terminal tests that failed in the [post-merge CI run for #1193](https://github.com/railwayapp/cli/actions/runs/34557183827). That run had ten link/scrollback failures with empty terminal screens. #1195 fixed one short wait, but other affected tests still used 1–6 second polling loops that silently continued on timeout.

- Share a test-only, 15-second bounded wait for expected screen output. It returns as soon as output arrives and reports the expected text and actual screen at the caller on timeout.
- Wait for complete output before asserting link hit-testing, wrapped URLs, scrollback, resizing, and rendering. Negative link tests also wait for their fixture text, avoiding assertions against empty screens.
- Send a fresh completion marker after the churn fixture's final resize. Shrinking the screen can discard bottom rows (including an already-delivered tail), and sending the marker also returns the viewport to live output.

## Validation

- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Local TUI suite: 399 passed, 1 ignored.
- `cargo clippy --locked --all-targets --all-features`: passed (existing warnings).
- Churn regression after the final-resize fix: 50/50 repeated runs passed.
- Full local suite (`cargo test --locked`): 1,595 passed, 2 ignored.
- [CI on final commit `235649a`](https://github.com/railwayapp/cli/actions/runs/34649069549): all checks passed, including Windows/Linux/macOS tests, the i686 Windows GNU release build, lints, compile check, installer checks, and the release label check.

## Merge investigation

The pre-merge checks on #1193 passed; the Windows failures occurred on the merged commit. The latest #1195 Windows run passed as well. Separately, `master` currently has an empty required-status-check list, so failing CI does not block merges through branch protection.
