### PR TITLE
Focus cloud-agent and sandbox command help

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ railway setup agent -y --local
 railway mcp install --local --agent cursor
 ```
 
+For VM launch, reconnection, Desktop setup, and authentication details, see the
+[cloud-agent command guide](docs/cloud-agents.md).
+
 ## Update progress and status
 
 `railway upgrade` presents CLI installation and managed skill synchronization as

--- a/docs/cloud-agents.md
+++ b/docs/cloud-agents.md
@@ -134,9 +134,17 @@ railway code --codex --bootstrap dev
 railway ca create my-box --from-checkpoint <checkpoint-id>
 ```
 
+`railway ca bootstrap list` shows saved names, capture status, and last-saved
+times. An asterisk marks this machine's default. Use `--environment staging`
+to select another environment or `--json` for structured output.
+
 Bootstraps capture running VMs for reuse. Saving the same name creates a new
-version. `railway ca bootstrap default dev` selects a ready bootstrap as this
-machine's default for the environment. `--no-bootstrap` skips the default.
+version. Save waits for the capture to finish, and `--default` changes only after
+success. Variables supplied with `--variable` or `--env-file` are saved with the
+bootstrap; explicit variables override matching file entries.
+
+`railway ca bootstrap default dev` selects a ready bootstrap as this machine's default for future VM creation in the environment; existing VMs are
+unaffected. `--no-bootstrap` skips the default.
 `--from-checkpoint` on `ca create` accepts a cloud-agent checkpoint ID and bypasses
 the default bootstrap.
 

--- a/docs/cloud-agents.md
+++ b/docs/cloud-agents.md
@@ -1,0 +1,150 @@
+# Cloud-agent command guide
+
+Use `railway ca` to browse and manage VMs, `railway code` to launch a coding
+session, and `railway ca desktop` to configure a desktop app. Cloud Agents access
+is required. Run any command with `--help` for its options.
+
+## Launch and reconnect
+
+```sh
+railway code --codex
+railway code --opencode
+railway code --claude
+railway code --codex connect my-box
+```
+
+An explicit agent flag on `railway code` creates a new VM unless `connect` or
+`--agent` selects an existing one. `connect [agent]` connects to an existing
+Codex/OpenCode server; `--agent <name-or-id>` selects a VM for server setup.
+
+Codex, OpenCode, and OpenCode2 normally run a local client connected to the VM.
+Their clients run inside the Railway CA interface with command approvals disabled.
+Codex matches the local client to its server version and trusts the remote project.
+Missing OpenCode clients can be installed after confirmation. OpenCode2 downloads
+its latest Beta runtime onto the VM at startup.
+
+Use `remote` to run the client on the VM. Use `--` to pass arguments to the agent:
+
+```sh
+railway code --codex remote
+railway code --codex -- exec "explain this codebase"
+```
+
+`railway ca --codex` and `railway ca start --codex` launch on the VM and do not
+use `code`'s local-client actions. `ca start` also skips the management interface.
+These CA paths do not automatically request a fresh VM; use `--new` when needed.
+
+## Defaults, targeting, and lifecycle
+
+`railway ca setup` saves the default agent, project, and skills. Explicit flags
+win over preferences. `RAILWAY_CA_AGENT` overrides the saved agent for one run.
+A directory's linked project takes precedence over the saved default project.
+Preferences live in `~/.railway/agent-prefs.json`.
+
+Agent selectors accept names or IDs. Lifecycle commands without a selector use
+this directory's agent or your only agent, otherwise show candidates.
+
+Disconnecting leaves the VM running and compute billing continues.
+`railway ca sleep <agent>` stops compute and ends running processes while keeping
+the disk. `railway ca delete <agent>` deletes the VM and its disk.
+The older `railway code --rm` deletes this environment's agent and disk.
+
+Use `railway ca ssh <agent>` for a shell, `--session [name]` to attach to or start
+a terminal session, and `--resume` to resume the most recent Claude conversation
+in a fresh terminal session after sleep or restart.
+
+In the management interface, Option+F toggles the tree and Option+N starts another
+session. Piped sessions and agent arguments after `--` use the terminal directly.
+
+## Authentication
+
+Local sign-ins are optional: without one, sign in using the agent's login flow
+on the VM. When available, Codex copies `~/.codex/auth.json`, Grok copies
+`~/.grok/auth.json`, and OpenCode carries local provider sign-ins to the VM.
+
+Claude uses a setup token from `claude setup-token`, or the supplied
+`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY`. The CLI can mint the setup token
+and caches it locally in `~/.railway/claude-code-token`. It reuses a credential
+already on the VM. `--refresh-auth` replaces the cached credentials with a newly
+minted token; use it after revoking a token or when authentication fails.
+`railway logout` clears the local token cache.
+
+Railway Agent uses credentials already on the VM and needs no separate model
+provider sign-in.
+
+## Desktop setup
+
+```sh
+railway ca desktop --claude
+railway ca desktop --codex
+railway ca desktop --opencode --agent my-box
+railway code --codex desktop-only --agent my-box --dir /app
+```
+
+Desktop setup uses an existing VM when available, creating one if needed.
+`--new` requests a fresh VM; `--agent` selects an existing one.
+`railway ca desktop --codex` alone is an alias for Codex `desktop-only` setup.
+Setup writes configuration without opening the desktop app. Restart the app to
+load the connection. The VM remains awake; rerun setup after sleep or restart.
+
+Normal `railway code` Codex setup and connect also configure Desktop in the
+background. OpenCode setup and connect configure the matching Desktop edition
+when its settings are detected. The command reports configuration success or
+failure.
+
+Claude and Codex use generated SSH configuration. `--ssh-config` selects the file.
+Codex also saves its connection and remote project in
+`$CODEX_HOME/codex-app/config.json` (default `~/.codex/codex-app/config.json`).
+After restarting Codex, find `Railway: <agent-name>` in the project sidebar.
+
+OpenCode uses a public HTTPS endpoint. New VMs request a code endpoint on port
+4096; existing VMs use their configured endpoint or app port 8080. Setup saves
+the URL, credentials, default server, and project in the selected Desktop edition.
+Open Home → Projects → Railway: <agent-name> → /app (or the selected `--dir`) →
+New session. Changing the default server does not move existing chats.
+An occupied server port causes setup to fail without stopping its process.
+
+`--dry-run` previews changes without changing local configuration or the VM.
+`--remove` removes local Desktop configuration and stops the managed OpenCode
+server on a running VM. For Codex it removes the import declaration; remove
+already-imported hosts and projects in Settings → Connections and the sidebar.
+
+## Saved connection details and JSON
+
+```sh
+railway code get-config
+railway code get-config my-box --json
+railway code --codex connect my-box --connection-json
+```
+
+`get-config` shows local snapshots without login, network access, or waking a VM.
+It does not verify that a saved connection still works. Omit the selector for the
+latest snapshot; use an ID when names are ambiguous. Snapshots contain credentials
+and are removed by `railway logout`.
+
+`--connection-json` returns verified connection details including credentials for
+Codex or OpenCode2, without opening a local client. Progress goes to stderr.
+It works with setup, `connect`, and Codex `desktop-only`.
+
+## Reusable VMs and variables
+
+```sh
+railway ca bootstrap save dev --agent my-box --default
+railway code --codex --bootstrap dev
+railway ca create my-box --from-checkpoint <checkpoint-id>
+```
+
+Bootstraps capture running VMs for reuse. Saving the same name creates a new
+version. `railway ca bootstrap default dev` selects a ready bootstrap as this
+machine's default for the environment. `--no-bootstrap` skips the default.
+`--from-checkpoint` on `ca create` accepts a cloud-agent checkpoint ID and bypasses
+the default bootstrap.
+
+`--variable` sets creation-time variables and supports comma-separated values,
+repeated flags, and service references such as `DB_URL=postgres.DATABASE_URL` or
+`DB_URL=${{postgres.DATABASE_URL}}`. Quote the latter in a shell. Repeat
+`--env-file` to load files; `--variable` overrides matching file entries.
+
+Local clients request their code endpoint automatically. When configuring one
+explicitly on `railway code` or `ca start`, `--code-endpoint` and `--code-port`
+require an explicit `--new`, even when the launcher would create a VM by default.

--- a/src/commands/cloud_agent/bootstrap.rs
+++ b/src/commands/cloud_agent/bootstrap.rs
@@ -13,12 +13,14 @@ use crate::{
 
 #[derive(Parser)]
 #[clap(after_help = r#"Examples:
+  railway ca bootstrap list
   railway ca bootstrap save dev --agent my-box
   railway ca bootstrap default dev
   railway code --codex --bootstrap dev
 
 A bootstrap captures a running VM for reuse when creating new VMs.
 The default is saved on this machine for the selected project/environment.
+Project/environment flags override the linked directory and saved preferences.
 Use --no-bootstrap when creating a VM to skip that default."#)]
 pub struct Args {
     #[clap(subcommand)]
@@ -27,16 +29,23 @@ pub struct Args {
 
 #[derive(Parser)]
 enum Command {
-    /// List bootstraps in the linked project/environment
+    /// List saved bootstraps and their status in an environment
     #[clap(visible_alias = "ls")]
     List(ListArgs),
     /// Save a running VM as a named bootstrap (or a new version of that name)
     Save(SaveArgs),
-    /// Select the local default bootstrap for the linked project/environment
+    /// Choose the default bootstrap for new VMs in an environment
     Default(DefaultArgs),
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway ca bootstrap list
+  railway ca bootstrap list --environment staging
+  railway ca bootstrap list --json
+
+Lists names, capture status, and last-saved times. An asterisk marks this
+machine's default for the environment. Only READY bootstraps can be used."#)]
 struct ListArgs {
     #[clap(flatten)]
     target: TargetArgs,
@@ -47,10 +56,13 @@ struct ListArgs {
 
 #[derive(Parser)]
 #[clap(after_help = r#"Examples:
+  railway ca bootstrap save dev --agent my-box
   railway ca bootstrap save dev --agent my-box --default
+  railway ca bootstrap save dev --agent my-box --env-file .env --variable MODE=dev
 
 The source VM must be running. Reusing a name saves a new version.
---default selects it locally after the capture succeeds."#)]
+Waits for the capture to finish; --default changes only after it succeeds.
+Variables are saved with the bootstrap; --variable overrides matching file values."#)]
 struct SaveArgs {
     /// Bootstrap name, unique within this environment
     name: String,
@@ -60,7 +72,7 @@ struct SaveArgs {
     /// Make this the local default after its capture succeeds
     #[clap(long)]
     default: bool,
-    /// Bootstrap variables; --variable overrides entries from --env-file
+    /// Set bootstrap variables (repeatable or comma-separated; supports service references)
     #[clap(long = "variable", value_name = "KEY=VALUE[,KEY=VALUE...]")]
     variables: Vec<String>,
     /// Load bootstrap variables from a .env file (repeatable)
@@ -74,6 +86,13 @@ struct SaveArgs {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway ca bootstrap default dev
+  railway ca bootstrap default dev --environment staging
+
+Selects a READY bootstrap for future VM creation in this environment.
+The choice is local to this machine and does not change existing VMs.
+Use --bootstrap <name> or --no-bootstrap when creating a VM to override it."#)]
 struct DefaultArgs {
     /// Name of a ready bootstrap in this environment
     name: String,

--- a/src/commands/cloud_agent/bootstrap.rs
+++ b/src/commands/cloud_agent/bootstrap.rs
@@ -12,6 +12,14 @@ use crate::{
 };
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway ca bootstrap save dev --agent my-box
+  railway ca bootstrap default dev
+  railway code --codex --bootstrap dev
+
+A bootstrap captures a running VM for reuse when creating new VMs.
+The default is saved on this machine for the selected project/environment.
+Use --no-bootstrap when creating a VM to skip that default."#)]
 pub struct Args {
     #[clap(subcommand)]
     command: Command,
@@ -38,6 +46,11 @@ struct ListArgs {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway ca bootstrap save dev --agent my-box --default
+
+The source VM must be running. Reusing a name saves a new version.
+--default selects it locally after the capture succeeds."#)]
 struct SaveArgs {
     /// Bootstrap name, unique within this environment
     name: String,
@@ -62,6 +75,7 @@ struct SaveArgs {
 
 #[derive(Parser)]
 struct DefaultArgs {
+    /// Name of a ready bootstrap in this environment
     name: String,
     #[clap(flatten)]
     target: TargetArgs,

--- a/src/commands/cloud_agent/desktop.rs
+++ b/src/commands/cloud_agent/desktop.rs
@@ -40,11 +40,23 @@ mod codex_config;
 mod opencode_config;
 pub(crate) use opencode_config::configure_installed as configure_installed_opencode;
 
-/// Set up a desktop coding app to work on a cloud agent over SSH
+/// Connect a desktop coding app to a cloud agent
 #[derive(Parser)]
-#[clap(
-    after_help = "Examples:\n\n  railway ca desktop --claude\n  railway ca desktop --codex\n  railway ca desktop --opencode\n  railway ca desktop --opencode --new\n  railway ca desktop --opencode2 --new\n  railway ca desktop --opencode --agent my-box\n  railway ca desktop --claude --codex\n\nReuses and wakes the selected agent, creating one if needed. --new always\ncreates a fresh agent. --agent selects an existing box.\n\nClaude and Codex use the generated SSH configuration. Restart Claude after setup.\nCodex also imports the SSH connection and remote project through\n$CODEX_HOME/codex-app/config.json (default ~/.codex/codex-app/config.json).\nSetup saves configuration in the background without opening Codex Desktop.\nThe app imports it on its next startup.\nFind Railway: <agent-name> in Codex's project sidebar.\n\nOpenCode setup requests a code endpoint on newly created VMs (default port 4096).\nExisting VMs use their configured endpoint, or the app port (8080) without one.\nSetup saves the URL, credentials, default server, and project in\nstandard OpenCode with --opencode, or OpenCode2 [Beta] with --opencode2.\nBeta downloads its latest official runtime onto the agent at startup.\nYou may need to restart OpenCode Desktop to load the updated configuration.\nOpen Home → Projects → Railway: <agent-name> → /app (or --dir) → New session.\nSetting a default server does not move existing chats.\nYou can close this terminal after setup. Rerun setup after sleeping or\nrestarting the agent. An occupied server port fails without stopping its process.\n\n--dry-run previews setup without creating, waking, or changing an agent.\n--remove stops the managed OpenCode server on a running agent and removes\nlocal desktop configuration, including the managed OpenCode server entry.\nFor Codex it removes the import declaration; remove already-imported hosts\nand projects in Codex Settings → Connections and the sidebar.\n--ssh-config selects the SSH file used during setup.\n\nThe agent stays awake after setup. `railway ca sleep <name>` stops its compute bill."
-)]
+#[clap(after_help = r#"Examples:
+  railway ca desktop --claude
+  railway ca desktop --codex
+  railway ca desktop --opencode --agent my-box
+  railway ca desktop --opencode2 --new
+
+Sets up the selected app's connection and credentials without opening the app.
+Uses an existing VM when available; --new creates one, --agent selects one.
+Restart the app after setup to load its connection. The VM stays running;
+railway ca sleep <agent> stops compute. Rerun setup after sleep or restart.
+
+--dry-run previews changes without modifying the VM or local configuration.
+--remove removes local configuration and stops the managed OpenCode server.
+Already-imported Codex connections must also be removed in the app.
+Guide: https://github.com/railwayapp/cli/blob/master/docs/cloud-agents.md"#)]
 pub struct Args {
     /// Configure Claude Code Desktop
     #[clap(long)]

--- a/src/commands/cloud_agent/lifecycle.rs
+++ b/src/commands/cloud_agent/lifecycle.rs
@@ -75,6 +75,14 @@ pub struct ListArgs {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway ca create my-box
+  railway ca create my-box --bootstrap dev
+  railway ca create my-box --from-checkpoint <checkpoint-id>
+
+Creates a VM without connecting. Uses the local default bootstrap unless
+--no-bootstrap or --from-checkpoint is given. --bootstrap accepts a name;
+--from-checkpoint requires a cloud-agent checkpoint ID."#)]
 pub struct CreateArgs {
     /// Name for the agent (defaults to a generated one)
     #[clap(value_name = "NAME")]
@@ -154,6 +162,13 @@ pub struct SleepArgs {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway ca ssh my-box                    # open a shell
+  railway ca ssh my-box --session          # attach to or start a session
+  railway ca ssh my-box --resume           # resume the latest Claude conversation
+  railway ca ssh my-box -- ls -la /app     # run a command
+
+Disconnecting leaves the VM running. Sleep ends its processes and keeps its disk."#)]
 pub struct SshArgs {
     /// Agent name or ID (defaults to this directory's, or your only one)
     #[clap(value_name = "AGENT")]
@@ -163,9 +178,7 @@ pub struct SshArgs {
     #[clap(long, value_name = "NAME", num_args = 0..=1, default_missing_value = "", conflicts_with = "command")]
     session: Option<String>,
 
-    /// Resume the agent's most recent Claude conversation in a fresh session
-    /// (after a sleep or reboot ended the terminal it ran in), instead of
-    /// starting a new one or being asked
+    /// Resume the most recent Claude conversation in a new terminal session
     #[clap(long, conflicts_with_all = ["session", "command"])]
     resume: bool,
 

--- a/src/commands/cloud_agent/mod.rs
+++ b/src/commands/cloud_agent/mod.rs
@@ -43,7 +43,19 @@ use tui::{App, Outcome};
 #[derive(Parser)]
 #[clap(
     args_conflicts_with_subcommands = true,
-    after_help = "Examples:\n\n  railway ca                        # browse and launch agents (TUI)\n  railway ca manage                 # jump straight into the manage screen\n  railway ca setup                  # choose your default agent and skills\n  railway ca setup --show           # print current preferences\n  railway ca desktop --claude       # drive an agent from Claude Code Desktop\n  railway ca desktop --codex        # …or from the Codex app\n  railway ca desktop --opencode     # …or from OpenCode Desktop\n  railway ca start --claude         # skip the TUI and launch\n\n  railway ca list                   # every agent you own, everywhere\n  railway ca list -e production     # just this environment\n  railway ca create my-agent        # a VM, without connecting to it\n  railway ca ssh my-agent           # open a shell on the agent\n  railway ca ssh my-agent --session # attach to or start an agent session\n  railway ca sleep my-agent         # stop the compute bill, keep the disk\n  railway ca sleep --all            # every running agent you own\n  railway ca delete my-agent        # the agent and its disk\n\nAgents are addressed by name or id. With neither, commands use this\ndirectory's agent, or your only one, and otherwise list the candidates.\n\n`railway code` is the launcher pointed straight at a session — same flags,\nsame preferences, no browsing: it opens the manage screen with the tree collapsed\nand your default harness already starting (⌥f brings the tree back). `railway\nca start` skips the TUI altogether.\n\nPreferences live in ~/.railway/agent-prefs.json; a flag always wins over\nthem, and RAILWAY_CA_AGENT overrides the saved default for one run. A\ndirectory linked with `railway link` wins over the saved default project too\n— new agents land there instead.\n\nNote: requires the CLOUD_AGENTS feature to be enabled."
+    after_help = r#"Examples:
+  railway ca                         # browse and launch agents
+  railway ca setup                   # choose defaults and skills
+  railway ca ssh my-box               # open a shell
+  railway ca sleep my-box             # stop compute, keep the disk
+  railway ca desktop --codex          # configure a desktop app
+
+Use railway code for a local Codex/OpenCode client connected to a VM.
+Agent flags here launch on the VM. Use --new to create a fresh VM.
+Flags override preferences; the linked project overrides the saved project.
+Disconnecting leaves the VM running. Sleep stops processes and keeps the disk.
+Requires Cloud Agents access.
+Guide: https://github.com/railwayapp/cli/blob/master/docs/cloud-agents.md"#
 )]
 pub struct Args {
     #[clap(subcommand)]
@@ -62,13 +74,24 @@ enum Command {
     /// Configure how cloud agents are launched (default agent, skills)
     Setup(setup::Args),
 
-    /// Set up a desktop coding app to work on a cloud agent over SSH
+    /// Connect a desktop coding app to a cloud agent
     Desktop(desktop::Args),
 
     /// Open the TUI directly on the manage screen, skipping the first-run nudge
     Manage,
 
     /// Launch a coding agent on a cloud agent VM, without the TUI
+    #[clap(after_help = r#"Examples:
+  railway ca start --claude           # launch Claude Code on the VM
+  railway ca start --codex --new       # launch Codex on a new VM
+  railway ca start --claude -- exec "explain this codebase"
+
+Launches on the VM directly, without the management interface.
+Uses your configured agent and project defaults; --new creates a fresh VM.
+Available local credentials are copied to the VM; Claude can mint a setup token.
+Disconnecting leaves the VM running. Use railway ca sleep <agent> to stop compute.
+Requires Cloud Agents access.
+Guide: https://github.com/railwayapp/cli/blob/master/docs/cloud-agents.md"#)]
     Start(LaunchArgs),
 
     /// List your cloud agents
@@ -92,6 +115,19 @@ enum Command {
     /// Delete an agent and everything on its disk
     #[clap(visible_alias = "rm")]
     Delete(lifecycle::DeleteArgs),
+}
+
+/// Shared launch arguments have different help in CA's in-VM execution path.
+pub fn get_dynamic_args(cmd: clap::Command) -> clap::Command {
+    fn in_vm_help(mut cmd: clap::Command) -> clap::Command {
+        for id in ["connection_json", "remote_dir", "remote_agent"] {
+            cmd = cmd.mut_arg(id, |arg| arg.hide(true));
+        }
+        cmd.mut_arg("agent_args", |arg| {
+            arg.help("Arguments to pass to the agent after --")
+        })
+    }
+    in_vm_help(cmd).mut_subcommand("start", in_vm_help)
 }
 
 /// Time one lifecycle verb and report its outcome, passing the result through

--- a/src/commands/code.rs
+++ b/src/commands/code.rs
@@ -117,7 +117,29 @@ pub(crate) fn save_desktop_configuration(
 
 /// Launch a coding agent on a Railway cloud agent VM
 #[derive(Parser)]
-#[clap(args_conflicts_with_subcommands = true)]
+#[clap(
+    args_conflicts_with_subcommands = true,
+    after_help = r#"Examples:
+  railway code --codex                    # start Codex on a new VM
+  railway code --claude                   # start Claude Code on a new VM
+  railway code --codex connect my-box     # connect to an existing server
+  railway code --codex desktop-only       # configure Codex Desktop
+  railway code get-config my-box          # show saved connection details
+
+An explicit agent flag creates a new VM unless you use connect or --agent.
+Without an agent flag, uses the default from railway ca setup.
+Flags override preferences; the linked project overrides the saved project.
+
+Codex and OpenCode open a local client connected to the VM, with command
+approvals disabled. Use remote to run the client on the VM, or -- to pass
+arguments to the agent. Available local credentials are copied to the VM;
+Claude can mint a setup token. Codex saves Desktop setup; OpenCode configures
+detected Desktop installs.
+
+Disconnecting leaves the VM running. Use railway ca sleep <agent> to stop compute.
+Requires Cloud Agents access.
+Guide: https://github.com/railwayapp/cli/blob/master/docs/cloud-agents.md"#
+)]
 pub struct Args {
     #[clap(subcommand)]
     command: Option<Commands>,
@@ -213,130 +235,51 @@ pub(crate) async fn launch_in_cloud(args: LaunchArgs) -> Result<()> {
 // they would show up in `--help`.
 #[derive(Parser, Default, Clone, Debug, PartialEq, Eq)]
 #[clap(
-    group(clap::ArgGroup::new("client_json_harness").args(["codex", "opencode2"]).multiple(true)),
-    after_help = r#"Examples:
-
-  railway ca                        # launch your configured default
-  railway ca setup                  # choose the default agent and skills
-  railway code --codex              # remote Codex server + local terminal client
-  railway code --codex connect      # choose a running Codex server
-  railway code --codex connect my-box
-  railway code --codex desktop-only # backend + Desktop configuration, then exit
-  railway code --codex desktop-only --agent my-box --dir /app
-  railway code get-config           # replay the latest saved connection
-  railway code get-config my-box    # replay a specific agent (name or ID)
-  railway code get-config my-box --json
-  railway code --codex remote       # run the Codex UI inside Railway CA
-  railway code --claude             # agent VM + your Claude setup-token
-  railway code --grok               # agent VM + your local Grok sign-in
-  railway code --opencode           # remote OpenCode server + local client
-  railway code --opencode2          # same, with OpenCode2 Beta
-  railway code --opencode remote    # run client and server inside Railway CA
-  railway code --opencode2 --name my-box
-  railway code --opencode2 connect
-  railway code --opencode connect my-box
-  railway code --railway            # Railway's own agent, no sign-in needed
-  railway code --codex --new        # optional: harness launches already create a VM
-  railway code --codex --variable DB_URL=postgres.DATABASE_URL
-  railway code --codex --env-file .env
-  railway code --codex -- exec "explain this codebase"
-
-With no agent flag, the default saved by `railway ca setup` is used
-(RAILWAY_CA_AGENT overrides it for one run). With no project or environment
-flag, this directory's linked project is used, and your default project when
-the directory has no link.
-
-Each `railway code` launch with an explicit harness flag creates a fresh VM by
-default, including `remote` and `--` passthrough commands. Use `connect [agent]`
-for an existing Codex/OpenCode server, or `railway ca ssh <agent>` for a shell.
-`--new` is optional for harness launches; an explicit `--agent` selects an existing
-VM for server setup.
-
-`railway code --codex`, `--opencode`, and `--opencode2` prepare a server, print
-connection details, and automatically open your local client with command
-approvals disabled. Codex updates its server at startup and automatically matches
-the local client version and trusts the remote project. All three clients open
-inside the Railway CA frame, whose sidebar lists conversation titles and resumes
-the selected thread. Missing OpenCode
-clients can be installed after confirmation. `connect [agent]` reconnects locally;
-`remote` runs the client on the VM over SSH. `--dir` selects the remote directory
-(default /app).
-`--connection-json` returns credentials as JSON for Codex or OpenCode2.
-Codex setup and connect also register and verify its SSH host and save its remote
-project in the background. Codex Desktop imports it on its next startup;
-setup never launches or activates the app.
-`railway code --codex desktop-only` prepares the same backend and Desktop
-connection, then exits without prompting for or launching a local terminal client.
-`railway ca desktop --codex` is an alias for this setup.
-OpenCode launch and connect automatically save the connection in the matching
-Desktop edition when its settings file or database is detected. The final output
-reports success or a non-fatal configuration failure. You may need to restart
-OpenCode Desktop to load the updated configuration.
-
-Sessions running inside `railway ca` open in its manage screen with the
-tree collapsed, so it has the whole window and the other agents are one key
-away — ⌥f brings the tree back, ⌥n starts another session. `--rm`, a `--`
-passthrough, and piped in-VM sessions take the terminal directly instead;
-so does `railway ca start`, which never draws the TUI.
-
-Agents persist between runs and stay running when you disconnect, so your
-sessions survive to reattach to. `railway ca sleep <agent>` stops the compute
-bill; `railway code --rm` destroys it.
-
-Claude auth is minted once (`claude setup-token`), cached locally, and reused —
-including the copy already on a reused agent. `--refresh-auth` clears both
-caches and re-mints.
-
-Carrying a sign-in from this machine is optional. With no local credential,
-sign in on the agent using the harness's login flow.
-
-Note: requires the CLOUD_AGENTS feature to be enabled."#
+    group(clap::ArgGroup::new("client_json_harness").args(["codex", "opencode2"]).multiple(true))
 )]
 pub struct LaunchArgs {
-    /// Prepare a Codex server and launch your local client, carrying your ChatGPT sign-in
-    /// (~/.codex/auth.json) when there is one to carry
-    #[clap(long)]
+    /// Select Codex
+    #[clap(long, help_heading = "Agent")]
     codex: bool,
 
-    /// Launch OpenCode, carrying your local provider sign-ins when available
-    #[clap(long)]
+    /// Select OpenCode
+    #[clap(long, help_heading = "Agent")]
     opencode: bool,
 
-    /// Launch the latest OpenCode2 Beta, downloaded onto the agent at startup
-    #[clap(long)]
+    /// Select OpenCode2 Beta
+    #[clap(long, help_heading = "Agent")]
     opencode2: bool,
 
-    /// Return verified Codex or OpenCode2 connection details as JSON, including credentials,
-    /// without launching a local client. Progress is written to stderr.
-    #[clap(long, requires = "client_json_harness")]
+    /// Return Codex/OpenCode2 connection credentials as JSON without opening a client
+    #[clap(
+        long,
+        requires = "client_json_harness",
+        help_heading = "Authentication and output"
+    )]
     connection_json: bool,
 
-    /// Launch Claude Code — runs `claude setup-token` for you to mint a
-    /// token for the VM (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY env
-    /// variables skip that when set)
-    #[clap(long)]
+    /// Select Claude Code
+    #[clap(long, help_heading = "Agent")]
     claude: bool,
 
-    /// Launch Grok CLI, carrying your local sign-in (~/.grok/auth.json) when
-    /// there is one to carry
-    #[clap(long)]
+    /// Select Grok CLI
+    #[clap(long, help_heading = "Agent")]
     grok: bool,
 
-    /// Launch Railway's own agent — no sign-in needed; it uses credentials
-    /// already on the VM
-    #[clap(long)]
+    /// Select Railway Agent (uses credentials already on the VM)
+    #[clap(long, help_heading = "Agent")]
     railway: bool,
 
-    /// Create a fresh agent (already the default for railway code with a harness flag)
-    #[clap(long)]
+    /// Create a new VM
+    #[clap(long, help_heading = "VM creation")]
     pub new: bool,
 
-    /// Create a VM from this named bootstrap instead of your local environment default
-    #[clap(long, conflicts_with_all = ["no_bootstrap", "remote_agent", "rm"])]
+    /// Create from a named bootstrap instead of the local default
+    #[clap(long, conflicts_with_all = ["no_bootstrap", "remote_agent", "rm"], help_heading = "VM creation")]
     bootstrap: Option<String>,
 
-    /// Create a clean VM without your local environment default bootstrap
-    #[clap(long, conflicts_with_all = ["remote_agent", "rm"])]
+    /// Create without the local default bootstrap
+    #[clap(long, conflicts_with_all = ["remote_agent", "rm"], help_heading = "VM creation")]
     no_bootstrap: bool,
 
     /// Accepted for compatibility; agents now always stay running on
@@ -344,27 +287,24 @@ pub struct LaunchArgs {
     #[clap(long, hide = true)]
     keep_awake: bool,
 
-    /// Destroy this environment's agent and exit. Its disk goes with it.
-    /// Superseded by `railway ca delete`, which can name any agent and asks
-    /// before it destroys one
-    #[clap(long)]
+    /// Delete this environment's agent and disk (prefer railway ca delete)
+    #[clap(long, help_heading = "Lifecycle")]
     rm: bool,
 
-    /// Re-mint the Claude credential even if the agent already has a working
-    /// one, clearing our local token cache first. Use after revoking a token,
-    /// or when auth fails on an existing agent
-    #[clap(long)]
+    /// Replace cached Claude credentials with a new setup token
+    #[clap(long, help_heading = "Authentication and output")]
     refresh_auth: bool,
 
     /// Name for a newly created agent (defaults to a generated one)
-    #[clap(long)]
+    #[clap(long, help_heading = "VM creation")]
     name: Option<String>,
 
-    /// Set a variable on the agent (repeatable, comma-separable). Values
-    /// may reference other variables — `DB_URL=postgres.DATABASE_URL` or the
-    /// full `${{postgres.DATABASE_URL}}` form — resolved server-side at
-    /// create time. Applies to newly created agents
-    #[clap(long = "variable", value_name = "KEY=VALUE[,KEY=VALUE...]")]
+    /// Set variables on a new VM; repeat or separate with commas (supports service references)
+    #[clap(
+        long = "variable",
+        value_name = "KEY=VALUE[,KEY=VALUE...]",
+        help_heading = "VM creation"
+    )]
     variables: Vec<String>,
 
     /// Internal create-time variables supplied by desktop setup. These are
@@ -372,21 +312,20 @@ pub struct LaunchArgs {
     #[clap(skip)]
     pub(crate) boot_variables: std::collections::BTreeMap<String, String>,
 
-    /// Provision the code endpoint on a new VM (automatic for managed clients)
-    #[clap(long, requires = "new")]
+    /// Enable a code endpoint on port 4096 (requires --new; automatic for local clients)
+    #[clap(long, requires = "new", help_heading = "VM creation")]
     pub(crate) code_endpoint: bool,
 
-    /// Provision a new VM's code endpoint on this port (defaults to 4096)
-    #[clap(long, requires = "new", value_parser = ca::parse_code_port)]
+    /// Enable a code endpoint on this port (requires --new)
+    #[clap(long, requires = "new", value_parser = ca::parse_code_port, help_heading = "VM creation")]
     code_port: Option<u16>,
 
-    /// Load variables from a .env file (repeatable). `--variable` flags
-    /// override file entries with the same key
-    #[clap(long = "env-file", value_name = "PATH")]
+    /// Load a .env file (repeatable; --variable overrides file values)
+    #[clap(long = "env-file", value_name = "PATH", help_heading = "VM creation")]
     env_files: Vec<std::path::PathBuf>,
 
     /// Environment name or ID (defaults to the linked environment)
-    #[clap(long, short)]
+    #[clap(long, short, help_heading = "Target")]
     pub environment: Option<String>,
 
     /// Preserve directory-based naming when Desktop/the TUI pins a resolved target.
@@ -394,18 +333,23 @@ pub struct LaunchArgs {
     pub(crate) local_name_project: Option<String>,
 
     /// Project ID (defaults to the linked project)
-    #[clap(long, short)]
+    #[clap(long, short, help_heading = "Target")]
     pub project: Option<String>,
 
-    /// Client action: `remote`, `connect [AGENT]`, or Codex `desktop-only`
+    /// Client action: remote, connect [AGENT], desktop-only (Codex); or agent arguments after --
     agent_args: Vec<String>,
 
     /// Remote project directory for Codex/OpenCode server mode (default: /app)
-    #[clap(long = "dir", value_name = "PATH")]
+    #[clap(long = "dir", value_name = "PATH", help_heading = "Target")]
     remote_dir: Option<String>,
 
     /// Existing cloud agent for a local Codex/OpenCode client, by name or ID
-    #[clap(long = "agent", value_name = "NAME_OR_ID", conflicts_with = "new")]
+    #[clap(
+        long = "agent",
+        value_name = "NAME_OR_ID",
+        conflicts_with = "new",
+        help_heading = "Target"
+    )]
     remote_agent: Option<String>,
 
     /// A task to hand the agent as it starts. Set by the TUI's prompt box, not

--- a/src/commands/code/saved_config.rs
+++ b/src/commands/code/saved_config.rs
@@ -40,7 +40,7 @@ pub(crate) fn client_connection(
         })
 }
 
-/// Replay locally saved connection details without creating or waking an agent
+/// Show locally saved connection details without creating or waking an agent
 #[derive(Parser)]
 #[clap(
     after_help = "Examples:\n  railway code get-config\n  railway code get-config my-box\n  railway code get-config my-box --json\n\nReads local snapshots from any directory, without login or network access.\nOmit the agent to show the latest snapshot; use an ID for ambiguous names.\nSnapshots include credentials and are removed by railway logout."

--- a/src/commands/sandbox.rs
+++ b/src/commands/sandbox.rs
@@ -24,9 +24,16 @@ use crate::util::shell::shell_join;
 
 /// Manage ephemeral sandboxes
 #[derive(Parser)]
-#[clap(
-    after_help = "Examples:\n\n  railway sandbox create            # create + remember it as active\n  railway sandbox create --variable FOO=bar,DB_URL=postgres.DATABASE_URL\n  railway sandbox create --env-file .env\n  railway sandbox template build --name dev -c 'npm i -g pnpm' --wait\n  railway sandbox create --template dev   # boot from the pre-built snapshot\n  railway sandbox checkpoint create my-setup       # capture the active sandbox's disk\n  railway sandbox create --checkpoint my-setup     # boot a new sandbox from it\n  railway sandbox checkpoint list   # list named checkpoints in the environment\n  railway sandbox list              # list sandboxes in the environment\n  railway sandbox ssh               # connect to the active (last) sandbox\n  railway sandbox ssh --id <id>     # connect to a specific sandbox\n  railway sandbox exec --id <id> -- ls -la\n  railway sandbox exec --detach -- npm run build   # leave it running, prints a session name\n  railway sandbox exec --session <name>            # reattach to a detached/disconnected command\n  railway sandbox forward 3000      # localhost:3000 → port 3000 in the active sandbox\n  railway sandbox forward 8080:3000 # localhost:8080 → port 3000 (explicit local port)\n  railway sandbox forward 3000 5432 # several ports over one connection\n  railway sandbox fork              # fork the active sandbox; the fork becomes active\n  railway sandbox fork <id> --variable FOO=bar\n  railway sandbox destroy --id <id>\n\nNote: requires the PROJECT_SANDBOXES feature to be enabled."
-)]
+#[clap(after_help = r#"Examples:
+  railway sandbox create                 # create and select the active sandbox
+  railway sandbox ssh                    # connect to the active sandbox
+  railway sandbox exec -- ls -la         # run a command
+  railway sandbox fork                   # fork and select the new sandbox
+  railway sandbox destroy                # delete the active sandbox
+
+Commands use the active sandbox unless you specify an ID.
+Use railway sandbox <command> --help for options and examples.
+Requires Sandboxes access."#)]
 pub struct Args {
     #[clap(subcommand)]
     command: Commands,
@@ -77,6 +84,16 @@ enum Commands {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway sandbox create --private-network --domain 3000
+  railway sandbox create --template dev
+  railway sandbox create --checkpoint my-setup
+  railway sandbox create --env-file .env --variable MODE=dev
+
+--domain publishes an HTTP port and requires --private-network.
+Use --domain web:3000 for a hostname prefix; repeat for multiple ports.
+Build templates with railway sandbox template build; capture checkpoints with
+railway sandbox checkpoint create."#)]
 struct CreateArgs {
     /// Minutes the sandbox may sit idle before it is auto-destroyed
     #[clap(long)]
@@ -111,7 +128,7 @@ struct CreateArgs {
     private_network: bool,
 
     /// Publish an HTTP domain on a port, optionally with a prefix (repeatable).
-    /// Requires --private-network; forks do not inherit source domains
+    /// Requires --private-network
     #[clap(
         long = "domain",
         value_name = "[PREFIX:]PORT",
@@ -147,6 +164,9 @@ enum TemplateCommands {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway sandbox template build --name dev -c 'npm i -g pnpm' --wait
+  railway sandbox create --template dev"#)]
 struct TemplateBuildArgs {
     /// Shell instruction to run while building (repeatable, runs in order;
     /// each step must exit 0 within 10 minutes)
@@ -203,6 +223,11 @@ enum CheckpointCommands {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway sandbox checkpoint create my-setup
+  railway sandbox create --checkpoint my-setup
+
+Reusing a name replaces the previous checkpoint."#)]
 struct CheckpointCreateArgs {
     /// Name for the checkpoint, usable with `railway sandbox create
     /// --checkpoint <name>` (64-character hex names are reserved for
@@ -269,6 +294,13 @@ struct TemplateListArgs {
 /// Fork has no trailing command, so a positional id is unambiguous; `--id` is
 /// also accepted. Omitted → the active sandbox is the fork source.
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway sandbox fork
+  railway sandbox fork <id> --private-network --domain web:3000
+  railway sandbox fork <id> --env-file .env
+
+The fork becomes active. Variables, private-network mode, and public domains
+are not inherited; supply them again as needed."#)]
 struct ForkArgs {
     /// Source sandbox ID to fork (defaults to the active sandbox)
     #[clap(value_name = "ID")]
@@ -359,6 +391,10 @@ struct SshArgs {
 }
 
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway sandbox exec -- ls -la
+  railway sandbox exec --detach -- npm run build
+  railway sandbox exec --session <name>"#)]
 struct ExecArgs {
     /// Sandbox ID to run in (defaults to the active sandbox)
     #[clap(long = "id", value_name = "ID")]
@@ -394,6 +430,10 @@ struct ExecArgs {
 /// Ports are positional so the common case stays short; `--id` selects a
 /// sandbox other than the active one.
 #[derive(Parser)]
+#[clap(after_help = r#"Examples:
+  railway sandbox forward 3000            # localhost:3000 to sandbox port 3000
+  railway sandbox forward 8080:3000       # localhost:8080 to sandbox port 3000
+  railway sandbox forward 3000 5432       # forward several ports"#)]
 struct ForwardArgs {
     /// Ports to forward: `REMOTE` (same port locally) or `LOCAL:REMOTE`
     #[clap(value_name = "[LOCAL:]REMOTE", required = true)]

--- a/src/help_tests.rs
+++ b/src/help_tests.rs
@@ -54,7 +54,7 @@ fn focused_help_retains_side_effects_and_workflow_examples() {
         ),
         (
             vec!["ca", "bootstrap", "default"],
-            vec!["Name of a ready bootstrap"],
+            vec!["Name of a ready bootstrap", "does not change existing VMs"],
         ),
         (
             vec!["ca", "create"],
@@ -123,6 +123,28 @@ fn documented_examples_parse_without_executing_commands() {
             "--default",
         ],
         vec!["ca", "bootstrap", "default", "dev"],
+        vec![
+            "ca",
+            "bootstrap",
+            "default",
+            "dev",
+            "--environment",
+            "staging",
+        ],
+        vec!["ca", "bootstrap", "list", "--environment", "staging"],
+        vec!["ca", "bootstrap", "list", "--json"],
+        vec![
+            "ca",
+            "bootstrap",
+            "save",
+            "dev",
+            "--agent",
+            "my-box",
+            "--env-file",
+            ".env",
+            "--variable",
+            "MODE=dev",
+        ],
         vec!["code", "--codex", "--bootstrap", "dev"],
         vec![
             "ca",

--- a/src/help_tests.rs
+++ b/src/help_tests.rs
@@ -1,0 +1,152 @@
+//! Check command-specific help through the same command builder used by the CLI.
+use clap::error::ErrorKind;
+
+fn help(args: &[&str], flag: &str) -> String {
+    let error = crate::build_args()
+        .try_get_matches_from(
+            std::iter::once("railway")
+                .chain(args.iter().copied())
+                .chain(std::iter::once(flag)),
+        )
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::DisplayHelp);
+    error
+        .to_string()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[test]
+fn launcher_help_matches_each_execution_path() {
+    for flag in ["-h", "--help"] {
+        let code = help(&["code"], flag);
+        assert!(code.contains("railway code --codex connect my-box"));
+        assert!(code.contains("--connection-json"));
+        assert!(code.contains("command approvals disabled"));
+        assert!(code.contains("An explicit agent flag creates a new VM"));
+        for args in [vec!["ca"], vec!["ca", "start"]] {
+            let text = help(&args, flag);
+            assert!(!text.contains("railway code --codex connect"));
+            assert!(!text.contains("--connection-json"));
+            assert!(!text.contains("desktop-only"));
+            assert!(!text.contains("--agent <NAME_OR_ID>"));
+            assert!(text.contains("Arguments to pass to the agent after --"));
+            assert!(text.contains("VM running"));
+        }
+    }
+}
+
+#[test]
+fn focused_help_retains_side_effects_and_workflow_examples() {
+    for (args, expected) in [
+        (
+            vec!["ca", "desktop"],
+            vec![
+                "--remove",
+                "stops the managed OpenCode server",
+                "VM stays running",
+            ],
+        ),
+        (
+            vec!["ca", "bootstrap"],
+            vec!["bootstrap save dev", "saved on this machine"],
+        ),
+        (
+            vec!["ca", "bootstrap", "default"],
+            vec!["Name of a ready bootstrap"],
+        ),
+        (
+            vec!["ca", "create"],
+            vec![
+                "--from-checkpoint <checkpoint-id>",
+                "cloud-agent checkpoint ID",
+            ],
+        ),
+        (
+            vec!["ca", "ssh"],
+            vec!["--session", "--resume", "Sleep ends its processes"],
+        ),
+        (
+            vec!["code", "get-config"],
+            vec![
+                "without login or network access",
+                "Snapshots include credentials",
+            ],
+        ),
+        (
+            vec!["sandbox", "create"],
+            vec!["--private-network --domain 3000"],
+        ),
+        (
+            vec!["sandbox", "fork"],
+            vec!["are not inherited", "--domain web:3000"],
+        ),
+    ] {
+        let text = help(&args, "--help");
+        for expected in expected {
+            assert!(text.contains(expected), "{args:?} missing {expected:?}");
+        }
+    }
+}
+
+#[test]
+fn documented_examples_parse_without_executing_commands() {
+    for args in [
+        vec!["code", "--codex"],
+        vec!["code", "--claude"],
+        vec!["code", "--codex", "connect", "my-box"],
+        vec!["code", "--codex", "desktop-only"],
+        vec!["code", "get-config", "my-box"],
+        vec!["ca", "start", "--codex", "--new"],
+        // Help visibility must not remove previously accepted options.
+        vec!["ca", "--codex", "--connection-json"],
+        vec![
+            "ca", "start", "--codex", "--agent", "my-box", "--dir", "/app",
+        ],
+        vec![
+            "ca",
+            "start",
+            "--claude",
+            "--",
+            "exec",
+            "explain this codebase",
+        ],
+        vec!["ca", "desktop", "--opencode", "--agent", "my-box"],
+        vec![
+            "ca",
+            "bootstrap",
+            "save",
+            "dev",
+            "--agent",
+            "my-box",
+            "--default",
+        ],
+        vec!["ca", "bootstrap", "default", "dev"],
+        vec!["code", "--codex", "--bootstrap", "dev"],
+        vec![
+            "ca",
+            "create",
+            "my-box",
+            "--from-checkpoint",
+            "checkpoint-id",
+        ],
+        vec!["ca", "ssh", "my-box", "--session"],
+        vec!["ca", "ssh", "my-box", "--resume"],
+        vec!["sandbox", "create", "--private-network", "--domain", "3000"],
+        vec![
+            "sandbox",
+            "fork",
+            "sandbox-id",
+            "--private-network",
+            "--domain",
+            "web:3000",
+        ],
+        vec!["sandbox", "exec", "--detach", "--", "npm", "run", "build"],
+        vec!["sandbox", "forward", "8080:3000"],
+    ] {
+        crate::build_args()
+            .try_get_matches_from(std::iter::once("railway").chain(args.iter().copied()))
+            .unwrap_or_else(|error| panic!("{args:?}: {error}"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ mod controllers;
 mod errors;
 mod exec_context;
 mod gql;
+#[cfg(test)]
+mod help_tests;
 mod oauth;
 mod resources;
 mod subscription;


### PR DESCRIPTION
Recent cloud-agent additions left `railway code` help at 138 lines and caused `ca start` to inherit examples for local-client actions it does not dispatch. Give each entry point focused examples and an accurate explanation of where the agent runs and when a new VM is created.

- Shorten and group launcher options; hide code-only client options from CA help and completion suggestions while preserving option acceptance.
- Keep credential, approval, deletion, and compute-lifecycle effects visible. Move detailed authentication and Desktop setup instructions into a linked cloud-agent guide.
- Document bootstrap `list`, `save`, and `default` with focused examples, capture status, variable precedence, and the local default's effect on future VMs.
- Add checkpoint-restore, SSH-session, and sandbox-domain examples at the commands that own those workflows. Move sandbox exec, forwarding, and snapshot examples out of parent help.

No launch, provisioning, or authentication behavior changes.

| Help page | Before | After |
| --- | ---: | ---: |
| code | 138 lines | 76 lines |
| ca | 105 lines | 76 lines |
| ca start | 133 lines | 59 lines |
| ca desktop | 62 lines | 38 lines |

Validation: 45 bootstrap-focused tests, 3 help/parser regression tests, and 63 existing launcher tests passed. Cargo check, build, formatting, and all-target/all-feature clippy passed; existing warnings remain. Reviewed rendered short and long help for the affected commands.
